### PR TITLE
[codex] Standardize web scrollbars

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -71,6 +71,34 @@
   }
   html {
     @apply font-sans;
+    scrollbar-color: color-mix(in oklch, var(--muted-foreground) 45%, transparent) transparent;
+    scrollbar-width: thin;
+  }
+  * {
+    scrollbar-color: inherit;
+    scrollbar-width: thin;
+  }
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: color-mix(in oklch, var(--muted-foreground) 35%, transparent);
+    background-clip: content-box;
+    border: 2px solid transparent;
+    border-radius: 999px;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  }
+}
+
+@media (forced-colors: active) {
+  * {
+    scrollbar-color: auto;
   }
 }
 


### PR DESCRIPTION
## Summary

- Add a global, theme-token-based scrollbar treatment for the web app.
- Use standard CSS scrollbar properties with a small WebKit fallback.
- Preserve forced-colors behavior by resetting scrollbar coloring to platform defaults.

## Why

The web app had no product-owned scrollbar styling, so scroll panes inherited inconsistent browser and OS defaults. The new rule makes sidebar, chat, menu, and settings scroll areas visually consistent with the existing theme.

## Validation

- `npm run test`
- `npm run lint -w apps/web`
- `npm run build -w apps/web`