### PR TITLE
fix(stt): wire STT_URL into the app container

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,7 @@ services:
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:4718}
       SEARXNG_URL: http://searxng:8080
       KOKORO_URL: http://kokoro:8880
+      STT_URL: http://stt:5092
       DATABASE_URL: /app/data/chat.db
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Summary
Missed adding `STT_URL: http://stt:5092` to the `app` service env in #6. Without it, `/api/transcribe` falls back to `http://localhost:5092` *inside* the app container, so every request 503'd "sidecar not running" even with `stt-cpu` healthy on the same network.

One-line compose change. No image rebuild needed — `docker compose up -d --no-build app` picks it up.

## Test plan
- [x] `docker exec overtchat-app sh -c "env | grep STT"` shows `STT_URL=http://stt:5092`
- [x] `fetch('http://stt:5092/health')` from inside the app container returns the model status
- [x] Mic button on prod transcribes successfully end-to-end