### PR TITLE
feat: Parakeet TDT v3 speech-to-text sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,17 @@ SEARXNG_SECRET=
 # In docker compose, the app talks to searxng via http://searxng:8080 automatically.
 SEARXNG_URL=http://localhost:8088
 
+# Base URL for the speech-to-text sidecar when running `npm run dev` on the host.
+# In docker compose, the app talks to it via http://stt:5092 automatically.
+# STT is opt-in: only enabled if you bring it up with `--profile stt` (CPU)
+# or `--profile stt-gpu` (NVIDIA GPU).
+STT_URL=http://localhost:5092
+
 # --- Dev-only (compose.dev.yml) port bindings, all 127.0.0.1 ---
 # Only used when you start the stack with `-f compose.dev.yml` for local curling.
 SEARXNG_PORT=8088
 KOKORO_PORT=8880
+STT_PORT=5092
 
 # SQLite file location for local `npm run dev`. Ignored in docker (path is baked in).
 # DATABASE_URL=./data/chat.db

--- a/.github/workflows/stt-images.yml
+++ b/.github/workflows/stt-images.yml
@@ -1,0 +1,85 @@
+name: Build and publish STT images
+
+# Tag a release with `stt-v<semver>` (e.g. `stt-v0.1.0`) to trigger.
+# CPU image is built for linux/amd64 + linux/arm64.
+# GPU image is built for linux/amd64 only (CUDA is amd64-only in practice).
+on:
+  push:
+    tags: ["stt-v*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: ${{ github.repository_owner }}
+
+jobs:
+  cpu:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/overtchat-stt-cpu
+          tags: |
+            type=match,pattern=stt-v(.*),group=1
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./stt
+          file: ./stt/Dockerfile.cpu
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=stt-cpu
+          cache-to: type=gha,scope=stt-cpu,mode=max
+
+  gpu:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/overtchat-stt-gpu
+          tags: |
+            type=match,pattern=stt-v(.*),group=1
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./stt
+          file: ./stt/Dockerfile.gpu
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=stt-gpu
+          cache-to: type=gha,scope=stt-gpu,mode=max

--- a/README.md
+++ b/README.md
@@ -45,8 +45,20 @@ To open it up to other devices on your LAN, set `BETTER_AUTH_URL` in `.env` to y
 - Reasoning models (DeepSeek, Qwen3, …) render `<think>` blocks natively
 - Web search via bundled SearXNG. No API key.
 - Text-to-speech via bundled Kokoro. No setup.
+- Speech-to-text via Parakeet TDT v3 (opt-in, CPU or NVIDIA GPU)
 - Chat export (JSON / Markdown)
 - No RAG, no embeddings, no vector DB. Search results go straight into context.
+
+## Speech-to-text (optional)
+
+Off by default — the mic button in the composer is greyed out until you bring up the Parakeet sidecar:
+
+```bash
+docker compose --profile stt up -d        # CPU (~670 MB model, ~2 GB RAM)
+docker compose --profile stt-gpu up -d    # NVIDIA GPU (requires NVIDIA Container Toolkit)
+```
+
+Multilingual (25 languages, auto-detected). All processing stays on your machine. Model downloads on first start (~10 s) and is cached in a Docker volume.
 
 ## Privacy
 

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,41 @@
+import { auth } from "@/lib/auth/server";
+
+const STT_URL = process.env.STT_URL ?? "http://localhost:5092";
+const MAX_BYTES = 25 * 1024 * 1024;
+
+export async function POST(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+
+  const len = Number(req.headers.get("content-length") ?? 0);
+  if (len && len > MAX_BYTES) {
+    return new Response("Audio too large", { status: 413 });
+  }
+
+  const upstream = await fetch(`${STT_URL}/v1/audio/transcriptions`, {
+    method: "POST",
+    body: req.body,
+    // @ts-expect-error duplex is required by Node when streaming a body
+    duplex: "half",
+    headers: {
+      "Content-Type": req.headers.get("content-type") ?? "application/octet-stream",
+    },
+    signal: req.signal,
+  }).catch(() => null);
+
+  if (!upstream) {
+    return Response.json(
+      { error: "stt_unavailable", role: session.user.role ?? "user" },
+      { status: 503 },
+    );
+  }
+
+  const body = await upstream.text();
+  return new Response(body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("content-type") ?? "application/json",
+    },
+  });
+}
+

--- a/components/ChatArea.tsx
+++ b/components/ChatArea.tsx
@@ -23,6 +23,7 @@ import {
   Ghost,
   Globe,
   Loader2,
+  Mic,
   Paperclip,
   Pencil,
   RotateCcw,
@@ -41,6 +42,8 @@ import {
 } from "@/lib/config";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import { useSpeech } from "@/lib/useSpeech";
+import { useDictation, type DictationError } from "@/lib/useDictation";
+import { authClient } from "@/lib/auth/client";
 import { ModelPicker } from "@/components/ModelPicker";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import {
@@ -146,6 +149,23 @@ const PLUGINS = { code, math, cjk };
 
 const stripper = remark().use(strip);
 
+function dictationErrorMessage(err: DictationError, isAdmin: boolean): string {
+  switch (err.kind) {
+    case "permission":
+      return "Microphone access denied. Allow it in your browser settings to dictate.";
+    case "unsupported":
+      return "Your browser doesn't support audio recording.";
+    case "stt_unavailable":
+      return isAdmin || err.role === "admin"
+        ? "Speech-to-text isn't running. Start it with: docker compose --profile stt up -d (or --profile stt-gpu for NVIDIA GPU)."
+        : "Speech-to-text isn't enabled. Ask the admin to enable it.";
+    case "empty":
+      return "No speech detected. Try again.";
+    case "other":
+      return err.message || "Transcription failed.";
+  }
+}
+
 function stripMarkdown(s: string): string {
   return String(stripper.processSync(s)).replace(/\s+/g, " ").trim();
 }
@@ -213,6 +233,8 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   });
 
   const speech = useSpeech();
+  const { data: session } = authClient.useSession();
+  const isAdmin = session?.user.role === "admin";
 
   const requestBody = () => ({
     modelConfigId: selectedId,
@@ -233,6 +255,15 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const stickToBottomRef = useRef(true);
+
+  const dictation = useDictation((text) => {
+    setInput((prev) => {
+      const trimmed = prev.trimEnd();
+      if (!trimmed) return text;
+      return `${trimmed} ${text}`;
+    });
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  });
 
   const streaming = status === "streaming" || status === "submitted";
 
@@ -418,6 +449,11 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
           {uploadError && (
             <p className="mb-2 text-sm text-destructive">{uploadError}</p>
           )}
+          {dictation.error && (
+            <p className="mb-2 text-sm text-destructive">
+              {dictationErrorMessage(dictation.error, isAdmin)}
+            </p>
+          )}
           <div className="flex flex-col gap-2 rounded-3xl border bg-background px-3 py-2.5 shadow-sm transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring">
             {attachments.length > 0 && (
               <div className="flex flex-wrap gap-2 px-1 pt-1">
@@ -488,27 +524,63 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
                   <span className="text-xs">Search</span>
                 </Button>
               </div>
-              {streaming ? (
+              <div className="flex items-center gap-1">
                 <Button
+                  type="button"
+                  variant="ghost"
                   size="icon-sm"
-                  variant="secondary"
-                  className="shrink-0 rounded-full"
-                  onClick={() => stop()}
-                  aria-label="Stop generating"
+                  className={cn(
+                    "rounded-full",
+                    dictation.status === "recording" &&
+                      "bg-destructive text-destructive-foreground hover:bg-destructive hover:text-destructive-foreground",
+                  )}
+                  onClick={() => {
+                    if (dictation.status === "recording") {
+                      dictation.stop();
+                    } else if (dictation.status === "idle") {
+                      void dictation.start();
+                    }
+                  }}
+                  disabled={dictation.status === "transcribing"}
+                  aria-label={
+                    dictation.status === "recording"
+                      ? "Stop dictation"
+                      : dictation.status === "transcribing"
+                        ? "Transcribing"
+                        : "Dictate"
+                  }
+                  aria-pressed={dictation.status === "recording"}
                 >
-                  <Square className="size-3 fill-current" />
+                  {dictation.status === "transcribing" ? (
+                    <Loader2 className="animate-spin" />
+                  ) : dictation.status === "recording" ? (
+                    <Square className="size-3 fill-current" />
+                  ) : (
+                    <Mic />
+                  )}
                 </Button>
-              ) : (
-                <Button
-                  size="icon-sm"
-                  className="shrink-0 rounded-full"
-                  disabled={uploading || (!input.trim() && attachments.length === 0)}
-                  onClick={submit}
-                  aria-label="Send message"
-                >
-                  <ArrowUp />
-                </Button>
-              )}
+                {streaming ? (
+                  <Button
+                    size="icon-sm"
+                    variant="secondary"
+                    className="shrink-0 rounded-full"
+                    onClick={() => stop()}
+                    aria-label="Stop generating"
+                  >
+                    <Square className="size-3 fill-current" />
+                  </Button>
+                ) : (
+                  <Button
+                    size="icon-sm"
+                    className="shrink-0 rounded-full"
+                    disabled={uploading || (!input.trim() && attachments.length === 0)}
+                    onClick={submit}
+                    aria-label="Send message"
+                  >
+                    <ArrowUp />
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -11,3 +11,11 @@ services:
   kokoro:
     ports:
       - "127.0.0.1:${KOKORO_PORT:-8880}:8880"
+
+  stt-cpu:
+    ports:
+      - "127.0.0.1:${STT_PORT:-5092}:5092"
+
+  stt-gpu:
+    ports:
+      - "127.0.0.1:${STT_PORT:-5092}:5092"

--- a/compose.yml
+++ b/compose.yml
@@ -47,6 +47,45 @@ services:
       retries: 20
       start_period: 60s
 
+  # Speech-to-text via Parakeet TDT v3. Off by default; opt in with:
+  #   docker compose --profile stt up -d        (CPU, ~670MB model, ~2GB RAM)
+  #   docker compose --profile stt-gpu up -d    (NVIDIA GPU, requires NVIDIA Container Toolkit)
+  # Both services are reachable from `app` as `http://stt:5092`.
+  stt-cpu:
+    image: ghcr.io/yoloyash/overtchat-stt-cpu:${STT_VERSION:-0.1.0}
+    build:
+      context: ./stt
+      dockerfile: Dockerfile.cpu
+    container_name: overtchat-stt-cpu
+    restart: unless-stopped
+    profiles: [stt]
+    networks:
+      default:
+        aliases: [stt]
+    volumes:
+      - overtchat-stt-models:/models
+
+  stt-gpu:
+    image: ghcr.io/yoloyash/overtchat-stt-gpu:${STT_VERSION:-0.1.0}
+    build:
+      context: ./stt
+      dockerfile: Dockerfile.gpu
+    container_name: overtchat-stt-gpu
+    restart: unless-stopped
+    profiles: [stt-gpu]
+    networks:
+      default:
+        aliases: [stt]
+    volumes:
+      - overtchat-stt-models:/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
   # To expose overtchat via Cloudflare Tunnel, uncomment below and paste your
   # tunnel token. Nothing else on this stack is reachable from the internet —
   # searxng and kokoro stay on the internal Docker network.
@@ -64,3 +103,4 @@ services:
 
 volumes:
   overtchat-data:
+  overtchat-stt-models:

--- a/lib/useDictation.ts
+++ b/lib/useDictation.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type DictationStatus = "idle" | "recording" | "transcribing";
+
+export type DictationError =
+  | { kind: "permission" }
+  | { kind: "unsupported" }
+  | { kind: "stt_unavailable"; role: "admin" | "user" }
+  | { kind: "empty" }
+  | { kind: "other"; message: string };
+
+const PREFERRED_MIME = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/mp4",
+  "audio/ogg;codecs=opus",
+];
+
+function pickMime(): string | undefined {
+  if (typeof MediaRecorder === "undefined") return undefined;
+  for (const m of PREFERRED_MIME) {
+    if (MediaRecorder.isTypeSupported(m)) return m;
+  }
+  return undefined;
+}
+
+export function useDictation(onResult: (text: string) => void) {
+  const [status, setStatus] = useState<DictationStatus>("idle");
+  const [error, setError] = useState<DictationError | null>(null);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const cancelledRef = useRef(false);
+
+  const cleanupStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    recorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  useEffect(() => () => cleanupStream(), [cleanupStream]);
+
+  const start = useCallback(async () => {
+    setError(null);
+    if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      setError({ kind: "unsupported" });
+      return;
+    }
+    const mimeType = pickMime();
+    if (!mimeType) {
+      setError({ kind: "unsupported" });
+      return;
+    }
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+    } catch {
+      setError({ kind: "permission" });
+      return;
+    }
+
+    cancelledRef.current = false;
+    chunksRef.current = [];
+    streamRef.current = stream;
+
+    const recorder = new MediaRecorder(stream, { mimeType });
+    recorderRef.current = recorder;
+
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data);
+    };
+
+    recorder.onstop = async () => {
+      const blob = new Blob(chunksRef.current, { type: mimeType });
+      cleanupStream();
+
+      if (cancelledRef.current || blob.size === 0) {
+        setStatus("idle");
+        if (blob.size === 0 && !cancelledRef.current) {
+          setError({ kind: "empty" });
+        }
+        return;
+      }
+
+      setStatus("transcribing");
+      try {
+        const ext = mimeType.includes("webm")
+          ? "webm"
+          : mimeType.includes("mp4")
+            ? "m4a"
+            : "ogg";
+        const fd = new FormData();
+        fd.append("file", blob, `dictation.${ext}`);
+        const res = await fetch("/api/transcribe", { method: "POST", body: fd });
+
+        if (res.status === 503) {
+          const j = (await res.json().catch(() => ({}))) as {
+            role?: "admin" | "user";
+          };
+          setError({ kind: "stt_unavailable", role: j.role ?? "user" });
+          setStatus("idle");
+          return;
+        }
+        if (!res.ok) {
+          const text = await res.text().catch(() => "");
+          setError({ kind: "other", message: text || `HTTP ${res.status}` });
+          setStatus("idle");
+          return;
+        }
+
+        const j = (await res.json().catch(() => ({}))) as { text?: string };
+        const out = (j.text ?? "").trim();
+        if (out) onResult(out);
+        else setError({ kind: "empty" });
+      } catch (e) {
+        setError({
+          kind: "other",
+          message: e instanceof Error ? e.message : "Transcription failed",
+        });
+      } finally {
+        setStatus("idle");
+      }
+    };
+
+    recorder.start();
+    setStatus("recording");
+  }, [cleanupStream, onResult]);
+
+  const stop = useCallback(() => {
+    const r = recorderRef.current;
+    if (r && r.state !== "inactive") r.stop();
+  }, []);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+    const r = recorderRef.current;
+    if (r && r.state !== "inactive") r.stop();
+    setStatus("idle");
+    setError(null);
+  }, []);
+
+  return { status, error, start, stop, cancel, clearError: () => setError(null) };
+}

--- a/stt/.dockerignore
+++ b/stt/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__
+*.pyc
+.venv
+.env

--- a/stt/Dockerfile.cpu
+++ b/stt/Dockerfile.cpu
@@ -1,0 +1,30 @@
+FROM python:3.11-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/models \
+    HF_HUB_CACHE=/models \
+    HF_HUB_DISABLE_SYMLINKS_WARNING=1
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ffmpeg ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --upgrade pip \
+ && pip install -r requirements.txt \
+ && pip install "onnx-asr[cpu,hub]>=0.11"
+
+COPY main.py .
+
+RUN mkdir -p /models
+
+EXPOSE 5092
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+  CMD curl -fsS http://localhost:5092/health || exit 1
+
+CMD ["python", "main.py"]

--- a/stt/Dockerfile.gpu
+++ b/stt/Dockerfile.gpu
@@ -1,0 +1,36 @@
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/models \
+    HF_HUB_CACHE=/models \
+    HF_HUB_DISABLE_SYMLINKS_WARNING=1 \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      python3.11 python3.11-venv python3-pip \
+      ffmpeg ca-certificates curl \
+ && ln -sf /usr/bin/python3.11 /usr/bin/python \
+ && ln -sf /usr/bin/python3.11 /usr/bin/python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --upgrade pip \
+ && pip install -r requirements.txt \
+ && pip install "onnx-asr[gpu,hub]>=0.11"
+
+COPY main.py .
+
+RUN mkdir -p /models
+
+EXPOSE 5092
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=180s --retries=3 \
+  CMD curl -fsS http://localhost:5092/health || exit 1
+
+CMD ["python", "main.py"]

--- a/stt/main.py
+++ b/stt/main.py
@@ -1,0 +1,97 @@
+"""Parakeet TDT v3 STT service for overtchat.
+
+Exposes an OpenAI-compatible /v1/audio/transcriptions endpoint backed by the
+istupakov/onnx-asr Parakeet TDT 0.6B v3 model. Any ffmpeg-decodable input is
+accepted; ffmpeg normalizes it to 16 kHz mono float32 PCM in-process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+from contextlib import asynccontextmanager
+
+import numpy as np
+import onnx_asr
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("stt")
+
+MODEL_NAME = os.environ.get("STT_MODEL", "nemo-parakeet-tdt-0.6b-v3")
+QUANTIZATION = os.environ.get("STT_QUANTIZATION", "int8") or None
+MAX_UPLOAD_BYTES = int(os.environ.get("STT_MAX_UPLOAD_BYTES", 50 * 1024 * 1024))
+SAMPLE_RATE = 16_000
+
+state: dict = {}
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    log.info("loading model %s (quantization=%s)", MODEL_NAME, QUANTIZATION)
+    state["model"] = onnx_asr.load_model(MODEL_NAME, quantization=QUANTIZATION)
+    state["lock"] = asyncio.Lock()
+    log.info("model ready")
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok" if "model" in state else "loading", "model": MODEL_NAME}
+
+
+def _decode_to_pcm(blob: bytes) -> np.ndarray:
+    """Run ffmpeg to convert any audio container to 16 kHz mono float32 PCM."""
+    proc = subprocess.run(
+        [
+            "ffmpeg", "-nostdin", "-loglevel", "error",
+            "-i", "pipe:0",
+            "-f", "f32le", "-ac", "1", "-ar", str(SAMPLE_RATE),
+            "pipe:1",
+        ],
+        input=blob, capture_output=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise HTTPException(
+            status_code=400,
+            detail=f"could not decode audio: {proc.stderr.decode('utf-8', 'replace').strip()[:500]}",
+        )
+    audio = np.frombuffer(proc.stdout, dtype=np.float32)
+    if audio.size == 0:
+        raise HTTPException(status_code=400, detail="decoded audio is empty")
+    return audio
+
+
+@app.post("/v1/audio/transcriptions")
+async def transcribe(
+    file: UploadFile = File(...),
+    response_format: str = Form("json"),
+):
+    blob = await file.read()
+    if not blob:
+        raise HTTPException(status_code=400, detail="empty upload")
+    if len(blob) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="upload too large")
+
+    audio = await asyncio.to_thread(_decode_to_pcm, blob)
+
+    async with state["lock"]:
+        text = await asyncio.to_thread(
+            state["model"].recognize, audio, sample_rate=SAMPLE_RATE
+        )
+
+    text = (text or "").strip()
+    if response_format == "text":
+        return PlainTextResponse(text)
+    return JSONResponse({"text": text})
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("STT_PORT", 5092)))

--- a/stt/requirements.txt
+++ b/stt/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115
+uvicorn[standard]>=0.32
+python-multipart>=0.0.20
+numpy<2


### PR DESCRIPTION
## Summary
- New opt-in STT sidecar: `docker compose --profile stt up -d` (CPU) or `--profile stt-gpu` (NVIDIA GPU). Both services share the `stt` network alias and a model-cache volume.
- Thin FastAPI wrapper around istupakov/onnx-asr; ffmpeg handles container decode in-process so the browser can send opus/webm from MediaRecorder.
- Mic button in the composer next to send. Role-aware error copy: admins see the exact compose command when the sidecar is down; non-admins are told to ask the admin.
- GHA workflow publishes `ghcr.io/yoloyash/overtchat-stt-{cpu,gpu}` on tag `stt-v*`. CPU multi-arch, GPU amd64-only.

Closes #2

## Test plan
- [x] `docker compose --profile stt up -d stt-cpu` → healthy, `/health` returns `{"status":"ok"}`
- [x] POST sample audio to `/v1/audio/transcriptions` returns correct transcription
- [x] Mic button records, transcribes, and appends to input in dev (host)
- [x] `npx tsc --noEmit` and `npx eslint .` clean
- [ ] Repeat browser test on `main` after merge
- [ ] Tag `stt-v0.1.0`, confirm GHA workflow builds and pushes both images
- [ ] Flip GHCR packages to public after first push