### PR TITLE
release: admin onboarding, search tool-choice, shortcut cleanup

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -92,6 +92,10 @@ export async function POST(req: Request) {
     messages: await convertToModelMessages(inlined),
     tools: searchEnabled ? webTools : undefined,
     stopWhen: searchEnabled ? stepCountIs(10) : undefined,
+    prepareStep: searchEnabled
+      ? async ({ stepNumber }) =>
+          stepNumber === 0 ? { toolChoice: "required" } : {}
+      : undefined,
     abortSignal: req.signal,
     providerOptions,
   });

--- a/components/AdminOnboardingCard.tsx
+++ b/components/AdminOnboardingCard.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ModelConfigDialog } from "@/app/(app)/settings/models/ModelConfigDialog";
+import { AddUserDialog } from "@/app/(app)/settings/users/AddUserDialog";
+import { useCreateModelConfig } from "@/lib/queries/modelConfigs";
+import type { ModelConfigInput } from "@/lib/config";
+import { useLocalStorage } from "@/lib/useLocalStorage";
+import { cn } from "@/lib/utils";
+
+export function AdminOnboardingCard({
+  modelCount,
+  onDismiss,
+}: {
+  modelCount: number;
+  onDismiss: () => void;
+}) {
+  const [modelMode, setModelMode] = useState<"new" | null>(null);
+  const [userOpen, setUserOpen] = useState(false);
+  const [userAdded, setUserAdded] = useLocalStorage<boolean>(
+    "overtchat_onboarding_user_added",
+    false,
+  );
+  const createMut = useCreateModelConfig();
+
+  const modelDone = modelCount > 0;
+
+  async function saveModel(input: ModelConfigInput) {
+    await createMut.mutateAsync(input);
+    setModelMode(null);
+  }
+
+  return (
+    <>
+      <div className="mx-auto w-full max-w-md">
+        <div className="text-center">
+          <h1 className="font-heading text-2xl font-semibold tracking-tight md:text-3xl">
+            Welcome to overtchat
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            A couple of quick steps to get your workspace running.
+          </p>
+        </div>
+
+        <ol className="mt-10 space-y-6">
+          <Step
+            done={modelDone}
+            title="Add your first model"
+            description="Connect an OpenAI-compatible endpoint."
+            action={
+              <Button size="sm" onClick={() => setModelMode("new")}>
+                <Plus /> {modelDone ? "Add another" : "Add model"}
+              </Button>
+            }
+          />
+          <Step
+            done={userAdded}
+            optional
+            title="Invite a teammate"
+            description="Skip this if you're the only one using overtchat."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setUserOpen(true)}
+              >
+                <Plus /> Add user
+              </Button>
+            }
+          />
+        </ol>
+
+        <div className="mt-10 flex items-center justify-center">
+          <Button
+            variant={modelDone ? "default" : "ghost"}
+            size="sm"
+            onClick={onDismiss}
+          >
+            {modelDone ? "Continue to chat" : "Skip for now"}
+          </Button>
+        </div>
+      </div>
+
+      <ModelConfigDialog
+        mode={modelMode}
+        onClose={() => setModelMode(null)}
+        onSave={saveModel}
+      />
+      <AddUserDialog
+        open={userOpen}
+        onOpenChange={setUserOpen}
+        onCreated={() => setUserAdded(true)}
+      />
+    </>
+  );
+}
+
+function Step({
+  done,
+  optional,
+  title,
+  description,
+  action,
+}: {
+  done: boolean;
+  optional?: boolean;
+  title: string;
+  description: string;
+  action: React.ReactNode;
+}) {
+  return (
+    <li className="flex items-start gap-4">
+      <span
+        className={cn(
+          "mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border",
+          done
+            ? "border-transparent bg-primary text-primary-foreground"
+            : "border-border bg-background text-transparent",
+        )}
+        aria-hidden="true"
+      >
+        <Check className="size-3.5" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <span className={cn(done && "text-muted-foreground")}>{title}</span>
+          {optional && !done && (
+            <span className="text-xs font-normal text-muted-foreground">
+              (optional)
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+        <div className="mt-3">{action}</div>
+      </div>
+    </li>
+  );
+}

--- a/components/ChatArea.tsx
+++ b/components/ChatArea.tsx
@@ -42,6 +42,7 @@ import { useLocalStorage } from "@/lib/useLocalStorage";
 import { useSpeech } from "@/lib/useSpeech";
 import { useDictation, type DictationError } from "@/lib/useDictation";
 import { authClient } from "@/lib/auth/client";
+import { AdminOnboardingCard } from "@/components/AdminOnboardingCard";
 import { ModelPicker } from "@/components/ModelPicker";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import {
@@ -223,6 +224,16 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   const speech = useSpeech();
   const { data: session } = authClient.useSession();
   const isAdmin = session?.user.role === "admin";
+  const [onboardingDismissed, setOnboardingDismissed] = useLocalStorage<boolean>(
+    "overtchat_onboarding_dismissed",
+    false,
+  );
+  const showOnboarding =
+    isAdmin &&
+    !temporary &&
+    !configured &&
+    !onboardingDismissed &&
+    models !== null;
 
   const requestBody = () => ({
     modelConfigId: selectedId,
@@ -586,19 +597,29 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
 
       {messages.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
-          <div className="w-full max-w-3xl">
-            <h1 className="mb-10 text-center font-heading text-2xl font-semibold tracking-tight md:text-3xl">
-              {temporary ? "Temporary chat" : "What can I help with?"}
-            </h1>
-            {(!configured || temporary) && (
-              <p className="mb-6 text-center text-sm text-muted-foreground">
-                {!configured
-                  ? "No models configured yet. An admin needs to add one in Settings → Models."
-                  : "Messages won't be saved to your history."}
-              </p>
-            )}
-            {composer}
-          </div>
+          {showOnboarding ? (
+            <AdminOnboardingCard
+              modelCount={models?.length ?? 0}
+              onDismiss={() => setOnboardingDismissed(true)}
+            />
+          ) : (
+            <div className="w-full max-w-3xl">
+              <h1 className="mb-10 text-center font-heading text-2xl font-semibold tracking-tight md:text-3xl">
+                {temporary ? "Temporary chat" : "What can I help with?"}
+              </h1>
+              {!configured && (
+                <p className="mb-6 text-center text-sm text-muted-foreground">
+                  No models configured yet. An admin needs to add one in Settings → Models.
+                </p>
+              )}
+              {configured && temporary && (
+                <p className="mb-6 text-center text-sm text-muted-foreground">
+                  {"Messages won't be saved to your history."}
+                </p>
+              )}
+              {composer}
+            </div>
+          )}
         </div>
       ) : (
         <>

--- a/components/SidebarClient.tsx
+++ b/components/SidebarClient.tsx
@@ -53,15 +53,6 @@ export function SidebarClient() {
     }));
   }, [chats, projectOptions]);
 
-  const modKey = useMemo(
-    () =>
-      typeof navigator !== "undefined" &&
-      /mac|iphone|ipad|ipod/i.test(navigator.platform)
-        ? "⌘"
-        : "Ctrl",
-    [],
-  );
-
   return (
     <>
       <div className="flex h-12 shrink-0 items-center justify-between px-3">
@@ -94,7 +85,7 @@ export function SidebarClient() {
           >
             <Pencil className="size-4 shrink-0 text-muted-foreground" />
             <span className="flex-1">New chat</span>
-            <Shortcut keys={[modKey, "⇧", "O"]} />
+            <Shortcut keys={["Ctrl", "Shift", "O"]} />
           </Link>
           <button
             type="button"
@@ -103,7 +94,7 @@ export function SidebarClient() {
           >
             <Search className="size-4 shrink-0 text-muted-foreground" />
             <span className="flex-1 text-left">Search chats</span>
-            <Shortcut keys={[modKey, "K"]} />
+            <Shortcut keys={["Ctrl", "K"]} />
           </button>
         </nav>
 

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -5,33 +5,19 @@ import { searxngSearch, fetchReadable } from "./web";
 export const webTools = {
   web_search: tool({
     description:
-      "Search the web. Returns a ranked list of {link, title, snippet}.\n\n" +
-      "CALL this tool when the user asks about:\n" +
-      "- current events, news, or time-sensitive info\n" +
-      "- specific facts you're not confident in (dates, prices, versions, people's roles)\n" +
-      "- anything that may have changed after your training cutoff\n" +
-      "- a URL, product, or name you don't recognize\n\n" +
-      "Unless you're 100% certain, you MUST call web_search instead of guessing/hallucinating.\n\n" +
-      "After searching, use fetch_url on 1-3 promising results. Always cite sources.",
+      "Search the web. Returns {link, title, snippet}. Cite sources.",
     inputSchema: z.object({
-      query: z.string().describe("The search query"),
-      limit: z
-        .number()
-        .int()
-        .min(1)
-        .max(10)
-        .default(5)
-        .describe("Max number of results to return"),
+      query: z.string(),
+      limit: z.number().int().min(1).max(10).default(5),
     }),
     execute: async ({ query, limit }) => searxngSearch(query, limit),
   }),
 
   fetch_url: tool({
     description:
-      "Fetch a URL and return its main content as markdown. Use this after web_search " +
-      "to read specific pages in depth. Content is truncated to ~8k characters.",
+      "Fetch a URL as markdown (~8k chars). Use after web_search to read promising pages.",
     inputSchema: z.object({
-      url: z.string().url().describe("The URL to fetch"),
+      url: z.string().url(),
     }),
     execute: async ({ url }) => fetchReadable(url),
   }),


### PR DESCRIPTION
## Summary

Promotes three changes from `dev` to `main`:

- **feat: first-run admin onboarding screen** — replaces the chat empty state for admins with no models configured. Welcome heading + two-step checklist (add model, optional invite user) reusing the existing `ModelConfigDialog` and `AddUserDialog`. Dismiss persists in localStorage; non-admins are unaffected.
- **feat: force tool choice on first search step; simplify tool descriptions** — improves search reliability.
- **refactor(ui): simplify shortcut key display** — drops platform-specific `modKey` detection in favor of consistent "Ctrl"/"Shift" labels.

## Test plan

- [ ] Onboarding: wipe `data/chat.db*`, sign up as first user, confirm welcome screen renders; add a model + dismiss; confirm normal chat UI takes over
- [ ] Onboarding: sign in as a non-admin user, confirm original "ask an admin" message still shows
- [ ] Search: send a message with search enabled, confirm the search tool fires on the first step
- [ ] Shortcuts: confirm shortcut hints display "Ctrl"/"Shift" consistently across platforms