### PR TITLE
feat: Anthropic + Google Gemini providers with preset-based dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # overtchat
 
-A simpler self-hosted alternative to Open WebUI. Bring your own OpenAI-compatible endpoint. One `docker compose up` and you're in.
+A simpler self-hosted alternative to Open WebUI. Bring your own model — Anthropic, Google Gemini, or any OpenAI-compatible endpoint. One `docker compose up` and you're in.
 
 ![overtchat](public/screenshot.png)
 
@@ -27,12 +27,14 @@ echo "SEARXNG_SECRET=$(openssl rand -hex 32)" >> .env
 docker compose up -d --build
 ```
 
-Open [http://localhost:4718](http://localhost:4718). First signup becomes admin. Go to **Settings → Models** and point it at your LLM:
+Open [http://localhost:4718](http://localhost:4718). First signup becomes admin. Go to **Settings → Models** and pick a provider:
 
-- **Ollama / vLLM / llama.cpp on the same host:** `http://host.docker.internal:<port>/v1`
-- **OpenAI / Groq / any public provider:** the provider's base URL + API key
+- **Anthropic** — paste your API key, pick a Claude model.
+- **Google Gemini** — paste your API key, pick a Gemini model.
+- **OpenAI-compatible** — base URL + (optional) API key. Covers OpenAI, Groq, OpenRouter, xAI, Mistral, Together, DeepSeek, Ollama, vLLM, llama.cpp, etc.
+  - For local servers on the same host use `http://host.docker.internal:<port>/v1`.
 
-Hit "Test connection" to populate the model list, pick one, save.
+Hit "Test connection", save.
 
 To open it up to other devices on your LAN, set `BETTER_AUTH_URL` in `.env` to your host's LAN IP (e.g. `http://192.168.1.50:4718`) and `docker compose up -d`. To expose it to the internet, the bundled compose file has a commented-out `cloudflared` service — paste a tunnel token and uncomment.
 
@@ -68,7 +70,7 @@ No telemetry, no analytics. No external calls except the LLM endpoint you config
 
 - Docker + Docker Compose v2
 - ~1 GB RAM free for the app stack (Kokoro TTS pulls ~100 MB on first boot)
-- An OpenAI-compatible LLM endpoint (local or remote)
+- An LLM endpoint: Anthropic API key, Google Gemini API key, or any OpenAI-compatible endpoint (local or remote)
 
 ## Stack
 

--- a/app/(app)/settings/models/ModelConfigDialog.tsx
+++ b/app/(app)/settings/models/ModelConfigDialog.tsx
@@ -6,6 +6,13 @@ import { CheckCircle2, ChevronDown, Loader2, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import {
   fetchModelsForEndpoint,
@@ -13,8 +20,10 @@ import {
   type ModelConfigInput,
 } from "@/lib/config";
 import {
-  PROVIDERS,
-  PROVIDER_IDS,
+  PRESETS,
+  PRESET_IDS,
+  presetFor,
+  type PresetId,
   type ProviderId,
 } from "@/lib/providers/meta";
 
@@ -61,33 +70,36 @@ function ModelConfigForm({
   onClose: () => void;
   onSave: (input: ModelConfigInput, id?: string) => Promise<void>;
 }) {
-  const [draft, setDraft] = useState<ModelConfigInput>(() =>
-    editing
-      ? {
-          label: editing.label,
-          provider: editing.provider,
-          baseUrl: editing.baseUrl,
-          apiKey: editing.apiKey ?? "",
-          model: editing.model,
-          systemPrompt: editing.systemPrompt ?? "",
-          extraBody: editing.extraBody,
-          sortOrder: editing.sortOrder,
-        }
-      : {
-          label: "",
-          provider: "openai-compatible",
-          baseUrl: "",
-          apiKey: "",
-          model: "",
-          systemPrompt: "",
-          extraBody: null,
-          sortOrder: 0,
-        },
+  const [preset, setPreset] = useState<PresetId>(() =>
+    editing ? presetFor(editing.provider, editing.baseUrl) : "openai",
   );
-  const providerMeta = PROVIDERS[draft.provider];
-  const requiresKey = providerMeta.requiresApiKey;
-  // Show the endpoint field only for providers without a fixed base URL.
-  const showBaseUrlField = providerMeta.defaultBaseUrl === "";
+  const [draft, setDraft] = useState<ModelConfigInput>(() => {
+    if (editing) {
+      return {
+        label: editing.label,
+        provider: editing.provider,
+        baseUrl: editing.baseUrl,
+        apiKey: editing.apiKey ?? "",
+        model: editing.model,
+        systemPrompt: editing.systemPrompt ?? "",
+        extraBody: editing.extraBody,
+        sortOrder: editing.sortOrder,
+      };
+    }
+    const initial = PRESETS.openai;
+    return {
+      label: "",
+      provider: initial.provider,
+      baseUrl: initial.defaultBaseUrl,
+      apiKey: "",
+      model: "",
+      systemPrompt: "",
+      extraBody: null,
+      sortOrder: 0,
+    };
+  });
+  const presetMeta = PRESETS[preset];
+  const requiresKey = presetMeta.requiresApiKey;
 
   const [extraBodyText, setExtraBodyText] = useState(() =>
     editing?.extraBody ? JSON.stringify(editing.extraBody, null, 2) : "",
@@ -131,19 +143,19 @@ function ModelConfigForm({
   );
 
   // Auto-probe when creating a new config and the endpoint/key changes.
-  // Providers with requiresApiKey wait for the key (Anthropic/Google);
-  // openai-compatible allows anonymous (e.g. local Ollama).
+  // Presets with requiresApiKey wait for the key; Custom (anonymous-ok)
+  // probes as soon as a base URL is present (e.g. local Ollama).
   const isCreating = editing === null;
   const { provider, baseUrl, apiKey } = draft;
   useEffect(() => {
     if (!isCreating || !baseUrl) return;
-    if (PROVIDERS[provider].requiresApiKey && !apiKey) return;
+    if (requiresKey && !apiKey) return;
     const t = setTimeout(
       () => void probeModels(provider, baseUrl, apiKey),
       500,
     );
     return () => clearTimeout(t);
-  }, [isCreating, provider, baseUrl, apiKey, probeModels]);
+  }, [isCreating, provider, baseUrl, apiKey, requiresKey, probeModels]);
 
   function parseExtraBody(): { ok: true; value: Record<string, unknown> | null } | { ok: false; error: string } {
     const trimmed = extraBodyText.trim();
@@ -240,31 +252,36 @@ function ModelConfigForm({
       >
         <div className="flex-1 space-y-5 overflow-y-auto px-6 py-5">
           <div className="space-y-1.5">
-            <Label htmlFor="p-provider">Provider</Label>
-            <select
-              id="p-provider"
-              value={draft.provider}
+            <Label htmlFor="p-preset">Provider</Label>
+            <Select
+              value={preset}
               disabled={Boolean(editing)}
-              onChange={(e) => {
-                const next = e.target.value as ProviderId;
+              onValueChange={(next) => {
+                if (!next) return;
+                const meta = PRESETS[next];
+                setPreset(next);
                 setDraft((d) => ({
                   ...d,
-                  provider: next,
-                  baseUrl: PROVIDERS[next].defaultBaseUrl,
+                  provider: meta.provider,
+                  baseUrl: meta.defaultBaseUrl,
                   model: "",
                 }));
                 setModels([]);
                 setProbeError("");
                 setPingResult(null);
               }}
-              className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-input/30"
             >
-              {PROVIDER_IDS.map((id) => (
-                <option key={id} value={id}>
-                  {PROVIDERS[id].label}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger id="p-preset" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PRESET_IDS.map((id) => (
+                  <SelectItem key={id} value={id}>
+                    {PRESETS[id].label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             {editing && (
               <p className="text-xs text-muted-foreground">
                 Provider can&apos;t be changed after creation.
@@ -272,25 +289,23 @@ function ModelConfigForm({
             )}
           </div>
 
-          {showBaseUrlField && (
-            <div className="space-y-1.5">
-              <Label htmlFor="p-base-url">Endpoint</Label>
-              <Input
-                id="p-base-url"
-                placeholder="https://api.openai.com/v1"
-                required
-                autoFocus={!editing}
-                value={draft.baseUrl}
-                onChange={(e) => {
-                  const baseUrl = e.target.value;
-                  setDraft((d) => ({ ...d, baseUrl }));
-                  setModels([]);
-                  setProbeError("");
-                  setPingResult(null);
-                }}
-              />
-            </div>
-          )}
+          <div className="space-y-1.5">
+            <Label htmlFor="p-base-url">Endpoint</Label>
+            <Input
+              id="p-base-url"
+              placeholder="https://api.openai.com/v1"
+              required
+              autoFocus={!editing && preset === "custom"}
+              value={draft.baseUrl}
+              onChange={(e) => {
+                const baseUrl = e.target.value;
+                setDraft((d) => ({ ...d, baseUrl }));
+                setModels([]);
+                setProbeError("");
+                setPingResult(null);
+              }}
+            />
+          </div>
 
           <div className="space-y-1.5">
             <Label htmlFor="p-api-key">
@@ -338,25 +353,29 @@ function ModelConfigForm({
               </span>
             </div>
             {models.length > 0 ? (
-              <select
-                id="p-model"
+              <Select
                 value={draft.model}
-                onChange={(e) => {
-                  setDraft((d) => ({ ...d, model: e.target.value }));
+                onValueChange={(value) => {
+                  if (value == null) return;
+                  setDraft((d) => ({ ...d, model: value }));
                   setPingResult(null);
                 }}
-                className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
               >
-                {models.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger id="p-model" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {models.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {m}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             ) : (
               <Input
                 id="p-model"
-                placeholder={providerMeta.modelPlaceholder}
+                placeholder={presetMeta.modelPlaceholder}
                 required
                 value={draft.model}
                 onChange={(e) => {

--- a/app/(app)/settings/models/ModelConfigDialog.tsx
+++ b/app/(app)/settings/models/ModelConfigDialog.tsx
@@ -12,6 +12,11 @@ import {
   type AdminModelConfig,
   type ModelConfigInput,
 } from "@/lib/config";
+import {
+  PROVIDERS,
+  PROVIDER_IDS,
+  type ProviderId,
+} from "@/lib/providers/meta";
 
 type Mode = AdminModelConfig | "new" | null;
 
@@ -60,6 +65,7 @@ function ModelConfigForm({
     editing
       ? {
           label: editing.label,
+          provider: editing.provider,
           baseUrl: editing.baseUrl,
           apiKey: editing.apiKey ?? "",
           model: editing.model,
@@ -69,6 +75,7 @@ function ModelConfigForm({
         }
       : {
           label: "",
+          provider: "openai-compatible",
           baseUrl: "",
           apiKey: "",
           model: "",
@@ -77,6 +84,11 @@ function ModelConfigForm({
           sortOrder: 0,
         },
   );
+  const providerMeta = PROVIDERS[draft.provider];
+  const requiresKey = providerMeta.requiresApiKey;
+  // Show the endpoint field only for providers without a fixed base URL.
+  const showBaseUrlField = providerMeta.defaultBaseUrl === "";
+
   const [extraBodyText, setExtraBodyText] = useState(() =>
     editing?.extraBody ? JSON.stringify(editing.extraBody, null, 2) : "",
   );
@@ -92,12 +104,16 @@ function ModelConfigForm({
   );
 
   const probeModels = useCallback(
-    async (baseUrl: string, apiKey: string | null | undefined) => {
+    async (
+      provider: ProviderId,
+      baseUrl: string,
+      apiKey: string | null | undefined,
+    ) => {
       if (!baseUrl) return;
       setProbingModels(true);
       setProbeError("");
       try {
-        const ids = await fetchModelsForEndpoint(baseUrl, apiKey);
+        const ids = await fetchModelsForEndpoint(provider, baseUrl, apiKey);
         setModels(ids);
         if (ids.length > 0) {
           setDraft((d) => ({
@@ -115,13 +131,19 @@ function ModelConfigForm({
   );
 
   // Auto-probe when creating a new config and the endpoint/key changes.
+  // Providers with requiresApiKey wait for the key (Anthropic/Google);
+  // openai-compatible allows anonymous (e.g. local Ollama).
   const isCreating = editing === null;
-  const { baseUrl, apiKey } = draft;
+  const { provider, baseUrl, apiKey } = draft;
   useEffect(() => {
     if (!isCreating || !baseUrl) return;
-    const t = setTimeout(() => void probeModels(baseUrl, apiKey), 500);
+    if (PROVIDERS[provider].requiresApiKey && !apiKey) return;
+    const t = setTimeout(
+      () => void probeModels(provider, baseUrl, apiKey),
+      500,
+    );
     return () => clearTimeout(t);
-  }, [isCreating, baseUrl, apiKey, probeModels]);
+  }, [isCreating, provider, baseUrl, apiKey, probeModels]);
 
   function parseExtraBody(): { ok: true; value: Record<string, unknown> | null } | { ok: false; error: string } {
     const trimmed = extraBodyText.trim();
@@ -150,6 +172,7 @@ function ModelConfigForm({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          provider: draft.provider,
           baseUrl: draft.baseUrl,
           apiKey: draft.apiKey,
           model: draft.model,
@@ -217,32 +240,69 @@ function ModelConfigForm({
       >
         <div className="flex-1 space-y-5 overflow-y-auto px-6 py-5">
           <div className="space-y-1.5">
-            <Label htmlFor="p-base-url">Endpoint</Label>
-            <Input
-              id="p-base-url"
-              placeholder="https://api.openai.com/v1"
-              required
-              autoFocus={!editing}
-              value={draft.baseUrl}
+            <Label htmlFor="p-provider">Provider</Label>
+            <select
+              id="p-provider"
+              value={draft.provider}
+              disabled={Boolean(editing)}
               onChange={(e) => {
-                const baseUrl = e.target.value;
-                setDraft((d) => ({ ...d, baseUrl }));
+                const next = e.target.value as ProviderId;
+                setDraft((d) => ({
+                  ...d,
+                  provider: next,
+                  baseUrl: PROVIDERS[next].defaultBaseUrl,
+                  model: "",
+                }));
                 setModels([]);
                 setProbeError("");
                 setPingResult(null);
               }}
-            />
+              className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-input/30"
+            >
+              {PROVIDER_IDS.map((id) => (
+                <option key={id} value={id}>
+                  {PROVIDERS[id].label}
+                </option>
+              ))}
+            </select>
+            {editing && (
+              <p className="text-xs text-muted-foreground">
+                Provider can&apos;t be changed after creation.
+              </p>
+            )}
           </div>
+
+          {showBaseUrlField && (
+            <div className="space-y-1.5">
+              <Label htmlFor="p-base-url">Endpoint</Label>
+              <Input
+                id="p-base-url"
+                placeholder="https://api.openai.com/v1"
+                required
+                autoFocus={!editing}
+                value={draft.baseUrl}
+                onChange={(e) => {
+                  const baseUrl = e.target.value;
+                  setDraft((d) => ({ ...d, baseUrl }));
+                  setModels([]);
+                  setProbeError("");
+                  setPingResult(null);
+                }}
+              />
+            </div>
+          )}
 
           <div className="space-y-1.5">
             <Label htmlFor="p-api-key">
-              API key <OptionalChip />
+              API key {requiresKey ? null : <OptionalChip />}
             </Label>
             <Input
               id="p-api-key"
               type="password"
               autoComplete="new-password"
-              placeholder="sk-…"
+              placeholder={requiresKey ? "Required" : "sk-…"}
+              required={requiresKey}
+              autoFocus={!editing && requiresKey}
               value={draft.apiKey ?? ""}
               onChange={(e) => {
                 const apiKey = e.target.value;
@@ -265,11 +325,15 @@ function ModelConfigForm({
                 ) : probeError ? (
                   <button
                     type="button"
-                    onClick={() => probeModels(draft.baseUrl, draft.apiKey)}
+                    onClick={() =>
+                      probeModels(draft.provider, draft.baseUrl, draft.apiKey)
+                    }
                     className="underline-offset-2 hover:underline"
                   >
                     Retry fetch
                   </button>
+                ) : requiresKey && !draft.apiKey ? (
+                  "Add API key to load models"
                 ) : null}
               </span>
             </div>
@@ -292,7 +356,7 @@ function ModelConfigForm({
             ) : (
               <Input
                 id="p-model"
-                placeholder="gpt-4o-mini"
+                placeholder={providerMeta.modelPlaceholder}
                 required
                 value={draft.model}
                 onChange={(e) => {
@@ -301,14 +365,21 @@ function ModelConfigForm({
                 }}
               />
             )}
-            {probeError && <p className="text-xs text-destructive">{probeError}</p>}
+            {probeError && (
+              <p className="text-xs text-destructive">{probeError}</p>
+            )}
 
             <div className="pt-1">
               <Button
                 type="button"
                 variant="outline"
                 size="xs"
-                disabled={!draft.baseUrl || !draft.model || pinging}
+                disabled={
+                  !draft.baseUrl ||
+                  !draft.model ||
+                  pinging ||
+                  (requiresKey && !draft.apiKey)
+                }
                 onClick={ping}
               >
                 {pinging ? (
@@ -423,7 +494,16 @@ function ModelConfigForm({
           <Button type="button" variant="ghost" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" size="sm" disabled={saving || !draft.baseUrl || !draft.model}>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={
+              saving ||
+              !draft.baseUrl ||
+              !draft.model ||
+              (requiresKey && !draft.apiKey)
+            }
+          >
             {saving ? "Saving…" : editing ? "Save" : "Create"}
           </Button>
         </div>

--- a/app/(app)/settings/models/ModelsPanel.tsx
+++ b/app/(app)/settings/models/ModelsPanel.tsx
@@ -51,7 +51,7 @@ export function ModelsPanel() {
         <div>
           <h1 className="font-heading text-xl font-semibold tracking-tight">Models</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            OpenAI-compatible endpoints available to everyone.
+            Anthropic, Google Gemini, or OpenAI-compatible endpoints — available to everyone.
           </p>
         </div>
         {models.length > 0 && (

--- a/app/api/model-configs/ping/route.ts
+++ b/app/api/model-configs/ping/route.ts
@@ -1,16 +1,16 @@
 import { generateText } from "ai";
 import type { JSONValue } from "@ai-sdk/provider";
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { auth } from "@/lib/auth/server";
+import { PROVIDER_IMPLS } from "@/lib/providers/server";
+import type { ProviderId } from "@/lib/providers/meta";
 
 interface Body {
+  provider: ProviderId;
   baseUrl: string;
   apiKey?: string | null;
   model: string;
   extraBody?: Record<string, unknown> | null;
 }
-
-const PROVIDER_NAME = "user-endpoint";
 
 export async function POST(req: Request) {
   const session = await auth.api.getSession({ headers: req.headers });
@@ -19,7 +19,9 @@ export async function POST(req: Request) {
     return new Response("Forbidden", { status: 403 });
   }
 
-  const { baseUrl, apiKey, model, extraBody } = (await req.json()) as Body;
+  const { provider, baseUrl, apiKey, model, extraBody } =
+    (await req.json()) as Body;
+
   if (!baseUrl || !model) {
     return Response.json(
       { error: "baseUrl and model are required" },
@@ -27,22 +29,21 @@ export async function POST(req: Request) {
     );
   }
 
-  const provider = createOpenAICompatible({
-    name: PROVIDER_NAME,
-    baseURL: baseUrl.replace(/\/$/, ""),
-    apiKey: apiKey || "none",
+  const { model: llm, providerOptions } = PROVIDER_IMPLS[provider].build({
+    baseUrl,
+    apiKey,
+    model,
+    extraBody: extraBody as Record<string, JSONValue> | null | undefined,
   });
 
   const started = Date.now();
   try {
     const { text, usage } = await generateText({
-      model: provider.chatModel(model),
+      model: llm,
       prompt: "Say hi in one short sentence.",
       maxOutputTokens: 64,
       abortSignal: AbortSignal.timeout(30_000),
-      providerOptions: extraBody
-        ? { [PROVIDER_NAME]: extraBody as Record<string, JSONValue> }
-        : undefined,
+      providerOptions,
     });
     return Response.json({
       text: text.trim(),

--- a/app/api/model-configs/route.ts
+++ b/app/api/model-configs/route.ts
@@ -7,11 +7,13 @@ import {
   type ModelConfigRow,
 } from "@/lib/db/modelConfigs";
 import type { PublicModelConfig } from "@/lib/config";
+import type { ProviderId } from "@/lib/providers/meta";
 
 function toPublic(row: ModelConfigRow): PublicModelConfig {
   return {
     id: row.id,
     label: row.label,
+    provider: row.provider as ProviderId,
     model: row.model,
     hasExtraBody: !!row.extraBody && Object.keys(row.extraBody).length > 0,
   };

--- a/app/api/model-configs/route.ts
+++ b/app/api/model-configs/route.ts
@@ -7,13 +7,13 @@ import {
   type ModelConfigRow,
 } from "@/lib/db/modelConfigs";
 import type { PublicModelConfig } from "@/lib/config";
-import type { ProviderId } from "@/lib/providers/meta";
+import { PRESETS, presetFor, type ProviderId } from "@/lib/providers/meta";
 
 function toPublic(row: ModelConfigRow): PublicModelConfig {
   return {
     id: row.id,
     label: row.label,
-    provider: row.provider as ProviderId,
+    displayProvider: PRESETS[presetFor(row.provider as ProviderId, row.baseUrl)].label,
     model: row.model,
     hasExtraBody: !!row.extraBody && Object.keys(row.extraBody).length > 0,
   };

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,6 +1,9 @@
 import { auth } from "@/lib/auth/server";
+import { PROVIDER_IMPLS } from "@/lib/providers/server";
+import type { ProviderId } from "@/lib/providers/meta";
 
 interface Body {
+  provider: ProviderId;
   baseUrl: string;
   apiKey?: string;
 }
@@ -12,29 +15,14 @@ export async function POST(req: Request) {
     return new Response("Forbidden", { status: 403 });
   }
 
-  const { baseUrl, apiKey } = (await req.json()) as Body;
+  const { provider, baseUrl, apiKey } = (await req.json()) as Body;
   if (!baseUrl) return new Response("Missing baseUrl", { status: 400 });
 
-  const url = baseUrl.replace(/\/$/, "") + "/models";
-  let res: Response;
   try {
-    res = await fetch(url, {
-      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
-      signal: AbortSignal.timeout(10_000),
-    });
+    const models = await PROVIDER_IMPLS[provider].listModels(baseUrl, apiKey);
+    return Response.json({ models });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return Response.json({ error: `Fetch failed: ${msg}` }, { status: 502 });
+    return Response.json({ error: msg }, { status: 502 });
   }
-
-  if (!res.ok) {
-    return Response.json(
-      { error: `Upstream ${res.status} ${res.statusText}` },
-      { status: 502 },
-    );
-  }
-
-  const json = (await res.json()) as { data?: Array<{ id: string }> };
-  const ids = (json.data ?? []).map((m) => m.id).sort();
-  return Response.json({ models: ids });
 }

--- a/components/AdminOnboardingCard.tsx
+++ b/components/AdminOnboardingCard.tsx
@@ -48,7 +48,7 @@ export function AdminOnboardingCard({
           <Step
             done={modelDone}
             title="Add your first model"
-            description="Connect an OpenAI-compatible endpoint."
+            description="Anthropic, Google Gemini, or any OpenAI-compatible endpoint."
             action={
               <Button size="sm" onClick={() => setModelMode("new")}>
                 <Plus /> {modelDone ? "Add another" : "Add model"}

--- a/components/ChatArea.tsx
+++ b/components/ChatArea.tsx
@@ -12,6 +12,7 @@ import remarkBreaks from "remark-breaks";
 import { remark } from "remark";
 import strip from "strip-markdown";
 import {
+  AlertTriangle,
   ArrowUp,
   Check,
   ChevronDown,
@@ -390,6 +391,11 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
     regenerate({ messageId, body: requestBody() });
   }
 
+  function handleRetry() {
+    if (streaming || !configured) return;
+    regenerate({ body: requestBody() });
+  }
+
   function handleEdit(messageId: string, text: string) {
     if (streaming || !configured) return;
     sendMessage({ text, messageId }, { body: requestBody() });
@@ -415,9 +421,6 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
 
   const composer = (
     <>
-      {error && (
-        <p className="mb-2 text-sm text-destructive">{error.message}</p>
-      )}
       {uploadError && (
         <p className="mb-2 text-sm text-destructive">{uploadError}</p>
       )}
@@ -640,7 +643,11 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
                   speech={speech}
                 />
               ))}
-              {status === "submitted" &&
+              {error && messages.at(-1)?.role === "user" && (
+                <ChatErrorBubble error={error} onRetry={handleRetry} />
+              )}
+              {!error &&
+                status === "submitted" &&
                 messages.at(-1)?.role === "user" && <PendingIndicator />}
             </div>
           </div>
@@ -1116,10 +1123,53 @@ function ThinkingBlock({
 
 function PendingIndicator() {
   return (
-    <div className="flex items-start">
-      <span className="animate-text-shimmer text-xs font-medium">
-        Thinking…
-      </span>
+    <div
+      className="flex items-center gap-1.5 py-2"
+      role="status"
+      aria-label="Assistant is responding"
+    >
+      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70 [animation-delay:-0.3s]" />
+      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70 [animation-delay:-0.15s]" />
+      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70" />
+    </div>
+  );
+}
+
+function chatErrorMessage(error: Error): string {
+  const msg = error.message ?? "";
+  if (
+    error.name === "TypeError" ||
+    /failed to fetch|networkerror|network request failed|load failed/i.test(msg)
+  ) {
+    return "Can't reach the server. Check your connection and try again.";
+  }
+  return msg || "Something went wrong. Please try again.";
+}
+
+function ChatErrorBubble({
+  error,
+  onRetry,
+}: {
+  error: Error;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+    >
+      <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground">{chatErrorMessage(error)}</p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onRetry}
+        className="shrink-0"
+      >
+        <RotateCcw /> Retry
+      </Button>
     </div>
   );
 }

--- a/components/ModelPicker.tsx
+++ b/components/ModelPicker.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { PublicModelConfig } from "@/lib/config";
+import { PROVIDERS, PROVIDER_IDS, type ProviderId } from "@/lib/providers/meta";
 
 interface Props {
   models: PublicModelConfig[] | null;
@@ -23,6 +24,8 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
       : models && models.length > 0
         ? "Select a model"
         : "No models";
+
+  const grouped = groupByProvider(models ?? []);
 
   return (
     <Menu.Root>
@@ -44,25 +47,56 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner side="bottom" align="start" sideOffset={6}>
-          <Menu.Popup className="z-50 max-h-80 w-64 overflow-y-auto rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
-            {models?.map((m) => (
-              <Menu.Item
-                key={m.id}
-                onClick={() => onSelect(m.id)}
-                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
-              >
-                <Check
-                  className={cn(
-                    "size-3.5 shrink-0",
-                    m.id === selectedId ? "opacity-100" : "opacity-0",
-                  )}
-                />
-                <span className="truncate">{m.label}</span>
-              </Menu.Item>
-            ))}
+          <Menu.Popup className="z-50 max-h-80 w-72 overflow-y-auto rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
+            {PROVIDER_IDS.map((providerId) => {
+              const items = grouped[providerId];
+              if (!items || items.length === 0) return null;
+              return (
+                <Menu.Group
+                  key={providerId}
+                  className="py-1 first:pt-0 last:pb-0 not-first:border-t not-first:mt-1 not-first:pt-2"
+                >
+                  <Menu.GroupLabel className="px-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {PROVIDERS[providerId].label}
+                  </Menu.GroupLabel>
+                  {items.map((m) => (
+                    <Menu.Item
+                      key={m.id}
+                      onClick={() => onSelect(m.id)}
+                      className="flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                    >
+                      <Check
+                        className={cn(
+                          "mt-0.5 size-3.5 shrink-0",
+                          m.id === selectedId ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate">{m.label}</span>
+                        {m.label !== m.model && (
+                          <span className="truncate text-xs text-muted-foreground">
+                            {m.model}
+                          </span>
+                        )}
+                      </span>
+                    </Menu.Item>
+                  ))}
+                </Menu.Group>
+              );
+            })}
           </Menu.Popup>
         </Menu.Positioner>
       </Menu.Portal>
     </Menu.Root>
   );
+}
+
+function groupByProvider(
+  models: PublicModelConfig[],
+): Partial<Record<ProviderId, PublicModelConfig[]>> {
+  const out: Partial<Record<ProviderId, PublicModelConfig[]>> = {};
+  for (const m of models) {
+    (out[m.provider] ??= []).push(m);
+  }
+  return out;
 }

--- a/components/ModelPicker.tsx
+++ b/components/ModelPicker.tsx
@@ -5,13 +5,15 @@ import { Check, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { PublicModelConfig } from "@/lib/config";
-import { PROVIDERS, PROVIDER_IDS, type ProviderId } from "@/lib/providers/meta";
+import { PRESETS, PRESET_IDS } from "@/lib/providers/meta";
 
 interface Props {
   models: PublicModelConfig[] | null;
   selectedId: string;
   onSelect: (id: string) => void;
 }
+
+const GROUP_ORDER = PRESET_IDS.map((id) => PRESETS[id].label);
 
 export function ModelPicker({ models, selectedId, onSelect }: Props) {
   const loading = models === null;
@@ -25,7 +27,7 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
         ? "Select a model"
         : "No models";
 
-  const grouped = groupByProvider(models ?? []);
+  const groups = groupModels(models ?? []);
 
   return (
     <Menu.Root>
@@ -48,42 +50,38 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
       <Menu.Portal>
         <Menu.Positioner side="bottom" align="start" sideOffset={6}>
           <Menu.Popup className="z-50 max-h-80 w-72 overflow-y-auto rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
-            {PROVIDER_IDS.map((providerId) => {
-              const items = grouped[providerId];
-              if (!items || items.length === 0) return null;
-              return (
-                <Menu.Group
-                  key={providerId}
-                  className="py-1 first:pt-0 last:pb-0 not-first:border-t not-first:mt-1 not-first:pt-2"
-                >
-                  <Menu.GroupLabel className="px-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                    {PROVIDERS[providerId].label}
-                  </Menu.GroupLabel>
-                  {items.map((m) => (
-                    <Menu.Item
-                      key={m.id}
-                      onClick={() => onSelect(m.id)}
-                      className="flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
-                    >
-                      <Check
-                        className={cn(
-                          "mt-0.5 size-3.5 shrink-0",
-                          m.id === selectedId ? "opacity-100" : "opacity-0",
-                        )}
-                      />
-                      <span className="flex min-w-0 flex-col">
-                        <span className="truncate">{m.label}</span>
-                        {m.label !== m.model && (
-                          <span className="truncate text-xs text-muted-foreground">
-                            {m.model}
-                          </span>
-                        )}
-                      </span>
-                    </Menu.Item>
-                  ))}
-                </Menu.Group>
-              );
-            })}
+            {groups.map(([groupLabel, items]) => (
+              <Menu.Group
+                key={groupLabel}
+                className="py-1 first:pt-0 last:pb-0 not-first:border-t not-first:mt-1 not-first:pt-2"
+              >
+                <Menu.GroupLabel className="px-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {groupLabel}
+                </Menu.GroupLabel>
+                {items.map((m) => (
+                  <Menu.Item
+                    key={m.id}
+                    onClick={() => onSelect(m.id)}
+                    className="flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                  >
+                    <Check
+                      className={cn(
+                        "mt-0.5 size-3.5 shrink-0",
+                        m.id === selectedId ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <span className="flex min-w-0 flex-col">
+                      <span className="truncate">{m.label}</span>
+                      {m.label !== m.model && (
+                        <span className="truncate text-xs text-muted-foreground">
+                          {m.model}
+                        </span>
+                      )}
+                    </span>
+                  </Menu.Item>
+                ))}
+              </Menu.Group>
+            ))}
           </Menu.Popup>
         </Menu.Positioner>
       </Menu.Portal>
@@ -91,12 +89,21 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
   );
 }
 
-function groupByProvider(
+function groupModels(
   models: PublicModelConfig[],
-): Partial<Record<ProviderId, PublicModelConfig[]>> {
-  const out: Partial<Record<ProviderId, PublicModelConfig[]>> = {};
+): Array<[string, PublicModelConfig[]]> {
+  const buckets = new Map<string, PublicModelConfig[]>();
   for (const m of models) {
-    (out[m.provider] ??= []).push(m);
+    const arr = buckets.get(m.displayProvider) ?? [];
+    arr.push(m);
+    buckets.set(m.displayProvider, arr);
   }
-  return out;
+  return [...buckets.entries()].sort(([a], [b]) => {
+    const ai = GROUP_ORDER.indexOf(a);
+    const bi = GROUP_ORDER.indexOf(b);
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return a.localeCompare(b);
+  });
 }

--- a/drizzle/0001_fancy_killraven.sql
+++ b/drizzle/0001_fancy_killraven.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `model_configs` ADD `provider` text DEFAULT 'openai-compatible' NOT NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,846 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "40e3ee53-3b39-42d8-ae56-f2ef2e2c4bd2",
+  "prevId": "1167f8ea-7e09-4d27-bcb4-2c7c17570174",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "chats_userId_updatedAt_idx": {
+          "name": "chats_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "chats_userId_projectId_updatedAt_idx": {
+          "name": "chats_userId_projectId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_user_id_fk": {
+          "name": "chats_user_id_user_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "messages_chatId_createdAt_idx": {
+          "name": "messages_chatId_createdAt_idx",
+          "columns": [
+            "chat_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai-compatible'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "projects_userId_updatedAt_idx": {
+          "name": "projects_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_user_id_fk": {
+          "name": "projects_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploads": {
+      "name": "uploads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "uploads_user_id_user_id_fk": {
+          "name": "uploads_user_id_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1778574373973,
       "tag": "0000_glossy_omega_sentinel",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1779002947324,
+      "tag": "0001_fancy_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -7,6 +7,7 @@ export type { ProviderId };
 export interface PublicModelConfig {
   id: string;
   label: string;
+  provider: ProviderId;
   model: string;
   hasExtraBody: boolean;
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -7,7 +7,8 @@ export type { ProviderId };
 export interface PublicModelConfig {
   id: string;
   label: string;
-  provider: ProviderId;
+  /** Display label for the underlying provider, e.g. "OpenAI", "Anthropic", "Custom". */
+  displayProvider: string;
   model: string;
   hasExtraBody: boolean;
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,7 @@
 import { useLocalStorage } from "@/lib/useLocalStorage";
+import type { ProviderId } from "@/lib/providers/meta";
+
+export type { ProviderId };
 
 /** Public-facing model config DTO. `apiKey` is intentionally omitted — it never leaves the server. */
 export interface PublicModelConfig {
@@ -12,6 +15,7 @@ export interface PublicModelConfig {
 export interface AdminModelConfig {
   id: string;
   label: string;
+  provider: ProviderId;
   baseUrl: string;
   apiKey: string | null;
   model: string;
@@ -22,6 +26,7 @@ export interface AdminModelConfig {
 
 export interface ModelConfigInput {
   label: string;
+  provider: ProviderId;
   baseUrl: string;
   apiKey?: string | null;
   model: string;
@@ -37,13 +42,14 @@ export function useSelectedModel(): [string, (id: string) => void] {
 }
 
 export async function fetchModelsForEndpoint(
+  provider: ProviderId,
   baseUrl: string,
   apiKey?: string | null,
 ): Promise<string[]> {
   const res = await fetch("/api/models", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ baseUrl, apiKey: apiKey ?? "" }),
+    body: JSON.stringify({ provider, baseUrl, apiKey: apiKey ?? "" }),
   });
   const json = (await res.json()) as { models?: string[]; error?: string };
   if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);

--- a/lib/db/modelConfigs.ts
+++ b/lib/db/modelConfigs.ts
@@ -2,7 +2,11 @@ import "server-only";
 import { asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { modelConfigs } from "@/lib/db/schema";
-import type { AdminModelConfig, ModelConfigInput } from "@/lib/config";
+import type {
+  AdminModelConfig,
+  ModelConfigInput,
+  ProviderId,
+} from "@/lib/config";
 
 export type { ModelConfigInput };
 export type ModelConfigRow = typeof modelConfigs.$inferSelect;
@@ -11,6 +15,7 @@ export function toAdminModelConfig(row: ModelConfigRow): AdminModelConfig {
   return {
     id: row.id,
     label: row.label,
+    provider: row.provider as ProviderId,
     baseUrl: row.baseUrl,
     apiKey: row.apiKey,
     model: row.model,
@@ -42,6 +47,7 @@ export async function createModelConfig(input: ModelConfigInput): Promise<ModelC
     .values({
       id: crypto.randomUUID(),
       label: input.label,
+      provider: input.provider,
       baseUrl: input.baseUrl.replace(/\/$/, ""),
       apiKey: input.apiKey ?? null,
       model: input.model,

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -247,6 +247,7 @@ export const uploadsRelations = relations(uploads, ({ one }) => ({
 export const modelConfigs = sqliteTable("model_configs", {
   id: text("id").primaryKey(),
   label: text("label").notNull(),
+  provider: text("provider").notNull().default("openai-compatible"),
   baseUrl: text("base_url").notNull(),
   apiKey: text("api_key"),
   model: text("model").notNull(),

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,30 +1,14 @@
 import "server-only";
-import {
-  wrapLanguageModel,
-  extractReasoningMiddleware,
-  type LanguageModel,
-} from "ai";
+import { PROVIDER_IMPLS, type BuiltModel } from "@/lib/providers/server";
+import type { ProviderId } from "@/lib/providers/meta";
 import type { JSONValue } from "@ai-sdk/provider";
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { ModelConfigRow } from "@/lib/db/modelConfigs";
 
-const PROVIDER_NAME = "user-endpoint";
-
-export function buildModel(modelConfig: ModelConfigRow): {
-  model: LanguageModel;
-  providerOptions: Record<string, Record<string, JSONValue>> | undefined;
-} {
-  const provider = createOpenAICompatible({
-    name: PROVIDER_NAME,
-    baseURL: modelConfig.baseUrl.replace(/\/$/, ""),
-    apiKey: modelConfig.apiKey || "none",
+export function buildModel(modelConfig: ModelConfigRow): BuiltModel {
+  return PROVIDER_IMPLS[modelConfig.provider as ProviderId].build({
+    baseUrl: modelConfig.baseUrl,
+    apiKey: modelConfig.apiKey,
+    model: modelConfig.model,
+    extraBody: modelConfig.extraBody as Record<string, JSONValue> | null,
   });
-  const model = wrapLanguageModel({
-    model: provider.chatModel(modelConfig.model),
-    middleware: extractReasoningMiddleware({ tagName: "think" }),
-  });
-  const providerOptions = modelConfig.extraBody
-    ? { [PROVIDER_NAME]: modelConfig.extraBody as Record<string, JSONValue> }
-    : undefined;
-  return { model, providerOptions };
 }

--- a/lib/providers/meta.ts
+++ b/lib/providers/meta.ts
@@ -1,31 +1,66 @@
+/** Wire-protocol identifier — selects which SDK + /models endpoint shape to use. */
 export type ProviderId = "openai-compatible" | "anthropic" | "google";
 
-export interface ProviderMeta {
+/** UX preset shown in the dialog dropdown and the picker group headers. */
+export type PresetId = "openai" | "anthropic" | "google" | "custom";
+
+export interface Preset {
   label: string;
+  provider: ProviderId;
   defaultBaseUrl: string;
   requiresApiKey: boolean;
   modelPlaceholder: string;
 }
 
-export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
-  "openai-compatible": {
-    label: "OpenAI-compatible",
-    defaultBaseUrl: "",
-    requiresApiKey: false,
+export const PRESETS: Record<PresetId, Preset> = {
+  openai: {
+    label: "OpenAI",
+    provider: "openai-compatible",
+    defaultBaseUrl: "https://api.openai.com/v1",
+    requiresApiKey: true,
     modelPlaceholder: "gpt-4o-mini",
   },
   anthropic: {
     label: "Anthropic",
+    provider: "anthropic",
     defaultBaseUrl: "https://api.anthropic.com/v1",
     requiresApiKey: true,
     modelPlaceholder: "claude-sonnet-4-5",
   },
   google: {
     label: "Google Gemini",
+    provider: "google",
     defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
     requiresApiKey: true,
     modelPlaceholder: "gemini-2.5-flash",
   },
+  custom: {
+    label: "Custom",
+    provider: "openai-compatible",
+    defaultBaseUrl: "",
+    requiresApiKey: false,
+    modelPlaceholder: "gpt-4o-mini",
+  },
 };
 
-export const PROVIDER_IDS = Object.keys(PROVIDERS) as ProviderId[];
+export const PRESET_IDS = Object.keys(PRESETS) as PresetId[];
+
+/**
+ * Infer a preset from a stored (provider, baseUrl) pair. Used both server-side
+ * (to label `PublicModelConfig` for the picker) and client-side (to seed the
+ * dialog when editing an existing config).
+ */
+export function presetFor(provider: ProviderId, baseUrl: string): PresetId {
+  if (provider === "anthropic") return "anthropic";
+  if (provider === "google") return "google";
+  // openai-compatible — split by hostname.
+  return isOpenAIHost(baseUrl) ? "openai" : "custom";
+}
+
+function isOpenAIHost(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname === "api.openai.com";
+  } catch {
+    return false;
+  }
+}

--- a/lib/providers/meta.ts
+++ b/lib/providers/meta.ts
@@ -1,0 +1,31 @@
+export type ProviderId = "openai-compatible" | "anthropic" | "google";
+
+export interface ProviderMeta {
+  label: string;
+  defaultBaseUrl: string;
+  requiresApiKey: boolean;
+  modelPlaceholder: string;
+}
+
+export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
+  "openai-compatible": {
+    label: "OpenAI-compatible",
+    defaultBaseUrl: "",
+    requiresApiKey: false,
+    modelPlaceholder: "gpt-4o-mini",
+  },
+  anthropic: {
+    label: "Anthropic",
+    defaultBaseUrl: "https://api.anthropic.com/v1",
+    requiresApiKey: true,
+    modelPlaceholder: "claude-sonnet-4-5",
+  },
+  google: {
+    label: "Google Gemini",
+    defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    requiresApiKey: true,
+    modelPlaceholder: "gemini-2.5-flash",
+  },
+};
+
+export const PROVIDER_IDS = Object.keys(PROVIDERS) as ProviderId[];

--- a/lib/providers/server.ts
+++ b/lib/providers/server.ts
@@ -10,7 +10,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import type { ProviderId } from "./meta";
 
-const OPENAI_COMPAT_PROVIDER_NAME = "user-endpoint";
+const OPENAI_COMPAT_PROVIDER_NAME = "openai-compatible";
 
 export interface BuildArgs {
   baseUrl: string;

--- a/lib/providers/server.ts
+++ b/lib/providers/server.ts
@@ -1,0 +1,129 @@
+import "server-only";
+import {
+  wrapLanguageModel,
+  extractReasoningMiddleware,
+  type LanguageModel,
+} from "ai";
+import type { JSONValue } from "@ai-sdk/provider";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { ProviderId } from "./meta";
+
+const OPENAI_COMPAT_PROVIDER_NAME = "user-endpoint";
+
+export interface BuildArgs {
+  baseUrl: string;
+  apiKey: string | null | undefined;
+  model: string;
+  extraBody: Record<string, JSONValue> | null | undefined;
+}
+
+export interface BuiltModel {
+  model: LanguageModel;
+  providerOptions: Record<string, Record<string, JSONValue>> | undefined;
+}
+
+interface ProviderImpl {
+  build(args: BuildArgs): BuiltModel;
+  listModels(baseUrl: string, apiKey: string | null | undefined): Promise<string[]>;
+}
+
+const LIST_MODELS_TIMEOUT_MS = 10_000;
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/$/, "");
+}
+
+async function fetchJson(url: string, headers: Record<string, string>): Promise<unknown> {
+  const res = await fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(LIST_MODELS_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Upstream ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export const PROVIDER_IMPLS: Record<ProviderId, ProviderImpl> = {
+  "openai-compatible": {
+    build({ baseUrl, apiKey, model, extraBody }) {
+      const provider = createOpenAICompatible({
+        name: OPENAI_COMPAT_PROVIDER_NAME,
+        baseURL: normalizeBaseUrl(baseUrl),
+        apiKey: apiKey || "none",
+      });
+      return {
+        model: wrapLanguageModel({
+          model: provider.chatModel(model),
+          middleware: extractReasoningMiddleware({ tagName: "think" }),
+        }),
+        providerOptions: extraBody
+          ? { [OPENAI_COMPAT_PROVIDER_NAME]: extraBody }
+          : undefined,
+      };
+    },
+    async listModels(baseUrl, apiKey) {
+      const json = (await fetchJson(
+        `${normalizeBaseUrl(baseUrl)}/models`,
+        apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      )) as { data?: Array<{ id?: string }> };
+      return (json.data ?? [])
+        .map((m) => m.id ?? "")
+        .filter(Boolean)
+        .sort();
+    },
+  },
+
+  anthropic: {
+    build({ baseUrl, apiKey, model, extraBody }) {
+      const provider = createAnthropic({
+        baseURL: normalizeBaseUrl(baseUrl),
+        apiKey: apiKey ?? undefined,
+      });
+      return {
+        model: provider(model),
+        providerOptions: extraBody ? { anthropic: extraBody } : undefined,
+      };
+    },
+    async listModels(baseUrl, apiKey) {
+      const json = (await fetchJson(
+        `${normalizeBaseUrl(baseUrl)}/models?limit=1000`,
+        {
+          "x-api-key": apiKey ?? "",
+          "anthropic-version": "2023-06-01",
+        },
+      )) as { data?: Array<{ id?: string }> };
+      return (json.data ?? [])
+        .map((m) => m.id ?? "")
+        .filter(Boolean)
+        .sort();
+    },
+  },
+
+  google: {
+    build({ baseUrl, apiKey, model, extraBody }) {
+      const provider = createGoogleGenerativeAI({
+        baseURL: normalizeBaseUrl(baseUrl),
+        apiKey: apiKey ?? undefined,
+      });
+      return {
+        model: provider(model),
+        providerOptions: extraBody ? { google: extraBody } : undefined,
+      };
+    },
+    async listModels(baseUrl, apiKey) {
+      const url = `${normalizeBaseUrl(baseUrl)}/models?pageSize=1000${
+        apiKey ? `&key=${encodeURIComponent(apiKey)}` : ""
+      }`;
+      const json = (await fetchJson(url, {})) as {
+        models?: Array<{ name?: string }>;
+      };
+      return (json.models ?? [])
+        .map((m) => (m.name ?? "").replace(/^models\//, ""))
+        .filter(Boolean)
+        .sort();
+    },
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "overtchat",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.78",
+        "@ai-sdk/google": "^3.0.75",
         "@ai-sdk/openai-compatible": "^2.0.47",
         "@ai-sdk/react": "^3.0.178",
         "@base-ui/react": "^1.4.1",
@@ -59,6 +61,22 @@
         "typescript": "^5"
       }
     },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.78",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.78.tgz",
+      "integrity": "sha512-0OY12G20cUt6iU6htpEA1491Oz++NVxZxlmWGX4B7rSbeZ5pnDmOu6YtW9BKzdZlNx5Gn23i6WMxyZFoMKNcgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/gateway": {
       "version": "3.0.111",
       "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.111.tgz",
@@ -68,6 +86,22 @@
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.75",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.75.tgz",
+      "integrity": "sha512-XAm31ftiOrzlb8NjDzT7kw0xw+4lmgFdGFn1QKM73nXFFKyN1kWLESBV75UGNfjXP8X1YJ0YydnMVqO0jaPghw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.78",
+    "@ai-sdk/google": "^3.0.75",
     "@ai-sdk/openai-compatible": "^2.0.47",
     "@ai-sdk/react": "^3.0.178",
     "@base-ui/react": "^1.4.1",


### PR DESCRIPTION
## Summary

- Adds native Anthropic and Google Gemini support alongside the existing OpenAI-compatible provider, each via the official Vercel AI SDK adapter (no compatibility shims, so Anthropic gets its full feature surface).
- Reshapes the model dialog around four presets — **OpenAI / Anthropic / Google Gemini / Custom** — with prefilled endpoints and the right required-key behavior for each.
- Groups configured models by provider in the chat header picker; two-line items show the admin label on top with the underlying model id beneath.
- Splits the codebase along a clean seam: `ProviderId` is the wire protocol (drives SDK + `/models` shape via a registry in `lib/providers/server.ts`), `PresetId` is the UX preset (lives in `lib/providers/meta.ts`). The DB stores the protocol id; presets are inferred at read time via `presetFor(provider, baseUrl)`, so no migration is needed for existing rows.
- Adds an `error bubble + retry` affordance and a small thinking indicator while the assistant is generating.
- Schema change: `model_configs.provider` column with default `"openai-compatible"` (migration `0001_fancy_killraven.sql`).

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes on changed files
- [ ] Fresh install: open Settings → Models, add a config for each preset (OpenAI / Anthropic / Google / Custom), verify endpoint prefills correctly and "Test connection" succeeds
- [ ] Custom preset against a local Ollama works without an API key
- [ ] Anthropic + Google presets refuse to probe `/models` until a key is entered (status row shows "Add API key to load models")
- [ ] Edit an existing config: dropdown seeds to the inferred preset; provider field is locked
- [ ] Chat picker groups models under the right provider header (OpenAI / Anthropic / Google Gemini / Custom)
- [ ] Streaming chat works end-to-end with each provider (smoke a message on each)