### PR TITLE
feat(settings): adopt base-ui primitives for theme/toggle/textarea/select

### DIFF
--- a/apps/web/app/(app)/settings/general/GeneralForm.tsx
+++ b/apps/web/app/(app)/settings/general/GeneralForm.tsx
@@ -3,7 +3,6 @@
 import { useSyncExternalStore } from "react";
 import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { cn } from "@/lib/utils";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import {
   Select,
@@ -12,6 +11,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import {
   DEFAULT_FONT_ID,
   FONT_OPTIONS,
@@ -69,33 +71,23 @@ export function GeneralForm() {
             Choose how overtchat looks to you.
           </p>
         </div>
-        <div
-          role="radiogroup"
+        <RadioGroup
           aria-label="Theme"
+          value={current}
+          onValueChange={(next) => setTheme(next as ThemeValue)}
           className="grid grid-cols-3 gap-2"
         >
-          {OPTIONS.map(({ value, label, icon: Icon }) => {
-            const active = current === value;
-            return (
-              <button
-                key={value}
-                type="button"
-                role="radio"
-                aria-checked={active}
-                onClick={() => setTheme(value)}
-                className={cn(
-                  "flex flex-col items-center gap-2 rounded-lg border bg-card px-3 py-4 text-sm transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
-                  active
-                    ? "border-ring ring-1 ring-ring"
-                    : "hover:bg-accent/50",
-                )}
-              >
-                <Icon className="size-4 text-muted-foreground" />
-                <span>{label}</span>
-              </button>
-            );
-          })}
-        </div>
+          {OPTIONS.map(({ value, label, icon: Icon }) => (
+            <Label
+              key={value}
+              className="flex cursor-pointer flex-col items-center gap-2 rounded-lg border bg-card px-3 py-4 text-sm font-normal transition-colors outline-none has-data-[checked]:border-ring has-data-[checked]:ring-1 has-data-[checked]:ring-ring has-focus-visible:border-ring has-focus-visible:ring-3 has-focus-visible:ring-ring/50 not-has-data-[checked]:hover:bg-accent/50"
+            >
+              <RadioGroupItem value={value} className="sr-only" />
+              <Icon className="size-4 text-muted-foreground" />
+              <span>{label}</span>
+            </Label>
+          ))}
+        </RadioGroup>
       </section>
 
       <section className="space-y-3">
@@ -130,20 +122,23 @@ export function GeneralForm() {
             Browser-only message display preferences.
           </p>
         </div>
-        <label className="flex cursor-pointer items-start gap-3 rounded-lg border bg-card px-3 py-3 text-sm">
-          <input
-            type="checkbox"
-            checked={statsForNerds}
-            onChange={(e) => setStatsForNerds(e.target.checked)}
-            className="mt-0.5 size-4 accent-primary"
-          />
+        <Label
+          htmlFor="stats-for-nerds"
+          className="flex cursor-pointer items-start justify-between gap-3 rounded-lg border bg-card px-3 py-3 text-sm font-normal"
+        >
           <span>
             <span className="block font-medium">Stats for nerds</span>
             <span className="mt-0.5 block text-xs text-muted-foreground">
               Show token and speed stats on assistant messages.
             </span>
           </span>
-        </label>
+          <Switch
+            id="stats-for-nerds"
+            checked={statsForNerds}
+            onCheckedChange={(next) => setStatsForNerds(next)}
+            className="mt-0.5"
+          />
+        </Label>
       </section>
     </div>
   );

--- a/apps/web/app/(app)/settings/models/AdvancedFields.tsx
+++ b/apps/web/app/(app)/settings/models/AdvancedFields.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Editor from "react-simple-code-editor";
 import { ChevronDown } from "lucide-react";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
 const EXTRA_BODY_EXAMPLE = {
@@ -76,13 +77,12 @@ export function AdvancedFields({
             <Label htmlFor="p-system-prompt">
               System prompt <OptionalChip />
             </Label>
-            <textarea
+            <Textarea
               id="p-system-prompt"
               rows={3}
               placeholder="You are a helpful assistant…"
               value={systemPrompt}
               onChange={(e) => onSystemPromptChange(e.target.value)}
-              className="w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
             />
           </div>
 

--- a/apps/web/app/(app)/settings/users/AddUserDialog.tsx
+++ b/apps/web/app/(app)/settings/users/AddUserDialog.tsx
@@ -5,6 +5,13 @@ import { Dialog } from "@base-ui/react/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { authClient } from "@/lib/auth/client";
 
 type Role = "user" | "admin";
@@ -106,15 +113,15 @@ export function AddUserDialog({
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="new-role">Role</Label>
-              <select
-                id="new-role"
-                value={role}
-                onChange={(e) => setRole(e.target.value as Role)}
-                className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
-              >
-                <option value="user">user</option>
-                <option value="admin">admin</option>
-              </select>
+              <Select value={role} onValueChange={(next) => setRole(next as Role)}>
+                <SelectTrigger id="new-role" aria-label="Role" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="user">user</SelectItem>
+                  <SelectItem value="admin">admin</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             {error && <p className="text-sm text-destructive">{error}</p>}

--- a/apps/web/components/ui/radio-group.tsx
+++ b/apps/web/components/ui/radio-group.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { Radio as RadioPrimitive } from "@base-ui/react/radio"
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="radio-group"
+      className={cn("grid w-full gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="radio-group-item"
+      className={cn(
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <RadioPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex size-4 items-center justify-center"
+      >
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/apps/web/components/ui/switch.tsx
+++ b/apps/web/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }


### PR DESCRIPTION
## What

Settings consistency pass — adopt the Base UI primitives (`base-nova` registry, same flavor as the existing `select.tsx`) in place of hand-rolled controls.

### New primitives
- `components/ui/switch.tsx`
- `components/ui/radio-group.tsx`

Both pulled from the `base-nova` registry (shadcnspace's Base UI line — what `components.json`'s `"style": "base-nova"` already pins). The registry ships a `@/registry/base-nova/lib/utils` import for `cn`; **fixed to this repo's `@/lib/utils` alias** to match `select.tsx`.

### Refactors
| File | Before | After |
|---|---|---|
| `GeneralForm.tsx` | raw `<button role=radio>` theme cards | `RadioGroup` + `RadioGroupItem` (card visual preserved via `has-data-[checked]`) |
| `GeneralForm.tsx` | raw `<input type=checkbox>` | `Switch` |
| `AdvancedFields.tsx` | raw `<textarea>` duplicating the primitive's classes | `Textarea` primitive |
| `AddUserDialog.tsx` | native `<select>` | `Select` primitive |

## Scope notes
- This is **Tier A** (settings only). Intentionally left alone: the `extra_body` JSON `Editor` and the link-style / collapsible buttons in models — deliberate custom UI, not primitive gaps. App-wide raw-button cleanup (chat/sidebar icon buttons) is a separate follow-up.
- Theme `RadioGroup` is uncontrolled until mount (`value` is `undefined` pre-hydration) — preserves the original "nothing selected until mounted" anti-flash behavior.

## Verification
- `tsc --noEmit` — clean
- `npm run lint` — clean
- Compiled `globals.css` through the Tailwind v4 PostCSS plugin and confirmed the compound theme-card variants (`has-data-[checked]`, `not-has-data-[checked]:hover`, `has-focus-visible`) emit real CSS (invalid TW classes drop silently, so checked the generated selectors directly).
- `next build` not run: Turbopack misinfers the workspace root inside the git worktree (hoisted `node_modules`) — environment artifact, not a code issue. Worth a full build from the primary checkout before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)