### PR TITLE
feat(models): enable/disable toggle + on-demand health check in admin settings

### DIFF
--- a/app/(app)/settings/models/HealthBadge.tsx
+++ b/app/(app)/settings/models/HealthBadge.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useModelHealth } from "@/lib/queries/modelConfigs";
+
+export interface HealthBadgeProps {
+  id: string;
+  enabled: boolean;
+}
+
+export function HealthBadge({ id, enabled }: HealthBadgeProps) {
+  const { data, isFetching, refetch } = useModelHealth(id);
+
+  function onClick(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!isFetching) refetch();
+  }
+
+  let dotClass = "bg-muted-foreground/30";
+  let label = "Check";
+  let title = "Click to check connection";
+  if (isFetching) {
+    dotClass = "bg-muted-foreground/30";
+    label = "Checking…";
+    title = "Checking connection…";
+  } else if (data?.ok === true) {
+    dotClass = "bg-emerald-500";
+    label = `${data.elapsedMs}ms`;
+    title = `Working — responded in ${data.elapsedMs}ms`;
+  } else if (data?.ok === false) {
+    dotClass = "bg-destructive";
+    label = "Down";
+    title = data.error;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!enabled || isFetching}
+      title={title}
+      aria-label={title}
+      className="inline-flex shrink-0 items-center gap-1 rounded-full border bg-card/60 px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      {isFetching ? (
+        <Loader2 className="size-2.5 animate-spin" />
+      ) : (
+        <span className={`size-1.5 rounded-full ${dotClass}`} aria-hidden />
+      )}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/app/(app)/settings/models/ModelEditor.tsx
+++ b/app/(app)/settings/models/ModelEditor.tsx
@@ -49,6 +49,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
         model: existing.model,
         systemPrompt: existing.systemPrompt ?? "",
         extraBody: existing.extraBody,
+        enabled: existing.enabled,
         sortOrder: existing.sortOrder,
       };
     }
@@ -59,6 +60,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
       model: "",
       systemPrompt: "",
       extraBody: null,
+      enabled: true,
       sortOrder: 0,
     };
   });

--- a/app/(app)/settings/models/ModelsPanel.tsx
+++ b/app/(app)/settings/models/ModelsPanel.tsx
@@ -3,20 +3,46 @@
 import { useState } from "react";
 import Link from "next/link";
 import { AlertDialog } from "@base-ui/react/alert-dialog";
+import { Switch } from "@base-ui/react/switch";
 import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { AdminModelConfig } from "@/lib/config";
 import {
   useAdminModelConfigs,
   useDeleteModelConfig,
+  useUpdateModelConfig,
 } from "@/lib/queries/modelConfigs";
+import { HealthBadge } from "./HealthBadge";
 
 export function ModelsPanel() {
   const { data: models = [] } = useAdminModelConfigs();
   const deleteMut = useDeleteModelConfig();
+  const updateMut = useUpdateModelConfig();
 
   const [pendingDelete, setPendingDelete] = useState<AdminModelConfig | null>(null);
   const [deleteError, setDeleteError] = useState("");
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  async function toggleEnabled(m: AdminModelConfig, next: boolean) {
+    setTogglingId(m.id);
+    try {
+      await updateMut.mutateAsync({
+        id: m.id,
+        input: {
+          label: m.label,
+          baseUrl: m.baseUrl,
+          apiKey: m.apiKey,
+          model: m.model,
+          systemPrompt: m.systemPrompt,
+          extraBody: m.extraBody,
+          enabled: next,
+          sortOrder: m.sortOrder,
+        },
+      });
+    } finally {
+      setTogglingId(null);
+    }
+  }
 
   async function confirmDelete() {
     if (!pendingDelete) return;
@@ -65,11 +91,14 @@ export function ModelsPanel() {
               <Link
                 href={`/settings/models/${m.id}`}
                 aria-label={`Edit ${m.label}`}
-                className="flex w-full items-center rounded-lg border bg-card px-3.5 py-3 pr-12 text-left transition-colors hover:border-ring/40 hover:bg-accent/40 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+                className={`flex w-full items-center rounded-lg border bg-card px-3.5 py-3 pr-28 text-left transition-colors hover:border-ring/40 hover:bg-accent/40 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 ${m.enabled ? "" : "opacity-60"}`}
               >
                 <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm font-medium text-foreground">
-                    {m.label}
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {m.label}
+                    </span>
+                    <HealthBadge id={m.id} enabled={m.enabled} />
                   </div>
                   <div className="mt-0.5 flex items-center gap-2 font-mono text-xs text-muted-foreground">
                     <span className="truncate">{m.model}</span>
@@ -78,17 +107,28 @@ export function ModelsPanel() {
                   </div>
                 </div>
               </Link>
-              <button
-                type="button"
-                onClick={() => {
-                  setDeleteError("");
-                  setPendingDelete(m);
-                }}
-                aria-label={`Delete ${m.label}`}
-                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 group-hover:opacity-100"
-              >
-                <Trash2 className="size-4" />
-              </button>
+              <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+                <Switch.Root
+                  checked={m.enabled}
+                  disabled={togglingId === m.id}
+                  onCheckedChange={(next) => toggleEnabled(m, next)}
+                  aria-label={`${m.enabled ? "Disable" : "Enable"} ${m.label}`}
+                  className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-input bg-input/40 transition-colors data-[checked]:border-ring/40 data-[checked]:bg-ring/70 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                >
+                  <Switch.Thumb className="pointer-events-none ml-0.5 size-4 rounded-full bg-background shadow transition-transform data-[checked]:translate-x-4" />
+                </Switch.Root>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDeleteError("");
+                    setPendingDelete(m);
+                  }}
+                  aria-label={`Delete ${m.label}`}
+                  className="rounded-md p-1.5 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 group-hover:opacity-100"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
             </li>
           ))}
         </ul>

--- a/app/api/model-configs/[id]/health/route.ts
+++ b/app/api/model-configs/[id]/health/route.ts
@@ -1,0 +1,36 @@
+import { auth } from "@/lib/auth/server";
+import { getModelConfig } from "@/lib/db/modelConfigs";
+import { pingModel } from "@/lib/modelHealth";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const { id } = await params;
+  const row = await getModelConfig(id);
+  if (!row) return new Response("Not found", { status: 404 });
+
+  const result = await pingModel({
+    baseUrl: row.baseUrl,
+    apiKey: row.apiKey,
+    model: row.model,
+    extraBody: row.extraBody,
+  });
+
+  if (!result.ok) {
+    return Response.json(
+      { ok: false, error: result.error, elapsedMs: result.elapsedMs },
+      { status: 200 },
+    );
+  }
+  return Response.json({
+    ok: true,
+    elapsedMs: result.elapsedMs,
+  });
+}

--- a/app/api/model-configs/ping/route.ts
+++ b/app/api/model-configs/ping/route.ts
@@ -1,6 +1,5 @@
-import { generateText } from "ai";
 import { auth } from "@/lib/auth/server";
-import { buildModel } from "@/lib/llm";
+import { pingModel } from "@/lib/modelHealth";
 
 interface Body {
   baseUrl: string;
@@ -25,30 +24,14 @@ export async function POST(req: Request) {
     );
   }
 
-  const { model: llm, providerOptions } = buildModel({
-    baseUrl,
-    apiKey,
-    model,
-    extraBody,
-  });
-
-  const started = Date.now();
-  try {
-    const { text, usage } = await generateText({
-      model: llm,
-      prompt: "Say hi in one short sentence.",
-      maxOutputTokens: 64,
-      abortSignal: AbortSignal.timeout(30_000),
-      providerOptions,
-    });
-    return Response.json({
-      text: text.trim(),
-      elapsedMs: Date.now() - started,
-      inputTokens: usage?.inputTokens ?? null,
-      outputTokens: usage?.outputTokens ?? null,
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return Response.json({ error: msg }, { status: 502 });
+  const result = await pingModel({ baseUrl, apiKey, model, extraBody });
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: 502 });
   }
+  return Response.json({
+    text: result.text,
+    elapsedMs: result.elapsedMs,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
+  });
 }

--- a/app/api/model-configs/route.ts
+++ b/app/api/model-configs/route.ts
@@ -32,7 +32,9 @@ export async function GET(req: Request) {
     }
     return Response.json({ modelConfigs: rows.map(toAdminModelConfig) });
   }
-  return Response.json({ modelConfigs: rows.map(toPublic) });
+  return Response.json({
+    modelConfigs: rows.filter((r) => r.enabled).map(toPublic),
+  });
 }
 
 export async function POST(req: Request) {

--- a/drizzle/0001_lethal_pandemic.sql
+++ b/drizzle/0001_lethal_pandemic.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `model_configs` ADD `enabled` integer DEFAULT true NOT NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,846 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "43c2ffdc-150d-487d-905c-56091e5d0af1",
+  "prevId": "1167f8ea-7e09-4d27-bcb4-2c7c17570174",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "chats_userId_updatedAt_idx": {
+          "name": "chats_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "chats_userId_projectId_updatedAt_idx": {
+          "name": "chats_userId_projectId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_user_id_fk": {
+          "name": "chats_user_id_user_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "messages_chatId_createdAt_idx": {
+          "name": "messages_chatId_createdAt_idx",
+          "columns": [
+            "chat_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "projects_userId_updatedAt_idx": {
+          "name": "projects_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_user_id_fk": {
+          "name": "projects_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploads": {
+      "name": "uploads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "uploads_user_id_user_id_fk": {
+          "name": "uploads_user_id_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1778574373973,
       "tag": "0000_glossy_omega_sentinel",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1779355957251,
+      "tag": "0001_lethal_pandemic",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -20,6 +20,7 @@ export interface AdminModelConfig {
   model: string;
   systemPrompt: string | null;
   extraBody: Record<string, unknown> | null;
+  enabled: boolean;
   sortOrder: number;
 }
 
@@ -48,6 +49,7 @@ export const ModelConfigSchema = z.object({
     .record(z.string(), z.unknown())
     .nullish()
     .transform((v) => v ?? null),
+  enabled: z.boolean().nullish().transform((v) => v ?? true),
   sortOrder: z.number().int().nullish().transform((v) => v ?? 0),
 });
 

--- a/lib/db/modelConfigs.ts
+++ b/lib/db/modelConfigs.ts
@@ -16,6 +16,7 @@ export function toAdminModelConfig(row: ModelConfigRow): AdminModelConfig {
     model: row.model,
     systemPrompt: row.systemPrompt,
     extraBody: row.extraBody,
+    enabled: row.enabled,
     sortOrder: row.sortOrder,
   };
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -252,6 +252,7 @@ export const modelConfigs = sqliteTable("model_configs", {
   model: text("model").notNull(),
   systemPrompt: text("system_prompt"),
   extraBody: text("extra_body", { mode: "json" }).$type<Record<string, unknown>>(),
+  enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
   sortOrder: integer("sort_order").default(0).notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)

--- a/lib/modelHealth.ts
+++ b/lib/modelHealth.ts
@@ -1,0 +1,52 @@
+import "server-only";
+import { generateText } from "ai";
+import { buildModel } from "@/lib/llm";
+
+export interface PingArgs {
+  baseUrl: string;
+  apiKey?: string | null;
+  model: string;
+  extraBody?: Record<string, unknown> | null;
+}
+
+export type PingResult =
+  | {
+      ok: true;
+      text: string;
+      elapsedMs: number;
+      inputTokens: number | null;
+      outputTokens: number | null;
+    }
+  | { ok: false; error: string; elapsedMs: number };
+
+export async function pingModel(args: PingArgs): Promise<PingResult> {
+  const { model: llm, providerOptions } = buildModel({
+    baseUrl: args.baseUrl,
+    apiKey: args.apiKey ?? null,
+    model: args.model,
+    extraBody: args.extraBody ?? null,
+  });
+  const started = Date.now();
+  try {
+    const { text, usage } = await generateText({
+      model: llm,
+      prompt: "Say hi in one short sentence.",
+      maxOutputTokens: 64,
+      abortSignal: AbortSignal.timeout(30_000),
+      providerOptions,
+    });
+    return {
+      ok: true,
+      text: text.trim(),
+      elapsedMs: Date.now() - started,
+      inputTokens: usage?.inputTokens ?? null,
+      outputTokens: usage?.outputTokens ?? null,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      elapsedMs: Date.now() - started,
+    };
+  }
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -14,6 +14,7 @@ export const modelConfigKeys = {
   all: () => ["modelConfigs"] as const,
   publicList: () => [...modelConfigKeys.all(), "list", "public"] as const,
   adminList: () => [...modelConfigKeys.all(), "list", "admin"] as const,
+  health: (id: string) => [...modelConfigKeys.all(), "health", id] as const,
 };
 
 export const userKeys = {

--- a/lib/queries/modelConfigs.ts
+++ b/lib/queries/modelConfigs.ts
@@ -92,3 +92,30 @@ export function useDeleteModelConfig() {
     onSuccess: () => invalidateAll(qc),
   });
 }
+
+export type ModelHealth =
+  | { ok: true; elapsedMs: number }
+  | { ok: false; error: string; elapsedMs: number };
+
+export function useModelHealth(id: string) {
+  return useQuery({
+    queryKey: modelConfigKeys.health(id),
+    enabled: false,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: false,
+    queryFn: async (): Promise<ModelHealth> => {
+      const r = await fetch(`/api/model-configs/${id}/health`, {
+        method: "POST",
+      });
+      if (!r.ok) {
+        return {
+          ok: false,
+          error: `HTTP ${r.status}`,
+          elapsedMs: 0,
+        };
+      }
+      return (await r.json()) as ModelHealth;
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds an `enabled` boolean to `model_configs` (migration `0001_lethal_pandemic.sql`). Disabled models are hidden from the user picker but stay visible in admin so the row, key, label, system prompt, extra body and sort order all survive a temporary off.
- Per-row Base UI Switch in `/settings/models` round-trips through the existing PATCH endpoint (no new write route).
- New click-to-check health pill per row. Reuses the same `generateText` probe the editor's "Test connection" button already uses; the logic is now factored into `lib/modelHealth.ts` and called by both `/api/model-configs/ping` and the new `POST /api/model-configs/[id]/health`. Result cached per-id for 5 min via React Query so revisits don't re-fire calls.

## Test plan
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build` (typecheck + standalone build)
- [x] `docker build .` (multi-stage, runs migration on start)
- [x] Manual smoke on dev server: page renders, toggle persists, picker hides disabled models, health pill goes gray → green/red on click.