### PR TITLE
Add model brand logos

### DIFF
--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -13,10 +13,13 @@ import {
 } from "@/components/ui/select";
 import { fetchModelsForEndpoint } from "@/lib/config";
 import {
+  modelIconForModel,
   PRESETS,
   PRESET_IDS,
+  providerIconForPreset,
   type PresetId,
 } from "@/lib/providers/meta";
+import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 
 export interface ConnectionDraft {
   baseUrl: string;
@@ -41,6 +44,7 @@ export function ConnectionFields({
   const requiresKey = preset === null ? false : preset !== "custom";
   const presetMeta = preset === null ? PRESETS.custom : PRESETS[preset];
   const isCreating = preset !== null;
+  const presetIconId = preset === null ? null : providerIconForPreset(preset);
 
   const [models, setModels] = useState<string[]>([]);
   const [probing, setProbing] = useState(false);
@@ -90,11 +94,13 @@ export function ConnectionFields({
             }}
           >
             <SelectTrigger id="p-preset" className="w-full">
+              <ModelBrandIcon iconId={presetIconId} />
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {PRESET_IDS.map((id) => (
                 <SelectItem key={id} value={id}>
+                  <ModelBrandIcon iconId={providerIconForPreset(id)} />
                   {PRESETS[id].label}
                 </SelectItem>
               ))}
@@ -171,11 +177,13 @@ export function ConnectionFields({
             }}
           >
             <SelectTrigger id="p-model" className="w-full">
+              <ModelBrandIcon iconId={modelIconForModel(draft.model)} />
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {models.map((m) => (
                 <SelectItem key={m} value={m}>
+                  <ModelBrandIcon iconId={modelIconForModel(m)} />
                   {m}
                 </SelectItem>
               ))}

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -6,7 +6,12 @@ import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Switch } from "@base-ui/react/switch";
 import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import type { AdminModelConfig } from "@/lib/config";
+import {
+  modelIconForModel,
+  providerIdentityForBaseUrl,
+} from "@/lib/providers/meta";
 import {
   useAdminModelConfigs,
   useDeleteModelConfig,
@@ -86,51 +91,61 @@ export function ModelsPanel() {
         </div>
       ) : (
         <ul className="space-y-2">
-          {models.map((m) => (
-            <li key={m.id} className="group relative">
-              <Link
-                href={`/settings/models/${m.id}`}
-                aria-label={`Edit ${m.label}`}
-                className={`flex w-full items-center rounded-lg border bg-card px-3.5 py-3 pr-28 text-left transition-colors hover:border-ring/40 hover:bg-accent/40 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 ${m.enabled ? "" : "opacity-60"}`}
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-sm font-medium text-foreground">
-                      {m.label}
-                    </span>
-                    <HealthBadge id={m.id} enabled={m.enabled} />
+          {models.map((m) => {
+            const provider = providerIdentityForBaseUrl(m.baseUrl);
+            const iconId = modelIconForModel(m.model) ?? provider.iconId;
+            return (
+              <li key={m.id} className="group relative">
+                <Link
+                  href={`/settings/models/${m.id}`}
+                  aria-label={`Edit ${m.label}`}
+                  className={`flex w-full items-center rounded-lg border bg-card px-3.5 py-3 pr-28 text-left transition-colors hover:border-ring/40 hover:bg-accent/40 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 ${m.enabled ? "" : "opacity-60"}`}
+                >
+                  <ModelBrandIcon iconId={iconId} className="mr-2.5 size-5" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {m.label}
+                      </span>
+                      <HealthBadge id={m.id} enabled={m.enabled} />
+                    </div>
+                    <div className="mt-0.5 flex items-center gap-2 font-mono text-xs text-muted-foreground">
+                      <span className="truncate">{m.model}</span>
+                      <span
+                        aria-hidden="true"
+                        className="text-muted-foreground/50"
+                      >
+                        ·
+                      </span>
+                      <span className="truncate">{hostnameOf(m.baseUrl)}</span>
+                    </div>
                   </div>
-                  <div className="mt-0.5 flex items-center gap-2 font-mono text-xs text-muted-foreground">
-                    <span className="truncate">{m.model}</span>
-                    <span aria-hidden="true" className="text-muted-foreground/50">·</span>
-                    <span className="truncate">{hostnameOf(m.baseUrl)}</span>
-                  </div>
+                </Link>
+                <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+                  <Switch.Root
+                    checked={m.enabled}
+                    disabled={togglingId === m.id}
+                    onCheckedChange={(next) => toggleEnabled(m, next)}
+                    aria-label={`${m.enabled ? "Disable" : "Enable"} ${m.label}`}
+                    className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-input bg-input/40 transition-colors data-[checked]:border-ring/40 data-[checked]:bg-ring/70 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  >
+                    <Switch.Thumb className="pointer-events-none ml-0.5 size-4 rounded-full bg-background shadow transition-transform data-[checked]:translate-x-4" />
+                  </Switch.Root>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDeleteError("");
+                      setPendingDelete(m);
+                    }}
+                    aria-label={`Delete ${m.label}`}
+                    className="rounded-md p-1.5 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 group-hover:opacity-100"
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
                 </div>
-              </Link>
-              <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-                <Switch.Root
-                  checked={m.enabled}
-                  disabled={togglingId === m.id}
-                  onCheckedChange={(next) => toggleEnabled(m, next)}
-                  aria-label={`${m.enabled ? "Disable" : "Enable"} ${m.label}`}
-                  className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-input bg-input/40 transition-colors data-[checked]:border-ring/40 data-[checked]:bg-ring/70 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                >
-                  <Switch.Thumb className="pointer-events-none ml-0.5 size-4 rounded-full bg-background shadow transition-transform data-[checked]:translate-x-4" />
-                </Switch.Root>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setDeleteError("");
-                    setPendingDelete(m);
-                  }}
-                  aria-label={`Delete ${m.label}`}
-                  className="rounded-md p-1.5 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 group-hover:opacity-100"
-                >
-                  <Trash2 className="size-4" />
-                </button>
-              </div>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { convertToModelMessages, streamText, stepCountIs } from "ai";
-import type { ChatRequestBody } from "@overtchat/shared";
+import type { ChatRequestBody, ModelBrandIconId } from "@overtchat/shared";
 import { webTools, WEB_SEARCH_CITATION_PROMPT } from "@/lib/tools";
 import { corsHeaders, preflight, withCors } from "@/lib/cors";
 import { auth } from "@/lib/auth/server";
@@ -15,6 +15,10 @@ import { inlineUploads } from "@/lib/db/uploads";
 import { getModelConfig } from "@/lib/db/modelConfigs";
 import { getProject } from "@/lib/db/projects";
 import { buildModel } from "@/lib/llm";
+import {
+  modelIconForModel,
+  providerIdentityForBaseUrl,
+} from "@/lib/providers/meta";
 import { buildRuntimeContext } from "@/lib/runtime-context";
 import * as cancelRegistry from "@/lib/streams/cancel-registry";
 import { getStreamContext } from "@/lib/streams/context";
@@ -28,6 +32,10 @@ interface MessageStats {
   ttftMs?: number;
   tps?: number;
   finishReason?: string;
+  providerLabel?: string;
+  providerIconId?: ModelBrandIconId;
+  model?: string;
+  modelIconId?: ModelBrandIconId;
 }
 
 export function OPTIONS(req: Request) {
@@ -102,6 +110,9 @@ export async function POST(req: Request) {
   });
 
   const inlined = await inlineUploads(messages, userId);
+  const providerIdentity = providerIdentityForBaseUrl(modelConfig.baseUrl);
+  const modelIconId =
+    modelIconForModel(modelConfig.model) ?? providerIdentity.iconId ?? undefined;
   const startedAt = Date.now();
   let firstTokenAt: number | null = null;
   let streamError: unknown = null;
@@ -185,6 +196,10 @@ export async function POST(req: Request) {
             ? undefined
             : outputTokens / (generationMs / 1000),
         finishReason: part.finishReason,
+        providerLabel: providerIdentity.label,
+        providerIconId: providerIdentity.iconId ?? undefined,
+        model: modelConfig.model,
+        modelIconId,
       };
 
       return { stats };

--- a/apps/web/app/api/model-configs/route.ts
+++ b/apps/web/app/api/model-configs/route.ts
@@ -6,14 +6,20 @@ import {
   type ModelConfigRow,
 } from "@/lib/db/modelConfigs";
 import { ModelConfigSchema, type PublicModelConfig } from "@/lib/config";
-import { PRESETS, presetFor } from "@/lib/providers/meta";
+import {
+  modelIconForModel,
+  providerIdentityForBaseUrl,
+} from "@/lib/providers/meta";
 import { preflight, withCors } from "@/lib/cors";
 
 function toPublic(row: ModelConfigRow): PublicModelConfig {
+  const provider = providerIdentityForBaseUrl(row.baseUrl);
   return {
     id: row.id,
     label: row.label,
-    displayProvider: PRESETS[presetFor(row.baseUrl)].label,
+    displayProvider: provider.label,
+    providerIconId: provider.iconId ?? undefined,
+    modelIconId: modelIconForModel(row.model) ?? undefined,
     model: row.model,
     hasExtraBody: !!row.extraBody && Object.keys(row.extraBody).length > 0,
   };

--- a/apps/web/components/ModelBrandIcon.tsx
+++ b/apps/web/components/ModelBrandIcon.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Image, { type StaticImageData } from "next/image";
+import type { ModelBrandIconId } from "@overtchat/shared";
+import anthropic from "@lobehub/icons-static-svg/icons/anthropic.svg";
+import claude from "@lobehub/icons-static-svg/icons/claude-color.svg";
+import deepseek from "@lobehub/icons-static-svg/icons/deepseek-color.svg";
+import gemini from "@lobehub/icons-static-svg/icons/gemini-color.svg";
+import groq from "@lobehub/icons-static-svg/icons/groq.svg";
+import meta from "@lobehub/icons-static-svg/icons/meta-color.svg";
+import minimax from "@lobehub/icons-static-svg/icons/minimax-color.svg";
+import mistral from "@lobehub/icons-static-svg/icons/mistral-color.svg";
+import ollama from "@lobehub/icons-static-svg/icons/ollama.svg";
+import openai from "@lobehub/icons-static-svg/icons/openai.svg";
+import openrouter from "@lobehub/icons-static-svg/icons/openrouter.svg";
+import qwen from "@lobehub/icons-static-svg/icons/qwen-color.svg";
+import vllm from "@lobehub/icons-static-svg/icons/vllm-color.svg";
+import { cn } from "@/lib/utils";
+
+const ICONS = {
+  anthropic,
+  claude,
+  deepseek,
+  gemini,
+  groq,
+  meta,
+  minimax,
+  mistral,
+  ollama,
+  openai,
+  openrouter,
+  qwen,
+  vllm,
+} satisfies Record<ModelBrandIconId, StaticImageData | string>;
+
+const LABELS = {
+  anthropic: "Anthropic",
+  claude: "Claude",
+  deepseek: "DeepSeek",
+  gemini: "Gemini",
+  groq: "Groq",
+  meta: "Meta",
+  minimax: "MiniMax",
+  mistral: "Mistral",
+  ollama: "Ollama",
+  openai: "OpenAI",
+  openrouter: "OpenRouter",
+  qwen: "Qwen",
+  vllm: "vLLM",
+} satisfies Record<ModelBrandIconId, string>;
+
+export function ModelBrandIcon({
+  iconId,
+  className,
+  title,
+}: {
+  iconId: ModelBrandIconId | null | undefined;
+  className?: string;
+  title?: string;
+}) {
+  if (!iconId) return null;
+  const src = ICONS[iconId];
+  if (!src) return null;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex size-4 shrink-0 items-center justify-center rounded-sm border border-border/60 bg-white text-black",
+        className,
+      )}
+      title={title ?? LABELS[iconId]}
+    >
+      <Image
+        src={src}
+        alt=""
+        aria-hidden
+        width={16}
+        height={16}
+        className="size-3 object-contain"
+        unoptimized
+      />
+    </span>
+  );
+}

--- a/apps/web/components/ModelPicker.tsx
+++ b/apps/web/components/ModelPicker.tsx
@@ -3,6 +3,7 @@
 import { Menu } from "@base-ui/react/menu";
 import { Check, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import { cn } from "@/lib/utils";
 import type { PublicModelConfig } from "@/lib/config";
 import { PRESETS, PRESET_IDS } from "@/lib/providers/meta";
@@ -44,6 +45,10 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
           />
         }
       >
+        <ModelBrandIcon
+          iconId={selected?.modelIconId ?? selected?.providerIconId}
+          className="size-4"
+        />
         <span className="truncate">{label}</span>
         <ChevronDown className="shrink-0 text-muted-foreground" />
       </Menu.Trigger>
@@ -69,6 +74,10 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
                         "mt-0.5 size-3.5 shrink-0",
                         m.id === selectedId ? "opacity-100" : "opacity-0",
                       )}
+                    />
+                    <ModelBrandIcon
+                      iconId={m.modelIconId ?? m.providerIconId}
+                      className="mt-px"
                     />
                     <span className="flex min-w-0 flex-col">
                       <span className="truncate">{m.label}</span>
@@ -98,12 +107,14 @@ function groupModels(
     arr.push(m);
     buckets.set(m.displayProvider, arr);
   }
-  return [...buckets.entries()].sort(([a], [b]) => {
-    const ai = GROUP_ORDER.indexOf(a);
-    const bi = GROUP_ORDER.indexOf(b);
-    if (ai !== -1 && bi !== -1) return ai - bi;
-    if (ai !== -1) return -1;
-    if (bi !== -1) return 1;
-    return a.localeCompare(b);
-  });
+  return [...buckets.entries()]
+    .map(([label, items]) => [label, items] satisfies [string, PublicModelConfig[]])
+    .sort(([a], [b]) => {
+      const ai = GROUP_ORDER.indexOf(a);
+      const bi = GROUP_ORDER.indexOf(b);
+      if (ai !== -1 && bi !== -1) return ai - bi;
+      if (ai !== -1) return -1;
+      if (bi !== -1) return 1;
+      return a.localeCompare(b);
+    });
 }

--- a/apps/web/components/chat/StatsPopover.tsx
+++ b/apps/web/components/chat/StatsPopover.tsx
@@ -8,22 +8,49 @@ import {
   formatTps,
   type MessageStats,
 } from "@/lib/chat/stats";
+import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 
 export function StatsPopover({ stats }: { stats: MessageStats }) {
   const rows = [
+    stats.providerLabel !== undefined
+      ? {
+          iconId: stats.providerIconId,
+          label: "Provider",
+          value: stats.providerLabel,
+        }
+      : null,
+    stats.model !== undefined
+      ? {
+          iconId: stats.modelIconId ?? stats.providerIconId,
+          label: "Model",
+          value: stats.model,
+        }
+      : null,
     stats.contextTokens !== undefined
-      ? ["Context tokens", formatInteger(stats.contextTokens)]
+      ? { label: "Context tokens", value: formatInteger(stats.contextTokens) }
       : null,
     stats.responseTokens !== undefined
-      ? ["Response tokens", formatInteger(stats.responseTokens)]
+      ? { label: "Response tokens", value: formatInteger(stats.responseTokens) }
       : null,
     stats.totalTokens !== undefined
-      ? ["Total tokens", formatInteger(stats.totalTokens)]
+      ? { label: "Total tokens", value: formatInteger(stats.totalTokens) }
       : null,
-    stats.ttftMs !== undefined ? ["TTFT", formatDuration(stats.ttftMs)] : null,
-    stats.tps !== undefined ? ["TPS", formatTps(stats.tps)] : null,
-    stats.finishReason !== undefined ? ["Finish reason", stats.finishReason] : null,
-  ].filter((row): row is [string, string] => row !== null);
+    stats.ttftMs !== undefined
+      ? { label: "TTFT", value: formatDuration(stats.ttftMs) }
+      : null,
+    stats.tps !== undefined ? { label: "TPS", value: formatTps(stats.tps) } : null,
+    stats.finishReason !== undefined
+      ? { label: "Finish reason", value: stats.finishReason }
+      : null,
+  ].filter(
+    (
+      row,
+    ): row is {
+      iconId?: MessageStats["providerIconId"];
+      label: string;
+      value: string;
+    } => row !== null,
+  );
 
   if (!rows.length) return null;
 
@@ -41,10 +68,13 @@ export function StatsPopover({ stats }: { stats: MessageStats }) {
         <Popover.Positioner side="top" align="start" sideOffset={6}>
           <Popover.Popup className="z-50 w-56 rounded-lg border bg-popover p-3 text-xs text-popover-foreground shadow-md outline-none">
             <div className="space-y-2">
-              {rows.map(([label, value]) => (
+              {rows.map(({ iconId, label, value }) => (
                 <div key={label} className="flex items-center justify-between gap-4">
                   <span className="text-muted-foreground">{label}</span>
-                  <span className="font-mono text-foreground">{value}</span>
+                  <span className="flex min-w-0 items-center gap-1.5 font-mono text-foreground">
+                    <ModelBrandIcon iconId={iconId} className="size-3.5" />
+                    <span className="truncate">{value}</span>
+                  </span>
                 </div>
               ))}
             </div>

--- a/apps/web/lib/chat/stats.ts
+++ b/apps/web/lib/chat/stats.ts
@@ -1,4 +1,8 @@
 import type { UIMessage } from "ai";
+import {
+  MODEL_BRAND_ICON_IDS,
+  type ModelBrandIconId,
+} from "@overtchat/shared";
 
 const MESSAGE_STATS_STORAGE_KEY = "overtchat_message_stats";
 
@@ -9,6 +13,10 @@ export interface MessageStats {
   ttftMs?: number;
   tps?: number;
   finishReason?: string;
+  providerLabel?: string;
+  providerIconId?: ModelBrandIconId;
+  model?: string;
+  modelIconId?: ModelBrandIconId;
 }
 
 export type StoredMessageStats = Record<string, MessageStats>;
@@ -27,6 +35,14 @@ function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value ? value : undefined;
 }
 
+function optionalIconId(value: unknown): ModelBrandIconId | undefined {
+  const iconId = optionalString(value);
+  return iconId !== undefined &&
+    MODEL_BRAND_ICON_IDS.includes(iconId as ModelBrandIconId)
+    ? (iconId as ModelBrandIconId)
+    : undefined;
+}
+
 export function readMessageStats(message: UIMessage): MessageStats | null {
   if (!isRecord(message.metadata)) return null;
   const rawStats = message.metadata.stats;
@@ -38,6 +54,10 @@ export function readMessageStats(message: UIMessage): MessageStats | null {
     ttftMs: optionalNumber(rawStats.ttftMs),
     tps: optionalNumber(rawStats.tps),
     finishReason: optionalString(rawStats.finishReason),
+    providerLabel: optionalString(rawStats.providerLabel),
+    providerIconId: optionalIconId(rawStats.providerIconId),
+    model: optionalString(rawStats.model),
+    modelIconId: optionalIconId(rawStats.modelIconId),
   };
   return Object.values(stats).some((value) => value !== undefined)
     ? stats
@@ -62,6 +82,10 @@ export function readStoredMessageStats(): StoredMessageStats {
             ttftMs: optionalNumber(value.ttftMs),
             tps: optionalNumber(value.tps),
             finishReason: optionalString(value.finishReason),
+            providerLabel: optionalString(value.providerLabel),
+            providerIconId: optionalIconId(value.providerIconId),
+            model: optionalString(value.model),
+            modelIconId: optionalIconId(value.modelIconId),
           };
           return Object.values(stats).some((v) => v !== undefined)
             ? [id, stats]

--- a/apps/web/lib/providers/meta.test.ts
+++ b/apps/web/lib/providers/meta.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  modelIconForModel,
+  providerIdentityForBaseUrl,
+  providerIconForPreset,
+} from "./meta";
+
+describe("provider metadata", () => {
+  it("maps presets to provider icons", () => {
+    expect(providerIconForPreset("openai")).toBe("openai");
+    expect(providerIconForPreset("anthropic")).toBe("anthropic");
+    expect(providerIconForPreset("google")).toBe("gemini");
+    expect(providerIconForPreset("custom")).toBeNull();
+  });
+
+  it("keeps custom endpoints generic", () => {
+    expect(providerIdentityForBaseUrl("http://localhost:11434/v1")).toMatchObject({
+      iconId: null,
+      label: "Custom",
+      preset: "custom",
+    });
+  });
+
+  it.each([
+    ["claude-sonnet-4-5", "claude"],
+    ["gemini-2.5-flash", "gemini"],
+    ["deepseek-r1", "deepseek"],
+    ["qwen3-coder", "qwen"],
+    ["mixtral-8x7b", "mistral"],
+    ["minimax-m1", "minimax"],
+    ["llama-3.3-70b", "meta"],
+    ["gpt-4o-mini", "openai"],
+  ] as const)("maps %s to %s", (model, iconId) => {
+    expect(modelIconForModel(model)).toBe(iconId);
+  });
+});

--- a/apps/web/lib/providers/meta.ts
+++ b/apps/web/lib/providers/meta.ts
@@ -1,3 +1,5 @@
+import type { ModelBrandIconId } from "@overtchat/shared";
+
 /** UX preset shown in the dialog dropdown and as picker group headers. */
 export type PresetId = "openai" | "anthropic" | "google" | "custom";
 
@@ -38,6 +40,13 @@ export const PRESETS: Record<PresetId, Preset> = {
 
 export const PRESET_IDS = Object.keys(PRESETS) as PresetId[];
 
+export const PRESET_ICON_IDS: Record<PresetId, ModelBrandIconId | null> = {
+  openai: "openai",
+  anthropic: "anthropic",
+  google: "gemini",
+  custom: null,
+};
+
 /** Reverse lookup: which preset does this baseUrl match? Falls back to "custom". */
 export function presetFor(baseUrl: string): PresetId {
   let host: string;
@@ -50,4 +59,56 @@ export function presetFor(baseUrl: string): PresetId {
     if (PRESETS[id].hostname && PRESETS[id].hostname === host) return id;
   }
   return "custom";
+}
+
+export function providerIconForPreset(
+  preset: PresetId,
+): ModelBrandIconId | null {
+  return PRESET_ICON_IDS[preset];
+}
+
+export function providerIdentityForBaseUrl(baseUrl: string): {
+  iconId: ModelBrandIconId | null;
+  label: string;
+  preset: PresetId;
+} {
+  const preset = presetFor(baseUrl);
+  return {
+    iconId: providerIconForPreset(preset),
+    label: PRESETS[preset].label,
+    preset,
+  };
+}
+
+export function modelIconForModel(model: string): ModelBrandIconId | null {
+  const normalized = model.toLowerCase();
+
+  if (/\bclaude\b/.test(normalized)) return "claude";
+  if (normalized.includes("anthropic")) return "anthropic";
+  if (normalized.includes("gemini")) return "gemini";
+  if (normalized.includes("deepseek")) return "deepseek";
+  if (normalized.includes("qwen") || /\bqwq\b/.test(normalized)) return "qwen";
+  if (
+    normalized.includes("mistral") ||
+    normalized.includes("mixtral") ||
+    normalized.includes("codestral") ||
+    normalized.includes("magistral")
+  ) {
+    return "mistral";
+  }
+  if (normalized.includes("minimax")) return "minimax";
+  if (normalized.includes("openrouter")) return "openrouter";
+  if (normalized.includes("ollama")) return "ollama";
+  if (normalized.includes("vllm")) return "vllm";
+  if (normalized.includes("groq")) return "groq";
+  if (normalized.includes("llama") || normalized.includes("meta-")) return "meta";
+  if (
+    /\bgpt[-\d]/.test(normalized) ||
+    normalized.includes("chatgpt") ||
+    /\bo[1345](?:-|$)/.test(normalized)
+  ) {
+    return "openai";
+  }
+
+  return null;
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@ai-sdk/react": "^3.0.178",
     "@base-ui/react": "^1.4.1",
     "@better-auth/expo": "^1.6.11",
+    "@lobehub/icons-static-svg": "^1.91.0",
     "@overtchat/shared": "*",
     "@streamdown/cjk": "^1.0.3",
     "@streamdown/code": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/mobile": {
       "name": "@overtchat/mobile",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@ai-sdk/react": "^3.0.193",
         "@better-auth/expo": "^1.6.11",
@@ -123,6 +123,7 @@
         "@ai-sdk/react": "^3.0.178",
         "@base-ui/react": "^1.4.1",
         "@better-auth/expo": "^1.6.11",
+        "@lobehub/icons-static-svg": "^1.91.0",
         "@overtchat/shared": "*",
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",
@@ -5373,6 +5374,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lobehub/icons-static-svg": {
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@lobehub/icons-static-svg/-/icons-static-svg-1.91.0.tgz",
+      "integrity": "sha512-ZDflEq0uUvAkH4WK4h3qNvvY09ts4OqUb5azD7A0xKfcuYhffGwB1Q/As2RguZYq4Gh4v925CJ8iodiClzc4zw==",
+      "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
       "version": "1.1.1",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,7 +1,27 @@
+export const MODEL_BRAND_ICON_IDS = [
+  "anthropic",
+  "claude",
+  "deepseek",
+  "gemini",
+  "groq",
+  "meta",
+  "minimax",
+  "mistral",
+  "ollama",
+  "openai",
+  "openrouter",
+  "qwen",
+  "vllm",
+] as const;
+
+export type ModelBrandIconId = (typeof MODEL_BRAND_ICON_IDS)[number];
+
 export interface PublicModelConfig {
   id: string;
   label: string;
   displayProvider: string;
+  providerIconId?: ModelBrandIconId;
+  modelIconId?: ModelBrandIconId;
   model: string;
   hasExtraBody: boolean;
 }


### PR DESCRIPTION
## Summary
- Add maintained AI/LLM brand logo assets for model setup, model picker, model settings, and stats surfaces.
- Centralize provider and model-family identity mapping so UI surfaces stay consistent.
- Include provider/model identity in new message stats snapshots without changing storage or probing custom endpoints.

## Validation
- `npm run lint -w apps/web`
- `npm run test -w apps/web`
- `npm run build -w apps/web`