### PR TITLE
chore: add bug report template, bump compose APP_VERSION default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Something isn't working the way you'd expect.
+title: "bug: "
+labels: ["bug", "needs-repro"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The fields below are what I usually need to reproduce something locally.
+
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      description: |
+        Run `docker compose images app` and paste the tag (e.g. `0.7.0`). If you're running from source, paste the short commit hash from `git rev-parse --short HEAD`.
+      placeholder: "0.7.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A short description of the bug and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Sign in
+        2. Open Settings → Data
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Browser / OS
+      description: Browser + version, OS, and how you're reaching the app (https, http://localhost, http://<lan-ip>).
+      placeholder: "Chromium on macOS, http://localhost:4718"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs (optional)
+      description: |
+        Output of `docker compose logs app --tail=100` around the time of the bug, if it's a server-side issue. Browser DevTools console errors are great for UI bugs.
+      render: shell

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.2.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.7.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
Two small, independent fixes for issue triage hygiene.

## What
- Add `.github/ISSUE_TEMPLATE/bug_report.yml` — standardizes the version + repro info needed to reproduce reports locally. Auto-applies `bug` + `needs-repro` labels.
- Bump the `${APP_VERSION:-…}` default in `compose.yml` from `0.2.0` to `0.7.0` (current latest tag). The previous default predated chats, projects, and several settings routes, which made it easy for new users to land on a much older version unintentionally.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (18/18)
- [x] `docker compose config --quiet`
- [ ] Submit a test issue against the new template post-merge to confirm the labels apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)