### PR TITLE
fix(web): avoid sqlite build-time lock race

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -18,7 +18,12 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npx playwright install chromium --with-deps
-      - run: npm run build -w apps/web --
+      - env:
+          DATABASE_URL: ":memory:"
+          BETTER_AUTH_SECRET: ci-build-secret-12345678901234567890
+          BETTER_AUTH_URL: http://localhost:4717
+          NEXT_TELEMETRY_DISABLED: "1"
+        run: npm run build -w apps/web --
       - env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           CI: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ RUN npm ci --include=dev
 
 FROM deps AS builder
 COPY . .
-RUN npm run build -w apps/web
+RUN DATABASE_URL=:memory: \
+    BETTER_AUTH_SECRET=container-build-secret-123456789012345 \
+    BETTER_AUTH_URL=http://localhost:4717 \
+    NEXT_TELEMETRY_DISABLED=1 \
+    npm run build -w apps/web
 
 FROM base AS runner
 RUN groupadd --system --gid 1001 nodejs \

--- a/apps/web/lib/db/client.ts
+++ b/apps/web/lib/db/client.ts
@@ -8,7 +8,11 @@ const DB_PATH = process.env.DATABASE_URL ?? "./data/chat.db";
 fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
 
 const sqlite = new Database(DB_PATH);
-sqlite.pragma("journal_mode = WAL");
 sqlite.pragma("foreign_keys = ON");
 
 export const db = drizzle({ client: sqlite });
+
+export function enableWalMode() {
+  if (sqlite.memory) return;
+  sqlite.pragma("journal_mode = WAL");
+}

--- a/apps/web/lib/db/migrate.ts
+++ b/apps/web/lib/db/migrate.ts
@@ -1,9 +1,11 @@
 import "server-only";
 import path from "node:path";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import { db } from "./client";
+import { db, enableWalMode } from "./client";
 
 export function runMigrations() {
+  enableWalMode();
+
   const envFolder = process.env.MIGRATIONS_FOLDER;
   const migrationsFolder = envFolder
     ? path.resolve(/* turbopackIgnore: true */ envFolder)


### PR DESCRIPTION
## Summary
- move persistent SQLite WAL setup out of DB client module import and into startup migration flow
- make CI and Docker builds use an in-memory build DB with Better Auth placeholder env

## Validation
- npm run build
- npm run lint
- npm run test
- docker build --target builder -t overtchat-builder-check .
- docker build -t overtchat-image-check .
- Web E2E Smoke push run passed: https://github.com/yoloyash/overtchat/actions/runs/26694084762