### PR TITLE
Fix iOS PWA safe-area layout

### DIFF
--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -61,13 +61,13 @@ export function AppShell({
       }}
     >
       <Dialog.Root open={openMobile} onOpenChange={setOpenMobile}>
-        <div className="flex h-dvh overflow-hidden bg-background">
+        <div className="box-border flex h-dvh overflow-hidden bg-background pt-[env(safe-area-inset-top)]">
           {!collapsed && <div className="hidden md:flex">{sidebar}</div>}
           <Dialog.Portal>
             <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 md:hidden" />
             <Dialog.Popup
               ref={drawerRef as React.RefObject<HTMLDivElement>}
-              className="fixed inset-y-0 left-0 z-50 flex transition-transform duration-200 data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full md:hidden"
+              className="fixed inset-y-0 left-0 z-50 box-border flex bg-sidebar pt-[env(safe-area-inset-top)] transition-transform duration-200 data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full md:hidden"
             >
               {sidebar}
             </Dialog.Popup>

--- a/apps/web/lib/safe-area.test.ts
+++ b/apps/web/lib/safe-area.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const webRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function appShellClasses() {
+  const source = await readFile(
+    path.join(webRoot, "components/AppShell.tsx"),
+    "utf8",
+  );
+  return Array.from(source.matchAll(/className="([^"]+)"/g), (match) => match[1]);
+}
+
+describe("iOS PWA safe areas", () => {
+  it("reserves the top safe area before app headers render", async () => {
+    const classes = await appShellClasses();
+    const appFrame = classes.find(
+      (className) =>
+        className.includes("h-dvh") && className.includes("bg-background"),
+    );
+
+    expect(appFrame).toContain("box-border");
+    expect(appFrame).toContain("pt-[env(safe-area-inset-top)]");
+  });
+
+  it("keeps the mobile drawer controls below the top safe area", async () => {
+    const classes = await appShellClasses();
+    const mobileDrawer = classes.find(
+      (className) =>
+        className.includes("fixed") &&
+        className.includes("left-0") &&
+        className.includes("md:hidden"),
+    );
+
+    expect(mobileDrawer).toContain("box-border");
+    expect(mobileDrawer).toContain("bg-sidebar");
+    expect(mobileDrawer).toContain("pt-[env(safe-area-inset-top)]");
+  });
+});


### PR DESCRIPTION
## Summary
- Reserve `env(safe-area-inset-top)` at the authenticated web app shell so top bars render below iOS Dynamic Island/status areas.
- Apply the same top safe-area padding to the mobile drawer portal, which is fixed outside the main shell flow.
- Add a focused regression test for both safe-area hosts.

## Root cause
The web app enables iOS full-bleed PWA rendering with `viewportFit: "cover"` and a translucent status bar, but the app frame and mobile drawer were still positioned at the top of the viewport. On iPhones with Dynamic Island/notches, that placed the chat header and drawer controls under the unsafe top inset.

## Validation
- `npm run test -w apps/web -- lib/safe-area.test.ts`
- `npm run test -w apps/web`
- `npm run lint -w apps/web`
- `npm run build -w apps/web`

Note: local production build exits successfully but logs existing Better Auth warnings when `BETTER_AUTH_URL` and `BETTER_AUTH_SECRET` are not set.