### PR TITLE
fix: apply interface font to all text, fix brand font scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ playwright/.cache/
 /build
 /dist
 
-# data
-data/
+# data (dev SQLite DB only; anchored so it can't match source dirs like settings/data/)
+/apps/web/data/
 *.db
 *.db-journal
 *.db-wal

--- a/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
+++ b/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
@@ -157,7 +157,7 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
         <div className="mx-auto w-full max-w-3xl space-y-8 px-4 py-8 md:px-8">
           <section className="space-y-3">
             <div>
-              <h2 className="font-heading text-base font-semibold tracking-tight">
+              <h2 className="text-base font-semibold tracking-tight">
                 Instructions
               </h2>
               <p className="mt-0.5 text-xs text-muted-foreground">
@@ -184,7 +184,7 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
 
           <section className="space-y-3">
             <div className="flex items-center justify-between">
-              <h2 className="font-heading text-base font-semibold tracking-tight">
+              <h2 className="text-base font-semibold tracking-tight">
                 Chats
               </h2>
               <Button

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -67,7 +67,7 @@ export function AccountForm({
   return (
     <div className="max-w-xl space-y-10">
       <header>
-        <h1 className="font-heading text-xl font-semibold tracking-tight">
+        <h1 className="text-xl font-semibold tracking-tight">
           Account
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -60,7 +60,7 @@ export function DataForm() {
   return (
     <div className="max-w-xl space-y-10">
       <header>
-        <h1 className="font-heading text-xl font-semibold tracking-tight">
+        <h1 className="text-xl font-semibold tracking-tight">
           Data
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/app/(app)/settings/general/GeneralForm.tsx
+++ b/apps/web/app/(app)/settings/general/GeneralForm.tsx
@@ -56,7 +56,7 @@ export function GeneralForm() {
   return (
     <div className="max-w-xl space-y-8">
       <header>
-        <h1 className="font-heading text-xl font-semibold tracking-tight">General</h1>
+        <h1 className="text-xl font-semibold tracking-tight">General</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Personal preferences for this browser.
         </p>
@@ -102,7 +102,7 @@ export function GeneralForm() {
         <div>
           <h2 className="text-sm font-medium">Font</h2>
           <p className="mt-0.5 text-xs text-muted-foreground">
-            Interface font for this browser. Headings and code are unaffected.
+            Choose the font used in the app.
           </p>
         </div>
         <Select value={currentFont} onValueChange={(next) => selectFont(next as FontId)}>

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -155,7 +155,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
         >
           <ArrowLeft />
         </Button>
-        <h1 className="font-heading text-xl font-semibold tracking-tight">
+        <h1 className="text-xl font-semibold tracking-tight">
           {isEditing ? "Edit model" : "Add model"}
         </h1>
       </div>

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -61,7 +61,7 @@ export function ModelsPanel() {
     <div className="max-w-2xl space-y-6">
       <header className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="font-heading text-xl font-semibold tracking-tight">Models</h1>
+          <h1 className="text-xl font-semibold tracking-tight">Models</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Anthropic, Google Gemini, or OpenAI-compatible endpoints — available to everyone.
           </p>
@@ -146,7 +146,7 @@ export function ModelsPanel() {
         <AlertDialog.Portal>
           <AlertDialog.Backdrop className="fixed inset-0 z-40 bg-black/40 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity" />
           <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity">
-            <AlertDialog.Title className="font-heading text-base font-semibold tracking-tight">
+            <AlertDialog.Title className="text-base font-semibold tracking-tight">
               Delete model?
             </AlertDialog.Title>
             <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">

--- a/apps/web/app/(app)/settings/users/AddUserDialog.tsx
+++ b/apps/web/app/(app)/settings/users/AddUserDialog.tsx
@@ -65,7 +65,7 @@ export function AddUserDialog({
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity" />
         <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity">
-          <Dialog.Title className="font-heading text-lg font-semibold tracking-tight">
+          <Dialog.Title className="text-lg font-semibold tracking-tight">
             Add user
           </Dialog.Title>
           <Dialog.Description className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/app/(app)/settings/users/UsersPanel.tsx
+++ b/apps/web/app/(app)/settings/users/UsersPanel.tsx
@@ -27,7 +27,7 @@ export function UsersPanel({ currentUserId }: { currentUserId: string }) {
     <div className="max-w-3xl space-y-6">
       <header className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="font-heading text-xl font-semibold tracking-tight">Users</h1>
+          <h1 className="text-xl font-semibold tracking-tight">Users</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Manage who can sign in.
           </p>

--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -6,7 +6,7 @@ export default function AuthLayout({
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-10">
       <div className="mb-8 flex items-center gap-2">
-        <span className="font-heading text-lg font-semibold tracking-tight">
+        <span className="font-brand text-lg font-semibold tracking-tight">
           overtchat
         </span>
       </div>

--- a/apps/web/app/(auth)/login/LoginForm.tsx
+++ b/apps/web/app/(auth)/login/LoginForm.tsx
@@ -32,7 +32,7 @@ export function LoginForm() {
   return (
     <form onSubmit={onSubmit} className="space-y-5">
       <header>
-        <h1 className="font-heading text-xl font-semibold tracking-tight">
+        <h1 className="text-xl font-semibold tracking-tight">
           Welcome back
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/app/(auth)/signup/SignupForm.tsx
+++ b/apps/web/app/(auth)/signup/SignupForm.tsx
@@ -37,7 +37,7 @@ export function SignupForm() {
   return (
     <form onSubmit={onSubmit} className="space-y-5">
       <header>
-        <h1 className="font-heading text-xl font-semibold tracking-tight">
+        <h1 className="text-xl font-semibold tracking-tight">
           Create the first account
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -15,9 +15,8 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--app-font-sans, var(--font-plus-jakarta-sans));
-  --font-serif: var(--font-fraunces);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-fraunces);
+  --font-brand: var(--font-fraunces);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/apps/web/components/AdminOnboardingCard.tsx
+++ b/apps/web/components/AdminOnboardingCard.tsx
@@ -27,7 +27,7 @@ export function AdminOnboardingCard({
     <>
       <div className="mx-auto w-full max-w-md">
         <div className="text-center">
-          <h1 className="font-heading text-2xl font-semibold tracking-tight md:text-3xl">
+          <h1 className="text-2xl font-semibold tracking-tight md:text-3xl">
             Welcome to overtchat
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -56,7 +56,7 @@ export function SidebarClient() {
   return (
     <>
       <div className="flex h-12 shrink-0 items-center justify-between px-3">
-        <span className="text-sm font-semibold tracking-tight">overtchat</span>
+        <span className="font-brand text-sm font-semibold tracking-tight">overtchat</span>
         <button
           type="button"
           onClick={() => {

--- a/apps/web/components/SidebarProjects.tsx
+++ b/apps/web/components/SidebarProjects.tsx
@@ -167,7 +167,7 @@ export function CreateProjectDialog({
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[starting-style]:opacity-0 data-[ending-style]:opacity-0" />
         <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none transition-opacity data-[starting-style]:opacity-0 data-[ending-style]:opacity-0">
-          <Dialog.Title className="font-heading text-lg font-semibold tracking-tight">
+          <Dialog.Title className="text-lg font-semibold tracking-tight">
             New project
           </Dialog.Title>
           <Dialog.Description className="mt-1 text-sm text-muted-foreground">

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -224,7 +224,7 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
             />
           ) : (
             <div className="w-full max-w-3xl">
-              <h1 className="mb-10 text-center font-heading text-2xl font-semibold tracking-tight md:text-3xl">
+              <h1 className="mb-10 text-center text-2xl font-semibold tracking-tight md:text-3xl">
                 {temporary ? "Temporary chat" : "What can I help with?"}
               </h1>
               {!configured && (

--- a/apps/web/components/chat/MessageBubble.tsx
+++ b/apps/web/components/chat/MessageBubble.tsx
@@ -191,7 +191,7 @@ function AssistantBubble({
             return (
               <Streamdown
                 key={i}
-                className="font-serif space-y-3 text-[15px] leading-relaxed"
+                className="font-sans space-y-3 text-[15px] leading-relaxed"
                 plugins={STREAMDOWN_PLUGINS}
                 remarkPlugins={CITATION_REMARK_PLUGINS}
                 allowedTags={CITATION_ALLOWED_TAGS}

--- a/apps/web/lib/fonts.ts
+++ b/apps/web/lib/fonts.ts
@@ -3,8 +3,9 @@
  * picker — consumed by `app/layout.tsx` (the no-FOUC inline script) and the
  * settings picker in `app/(app)/settings/general/GeneralForm.tsx`.
  *
- * Only the body/UI sans is swappable. Headings (Fraunces) and code (Geist Mono)
- * are fixed. The choice lives in localStorage — no DB, no migration, per-browser.
+ * The picked font applies to all UI and content text. Only the brand wordmark
+ * (Fraunces, via --font-brand) and code (Geist Mono) are fixed. The choice lives
+ * in localStorage — no DB, no migration, per-browser.
  *
  * NOTE: the actual `next/font/google` calls must stay top-level in `layout.tsx`;
  * this module only owns the ids, labels, storage key, and the value written to


### PR DESCRIPTION
## What

The per-device font picker (#27) only swapped `--font-sans`, but assistant responses were hardcoded to `font-serif` (Fraunces) and ~14 headings used `font-heading` (also Fraunces). So picking a font silently left the largest blocks of text — model responses and every page/dialog title — unchanged. That's the report in #29.

## Change

Collapse three font concepts (sans / serif / heading) down to two:

- **The user's picked font, everywhere** — assistant responses (`MessageBubble`) and all headings now use `font-sans`, so the picker governs all UI and content text.
- **A fixed brand wordmark** — `--font-heading` renamed to `--font-brand` (still Fraunces) and applied to *only* the two "overtchat" wordmarks (sidebar + sign-in page). These represent the brand and are intentionally not user-themable. Note the sidebar wordmark was plain sans before — it's now correctly branded.

`--font-serif` is dropped (its sole use was the assistant body).

## Also

Anchor the `data/` gitignore rule to `/apps/web/data/` — the unanchored rule was matching source dirs like `app/(app)/settings/data/`. Dev SQLite DB stays ignored (verified); `.db` globs already cover the files independently.

## Test

- `npm run lint` ✅
- `npm run build` ✅
- Verified in the running app: picker now changes responses + headings; both wordmarks stay Fraunces.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)