### PR TITLE
fix(chat): surface mid-stream errors instead of swallowing them

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -104,6 +104,7 @@ export async function POST(req: Request) {
   const inlined = await inlineUploads(messages, userId);
   const startedAt = Date.now();
   let firstTokenAt: number | null = null;
+  let streamError: unknown = null;
 
   const turnNumber = messages.filter((m) => m.role === "user").length - 1;
   const runtimeContext = buildRuntimeContext({
@@ -144,6 +145,10 @@ export async function POST(req: Request) {
         firstTokenAt = Date.now();
       }
     },
+    onError: ({ error }) => {
+      streamError = error;
+      console.error("[chat-stream]", error);
+    },
   });
 
   const streamHeaders = corsHeaders(req);
@@ -153,6 +158,8 @@ export async function POST(req: Request) {
     originalMessages: messages,
     generateMessageId: () => crypto.randomUUID(),
     headers: streamHeaders,
+    onError: (error) =>
+      error instanceof Error ? error.message : "Something went wrong.",
     consumeSseStream: temporary
       ? undefined
       : async ({ stream }) => {
@@ -184,6 +191,15 @@ export async function POST(req: Request) {
     },
     onFinish: async ({ responseMessage }) => {
       if (temporary) return;
+      // A turn that errored mid-stream leaves a partial assistant message
+      // (e.g. reasoning with no answer). Persisting it would strand a dangling
+      // "Thought for Ns" block on reload. Drop it; the client surfaces the
+      // error and offers retry.
+      if (streamError) {
+        await setActiveStreamId(chatId, null);
+        cancelRegistry.unregister(streamId);
+        return;
+      }
       try {
         if (responseMessage.parts.length > 0) {
           await appendMessage(

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -70,9 +70,7 @@ export function MessageList({
             stats={readMessageStats(m) ?? storedStats[m.id] ?? null}
           />
         ))}
-        {error && messages.at(-1)?.role === "user" && (
-          <ChatErrorBubble error={error} onRetry={onRetry} />
-        )}
+        {error && <ChatErrorBubble error={error} onRetry={onRetry} />}
         {!error &&
           status === "submitted" &&
           messages.at(-1)?.role === "user" && <PendingIndicator />}


### PR DESCRIPTION
Fixes #40

## Problem

When an upstream provider fails mid-stream, the turn died invisibly. Traced via a wire tap between the app and vLLM: the engine returns 200, streams reasoning fine, then emits a 500 error chunk at the tool-call transition (an upstream xgrammar guided-decoding crash — out of scope here). Two app-side defects turned that into silent failure:

1. **Live:** the error bubble in `MessageList.tsx` only rendered when the last message was the user's. Once reasoning had streamed, the last message was the assistant's, so the error was swallowed — thinking block, then silence, then copy/retry.
2. **Persisted:** `onFinish` saved the partial reasoning-only assistant message, so a dangling "Thought for Ns" block survived a reload with no answer and no recovery.

## Changes

- `MessageList.tsx`: render the error bubble whenever an error exists (with retry), not only when the last message is the user's.
- `route.ts`: track a mid-stream error via `streamText.onError`; skip persisting the turn in `onFinish` when set; return the real upstream message to the client via `onError`.

## Testing

- `npm run build` ✅
- `docker compose build app` ✅
- `npm run test` ✅ (18 passed)
- Manual: reproduced the failing case (doc in thread + search), confirmed the error now surfaces with retry and no partial is persisted.