### PR TITLE
feat: add temporary chats

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -6,9 +6,11 @@ export default async function Home({
   searchParams: Promise<{ projectId?: string }>;
 }) {
   const { projectId } = await searchParams;
+  const chatId = crypto.randomUUID();
   return (
     <ChatArea
-      chatId={crypto.randomUUID()}
+      key={chatId}
+      chatId={chatId}
       projectId={projectId ?? null}
       isNew
     />

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -33,6 +33,7 @@ interface Body {
   projectId?: string | null;
   trigger?: "submit-message" | "regenerate-message";
   messageId?: string;
+  temporary?: boolean;
 }
 
 const PROVIDER_NAME = "user-endpoint";
@@ -50,6 +51,7 @@ export async function POST(req: Request) {
     projectId,
     trigger,
     messageId,
+    temporary,
   } = (await req.json()) as Body;
 
   if (!modelConfigId) return new Response("Missing modelConfigId", { status: 400 });
@@ -59,21 +61,29 @@ export async function POST(req: Request) {
   const modelConfig = await getModelConfig(modelConfigId);
   if (!modelConfig) return new Response("Model config not found", { status: 404 });
 
-  const chat = await ensureChat(chatId, userId, projectId ?? null);
-  if (!chat) return new Response("Not found", { status: 404 });
+  let resolvedProjectId: string | null;
+  if (temporary) {
+    resolvedProjectId = projectId ?? null;
+  } else {
+    const chat = await ensureChat(chatId, userId, projectId ?? null);
+    if (!chat) return new Response("Not found", { status: 404 });
+    resolvedProjectId = chat.projectId;
+  }
 
-  const project = chat.projectId
-    ? await getProject(chat.projectId, userId)
+  const project = resolvedProjectId
+    ? await getProject(resolvedProjectId, userId)
     : null;
 
   const last = messages[messages.length - 1];
-  if (trigger === "regenerate-message") {
-    if (messageId) await deleteMessagesFrom(chatId, messageId);
-  } else if (last.role === "user") {
-    if (messageId) await deleteMessagesFrom(chatId, messageId);
-    await appendMessage(chatId, "user", last.parts, last.id);
+  if (!temporary) {
+    if (trigger === "regenerate-message") {
+      if (messageId) await deleteMessagesFrom(chatId, messageId);
+    } else if (last.role === "user") {
+      if (messageId) await deleteMessagesFrom(chatId, messageId);
+      await appendMessage(chatId, "user", last.parts, last.id);
+    }
+    await touchChat(chatId);
   }
-  await touchChat(chatId);
 
   const provider = createOpenAICompatible({
     name: PROVIDER_NAME,
@@ -112,6 +122,7 @@ export async function POST(req: Request) {
     generateMessageId: () => crypto.randomUUID(),
     onFinish: async ({ responseMessage, isAborted }) => {
       if (isAborted) return;
+      if (temporary) return;
       try {
         await appendMessage(
           chatId,

--- a/components/ChatArea.tsx
+++ b/components/ChatArea.tsx
@@ -20,6 +20,7 @@ import {
   FileCode,
   FileSpreadsheet,
   FileText,
+  Ghost,
   Globe,
   Loader2,
   Paperclip,
@@ -189,16 +190,26 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
     false,
   );
 
+  const [temporary, setTemporary] = useState(false);
+
   const isNewRef = useRef(isNew ?? false);
 
   const [transport] = useState(
     () => new DefaultChatTransport<UIMessage>({ api: "/api/chat" }),
   );
 
+  const temporaryRef = useRef(false);
+  useEffect(() => {
+    temporaryRef.current = temporary;
+  }, [temporary]);
+
   const { messages, sendMessage, regenerate, status, stop, error } = useChat({
     transport,
     messages: initialMessages,
-    onFinish: () => router.refresh(),
+    onFinish: () => {
+      if (temporaryRef.current) return;
+      router.refresh();
+    },
   });
 
   const speech = useSpeech();
@@ -208,6 +219,7 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
     searchEnabled,
     chatId,
     projectId: projectId ?? null,
+    temporary,
   });
 
   const [input, setInput] = useState("");
@@ -249,7 +261,7 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
     if (streaming || uploading) return;
     if (!text && attachments.length === 0) return;
     if (!configured) return;
-    if (isNewRef.current) {
+    if (isNewRef.current && !temporary) {
       isNewRef.current = false;
       window.history.replaceState(null, "", `/chat/${chatId}`);
     }
@@ -344,6 +356,32 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
           selectedId={selectedId}
           onSelect={setSelectedId}
         />
+        <div className="ml-auto flex items-center">
+          {isNew && messages.length === 0 ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className={cn(
+                "rounded-full",
+                temporary && "bg-accent text-foreground hover:bg-accent",
+              )}
+              onClick={() => setTemporary((t) => !t)}
+              aria-label={
+                temporary ? "Disable temporary chat" : "Enable temporary chat"
+              }
+              aria-pressed={temporary}
+              title="Temporary chat — won't be saved to history"
+            >
+              <Ghost />
+            </Button>
+          ) : temporary ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-accent px-2.5 py-1 text-xs font-medium text-foreground">
+              <Ghost className="size-3.5" />
+              Temporary
+            </span>
+          ) : null}
+        </div>
       </header>
 
       <div
@@ -352,7 +390,7 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
         className="flex-1 overflow-y-auto overscroll-contain"
       >
         {messages.length === 0 ? (
-          <EmptyState configured={configured} />
+          <EmptyState configured={configured} temporary={temporary} />
         ) : (
           <div className="mx-auto w-full max-w-3xl space-y-6 px-4 pt-10 pb-8">
             {messages.map((m, i) => (
@@ -479,19 +517,31 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   );
 }
 
-function EmptyState({ configured }: { configured: boolean }) {
+function EmptyState({
+  configured,
+  temporary,
+}: {
+  configured: boolean;
+  temporary: boolean;
+}) {
   return (
     <div className="flex h-full min-h-[70vh] flex-col items-center justify-center px-4 text-center">
       <div className="mb-5 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
-        <Sparkles className="size-5" />
+        {temporary ? (
+          <Ghost className="size-5" />
+        ) : (
+          <Sparkles className="size-5" />
+        )}
       </div>
       <h1 className="font-heading text-2xl font-semibold tracking-tight">
-        What can I help with?
+        {temporary ? "Temporary chat" : "What can I help with?"}
       </h1>
       <p className="mt-3 max-w-sm text-sm text-muted-foreground">
-        {configured
-          ? "Ask a question or start a conversation."
-          : "No models configured yet. An admin needs to add one in Settings → Models."}
+        {!configured
+          ? "No models configured yet. An admin needs to add one in Settings → Models."
+          : temporary
+            ? "Messages won't be saved to your history."
+            : "Ask a question or start a conversation."}
       </p>
     </div>
   );

--- a/components/SidebarClient.tsx
+++ b/components/SidebarClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { FolderPlus, PanelLeft, Pencil, Search } from "lucide-react";
 import { SidebarChatList } from "@/components/SidebarChatList";
@@ -27,6 +28,8 @@ export function SidebarClient({
 }) {
   const { setOpenMobile, setCollapsed, openPalette } = useSidebar();
   const [creatingProject, setCreatingProject] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname();
 
   const modKey = useMemo(
     () =>
@@ -58,7 +61,13 @@ export function SidebarClient({
         <nav className="flex flex-col gap-0.5 py-1">
           <Link
             href="/"
-            onClick={() => setOpenMobile(false)}
+            onClick={(e) => {
+              setOpenMobile(false);
+              if (pathname === "/") {
+                e.preventDefault();
+                router.refresh();
+              }
+            }}
             className="group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-sidebar-accent"
           >
             <Pencil className="size-4 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- Adds an opt-in "temporary chat" mode (👻 toggle, top-right of the composer header) that streams normally but never writes to the DB.
- Server gates every persistence call in `/api/chat` on a `temporary` flag from the request body — no schema changes, no migration, no cron.
- Empty state branches to "Temporary chat — Messages won't be saved to your history." when the toggle is on; once the user sends, the toggle locks into a static "Temporary" pill so the mode stays visible.
- Drive-by fix: "New chat" was a no-op when already at `/` (Next.js skips identical-URL navigation). Keyed `ChatArea` on `chatId` and made the sidebar link `router.refresh()` when already at `/`.

Closes #4

## Test plan
- [ ] On `/`, toggle Ghost → send a message → no entry appears in the sidebar; refresh `/` and history is empty.
- [ ] On `/` with Ghost off, send a message → sidebar entry appears, URL becomes `/chat/[id]` (regression check).
- [ ] After first send in a temporary chat, the toggle is gone and a "Temporary" pill is visible.
- [ ] On an existing `/chat/[id]` page, no Ghost toggle and no pill render in the header.
- [ ] Web search toggle still works inside a temporary chat.
- [ ] Clicking "New chat" while in a temporary chat resets to a fresh empty chat.