### PR TITLE
Refresh model settings UX

### DIFF
--- a/apps/web/app/(app)/settings/_components/SettingsRows.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsRows.tsx
@@ -1,0 +1,77 @@
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+interface SettingsSectionProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SettingsSection({
+  title,
+  description,
+  children,
+  className,
+}: SettingsSectionProps) {
+  return (
+    <section className={cn("space-y-3", className)}>
+      <div>
+        <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
+        {description && (
+          <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="divide-y divide-border/70 border-y">{children}</div>
+    </section>
+  );
+}
+
+interface SettingsRowProps {
+  title: string;
+  description?: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+  align?: "start" | "center";
+  className?: string;
+}
+
+export function SettingsRow({
+  title,
+  description,
+  htmlFor,
+  children,
+  align = "start",
+  className,
+}: SettingsRowProps) {
+  const titleClass = "text-sm font-medium leading-5 text-foreground";
+  const titleNode = htmlFor ? (
+    <Label htmlFor={htmlFor} className={titleClass}>
+      {title}
+    </Label>
+  ) : (
+    <div className={titleClass}>{title}</div>
+  );
+
+  return (
+    <div
+      className={cn(
+        "grid gap-3 py-4 md:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] md:gap-6",
+        align === "center" && "md:items-center",
+        className,
+      )}
+    >
+      <div className="min-w-0">
+        {titleNode}
+        {description && (
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/settings/_components/SettingsRows.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsRows.tsx
@@ -4,27 +4,34 @@ import { cn } from "@/lib/utils";
 interface SettingsSectionProps {
   title: string;
   description?: string;
-  children: React.ReactNode;
+  action?: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
 }
 
 export function SettingsSection({
   title,
   description,
+  action,
   children,
   className,
 }: SettingsSectionProps) {
   return (
     <section className={cn("space-y-3", className)}>
-      <div>
-        <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
-        {description && (
-          <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
-            {description}
-          </p>
-        )}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
+          {description && (
+            <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
       </div>
-      <div className="divide-y divide-border/70 border-y">{children}</div>
+      {children ? (
+        <div className="divide-y divide-border/70 border-y">{children}</div>
+      ) : null}
     </section>
   );
 }
@@ -58,8 +65,8 @@ export function SettingsRow({
   return (
     <div
       className={cn(
-        "grid gap-3 py-4 md:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] md:gap-6",
-        align === "center" && "md:items-center",
+        "grid gap-3 py-4 lg:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] lg:gap-6",
+        align === "center" && "lg:items-center",
         className,
       )}
     >

--- a/apps/web/app/(app)/settings/models/AdvancedFields.tsx
+++ b/apps/web/app/(app)/settings/models/AdvancedFields.tsx
@@ -3,9 +3,10 @@
 import { useState } from "react";
 import Editor from "react-simple-code-editor";
 import { ChevronDown } from "lucide-react";
-import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { SettingsRow } from "../_components/SettingsRows";
 
 const EXTRA_BODY_EXAMPLE = {
   chat_template_kwargs: { thinking: true },
@@ -51,111 +52,123 @@ export function AdvancedFields({
         onExtraBodyTextChange(formatted, null);
       }
     } catch {
-      // already invalid; live error covers it
+      // Invalid JSON is already reported live.
     }
   }
 
   return (
-    <div className="border-t pt-4">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        aria-expanded={open}
-        className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-      >
-        Advanced
-        <ChevronDown
-          className={cn(
-            "size-3.5 transition-transform duration-200",
-            open && "rotate-180",
-          )}
-        />
-      </button>
+    <>
+      <div className="flex items-center justify-between gap-3 py-4">
+        <div className="min-w-0">
+          <div className="text-sm font-medium leading-5">Advanced options</div>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Add per-model prompt and provider-specific request overrides.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+        >
+          {open ? "Hide" : "Show"}
+          <ChevronDown
+            className={cn(
+              "transition-transform duration-200",
+              open && "rotate-180",
+            )}
+          />
+        </Button>
+      </div>
+
       {open && (
-        <div className="mt-4 space-y-4">
-          <div className="space-y-1.5">
-            <Label htmlFor="p-system-prompt">
-              System prompt <OptionalChip />
-            </Label>
+        <>
+          <SettingsRow
+            title="System prompt"
+            description="Prepended to every request sent through this model."
+            htmlFor="p-system-prompt"
+          >
             <Textarea
               id="p-system-prompt"
-              rows={3}
-              placeholder="You are a helpful assistant…"
+              rows={4}
+              className="min-h-28 resize-y"
+              placeholder="You are a helpful assistant..."
               value={systemPrompt}
               onChange={(e) => onSystemPromptChange(e.target.value)}
             />
-          </div>
+          </SettingsRow>
 
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <Label htmlFor="p-extra">
-                Extra body <OptionalChip />
-              </Label>
-              {!extraBodyText.trim() && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    const formatted = JSON.stringify(EXTRA_BODY_EXAMPLE, null, 2);
-                    onExtraBodyTextChange(formatted, null);
+          <SettingsRow
+            title="Extra body"
+            description="JSON object forwarded as provider-specific request options."
+            htmlFor="p-extra"
+          >
+            <div className="space-y-2">
+              <div
+                className={cn(
+                  "rounded-lg border border-input bg-transparent transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 dark:bg-input/30",
+                  extraBodyError &&
+                    "border-destructive focus-within:border-destructive focus-within:ring-destructive/20",
+                )}
+              >
+                <Editor
+                  value={extraBodyText}
+                  onValueChange={(next) =>
+                    onExtraBodyTextChange(next, parseExtraBody(next))
+                  }
+                  highlight={(code) => code}
+                  tabSize={2}
+                  insertSpaces
+                  padding={12}
+                  textareaId="p-extra"
+                  placeholder='{ "chat_template_kwargs": { "thinking": true } }'
+                  onBlur={handleExtraBodyBlur}
+                  spellCheck={false}
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  aria-label="Extra request body JSON"
+                  aria-invalid={extraBodyError ? true : undefined}
+                  style={{
+                    fontFamily:
+                      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                    fontSize: "0.8125rem",
+                    lineHeight: "1.55",
+                    minHeight: "9rem",
                   }}
-                  className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-                >
-                  Insert example
-                </button>
-              )}
+                />
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+                {extraBodyError ? (
+                  <p className="break-words text-destructive">
+                    {extraBodyError}
+                  </p>
+                ) : (
+                  <p className="text-muted-foreground">
+                    Must be a JSON object. Leave empty to send no override.
+                  </p>
+                )}
+                {!extraBodyText.trim() && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const formatted = JSON.stringify(
+                        EXTRA_BODY_EXAMPLE,
+                        null,
+                        2,
+                      );
+                      onExtraBodyTextChange(formatted, null);
+                    }}
+                    className="text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                  >
+                    Insert example
+                  </button>
+                )}
+              </div>
             </div>
-            <div
-              className={cn(
-                "rounded-lg border border-input bg-transparent transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 dark:bg-input/30",
-                extraBodyError &&
-                  "border-destructive focus-within:border-destructive focus-within:ring-destructive/20",
-              )}
-            >
-              <Editor
-                value={extraBodyText}
-                onValueChange={(next) =>
-                  onExtraBodyTextChange(next, parseExtraBody(next))
-                }
-                highlight={(code) => code}
-                tabSize={2}
-                insertSpaces
-                padding={8}
-                textareaId="p-extra"
-                placeholder='{ "chat_template_kwargs": { "thinking": true } }'
-                onBlur={handleExtraBodyBlur}
-                spellCheck={false}
-                autoCorrect="off"
-                autoCapitalize="off"
-                aria-label="Extra request body JSON"
-                aria-invalid={extraBodyError ? true : undefined}
-                style={{
-                  fontFamily:
-                    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-                  fontSize: "0.75rem",
-                  lineHeight: "1.5",
-                  minHeight: "8rem",
-                }}
-              />
-            </div>
-            {extraBodyError && (
-              <p className="text-xs text-destructive break-words">
-                {extraBodyError}
-              </p>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Provider-specific options forwarded as <code className="font-mono text-[11px]">extra_body</code>.
-            </p>
-          </div>
-        </div>
+          </SettingsRow>
+        </>
       )}
-    </div>
-  );
-}
-
-function OptionalChip() {
-  return (
-    <span className="ml-1 rounded px-1.5 py-px text-[10px] font-normal uppercase tracking-wide text-muted-foreground/80">
-      Optional
-    </span>
+    </>
   );
 }

--- a/apps/web/app/(app)/settings/models/AdvancedFields.tsx
+++ b/apps/web/app/(app)/settings/models/AdvancedFields.tsx
@@ -6,7 +6,7 @@ import { ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { SettingsRow } from "../_components/SettingsRows";
+import { SettingsRow, SettingsSection } from "../_components/SettingsRows";
 
 const EXTRA_BODY_EXAMPLE = {
   chat_template_kwargs: { thinking: true },
@@ -57,14 +57,10 @@ export function AdvancedFields({
   }
 
   return (
-    <>
-      <div className="flex items-center justify-between gap-3 py-4">
-        <div className="min-w-0">
-          <div className="text-sm font-medium leading-5">Advanced options</div>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            Add per-model prompt and provider-specific request overrides.
-          </p>
-        </div>
+    <SettingsSection
+      title="Advanced"
+      description="Optional prompt and request-body overrides for this model."
+      action={
         <Button
           type="button"
           variant="outline"
@@ -80,13 +76,13 @@ export function AdvancedFields({
             )}
           />
         </Button>
-      </div>
-
-      {open && (
+      }
+    >
+      {open ? (
         <>
           <SettingsRow
             title="System prompt"
-            description="Prepended to every request sent through this model."
+            description="Optional instructions sent before each conversation."
             htmlFor="p-system-prompt"
           >
             <Textarea
@@ -101,7 +97,7 @@ export function AdvancedFields({
 
           <SettingsRow
             title="Extra body"
-            description="JSON object forwarded as provider-specific request options."
+            description="Optional JSON object merged into each provider request."
             htmlFor="p-extra"
           >
             <div className="space-y-2">
@@ -168,7 +164,7 @@ export function AdvancedFields({
             </div>
           </SettingsRow>
         </>
-      )}
-    </>
+      ) : undefined}
+    </SettingsSection>
   );
 }

--- a/apps/web/app/(app)/settings/models/AdvancedFields.tsx
+++ b/apps/web/app/(app)/settings/models/AdvancedFields.tsx
@@ -89,7 +89,7 @@ export function AdvancedFields({
               id="p-system-prompt"
               rows={4}
               className="min-h-28 resize-y"
-              placeholder="You are a helpful assistant..."
+              placeholder="You are a helpful assistant…"
               value={systemPrompt}
               onChange={(e) => onSystemPromptChange(e.target.value)}
             />

--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/ui/password-input";
 import {
   Select,
   SelectContent,
@@ -20,6 +21,7 @@ import {
   type PresetId,
 } from "@/lib/providers/meta";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
+import { SettingsRow } from "../_components/SettingsRows";
 
 export interface ConnectionDraft {
   baseUrl: string;
@@ -30,9 +32,9 @@ export interface ConnectionDraft {
 export interface ConnectionFieldsProps {
   draft: ConnectionDraft;
   onChange: (next: Partial<ConnectionDraft>) => void;
-  /** When null, the preset selector is hidden (edit mode). */
-  preset: PresetId | null;
+  preset: PresetId;
   onPresetChange?: (next: PresetId) => void;
+  autoFetchModels?: boolean;
 }
 
 export function ConnectionFields({
@@ -40,15 +42,26 @@ export function ConnectionFields({
   onChange,
   preset,
   onPresetChange,
+  autoFetchModels = false,
 }: ConnectionFieldsProps) {
-  const requiresKey = preset === null ? false : preset !== "custom";
-  const presetMeta = preset === null ? PRESETS.custom : PRESETS[preset];
-  const isCreating = preset !== null;
-  const presetIconId = preset === null ? null : providerIconForPreset(preset);
+  const requiresKey = preset !== "custom";
+  const presetMeta = PRESETS[preset];
+  const presetIconId = providerIconForPreset(preset);
 
   const [models, setModels] = useState<string[]>([]);
+  const [modelMode, setModelMode] = useState<"manual" | "list">("manual");
   const [probing, setProbing] = useState(false);
   const [probeError, setProbeError] = useState("");
+  const lastAutoProbeKeyRef = useRef("");
+
+  const canProbe = Boolean(draft.baseUrl) && !(requiresKey && !draft.apiKey);
+  const probeKey = `${draft.baseUrl}\n${draft.apiKey}`;
+
+  function clearProbeState() {
+    setModels([]);
+    setProbeError("");
+    setModelMode("manual");
+  }
 
   const probe = useCallback(
     async (baseUrl: string, apiKey: string) => {
@@ -58,10 +71,19 @@ export function ConnectionFields({
       try {
         const ids = await fetchModelsForEndpoint(baseUrl, apiKey);
         setModels(ids);
-        if (ids.length > 0 && !ids.includes(draft.model)) {
+        if (ids.length === 0) {
+          setModelMode("manual");
+        } else if (!draft.model) {
           onChange({ model: ids[0] });
+          setModelMode("list");
+        } else if (ids.includes(draft.model)) {
+          setModelMode("list");
+        } else {
+          setModelMode("manual");
         }
       } catch (e) {
+        setModels([]);
+        setModelMode("manual");
         setProbeError(e instanceof Error ? e.message : String(e));
       } finally {
         setProbing(false);
@@ -70,51 +92,68 @@ export function ConnectionFields({
     [draft.model, onChange],
   );
 
-  // Auto-probe while creating; hosted presets wait for a key.
-  const { baseUrl, apiKey } = draft;
   useEffect(() => {
-    if (!isCreating || !baseUrl) return;
-    if (requiresKey && !apiKey) return;
-    const t = setTimeout(() => void probe(baseUrl, apiKey), 500);
+    if (
+      !autoFetchModels ||
+      !canProbe ||
+      lastAutoProbeKeyRef.current === probeKey
+    ) {
+      return;
+    }
+    lastAutoProbeKeyRef.current = probeKey;
+    const t = setTimeout(() => void probe(draft.baseUrl, draft.apiKey), 500);
     return () => clearTimeout(t);
-  }, [isCreating, baseUrl, apiKey, requiresKey, probe]);
+  }, [
+    autoFetchModels,
+    canProbe,
+    draft.apiKey,
+    draft.baseUrl,
+    probe,
+    probeKey,
+  ]);
+
+  const currentModelWasFetched = models.includes(draft.model);
+  const currentModelIsManual =
+    models.length > 0 && draft.model && !currentModelWasFetched;
+  const showList = modelMode === "list" && models.length > 0;
 
   return (
-    <div className="space-y-5">
-      {preset !== null && onPresetChange && (
-        <div className="space-y-1.5">
-          <Label htmlFor="p-preset">Provider</Label>
-          <Select
-            value={preset}
-            onValueChange={(next) => {
-              if (!next) return;
-              onPresetChange(next as PresetId);
-              setModels([]);
-              setProbeError("");
-            }}
-          >
-            <SelectTrigger id="p-preset" className="w-full">
-              <ModelBrandIcon iconId={presetIconId} />
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {PRESET_IDS.map((id) => (
-                <SelectItem key={id} value={id}>
-                  <ModelBrandIcon iconId={providerIconForPreset(id)} />
-                  {PRESETS[id].label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            Quick-fill for the endpoint below. All providers use the same
-            OpenAI-compatible chat API.
-          </p>
-        </div>
-      )}
+    <>
+      <SettingsRow
+        title="Provider"
+        description="Applies defaults for endpoint, credential handling, and display grouping."
+        htmlFor="p-preset"
+        align="center"
+      >
+        <Select
+          value={preset}
+          onValueChange={(next) => {
+            if (!next || next === preset) return;
+            onPresetChange?.(next as PresetId);
+            clearProbeState();
+          }}
+        >
+          <SelectTrigger id="p-preset" className="w-full">
+            <ModelBrandIcon iconId={presetIconId} />
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PRESET_IDS.map((id) => (
+              <SelectItem key={id} value={id}>
+                <ModelBrandIcon iconId={providerIconForPreset(id)} />
+                {PRESETS[id].label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingsRow>
 
-      <div className="space-y-1.5">
-        <Label htmlFor="p-base-url">Endpoint</Label>
+      <SettingsRow
+        title="Endpoint"
+        description="Base URL for the model API."
+        htmlFor="p-base-url"
+        align="center"
+      >
         <Input
           id="p-base-url"
           placeholder="https://api.openai.com/v1"
@@ -123,93 +162,146 @@ export function ConnectionFields({
           value={draft.baseUrl}
           onChange={(e) => {
             onChange({ baseUrl: e.target.value });
-            setModels([]);
-            setProbeError("");
+            clearProbeState();
           }}
         />
-      </div>
+      </SettingsRow>
 
-      <div className="space-y-1.5">
-        <Label htmlFor="p-api-key">
-          API key {requiresKey ? null : <OptionalChip />}
-        </Label>
-        <Input
+      <SettingsRow
+        title="API key"
+        description={
+          requiresKey
+            ? "Required for this hosted preset."
+            : "Optional for local or custom endpoints."
+        }
+        htmlFor="p-api-key"
+        align="center"
+      >
+        <PasswordInput
           id="p-api-key"
-          type="password"
           autoComplete="new-password"
-          placeholder={requiresKey ? "Required" : "sk-…"}
+          placeholder={requiresKey ? "Required" : "Optional"}
           required={requiresKey}
-          autoFocus={isCreating && requiresKey}
           value={draft.apiKey}
-          onChange={(e) => onChange({ apiKey: e.target.value })}
+          onChange={(e) => {
+            onChange({ apiKey: e.target.value });
+            clearProbeState();
+          }}
         />
-      </div>
+      </SettingsRow>
 
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between gap-2">
-          <Label htmlFor="p-model">Model</Label>
-          <span className="flex h-5 items-center text-xs text-muted-foreground">
+      <SettingsRow
+        title="Model"
+        description="Choose a fetched model or enter a model id manually."
+        htmlFor="p-model"
+      >
+        <div className="space-y-2">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {showList ? (
+              <Select
+                value={draft.model}
+                onValueChange={(value) => {
+                  if (value == null) return;
+                  onChange({ model: value });
+                }}
+              >
+                <SelectTrigger id="p-model" className="min-w-0 flex-1">
+                  <ModelBrandIcon iconId={modelIconForModel(draft.model)} />
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {models.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      <ModelBrandIcon iconId={modelIconForModel(m)} />
+                      {m}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                id="p-model"
+                className="min-w-0 flex-1 font-mono text-xs md:text-xs"
+                placeholder={presetMeta.modelPlaceholder}
+                required
+                value={draft.model}
+                onChange={(e) => {
+                  setModelMode("manual");
+                  onChange({ model: e.target.value });
+                }}
+              />
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!canProbe || probing}
+              onClick={() => void probe(draft.baseUrl, draft.apiKey)}
+              className="sm:w-auto"
+            >
+              {probing ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+              {models.length > 0 ? "Refresh" : "Fetch"}
+            </Button>
+          </div>
+
+          <div className="flex min-h-5 flex-wrap items-center gap-x-3 gap-y-1 text-xs">
             {probing ? (
-              <>
-                <Loader2 className="mr-1 size-3 animate-spin" /> Fetching…
-              </>
+              <span className="inline-flex items-center gap-1 text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" />
+                Fetching available models
+              </span>
             ) : models.length > 0 ? (
-              `${models.length} available`
+              <span className="text-muted-foreground">
+                {models.length} model{models.length === 1 ? "" : "s"} fetched
+              </span>
             ) : probeError ? (
+              <span className="inline-flex items-center gap-1 text-destructive">
+                <AlertCircle className="size-3" />
+                {probeError}
+              </span>
+            ) : requiresKey && !draft.apiKey ? (
+              <span className="text-muted-foreground">
+                Add an API key to fetch models.
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                {autoFetchModels
+                  ? "Models will load automatically when ready."
+                  : "Refresh to load available models."}
+              </span>
+            )}
+
+            {models.length > 0 && showList && (
               <button
                 type="button"
-                onClick={() => probe(draft.baseUrl, draft.apiKey)}
-                className="underline-offset-2 hover:underline"
+                className="text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                onClick={() => setModelMode("manual")}
               >
-                Retry fetch
+                Enter manually
               </button>
-            ) : requiresKey && !draft.apiKey ? (
-              "Add API key to load models"
-            ) : null}
-          </span>
-        </div>
-        {models.length > 0 ? (
-          <Select
-            value={draft.model}
-            onValueChange={(value) => {
-              if (value == null) return;
-              onChange({ model: value });
-            }}
-          >
-            <SelectTrigger id="p-model" className="w-full">
-              <ModelBrandIcon iconId={modelIconForModel(draft.model)} />
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {models.map((m) => (
-                <SelectItem key={m} value={m}>
-                  <ModelBrandIcon iconId={modelIconForModel(m)} />
-                  {m}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        ) : (
-          <Input
-            id="p-model"
-            placeholder={presetMeta.modelPlaceholder}
-            required
-            value={draft.model}
-            onChange={(e) => onChange({ model: e.target.value })}
-          />
-        )}
-        {probeError && (
-          <p className="text-xs text-destructive">{probeError}</p>
-        )}
-      </div>
-    </div>
-  );
-}
+            )}
+            {models.length > 0 && !showList && (
+              <button
+                type="button"
+                className="text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                onClick={() => {
+                  setModelMode("list");
+                  if (!currentModelWasFetched) onChange({ model: models[0] });
+                }}
+              >
+                Choose fetched model
+              </button>
+            )}
+          </div>
 
-function OptionalChip() {
-  return (
-    <span className="ml-1 rounded px-1.5 py-px text-[10px] font-normal uppercase tracking-wide text-muted-foreground/80">
-      Optional
-    </span>
+          {currentModelIsManual && (
+            <p className="text-xs leading-5 text-muted-foreground">
+              The current model id was not returned by the endpoint, so it is
+              being kept as a manual entry.
+            </p>
+          )}
+        </div>
+      </SettingsRow>
+    </>
   );
 }

--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -121,7 +121,7 @@ export function ConnectionFields({
     <>
       <SettingsRow
         title="Provider"
-        description="Applies defaults for endpoint, credential handling, and display grouping."
+        description="Sets endpoint defaults and picker grouping."
         htmlFor="p-preset"
         align="center"
       >
@@ -192,11 +192,11 @@ export function ConnectionFields({
 
       <SettingsRow
         title="Model"
-        description="Choose a fetched model or enter a model id manually."
+        description="Choose a fetched model or enter an id."
         htmlFor="p-model"
       >
         <div className="space-y-2">
-          <div className="flex flex-col gap-2 sm:flex-row">
+          <div className="flex flex-col gap-2 lg:flex-row">
             {showList ? (
               <Select
                 value={draft.model}
@@ -237,7 +237,7 @@ export function ConnectionFields({
               size="sm"
               disabled={!canProbe || probing}
               onClick={() => void probe(draft.baseUrl, draft.apiKey)}
-              className="sm:w-auto"
+              className="lg:w-auto"
             >
               {probing ? <Loader2 className="animate-spin" /> : <RefreshCw />}
               {models.length > 0 ? "Refresh" : "Fetch"}

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -166,7 +166,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
       <form onSubmit={submit} className="space-y-8">
         <SettingsSection
           title="Connection"
-          description="Provider, credentials, and upstream model discovery."
+          description="Provider, credentials, model discovery, and connectivity."
         >
           <ConnectionFields
             draft={{
@@ -187,11 +187,22 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
               }));
             }}
           />
+
+          <SettingsRow
+            title="Test connection"
+            description="Send a short request with the current connection settings."
+          >
+            <ConnectionTester
+              key={`${draft.baseUrl}|${draft.apiKey}|${draft.model}|${extraBodyText}`}
+              args={pingArgs}
+              disabled={requiresKey && !draft.apiKey}
+            />
+          </SettingsRow>
         </SettingsSection>
 
         <SettingsSection
-          title="Details"
-          description="How this model appears in the app."
+          title="Chat availability"
+          description="How this model appears to people using chat."
         >
           <SettingsRow
             title="Display name"
@@ -212,8 +223,8 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
           </SettingsRow>
 
           <SettingsRow
-            title="Enabled"
-            description="Disabled models stay configured but disappear from the chat picker."
+            title="Available in chat"
+            description="Turn off to keep the config without showing it in the picker."
             align="center"
           >
             <Switch
@@ -224,36 +235,20 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
               aria-label={draft.enabled ? "Disable model" : "Enable model"}
             />
           </SettingsRow>
-
-          <SettingsRow
-            title="Test connection"
-            description="Sends a short request with the current settings."
-          >
-            <ConnectionTester
-              key={`${draft.baseUrl}|${draft.apiKey}|${draft.model}|${extraBodyText}`}
-              args={pingArgs}
-              disabled={requiresKey && !draft.apiKey}
-            />
-          </SettingsRow>
         </SettingsSection>
 
-        <SettingsSection
-          title="Behavior"
-          description="Optional prompt and request-body overrides."
-        >
-          <AdvancedFields
-            systemPrompt={draft.systemPrompt ?? ""}
-            onSystemPromptChange={(next) =>
-              setDraft((d) => ({ ...d, systemPrompt: next }))
-            }
-            extraBodyText={extraBodyText}
-            onExtraBodyTextChange={(next, err) => {
-              setExtraBodyText(next);
-              setExtraBodyError(err);
-            }}
-            defaultOpen={Boolean(existing?.systemPrompt || existing?.extraBody)}
-          />
-        </SettingsSection>
+        <AdvancedFields
+          systemPrompt={draft.systemPrompt ?? ""}
+          onSystemPromptChange={(next) =>
+            setDraft((d) => ({ ...d, systemPrompt: next }))
+          }
+          extraBodyText={extraBodyText}
+          onExtraBodyTextChange={(next, err) => {
+            setExtraBodyText(next);
+            setExtraBodyError(err);
+          }}
+          defaultOpen={Boolean(existing?.systemPrompt || existing?.extraBody)}
+        />
 
         {saveError && (
           <div className="flex items-start gap-1.5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -267,7 +267,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
             Cancel
           </Button>
           <Button type="submit" size="sm" disabled={!canSave}>
-            {saving ? "Saving..." : isEditing ? "Save" : "Create"}
+            {saving ? "Saving…" : isEditing ? "Save" : "Create"}
           </Button>
         </div>
       </form>

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { ArrowLeft, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   ModelConfigSchema,
   type AdminModelConfig,
@@ -21,6 +21,7 @@ import { PRESETS, presetFor, type PresetId } from "@/lib/providers/meta";
 import { AdvancedFields } from "./AdvancedFields";
 import { ConnectionFields } from "./ConnectionFields";
 import { ConnectionTester } from "./ConnectionTester";
+import { SettingsRow, SettingsSection } from "../_components/SettingsRows";
 
 export interface ModelEditorProps {
   /** When provided, editor loads the existing config from cache; otherwise a new one is being created. */
@@ -35,7 +36,6 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
     : undefined;
   const isEditing = Boolean(modelId);
 
-  // For "new" we expose a preset selector. For "edit" the preset is implicit.
   const [preset, setPreset] = useState<PresetId>(() =>
     existing ? presetFor(existing.baseUrl) : "openai",
   );
@@ -75,9 +75,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
   const updateMut = useUpdateModelConfig();
   const saving = createMut.isPending || updateMut.isPending;
 
-  const requiresKey = isEditing
-    ? presetFor(draft.baseUrl) !== "custom"
-    : preset !== "custom";
+  const requiresKey = preset !== "custom";
 
   const canSave =
     !saving &&
@@ -145,7 +143,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
   }
 
   return (
-    <div className="max-w-2xl">
+    <div className="max-w-4xl">
       <div className="mb-6 flex items-center gap-2">
         <Button
           render={<Link href="/settings/models" />}
@@ -155,62 +153,107 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
         >
           <ArrowLeft />
         </Button>
-        <h1 className="text-xl font-semibold tracking-tight">
-          {isEditing ? "Edit model" : "Add model"}
-        </h1>
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">
+            {isEditing ? "Edit model" : "Add model"}
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Configure a model that everyone on this server can use.
+          </p>
+        </div>
       </div>
 
-      <form onSubmit={submit} className="space-y-6">
-        <ConnectionFields
-          draft={{
-            baseUrl: draft.baseUrl,
-            apiKey: draft.apiKey ?? "",
-            model: draft.model,
-          }}
-          onChange={(next) => setDraft((d) => ({ ...d, ...next }))}
-          preset={isEditing ? null : preset}
-          onPresetChange={(next) => {
-            setPreset(next);
-            setDraft((d) => ({
-              ...d,
-              baseUrl: PRESETS[next].defaultBaseUrl,
-              model: "",
-            }));
-          }}
-        />
-
-        <ConnectionTester
-          key={`${draft.baseUrl}|${draft.apiKey}|${draft.model}|${extraBodyText}`}
-          args={pingArgs}
-          disabled={requiresKey && !draft.apiKey}
-        />
-
-        <div className="space-y-1.5">
-          <Label htmlFor="p-label">Display name</Label>
-          <Input
-            id="p-label"
-            placeholder={
-              draft.model ? defaultLabelFor(draft.model) : "Shown in the picker"
-            }
-            value={draft.label}
-            onChange={(e) =>
-              setDraft((d) => ({ ...d, label: e.target.value }))
-            }
+      <form onSubmit={submit} className="space-y-8">
+        <SettingsSection
+          title="Connection"
+          description="Provider, credentials, and upstream model discovery."
+        >
+          <ConnectionFields
+            draft={{
+              baseUrl: draft.baseUrl,
+              apiKey: draft.apiKey ?? "",
+              model: draft.model,
+            }}
+            onChange={(next) => setDraft((d) => ({ ...d, ...next }))}
+            preset={preset}
+            autoFetchModels={!isEditing}
+            onPresetChange={(next) => {
+              setPreset(next);
+              setDraft((d) => ({
+                ...d,
+                baseUrl: PRESETS[next].defaultBaseUrl,
+                apiKey: "",
+                model: "",
+              }));
+            }}
           />
-        </div>
+        </SettingsSection>
 
-        <AdvancedFields
-          systemPrompt={draft.systemPrompt ?? ""}
-          onSystemPromptChange={(next) =>
-            setDraft((d) => ({ ...d, systemPrompt: next }))
-          }
-          extraBodyText={extraBodyText}
-          onExtraBodyTextChange={(next, err) => {
-            setExtraBodyText(next);
-            setExtraBodyError(err);
-          }}
-          defaultOpen={Boolean(existing?.systemPrompt || existing?.extraBody)}
-        />
+        <SettingsSection
+          title="Details"
+          description="How this model appears in the app."
+        >
+          <SettingsRow
+            title="Display name"
+            description="Shown in the chat model picker."
+            htmlFor="p-label"
+            align="center"
+          >
+            <Input
+              id="p-label"
+              placeholder={
+                draft.model ? defaultLabelFor(draft.model) : "Shown in the picker"
+              }
+              value={draft.label}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, label: e.target.value }))
+              }
+            />
+          </SettingsRow>
+
+          <SettingsRow
+            title="Enabled"
+            description="Disabled models stay configured but disappear from the chat picker."
+            align="center"
+          >
+            <Switch
+              checked={draft.enabled}
+              onCheckedChange={(next) =>
+                setDraft((d) => ({ ...d, enabled: next }))
+              }
+              aria-label={draft.enabled ? "Disable model" : "Enable model"}
+            />
+          </SettingsRow>
+
+          <SettingsRow
+            title="Test connection"
+            description="Sends a short request with the current settings."
+          >
+            <ConnectionTester
+              key={`${draft.baseUrl}|${draft.apiKey}|${draft.model}|${extraBodyText}`}
+              args={pingArgs}
+              disabled={requiresKey && !draft.apiKey}
+            />
+          </SettingsRow>
+        </SettingsSection>
+
+        <SettingsSection
+          title="Behavior"
+          description="Optional prompt and request-body overrides."
+        >
+          <AdvancedFields
+            systemPrompt={draft.systemPrompt ?? ""}
+            onSystemPromptChange={(next) =>
+              setDraft((d) => ({ ...d, systemPrompt: next }))
+            }
+            extraBodyText={extraBodyText}
+            onExtraBodyTextChange={(next, err) => {
+              setExtraBodyText(next);
+              setExtraBodyError(err);
+            }}
+            defaultOpen={Boolean(existing?.systemPrompt || existing?.extraBody)}
+          />
+        </SettingsSection>
 
         {saveError && (
           <div className="flex items-start gap-1.5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
@@ -229,7 +272,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
             Cancel
           </Button>
           <Button type="submit" size="sm" disabled={!canSave}>
-            {saving ? "Saving…" : isEditing ? "Save" : "Create"}
+            {saving ? "Saving..." : isEditing ? "Save" : "Create"}
           </Button>
         </div>
       </form>

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -91,7 +91,7 @@ export function ModelsPanel() {
 
   return (
     <div className="max-w-4xl space-y-6">
-      <header className="flex items-start justify-between gap-4">
+      <header className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Models</h1>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -99,14 +99,18 @@ export function ModelsPanel() {
           </p>
         </div>
         {models.length > 0 && (
-          <Button render={<Link href="/settings/models/new" />} size="sm">
+          <Button
+            render={<Link href="/settings/models/new" />}
+            size="sm"
+            className="self-start lg:self-auto"
+          >
             <Plus /> Add model
           </Button>
         )}
       </header>
 
       {models.length > 0 && (
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="relative max-w-md flex-1">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -156,7 +160,7 @@ export function ModelsPanel() {
               <div
                 key={m.id}
                 className={cn(
-                  "grid gap-3 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center",
+                  "grid gap-3 py-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center",
                   !m.enabled && "opacity-65",
                 )}
               >
@@ -184,36 +188,44 @@ export function ModelsPanel() {
                   </div>
                 </div>
 
-                <div className="flex items-center gap-1 justify-self-start md:justify-self-end">
-                  <Switch
-                    checked={m.enabled}
-                    disabled={togglingId === m.id}
-                    onCheckedChange={(next) => void toggleEnabled(m, next)}
-                    aria-label={`${m.enabled ? "Disable" : "Enable"} ${m.label}`}
-                  />
-                  <Button
-                    render={<Link href={`/settings/models/${m.id}`} />}
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={`Edit ${m.label}`}
-                    title={`Edit ${m.label}`}
-                  >
-                    <Pencil />
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => {
-                      setDeleteError("");
-                      setPendingDelete(m);
-                    }}
-                    aria-label={`Delete ${m.label}`}
-                    title={`Delete ${m.label}`}
-                    className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                  >
-                    <Trash2 />
-                  </Button>
+                <div className="flex items-center gap-3 justify-self-start lg:justify-self-end">
+                  <div className="flex min-w-16 items-center justify-end gap-2">
+                    <span className="hidden text-xs text-muted-foreground sm:inline">
+                      {m.enabled ? "On" : "Off"}
+                    </span>
+                    <Switch
+                      checked={m.enabled}
+                      disabled={togglingId === m.id}
+                      onCheckedChange={(next) => void toggleEnabled(m, next)}
+                      aria-label={`${m.enabled ? "Disable" : "Enable"} ${m.label}`}
+                    />
+                  </div>
+                  <div className="h-6 w-px bg-border" aria-hidden="true" />
+                  <div className="flex items-center gap-0.5 rounded-lg border bg-background/80 p-0.5">
+                    <Button
+                      render={<Link href={`/settings/models/${m.id}`} />}
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label={`Edit ${m.label}`}
+                      title={`Edit ${m.label}`}
+                    >
+                      <Pencil />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => {
+                        setDeleteError("");
+                        setPendingDelete(m);
+                      }}
+                      aria-label={`Delete ${m.label}`}
+                      title={`Delete ${m.label}`}
+                      className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                    >
+                      <Trash2 />
+                    </Button>
+                  </div>
                 </div>
               </div>
             );

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { AlertDialog } from "@base-ui/react/alert-dialog";
-import { Switch } from "@base-ui/react/switch";
-import { Plus, Trash2 } from "lucide-react";
+import { Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import type { AdminModelConfig } from "@/lib/config";
 import {
@@ -17,6 +18,7 @@ import {
   useDeleteModelConfig,
   useUpdateModelConfig,
 } from "@/lib/queries/modelConfigs";
+import { cn } from "@/lib/utils";
 import { HealthBadge } from "./HealthBadge";
 
 export function ModelsPanel() {
@@ -24,12 +26,35 @@ export function ModelsPanel() {
   const deleteMut = useDeleteModelConfig();
   const updateMut = useUpdateModelConfig();
 
+  const [query, setQuery] = useState("");
   const [pendingDelete, setPendingDelete] = useState<AdminModelConfig | null>(null);
   const [deleteError, setDeleteError] = useState("");
+  const [actionError, setActionError] = useState("");
   const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  const filteredModels = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return models;
+    return models.filter((m) => {
+      const provider = providerIdentityForBaseUrl(m.baseUrl);
+      const host = hostnameOf(m.baseUrl);
+      return [
+        m.label,
+        m.model,
+        m.baseUrl,
+        host,
+        provider.label,
+        m.enabled ? "enabled" : "disabled",
+      ]
+        .join(" ")
+        .toLowerCase()
+        .includes(q);
+    });
+  }, [models, query]);
 
   async function toggleEnabled(m: AdminModelConfig, next: boolean) {
     setTogglingId(m.id);
+    setActionError("");
     try {
       await updateMut.mutateAsync({
         id: m.id,
@@ -44,6 +69,8 @@ export function ModelsPanel() {
           sortOrder: m.sortOrder,
         },
       });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to update model");
     } finally {
       setTogglingId(null);
     }
@@ -57,29 +84,53 @@ export function ModelsPanel() {
       setPendingDelete(null);
     } catch (err) {
       setDeleteError(
-        err instanceof Error ? err.message : `Failed to delete`,
+        err instanceof Error ? err.message : "Failed to delete model",
       );
     }
   }
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="max-w-4xl space-y-6">
       <header className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Models</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Anthropic, Google Gemini, or OpenAI-compatible endpoints — available to everyone.
+            Configure the model endpoints available in chat.
           </p>
         </div>
         {models.length > 0 && (
           <Button render={<Link href="/settings/models/new" />} size="sm">
-            <Plus /> Add
+            <Plus /> Add model
           </Button>
         )}
       </header>
 
+      {models.length > 0 && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="relative max-w-md flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search models"
+              className="pl-8"
+              aria-label="Search models"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {models.length} configured
+          </p>
+        </div>
+      )}
+
+      {actionError && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          {actionError}
+        </div>
+      )}
+
       {models.length === 0 ? (
-        <div className="rounded-xl border border-dashed bg-muted/20 px-6 py-14 text-center">
+        <div className="border-y border-dashed px-6 py-14 text-center">
           <p className="text-sm text-muted-foreground">No models configured yet.</p>
           <Button
             render={<Link href="/settings/models/new" />}
@@ -89,64 +140,85 @@ export function ModelsPanel() {
             <Plus /> Add your first model
           </Button>
         </div>
+      ) : filteredModels.length === 0 ? (
+        <div className="border-y px-6 py-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            No models match <span className="text-foreground">{query.trim()}</span>.
+          </p>
+        </div>
       ) : (
-        <ul className="space-y-2">
-          {models.map((m) => {
+        <div className="divide-y divide-border/70 border-y">
+          {filteredModels.map((m) => {
             const provider = providerIdentityForBaseUrl(m.baseUrl);
+            const host = hostnameOf(m.baseUrl);
             const iconId = modelIconForModel(m.model) ?? provider.iconId;
             return (
-              <li key={m.id} className="group relative">
-                <Link
-                  href={`/settings/models/${m.id}`}
-                  aria-label={`Edit ${m.label}`}
-                  className={`flex w-full items-center rounded-lg border bg-card px-3.5 py-3 pr-28 text-left transition-colors hover:border-ring/40 hover:bg-accent/40 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40 ${m.enabled ? "" : "opacity-60"}`}
-                >
-                  <ModelBrandIcon iconId={iconId} className="mr-2.5 size-5" />
+              <div
+                key={m.id}
+                className={cn(
+                  "grid gap-3 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center",
+                  !m.enabled && "opacity-65",
+                )}
+              >
+                <div className="flex min-w-0 items-start gap-3">
+                  <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/30">
+                    <ModelBrandIcon iconId={iconId} className="size-4" />
+                  </div>
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate text-sm font-medium text-foreground">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <span className="min-w-0 truncate text-sm font-medium text-foreground">
                         {m.label}
                       </span>
                       <HealthBadge id={m.id} enabled={m.enabled} />
                     </div>
-                    <div className="mt-0.5 flex items-center gap-2 font-mono text-xs text-muted-foreground">
-                      <span className="truncate">{m.model}</span>
-                      <span
-                        aria-hidden="true"
-                        className="text-muted-foreground/50"
-                      >
-                        ·
+                    <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                      <span>{provider.label}</span>
+                      <span aria-hidden="true" className="text-muted-foreground/50">
+                        /
                       </span>
-                      <span className="truncate">{hostnameOf(m.baseUrl)}</span>
+                      <span className="font-mono">{host}</span>
+                    </div>
+                    <div className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                      {m.model}
                     </div>
                   </div>
-                </Link>
-                <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
-                  <Switch.Root
+                </div>
+
+                <div className="flex items-center gap-1 justify-self-start md:justify-self-end">
+                  <Switch
                     checked={m.enabled}
                     disabled={togglingId === m.id}
-                    onCheckedChange={(next) => toggleEnabled(m, next)}
+                    onCheckedChange={(next) => void toggleEnabled(m, next)}
                     aria-label={`${m.enabled ? "Disable" : "Enable"} ${m.label}`}
-                    className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-input bg-input/40 transition-colors data-[checked]:border-ring/40 data-[checked]:bg-ring/70 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  />
+                  <Button
+                    render={<Link href={`/settings/models/${m.id}`} />}
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`Edit ${m.label}`}
+                    title={`Edit ${m.label}`}
                   >
-                    <Switch.Thumb className="pointer-events-none ml-0.5 size-4 rounded-full bg-background shadow transition-transform data-[checked]:translate-x-4" />
-                  </Switch.Root>
-                  <button
+                    <Pencil />
+                  </Button>
+                  <Button
                     type="button"
+                    variant="ghost"
+                    size="icon-sm"
                     onClick={() => {
                       setDeleteError("");
                       setPendingDelete(m);
                     }}
                     aria-label={`Delete ${m.label}`}
-                    className="rounded-md p-1.5 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 group-hover:opacity-100"
+                    title={`Delete ${m.label}`}
+                    className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                   >
-                    <Trash2 className="size-4" />
-                  </button>
+                    <Trash2 />
+                  </Button>
                 </div>
-              </li>
+              </div>
             );
           })}
-        </ul>
+        </div>
       )}
 
       <AlertDialog.Root
@@ -159,8 +231,8 @@ export function ModelsPanel() {
         }}
       >
         <AlertDialog.Portal>
-          <AlertDialog.Backdrop className="fixed inset-0 z-40 bg-black/40 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity" />
-          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity">
+          <AlertDialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
             <AlertDialog.Title className="text-base font-semibold tracking-tight">
               Delete model?
             </AlertDialog.Title>
@@ -189,7 +261,7 @@ export function ModelsPanel() {
                 disabled={deleteMut.isPending}
                 onClick={confirmDelete}
               >
-                {deleteMut.isPending ? "Deleting…" : "Delete"}
+                {deleteMut.isPending ? "Deleting..." : "Delete"}
               </Button>
             </div>
           </AlertDialog.Popup>

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -273,7 +273,7 @@ export function ModelsPanel() {
                 disabled={deleteMut.isPending}
                 onClick={confirmDelete}
               >
-                {deleteMut.isPending ? "Deleting..." : "Delete"}
+                {deleteMut.isPending ? "Deleting…" : "Delete"}
               </Button>
             </div>
           </AlertDialog.Popup>

--- a/apps/web/components/ModelPicker.tsx
+++ b/apps/web/components/ModelPicker.tsx
@@ -26,7 +26,7 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
   const showSearch = (models?.length ?? 0) > SEARCH_THRESHOLD;
 
   const label = loading
-    ? "Loading..."
+    ? "Loading…"
     : selected
       ? selected.label
       : models && models.length > 0

--- a/apps/web/components/ModelPicker.tsx
+++ b/apps/web/components/ModelPicker.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { Menu } from "@base-ui/react/menu";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import { cn } from "@/lib/utils";
 import type { PublicModelConfig } from "@/lib/config";
@@ -15,20 +17,35 @@ interface Props {
 }
 
 const GROUP_ORDER = PRESET_IDS.map((id) => PRESETS[id].label);
+const SEARCH_THRESHOLD = 7;
 
 export function ModelPicker({ models, selectedId, onSelect }: Props) {
+  const [search, setSearch] = useState("");
   const loading = models === null;
   const selected = models?.find((m) => m.id === selectedId) ?? null;
+  const showSearch = (models?.length ?? 0) > SEARCH_THRESHOLD;
 
   const label = loading
-    ? "Loading…"
+    ? "Loading..."
     : selected
       ? selected.label
       : models && models.length > 0
         ? "Select a model"
         : "No models";
 
-  const groups = groupModels(models ?? []);
+  const filteredModels = useMemo(() => {
+    const list = models ?? [];
+    const q = search.trim().toLowerCase();
+    if (!q) return list;
+    return list.filter((m) =>
+      [m.label, m.model, m.displayProvider]
+        .join(" ")
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [models, search]);
+
+  const groups = groupModels(filteredModels);
 
   return (
     <Menu.Root>
@@ -38,7 +55,7 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
             variant="ghost"
             size="sm"
             className={cn(
-              "min-w-0 max-w-[60%] gap-1.5",
+              "min-w-0 max-w-[60%] gap-1.5 sm:max-w-96",
               !selected && "text-muted-foreground",
             )}
             disabled={loading || !models || models.length === 0}
@@ -54,43 +71,77 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner side="bottom" align="start" sideOffset={6}>
-          <Menu.Popup className="z-50 max-h-80 w-72 overflow-y-auto rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
-            {groups.map(([groupLabel, items]) => (
-              <Menu.Group
-                key={groupLabel}
-                className="py-1 first:pt-0 last:pb-0 not-first:border-t not-first:mt-1 not-first:pt-2"
-              >
-                <Menu.GroupLabel className="px-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                  {groupLabel}
-                </Menu.GroupLabel>
-                {items.map((m) => (
-                  <Menu.Item
-                    key={m.id}
-                    onClick={() => onSelect(m.id)}
-                    className="flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+          <Menu.Popup
+            className={cn(
+              "z-50 max-h-96 w-80 overflow-y-auto rounded-lg border bg-popover text-sm text-popover-foreground shadow-md outline-none",
+              showSearch ? "p-0" : "p-1",
+            )}
+          >
+            {showSearch && (
+              <div className="sticky top-0 z-10 border-b bg-popover p-2">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                    placeholder="Search models"
+                    aria-label="Search models"
+                    className="h-7 pl-7 text-xs md:text-xs"
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className={showSearch ? "p-1" : undefined}>
+              {groups.length === 0 ? (
+                <div className="px-2 py-6 text-center text-xs text-muted-foreground">
+                  No models match{" "}
+                  <span className="text-foreground">{search.trim()}</span>.
+                </div>
+              ) : (
+                groups.map(([groupLabel, items]) => (
+                  <Menu.Group
+                    key={groupLabel}
+                    className="py-1 first:pt-0 last:pb-0 not-first:border-t not-first:mt-1 not-first:pt-2"
                   >
-                    <Check
-                      className={cn(
-                        "mt-0.5 size-3.5 shrink-0",
-                        m.id === selectedId ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                    <ModelBrandIcon
-                      iconId={m.modelIconId ?? m.providerIconId}
-                      className="mt-px"
-                    />
-                    <span className="flex min-w-0 flex-col">
-                      <span className="truncate">{m.label}</span>
-                      {m.label !== m.model && (
-                        <span className="truncate text-xs text-muted-foreground">
-                          {m.model}
+                    <Menu.GroupLabel className="px-2 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {groupLabel}
+                    </Menu.GroupLabel>
+                    {items.map((m) => (
+                      <Menu.Item
+                        key={m.id}
+                        onClick={() => {
+                          onSelect(m.id);
+                          setSearch("");
+                        }}
+                        className="flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                      >
+                        <Check
+                          className={cn(
+                            "mt-0.5 size-3.5 shrink-0",
+                            m.id === selectedId ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <ModelBrandIcon
+                          iconId={m.modelIconId ?? m.providerIconId}
+                          className="mt-px"
+                        />
+                        <span className="flex min-w-0 flex-1 flex-col">
+                          <span className="truncate">{m.label}</span>
+                          <span className="truncate text-xs text-muted-foreground">
+                            {m.label === m.model
+                              ? m.displayProvider
+                              : `${m.displayProvider} / ${m.model}`}
+                          </span>
                         </span>
-                      )}
-                    </span>
-                  </Menu.Item>
-                ))}
-              </Menu.Group>
-            ))}
+                      </Menu.Item>
+                    ))}
+                  </Menu.Group>
+                ))
+              )}
+            </div>
           </Menu.Popup>
         </Menu.Positioner>
       </Menu.Portal>


### PR DESCRIPTION
## Summary
- Unifies the model create/edit experience around the same provider, connection, discovery, and save flow.
- Adds reusable settings row primitives for model settings and applies a more polished settings layout.
- Improves model discovery fallback behavior, advanced request override editing, the admin models list, and the web chat model picker.
- Refines the second-pass layout so advanced options are grouped logically, model list actions are easier to scan, and settings rows handle constrained web widths cleanly.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`
- Manual screenshot pass for `/settings/models` and `/settings/models/:id` at desktop and constrained web widths.