### PR TITLE
chore(ci): update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/app-image.yml
+++ b/.github/workflows/app-image.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/mobile-eas.yml
+++ b/.github/workflows/mobile-eas.yml
@@ -14,11 +14,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/stt-images.yml
+++ b/.github/workflows/stt-images.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -55,7 +55,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/tokens.yml
+++ b/.github/workflows/tokens.yml
@@ -15,7 +15,7 @@ jobs:
   update-tokens:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
@@ -28,7 +28,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           CI: true
         run: npm run test:e2e -w apps/web --
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary
- update official GitHub-maintained workflow actions to Node 24-backed majors
- keep checkout/setup-node consistent at v6 across workflows
- update upload-artifact to v7 for the web E2E failure artifact path

## Validation
- all workflow YAML parsed locally
- git diff --check
- verified action tags exist via GitHub API
- Web E2E Smoke push run passed: https://github.com/yoloyash/overtchat/actions/runs/26694753203