### PR TITLE
Fix mobile message editing parity

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -420,13 +420,13 @@ function ChatSurface({
     regenerate({ messageId, body: requestBody() });
   }
 
-  function handleSaveEdit(messageId: string, text: string) {
+  function handleSaveEdit(messageId: string, text: string, files: FileUIPart[]) {
     setEditingId(null);
     if (streaming || !configured) return;
     const trimmed = text.trim();
-    if (!trimmed) return;
+    if (!trimmed && files.length === 0) return;
     Keyboard.dismiss();
-    sendMessage({ text: trimmed, messageId }, { body: requestBody() });
+    sendMessage({ text: trimmed, files, messageId }, { body: requestBody() });
   }
 
   return (

--- a/apps/mobile/src/components/chat/AttachmentChip.tsx
+++ b/apps/mobile/src/components/chat/AttachmentChip.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import type { FileUIPart } from "ai";
 import { Image } from "expo-image";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import ImageView from "react-native-image-viewing";
@@ -50,16 +50,19 @@ export function AttachmentChip({
   attachment,
   meta,
   onRemove,
+  onLongPress,
 }: {
   attachment: FileUIPart;
   meta?: AttachmentMeta;
   onRemove?: () => void;
+  onLongPress?: () => void;
 }) {
   const { colors, radii, fonts } = useTheme();
   const insets = useSafeAreaInsets();
   const label = attachment.filename ?? "file";
   const cookie = getAuthCookie();
   const [previewOpen, setPreviewOpen] = useState(false);
+  const longPressedRef = useRef(false);
 
   if (isImageAttachment(attachment, meta)) {
     const localUri = meta?.localUri;
@@ -81,7 +84,22 @@ export function AttachmentChip({
         ]}
       >
         <Pressable
-          onPress={() => setPreviewOpen(true)}
+          onPress={() => {
+            if (longPressedRef.current) {
+              longPressedRef.current = false;
+              return;
+            }
+            setPreviewOpen(true);
+          }}
+          onLongPress={
+            onLongPress
+              ? () => {
+                  longPressedRef.current = true;
+                  onLongPress();
+                }
+              : undefined
+          }
+          delayLongPress={300}
           accessibilityRole="imagebutton"
           accessibilityLabel={`Preview ${label}`}
           style={({ pressed }) => [
@@ -142,18 +160,17 @@ export function AttachmentChip({
       .filter(Boolean)
       .join(" · ");
 
-  return (
-    <View
-      style={[
-        styles.docWrap,
-        {
-          borderColor: colors.border,
-          backgroundColor: colors.muted,
-          borderRadius: radii.md,
-          paddingRight: onRemove ? 30 : 14,
-        },
-      ]}
-    >
+  const docStyle = [
+    styles.docWrap,
+    {
+      borderColor: colors.border,
+      backgroundColor: colors.muted,
+      borderRadius: radii.md,
+      paddingRight: onRemove ? 30 : 14,
+    },
+  ];
+  const docContent = (
+    <>
       <View
         style={[
           styles.docIcon,
@@ -189,8 +206,22 @@ export function AttachmentChip({
         ) : null}
       </View>
       {onRemove && <RemoveButton onPress={onRemove} label={label} />}
-    </View>
+    </>
   );
+
+  if (onLongPress) {
+    return (
+      <Pressable
+        onLongPress={onLongPress}
+        delayLongPress={300}
+        style={({ pressed }) => [...docStyle, { opacity: pressed ? 0.9 : 1 }]}
+      >
+        {docContent}
+      </Pressable>
+    );
+  }
+
+  return <View style={docStyle}>{docContent}</View>;
 }
 
 function RemoveButton({

--- a/apps/mobile/src/components/chat/EditBubble.tsx
+++ b/apps/mobile/src/components/chat/EditBubble.tsx
@@ -1,18 +1,23 @@
 import { useEffect, useRef, useState } from "react";
+import type { FileUIPart } from "ai";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import { useTheme } from "@/lib/theme";
+import { AttachmentChip } from "./AttachmentChip";
 
 export function EditBubble({
   initialText,
+  initialFiles,
   onSave,
   onCancel,
 }: {
   initialText: string;
-  onSave: (text: string) => void;
+  initialFiles: FileUIPart[];
+  onSave: (text: string, files: FileUIPart[]) => void;
   onCancel: () => void;
 }) {
   const { colors, fonts, radii } = useTheme();
   const [draft, setDraft] = useState(initialText);
+  const [files, setFiles] = useState(initialFiles);
   const inputRef = useRef<TextInput>(null);
 
   useEffect(() => {
@@ -20,7 +25,15 @@ export function EditBubble({
     return () => cancelAnimationFrame(id);
   }, []);
 
-  const dirty = draft.trim().length > 0 && draft !== initialText;
+  const nextText = draft.trim();
+  const dirty =
+    nextText !== initialText.trim() || files.length !== initialFiles.length;
+  const canSend = dirty && (nextText.length > 0 || files.length > 0);
+
+  function send() {
+    if (!canSend) return;
+    onSave(nextText, files);
+  }
 
   return (
     <View style={styles.row}>
@@ -28,20 +41,35 @@ export function EditBubble({
         style={[
           styles.bubble,
           {
-            backgroundColor: colors.secondary,
+            backgroundColor: colors.card,
+            borderColor: colors.border,
             borderRadius: radii.xxl,
           },
         ]}
       >
+        {files.length > 0 ? (
+          <View style={styles.attachments}>
+            {files.map((file, i) => (
+              <AttachmentChip
+                key={`${file.url}-${i}`}
+                attachment={file}
+                onRemove={() =>
+                  setFiles((prev) => prev.filter((_, j) => j !== i))
+                }
+              />
+            ))}
+          </View>
+        ) : null}
         <TextInput
           ref={inputRef}
           value={draft}
           onChangeText={setDraft}
           multiline
+          accessibilityLabel="Edit message"
           textAlignVertical="top"
           style={[
             styles.input,
-            { color: colors.secondaryForeground, fontFamily: fonts.sansRegular },
+            { color: colors.cardForeground, fontFamily: fonts.sansRegular },
           ]}
         />
         <View style={styles.actions}>
@@ -56,8 +84,8 @@ export function EditBubble({
             </Text>
           </Pressable>
           <Pressable
-            onPress={() => onSave(draft.trim())}
-            disabled={!dirty}
+            onPress={send}
+            disabled={!canSend}
             hitSlop={6}
             style={[
               styles.btn,
@@ -65,7 +93,7 @@ export function EditBubble({
               {
                 backgroundColor: colors.primary,
                 borderRadius: radii.pill,
-                opacity: dirty ? 1 : 0.5,
+                opacity: canSend ? 1 : 0.5,
               },
             ]}
           >
@@ -75,7 +103,7 @@ export function EditBubble({
                 { color: colors.primaryForeground, fontFamily: fonts.sansSemiBold },
               ]}
             >
-              Save
+              Send
             </Text>
           </Pressable>
         </View>
@@ -87,15 +115,24 @@ export function EditBubble({
 const styles = StyleSheet.create({
   row: { alignItems: "flex-end" },
   bubble: {
-    maxWidth: "85%",
-    minWidth: 220,
+    maxWidth: "92%",
+    minWidth: 260,
+    borderWidth: StyleSheet.hairlineWidth,
     paddingHorizontal: 14,
     paddingVertical: 10,
+  },
+  attachments: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "flex-end",
+    gap: 6,
+    marginBottom: 10,
   },
   input: {
     fontSize: 15,
     lineHeight: 22,
-    minHeight: 22,
+    minHeight: 80,
+    maxHeight: 240,
   },
   actions: {
     flexDirection: "row",

--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -32,7 +32,7 @@ export function MessageBubble({
   speech: ReturnType<typeof useSpeech>;
   onStartEdit: (id: string) => void;
   onCancelEdit: () => void;
-  onSaveEdit: (id: string, text: string) => void;
+  onSaveEdit: (id: string, text: string, files: FileUIPart[]) => void;
   onRegenerate: (id: string) => void;
 }) {
   const { colors, radii, fonts } = useTheme();
@@ -62,7 +62,11 @@ export function MessageBubble({
     );
     if (!text && fileParts.length === 0 && !editing) return null;
 
-    const actions: MessageAction[] = streaming ? [] : ["copy", "edit"];
+    const actions: MessageAction[] = streaming
+      ? []
+      : text
+        ? ["copy", "edit"]
+        : ["edit"];
 
     function onMenuSelect(action: MessageAction) {
       if (action === "copy") copyText(text);
@@ -80,7 +84,11 @@ export function MessageBubble({
         {fileParts.length > 0 && !editing ? (
           <View style={styles.attachmentsRow}>
             {fileParts.map((part, i) => (
-              <AttachmentChip key={`${part.url}-${i}`} attachment={part} />
+              <AttachmentChip
+                key={`${part.url}-${i}`}
+                attachment={part}
+                onLongPress={openUserMenu}
+              />
             ))}
           </View>
         ) : null}
@@ -88,8 +96,9 @@ export function MessageBubble({
           {editing ? (
             <EditBubble
               initialText={text}
+              initialFiles={fileParts}
               onCancel={onCancelEdit}
-              onSave={(next) => onSaveEdit(message.id, next)}
+              onSave={(next, files) => onSaveEdit(message.id, next, files)}
             />
           ) : text ? (
             <Pressable

--- a/apps/mobile/src/components/chat/MessageList.tsx
+++ b/apps/mobile/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import type { ChatStatus, UIMessage } from "ai";
+import type { ChatStatus, FileUIPart, UIMessage } from "ai";
 import { useEffect, useRef } from "react";
 import {
   RefreshControl,
@@ -35,7 +35,7 @@ export function MessageList({
   onRefresh?: () => void;
   onStartEdit: (id: string) => void;
   onCancelEdit: () => void;
-  onSaveEdit: (id: string, text: string) => void;
+  onSaveEdit: (id: string, text: string, files: FileUIPart[]) => void;
   onRegenerate: (id: string) => void;
 }) {
   const { colors, fonts } = useTheme();
@@ -43,7 +43,7 @@ export function MessageList({
 
   useEffect(() => {
     scrollRef.current?.scrollToEnd({ animated: true });
-  }, [messages, status, editingId]);
+  }, [messages, status]);
 
   const lastIsUser = messages.at(-1)?.role === "user";
 


### PR DESCRIPTION
## Summary
- bring mobile message editing in line with the polished web behavior
- preserve and remove attachments while editing user messages
- allow attachment-only user messages to enter edit mode from the attachment chip
- stop edit mode from briefly auto-scrolling the chat to the bottom

## Why
The mobile edit flow had drifted from web: attachments could be lost during edits, file-only messages were awkward to edit, and toggling edit mode triggered an unexpected scroll jump. This keeps mobile behavior familiar while leaving the branch isolated for separate review after the web release.

## Validation
- `npm run lint --workspace apps/mobile`
- `git diff --check main...HEAD`