### PR TITLE
Remove Android foreground service permissions

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -22,9 +22,7 @@
       },
       "permissions": [
         "android.permission.RECORD_AUDIO",
-        "android.permission.MODIFY_AUDIO_SETTINGS",
-        "android.permission.FOREGROUND_SERVICE",
-        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
+        "android.permission.MODIFY_AUDIO_SETTINGS"
       ]
     },
     "plugins": [

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "overtchat",
     "slug": "overtchat",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "orientation": "portrait",
     "scheme": "overtchat",
     "userInterfaceStyle": "automatic",
@@ -10,11 +10,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.overtchat.mobile",
-      "buildNumber": "6"
+      "buildNumber": "7"
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 6,
+      "versionCode": 7,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@overtchat/mobile",
   "main": "expo-router/entry",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "expo start --host=lan",


### PR DESCRIPTION
## Summary

- removes Android foreground service permissions from the mobile manifest
- bumps the mobile app release to 1.2.1 with Android versionCode 7 and iOS buildNumber 7

## Why

The mobile app does not need to support background text-to-speech playback for the closed testing release. Removing the foreground media playback permission avoids the Play Console foreground service declaration requirement for the next uploaded AAB.

## Validation

- npm run lint --workspace apps/mobile

## Release notes

After this is squash-merged into main, tag the merged commit as mobile-v1.2.1 and push the tag. The Mobile release workflow should build the AAB/APK on the self-hosted runner, submit the AAB to the closed testing alpha track as a draft, and attach the APK to a draft GitHub release.