### PR TITLE
chore(compose): bump APP_VERSION default to 0.9.0

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.7.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.9.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## What

The `APP_VERSION` default in `compose.yml` fell out of sync at the v0.8.0 release — it stayed at `0.7.0`. This realigns it with the just-tagged **v0.9.0** image (published to GHCR by CI on the `v*` tag).

## Why

The default is only used when `APP_VERSION` isn't set in the environment, but a stale default is misleading to anyone reading the compose file or running it without an explicit version. Keeping it in lockstep with the latest release tag matches the established pattern (#23, #24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)