### PR TITLE
chore(mobile): automate Play Store submit + APK release on tag

### DIFF
--- a/.github/workflows/mobile-eas.yml
+++ b/.github/workflows/mobile-eas.yml
@@ -1,51 +1,68 @@
-name: Build mobile app on EAS
+name: Mobile release
 
-# Tag a release with `mobile-v<semver>` (e.g. `mobile-v1.0.0`) to trigger.
-# Cuts an Android production build (app-bundle) on EAS.
 on:
   push:
     tags: ["mobile-v*"]
   workflow_dispatch:
-    inputs:
-      profile:
-        description: "EAS build profile"
-        required: true
-        default: "production"
-        type: choice
-        options: ["development", "preview", "production"]
-      platform:
-        description: "Platform"
-        required: true
-        default: "android"
-        type: choice
-        options: ["android", "ios", "all"]
 
 jobs:
-  build:
+  aab:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/mobile
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: npm
           cache-dependency-path: package-lock.json
-
-      # Hoisted root install — apps/mobile reads from the root node_modules.
       - name: Install dependencies
         working-directory: .
         run: npm ci
-
-      - name: Build on EAS
+      - name: Build AAB and auto-submit to Play
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           npx eas-cli@latest build \
-            --non-interactive \
-            --no-wait \
-            --platform "${{ github.event.inputs.platform || 'android' }}" \
-            --profile "${{ github.event.inputs.profile || 'production' }}"
+            --non-interactive --no-wait --auto-submit \
+            --platform android --profile production
+
+  apk:
+    if: startsWith(github.ref, 'refs/tags/mobile-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        working-directory: .
+        run: npm ci
+      - name: Build APK and attach to GitHub release
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OUT=$(npx eas-cli@latest build \
+            --non-interactive --wait --json \
+            --platform android --profile production-apk)
+          URL=$(echo "$OUT" | jq -r '.[0].artifacts.buildUrl')
+          MOBILE_TAG="${GITHUB_REF_NAME}"
+          VERSION="${MOBILE_TAG#mobile-v}"
+          PAIRED=$(git tag --points-at "$GITHUB_SHA" | grep -E '^v[0-9]' | sort -V | tail -1 || true)
+          TAG="${PAIRED:-$MOBILE_TAG}"
+          curl -fsSL "$URL" -o "overtchat-v${VERSION}.apk"
+          gh release view "$TAG" >/dev/null 2>&1 || \
+            gh release create "$TAG" --draft --title "$TAG" --notes "Draft — fill in notes before publishing."
+          gh release upload "$TAG" "overtchat-v${VERSION}.apk" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ yarn-error.log*
 .env
 .env*.local
 
+# Google service account JSON keys (any *.json at repo root looking like a key)
+/overtchat-*.json
+/*-service-account*.json
+
 # local-only compose overrides (per-developer)
 *.local.yml
 compose.override.yml

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,7 +14,6 @@
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 1,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -25,9 +25,19 @@
       "android": {
         "buildType": "app-bundle"
       }
+    },
+    "production-apk": {
+      "android": {
+        "buildType": "apk"
+      }
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "alpha",
+        "releaseStatus": "draft"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- AAB build auto-submits to Play alpha track via `--auto-submit` (configured in `eas.json` `submit.production`).
- APK built in parallel via new `production-apk` profile and attached to the paired `v*` GitHub release on the same commit (falls back to the `mobile-v*` tag if no paired release exists).
- Two parallel jobs, no chaining or build-id capture — `--auto-submit` handles AAB→submit internally.
- `.gitignore` updated to cover Google service account JSON keys at repo root.

## Test plan
- [ ] Push throwaway tag `mobile-v1.0.1-rc1` from this branch
- [ ] Verify `aab` job triggers build + submit on EAS
- [ ] Verify `apk` job builds, downloads, attaches APK to a GH draft release at the rc tag
- [ ] Verify Play Console alpha shows a draft AAB with versionCode=2
- [ ] Cleanup: discard Play draft, delete GH draft release, delete rc tag
- [ ] Merge PR; real `mobile-v1.0.1` next time runs the full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)