### PR TITLE
refactor(chat): extract attachment logic into custom hook

### DIFF
--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai";
+import { FileUp } from "lucide-react";
 import { useSelectedModel } from "@/lib/config";
 import { useModelConfigs } from "@/lib/queries/modelConfigs";
 import { chatKeys } from "@/lib/queries/keys";
@@ -17,9 +18,13 @@ import {
   writeStoredMessageStats,
   type StoredMessageStats,
 } from "@/lib/chat/stats";
+import {
+  getDataTransferFiles,
+  hasDataTransferFiles,
+} from "@/lib/chat/attachments";
 import { AdminOnboardingCard } from "@/components/AdminOnboardingCard";
 import { ChatHeader } from "./ChatHeader";
-import { Composer } from "./Composer";
+import { Composer, type ComposerHandle } from "./Composer";
 import { MessageList } from "./MessageList";
 import { MiniSpeechPlayer } from "./MiniSpeechPlayer";
 
@@ -63,8 +68,10 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   const [storedStats, setStoredStats] = useState<StoredMessageStats>(() =>
     readStoredMessageStats(),
   );
+  const [dragDepth, setDragDepth] = useState(0);
 
   const isNewRef = useRef(isNew ?? false);
+  const composerRef = useRef<ComposerHandle>(null);
 
   const [transport] = useState(
     () =>
@@ -123,6 +130,37 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   });
 
   const streaming = status === "streaming" || status === "submitted";
+  const dropActive = dragDepth > 0;
+
+  function handleDragEnter(e: React.DragEvent<HTMLDivElement>) {
+    if (!hasDataTransferFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setDragDepth((depth) => depth + 1);
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    if (!hasDataTransferFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = "copy";
+  }
+
+  function handleDragLeave(e: React.DragEvent<HTMLDivElement>) {
+    if (!hasDataTransferFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setDragDepth((depth) => Math.max(0, depth - 1));
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    if (!hasDataTransferFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setDragDepth(0);
+    const files = getDataTransferFiles(e.dataTransfer);
+    if (files.length > 0) composerRef.current?.addFiles(files);
+  }
 
   function handleStop() {
     stop();
@@ -192,9 +230,11 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
 
   const composer = (
     <Composer
+      ref={composerRef}
       configured={configured}
       streaming={streaming}
       searchEnabled={searchEnabled}
+      dropActive={dropActive}
       onToggleSearch={() => setSearchEnabled(!searchEnabled)}
       onSubmit={handleSubmit}
       onStop={handleStop}
@@ -203,7 +243,13 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   );
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div
+      className="relative flex flex-1 flex-col overflow-hidden"
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
       <ChatHeader
         models={models}
         selectedId={selectedId}
@@ -214,6 +260,22 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
       />
 
       <MiniSpeechPlayer speech={speech} />
+
+      {dropActive && (
+        <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center bg-background/70 backdrop-blur-[2px]">
+          <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-ring bg-background/90 px-8 py-6 text-center shadow-lg ring-1 ring-ring/20">
+            <div className="flex size-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm animate-in zoom-in-95">
+              <FileUp className="size-6" />
+            </div>
+            <div>
+              <div className="text-sm font-medium">Drop files to attach</div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                Images, PDFs, docs, spreadsheets, and text files
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {messages.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">

--- a/apps/web/components/chat/Composer.tsx
+++ b/apps/web/components/chat/Composer.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import type { FileUIPart } from "ai";
 import {
   AlertCircle,
@@ -17,63 +23,68 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import {
   ATTACH_ACCEPT,
-  type AttachmentCategory,
-  type AttachmentMeta,
   formatSize,
+  getDataTransferFiles,
 } from "@/lib/chat/attachments";
 import { dictationErrorMessage } from "@/lib/chat/message";
 import { useDictation } from "@/lib/useDictation";
 import { CategoryIcon } from "./attachment-icons";
+import {
+  type ChatAttachment,
+  useChatAttachments,
+} from "./useChatAttachments";
 
-interface Attachment {
-  id: number;
-  status: "uploading" | "ready" | "error";
-  filename: string;
-  mediaType: string;
-  previewUrl?: string;
-  part?: FileUIPart;
-  meta?: AttachmentMeta;
-  error?: string;
+export interface ComposerHandle {
+  addFiles: (files: readonly File[]) => void;
+  focus: () => void;
 }
 
-export function Composer({
-  configured,
-  streaming,
-  searchEnabled,
-  onToggleSearch,
-  onSubmit,
-  onStop,
-  isAdmin,
-}: {
+interface ComposerProps {
   configured: boolean;
   streaming: boolean;
   searchEnabled: boolean;
+  dropActive: boolean;
   onToggleSearch: () => void;
   onSubmit: (input: string, attachments: FileUIPart[]) => void;
   onStop: () => void;
   isAdmin: boolean;
-}) {
+}
+
+export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer({
+  configured,
+  streaming,
+  searchEnabled,
+  dropActive,
+  onToggleSearch,
+  onSubmit,
+  onStop,
+  isAdmin,
+}, ref) {
   const [input, setInput] = useState("");
-  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const {
+    attachments,
+    uploading,
+    readyParts,
+    addFiles,
+    removeAttachment,
+    clearAttachments,
+  } = useChatAttachments();
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const nextIdRef = useRef(0);
 
-  const uploading = attachments.some((a) => a.status === "uploading");
-
-  // Revoke any outstanding image preview object URLs on unmount.
-  const attachmentsRef = useRef(attachments);
-  useEffect(() => {
-    attachmentsRef.current = attachments;
-  }, [attachments]);
-  useEffect(
-    () => () => {
-      for (const a of attachmentsRef.current) {
-        if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
-      }
-    },
-    [],
+  useImperativeHandle(
+    ref,
+    () => ({
+      addFiles(files) {
+        addFiles(files);
+        setTimeout(() => textareaRef.current?.focus(), 0);
+      },
+      focus() {
+        textareaRef.current?.focus();
+      },
+    }),
+    [addFiles],
   );
 
   const dictation = useDictation((text) => {
@@ -95,93 +106,17 @@ export function Composer({
   function submit() {
     const text = input.trim();
     if (streaming || uploading) return;
-    const ready = attachments
-      .filter((a) => a.status === "ready" && a.part)
-      .map((a) => a.part as FileUIPart);
-    if (!text && ready.length === 0) return;
+    if (!text && readyParts.length === 0) return;
     if (!configured) return;
-    onSubmit(text, ready);
+    onSubmit(text, readyParts);
     setInput("");
-    for (const a of attachments) {
-      if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
-    }
-    setAttachments([]);
-  }
-
-  function removeAttachment(id: number) {
-    setAttachments((prev) => {
-      const target = prev.find((a) => a.id === id);
-      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
-      return prev.filter((a) => a.id !== id);
-    });
+    clearAttachments();
   }
 
   function handleFiles(files: FileList | null) {
     if (!files || files.length === 0) return;
-    for (const file of Array.from(files)) {
-      void uploadOne(file);
-    }
+    addFiles(Array.from(files));
     if (fileInputRef.current) fileInputRef.current.value = "";
-  }
-
-  // Optimistically insert a pending chip (with an image preview if applicable)
-  // so the attachment is visible the instant it's added, then upload in the
-  // background and flip it to ready/error in place.
-  async function uploadOne(file: File) {
-    const id = nextIdRef.current++;
-    const isImage = file.type.startsWith("image/");
-    const previewUrl = isImage ? URL.createObjectURL(file) : undefined;
-    setAttachments((prev) => [
-      ...prev,
-      {
-        id,
-        status: "uploading",
-        previewUrl,
-        filename: file.name || "file",
-        mediaType: file.type || "application/octet-stream",
-      },
-    ]);
-
-    try {
-      const form = new FormData();
-      form.append("file", file);
-      const res = await fetch("/api/uploads", { method: "POST", body: form });
-      const json = (await res.json().catch(() => ({}))) as {
-        url?: string;
-        mediaType?: string;
-        filename?: string;
-        category?: AttachmentCategory;
-        size?: number;
-        pageCount?: number | null;
-        truncated?: boolean;
-        error?: string;
-      };
-      if (!res.ok || !json.url || !json.mediaType) {
-        throw new Error(json.error ?? `Upload failed (${res.status})`);
-      }
-      const part: FileUIPart = {
-        type: "file",
-        url: json.url,
-        mediaType: json.mediaType,
-        filename: json.filename,
-      };
-      const meta: AttachmentMeta = {
-        category: json.category,
-        size: json.size,
-        pageCount: json.pageCount,
-        truncated: json.truncated,
-      };
-      setAttachments((prev) =>
-        prev.map((a) =>
-          a.id === id ? { ...a, status: "ready", part, meta } : a,
-        ),
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Upload failed";
-      setAttachments((prev) =>
-        prev.map((a) => (a.id === id ? { ...a, status: "error", error: message } : a)),
-      );
-    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -192,14 +127,10 @@ export function Composer({
   }
 
   function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
-    const files = Array.from(e.clipboardData.files).filter((f) =>
-      f.type.startsWith("image/"),
-    );
+    const files = getDataTransferFiles(e.clipboardData);
     if (files.length === 0) return;
     e.preventDefault();
-    const dt = new DataTransfer();
-    for (const f of files) dt.items.add(f);
-    void handleFiles(dt.files);
+    addFiles(files);
   }
 
   return (
@@ -209,7 +140,12 @@ export function Composer({
           {dictationErrorMessage(dictation.error, isAdmin)}
         </p>
       )}
-      <div className="flex flex-col gap-2 rounded-3xl border bg-background px-3.5 pt-3.5 pb-2.5 shadow-sm transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring">
+      <div
+        className={cn(
+          "flex flex-col gap-2 rounded-3xl border bg-background px-3.5 pt-3.5 pb-2.5 shadow-sm transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
+          dropActive && "border-ring bg-accent/20 ring-2 ring-ring/30",
+        )}
+      >
         {attachments.length > 0 && (
           <div className="flex flex-wrap gap-2 px-1 pt-1">
             {attachments.map((att) => (
@@ -327,7 +263,7 @@ export function Composer({
                 disabled={
                   uploading ||
                   (!input.trim() &&
-                    !attachments.some((a) => a.status === "ready"))
+                    readyParts.length === 0)
                 }
                 onClick={submit}
                 aria-label="Send message"
@@ -340,13 +276,13 @@ export function Composer({
       </div>
     </>
   );
-}
+});
 
 function AttachmentChip({
   attachment,
   onRemove,
 }: {
-  attachment: Attachment;
+  attachment: ChatAttachment;
   onRemove: () => void;
 }) {
   const { status, meta, part } = attachment;

--- a/apps/web/components/chat/useChatAttachments.ts
+++ b/apps/web/components/chat/useChatAttachments.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FileUIPart } from "ai";
+import {
+  type AttachmentCategory,
+  type AttachmentMeta,
+  isSupportedAttachment,
+  unsupportedAttachmentMessage,
+} from "@/lib/chat/attachments";
+
+export interface ChatAttachment {
+  id: number;
+  status: "uploading" | "ready" | "error";
+  filename: string;
+  mediaType: string;
+  previewUrl?: string;
+  part?: FileUIPart;
+  meta?: AttachmentMeta;
+  error?: string;
+}
+
+export function useChatAttachments() {
+  const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
+  const attachmentsRef = useRef(attachments);
+  const nextIdRef = useRef(0);
+
+  useEffect(() => {
+    attachmentsRef.current = attachments;
+  }, [attachments]);
+
+  useEffect(
+    () => () => {
+      for (const attachment of attachmentsRef.current) {
+        revokePreview(attachment);
+      }
+    },
+    [],
+  );
+
+  const uploading = attachments.some((a) => a.status === "uploading");
+  const readyParts = useMemo(
+    () =>
+      attachments
+        .filter((a) => a.status === "ready" && a.part)
+        .map((a) => a.part as FileUIPart),
+    [attachments],
+  );
+
+  function addFiles(files: readonly File[]): void {
+    for (const file of files) {
+      if (!isSupportedAttachment(file)) {
+        addRejectedFile(file);
+        continue;
+      }
+      void uploadOne(file);
+    }
+  }
+
+  function removeAttachment(id: number): void {
+    setAttachments((prev) => {
+      const target = prev.find((a) => a.id === id);
+      if (target) revokePreview(target);
+      return prev.filter((a) => a.id !== id);
+    });
+  }
+
+  function clearAttachments(): void {
+    setAttachments((prev) => {
+      for (const attachment of prev) revokePreview(attachment);
+      return [];
+    });
+  }
+
+  function addRejectedFile(file: File): void {
+    const id = nextIdRef.current++;
+    setAttachments((prev) => [
+      ...prev,
+      {
+        id,
+        status: "error",
+        filename: file.name || "file",
+        mediaType: file.type || "application/octet-stream",
+        error: unsupportedAttachmentMessage(file),
+      },
+    ]);
+  }
+
+  async function uploadOne(file: File): Promise<void> {
+    const id = nextIdRef.current++;
+    const isImage = file.type.startsWith("image/");
+    const previewUrl = isImage ? URL.createObjectURL(file) : undefined;
+    setAttachments((prev) => [
+      ...prev,
+      {
+        id,
+        status: "uploading",
+        previewUrl,
+        filename: file.name || "file",
+        mediaType: file.type || "application/octet-stream",
+      },
+    ]);
+
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch("/api/uploads", { method: "POST", body: form });
+      const json = (await res.json().catch(() => ({}))) as {
+        url?: string;
+        mediaType?: string;
+        filename?: string;
+        category?: AttachmentCategory;
+        size?: number;
+        pageCount?: number | null;
+        truncated?: boolean;
+        error?: string;
+      };
+      if (!res.ok || !json.url || !json.mediaType) {
+        throw new Error(json.error ?? `Upload failed (${res.status})`);
+      }
+      const part: FileUIPart = {
+        type: "file",
+        url: json.url,
+        mediaType: json.mediaType,
+        filename: json.filename,
+      };
+      const meta: AttachmentMeta = {
+        category: json.category,
+        size: json.size,
+        pageCount: json.pageCount,
+        truncated: json.truncated,
+      };
+      setAttachments((prev) =>
+        prev.map((a) =>
+          a.id === id ? { ...a, status: "ready", part, meta } : a,
+        ),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upload failed";
+      setAttachments((prev) =>
+        prev.map((a) =>
+          a.id === id ? { ...a, status: "error", error: message } : a,
+        ),
+      );
+    }
+  }
+
+  return {
+    attachments,
+    uploading,
+    readyParts,
+    addFiles,
+    removeAttachment,
+    clearAttachments,
+  };
+}
+
+function revokePreview(attachment: ChatAttachment): void {
+  if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+}

--- a/apps/web/lib/chat/attachments.test.ts
+++ b/apps/web/lib/chat/attachments.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDataTransferFiles,
+  hasDataTransferFiles,
+  isSupportedAttachment,
+} from "./attachments";
+
+function file(name: string, type = ""): File {
+  return new File(["hello"], name, { type });
+}
+
+describe("attachment helpers", () => {
+  it("accepts supported files by MIME type", () => {
+    expect(isSupportedAttachment(file("screenshot.png", "image/png"))).toBe(true);
+    expect(isSupportedAttachment(file("notes.txt", "text/plain"))).toBe(true);
+    expect(isSupportedAttachment(file("report.pdf", "application/pdf"))).toBe(true);
+  });
+
+  it("accepts supported files by extension when MIME type is missing", () => {
+    expect(isSupportedAttachment(file("report.pdf"))).toBe(true);
+    expect(isSupportedAttachment(file("document.docx"))).toBe(true);
+    expect(isSupportedAttachment(file("sheet.xlsx"))).toBe(true);
+    expect(isSupportedAttachment(file("script.ts"))).toBe(true);
+  });
+
+  it("rejects unsupported files", () => {
+    expect(isSupportedAttachment(file("archive.zip", "application/zip"))).toBe(false);
+    expect(isSupportedAttachment(file("movie.mp4", "video/mp4"))).toBe(false);
+  });
+
+  it("detects and extracts file items from a data transfer", () => {
+    const png = file("screenshot.png", "image/png");
+    const data = {
+      types: ["Files"],
+      files: [],
+      items: [{ kind: "file", getAsFile: () => png }],
+    } as unknown as DataTransfer;
+
+    expect(hasDataTransferFiles(data)).toBe(true);
+    expect(getDataTransferFiles(data)).toEqual([png]);
+  });
+
+  it("skips dropped directories", () => {
+    const data = {
+      types: ["Files"],
+      files: [],
+      items: [
+        {
+          kind: "file",
+          webkitGetAsEntry: () => ({ isDirectory: true }),
+          getAsFile: () => file("folder"),
+        },
+      ],
+    } as unknown as DataTransfer;
+
+    expect(getDataTransferFiles(data)).toEqual([]);
+  });
+});

--- a/apps/web/lib/chat/attachments.ts
+++ b/apps/web/lib/chat/attachments.ts
@@ -1,4 +1,4 @@
-export const ATTACH_ACCEPT = [
+const MIME_ACCEPT = [
   "image/png",
   "image/jpeg",
   "image/gif",
@@ -8,6 +8,13 @@ export const ATTACH_ACCEPT = [
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.ms-excel",
   "text/*",
+];
+
+const EXTENSION_ACCEPT = [
+  ".pdf",
+  ".docx",
+  ".xlsx",
+  ".xls",
   ".md",
   ".csv",
   ".json",
@@ -27,7 +34,12 @@ export const ATTACH_ACCEPT = [
   ".h",
   ".sh",
   ".sql",
-].join(",");
+];
+
+export const ATTACH_ACCEPT = [...MIME_ACCEPT, ...EXTENSION_ACCEPT].join(",");
+
+const EXACT_MIME_ACCEPT = new Set(MIME_ACCEPT.filter((item) => !item.endsWith("/*")));
+const EXTENSION_ACCEPT_SET = new Set(EXTENSION_ACCEPT);
 
 export type AttachmentCategory = "image" | "document" | "text" | "spreadsheet";
 
@@ -36,6 +48,50 @@ export interface AttachmentMeta {
   size?: number;
   pageCount?: number | null;
   truncated?: boolean;
+}
+
+export function isSupportedAttachment(file: File): boolean {
+  const mediaType = file.type.toLowerCase();
+  if (EXACT_MIME_ACCEPT.has(mediaType)) return true;
+  if (mediaType.startsWith("text/")) return true;
+
+  const filename = file.name.toLowerCase();
+  const dot = filename.lastIndexOf(".");
+  if (dot >= 0 && EXTENSION_ACCEPT_SET.has(filename.slice(dot))) return true;
+
+  return false;
+}
+
+export function unsupportedAttachmentMessage(file: File): string {
+  const label = file.name || file.type || "This file";
+  return `${label} is not a supported attachment type.`;
+}
+
+export function hasDataTransferFiles(data: DataTransfer): boolean {
+  if (Array.from(data.types).includes("Files")) return true;
+  return Array.from(data.items).some((item) => item.kind === "file");
+}
+
+interface WebKitEntry {
+  isDirectory?: boolean;
+}
+
+type EntryItem = DataTransferItem & {
+  webkitGetAsEntry?: () => WebKitEntry | null;
+};
+
+export function getDataTransferFiles(data: DataTransfer): File[] {
+  if (data.items.length > 0) {
+    return Array.from(data.items).flatMap((item) => {
+      if (item.kind !== "file") return [];
+      const entry = (item as EntryItem).webkitGetAsEntry?.();
+      if (entry?.isDirectory) return [];
+      const file = item.getAsFile();
+      return file ? [file] : [];
+    });
+  }
+
+  return Array.from(data.files);
 }
 
 export function formatSize(bytes: number): string {


### PR DESCRIPTION
Move attachment handling from Composer.tsx and ChatArea.tsx into a dedicated
useChatAttachments hook with test coverage
