### PR TITLE
Use latest SearXNG image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -50,12 +50,13 @@ services:
       retries: 5
 
   searxng:
-    image: docker.io/searxng/searxng:2026.5.5-0ac5254b8
+    image: docker.io/searxng/searxng:latest
     container_name: overtchat-searxng
     restart: unless-stopped
     ports:
       - "${BIND_ADDR:-127.0.0.1}:${SEARXNG_PORT:-8088}:8080"
     environment:
+      FORCE_OWNERSHIP: "false"
       SEARXNG_SECRET: ${SEARXNG_SECRET:?set SEARXNG_SECRET in .env}
     volumes:
       - ./searxng:/etc/searxng:rw

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -24,15 +24,5 @@ outgoing:
   pool_maxsize: 20
 
 engines:
-  - name: ahmia
-    disabled: true
-  - name: torch
-    disabled: true
-  - name: wikidata
-    disabled: true
   - name: brave
-    disabled: true
-  - name: karmasearch
-    disabled: true
-  - name: karmasearch videos
     disabled: true


### PR DESCRIPTION
Updates the bundled SearXNG service to use the latest upstream image and removes stale engine overrides.

After updating, recreate SearXNG:

```bash
docker compose up -d searxng
```