### PR TITLE
fix(docker): drop COPY of nonexistent public/ directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN groupadd --system --gid 1001 nodejs \
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle.config.ts ./
 COPY --from=builder --chown=nextjs:nodejs /app/lib/db/schema.ts ./lib/db/schema.ts


### PR DESCRIPTION
## Summary
v0.6.0 image build failed on \`COPY /app/public ./public: not found\`.

\`public/screenshot.png\` was deleted in 541eee1 ("docs: replace screenshot with demo video", May 18). Git doesn't track empty directories so \`public/\` vanished entirely. The app doesn't reference anything under \`public/\` (\`grep -rn public/ app/ components/ lib/\` is empty), so the cleanest fix is to drop the COPY line — no need for a placeholder file.

## Verified
- \`docker build .\` succeeds end-to-end on this commit (full multi-stage, both architectures)