### PR TITLE
Polish settings consistency

### DIFF
--- a/apps/web/app/(app)/settings/SettingsNav.tsx
+++ b/apps/web/app/(app)/settings/SettingsNav.tsx
@@ -31,7 +31,10 @@ export function SettingsNav() {
   const items = isAdmin ? [...USER_ITEMS, ...ADMIN_ITEMS] : USER_ITEMS;
 
   return (
-    <nav className="-mx-1 flex gap-1 overflow-x-auto md:mx-0 md:flex-col md:gap-0 md:space-y-5 md:overflow-visible">
+    <nav
+      aria-label="Settings"
+      className="-mx-1 flex gap-1 overflow-x-auto md:mx-0 md:flex-col md:gap-0 md:space-y-5 md:overflow-visible"
+    >
       <Section
         label="User settings"
         items={USER_ITEMS}

--- a/apps/web/app/(app)/settings/_components/SettingsRows.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsRows.tsx
@@ -7,6 +7,7 @@ interface SettingsSectionProps {
   action?: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
+  contentClassName?: string;
 }
 
 export function SettingsSection({
@@ -15,9 +16,10 @@ export function SettingsSection({
   action,
   children,
   className,
+  contentClassName,
 }: SettingsSectionProps) {
   return (
-    <section className={cn("space-y-3", className)}>
+    <section className={cn("@container space-y-3", className)}>
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
@@ -30,9 +32,49 @@ export function SettingsSection({
         {action && <div className="shrink-0">{action}</div>}
       </div>
       {children ? (
-        <div className="divide-y divide-border/70 border-y">{children}</div>
+        <div className={cn("divide-y divide-border/70 border-y", contentClassName)}>
+          {children}
+        </div>
       ) : null}
     </section>
+  );
+}
+
+interface SettingsPageHeaderProps {
+  title: string;
+  description?: React.ReactNode;
+  leading?: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function SettingsPageHeader({
+  title,
+  description,
+  leading,
+  action,
+  className,
+}: SettingsPageHeaderProps) {
+  return (
+    <header
+      className={cn(
+        "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-2">
+        {leading && <div className="shrink-0">{leading}</div>}
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+          {description && (
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </header>
   );
 }
 
@@ -65,8 +107,8 @@ export function SettingsRow({
   return (
     <div
       className={cn(
-        "grid gap-3 py-4 lg:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] lg:gap-6",
-        align === "center" && "lg:items-center",
+        "grid gap-3 py-4 @2xl:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] @2xl:gap-6",
+        align === "center" && "@2xl:items-center",
         className,
       )}
     >
@@ -80,5 +122,55 @@ export function SettingsRow({
       </div>
       <div className="min-w-0">{children}</div>
     </div>
+  );
+}
+
+interface SettingsActionsProps {
+  children: React.ReactNode;
+  className?: string;
+  bordered?: boolean;
+}
+
+export function SettingsActions({
+  children,
+  className,
+  bordered = true,
+}: SettingsActionsProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-end gap-2",
+        bordered && "border-t pt-4",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface SettingsNoticeProps {
+  children: React.ReactNode;
+  tone?: "muted" | "success" | "error";
+  className?: string;
+}
+
+export function SettingsNotice({
+  children,
+  tone = "muted",
+  className,
+}: SettingsNoticeProps) {
+  return (
+    <p
+      className={cn(
+        "text-sm leading-5",
+        tone === "muted" && "text-muted-foreground",
+        tone === "success" && "text-ring",
+        tone === "error" && "text-destructive",
+        className,
+      )}
+    >
+      {children}
+    </p>
   );
 }

--- a/apps/web/app/(app)/settings/_components/SettingsRows.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsRows.tsx
@@ -80,10 +80,12 @@ export function SettingsPageHeader({
 
 interface SettingsRowProps {
   title: string;
-  description?: string;
+  description?: React.ReactNode;
   htmlFor?: string;
   children: React.ReactNode;
   align?: "start" | "center";
+  controlAlign?: "start" | "end" | "stretch";
+  controlClassName?: string;
   className?: string;
 }
 
@@ -93,6 +95,8 @@ export function SettingsRow({
   htmlFor,
   children,
   align = "start",
+  controlAlign = "stretch",
+  controlClassName,
   className,
 }: SettingsRowProps) {
   const titleClass = "text-sm font-medium leading-5 text-foreground";
@@ -120,7 +124,16 @@ export function SettingsRow({
           </p>
         )}
       </div>
-      <div className="min-w-0">{children}</div>
+      <div
+        className={cn(
+          "min-w-0",
+          controlAlign === "start" && "@2xl:flex @2xl:justify-start",
+          controlAlign === "end" && "@2xl:flex @2xl:justify-end",
+          controlClassName,
+        )}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/_components/SettingsRows.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsRows.tsx
@@ -20,7 +20,7 @@ export function SettingsSection({
 }: SettingsSectionProps) {
   return (
     <section className={cn("@container space-y-3", className)}>
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-3 @xl:flex-row @xl:items-start @xl:justify-between">
         <div className="min-w-0">
           <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
           {description && (
@@ -56,24 +56,21 @@ export function SettingsPageHeader({
   className,
 }: SettingsPageHeaderProps) {
   return (
-    <header
-      className={cn(
-        "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between",
-        className,
-      )}
-    >
-      <div className="flex min-w-0 items-start gap-2">
-        {leading && <div className="shrink-0">{leading}</div>}
-        <div className="min-w-0">
-          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
-          {description && (
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              {description}
-            </p>
-          )}
+    <header className={cn("@container", className)}>
+      <div className="flex flex-col gap-3 @xl:flex-row @xl:items-start @xl:justify-between">
+        <div className="flex min-w-0 items-start gap-2">
+          {leading && <div className="shrink-0">{leading}</div>}
+          <div className="min-w-0">
+            <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+            {description && (
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                {description}
+              </p>
+            )}
+          </div>
         </div>
+        {action && <div className="shrink-0">{action}</div>}
       </div>
-      {action && <div className="shrink-0">{action}</div>}
     </header>
   );
 }
@@ -152,7 +149,7 @@ export function SettingsActions({
   return (
     <div
       className={cn(
-        "flex items-center justify-end gap-2",
+        "flex flex-wrap items-center justify-end gap-2",
         bordered && "border-t pt-4",
         className,
       )}

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -114,7 +114,7 @@ export function AccountForm({
             <SettingsNotice tone="error">{profileError}</SettingsNotice>
           )}
 
-          <SettingsActions>
+          <SettingsActions bordered={false}>
             {profileStatus === "ok" && (
               <SettingsNotice tone="success" className="mr-auto">
                 Profile updated
@@ -193,7 +193,7 @@ export function AccountForm({
 
           {pwError && <SettingsNotice tone="error">{pwError}</SettingsNotice>}
 
-          <SettingsActions>
+          <SettingsActions bordered={false}>
             {pwStatus === "ok" && (
               <SettingsNotice tone="success" className="mr-auto">
                 Password updated

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -92,11 +92,13 @@ export function AccountForm({
               description="Use the name people should recognize on this server."
               htmlFor="name"
               align="center"
+              controlAlign="end"
             >
               <Input
                 id="name"
                 type="text"
                 autoComplete="name"
+                className="w-full @2xl:max-w-sm"
                 required
                 value={name}
                 onChange={(e) => {
@@ -148,18 +150,21 @@ export function AccountForm({
               title="Current password"
               htmlFor="current"
               align="center"
+              controlAlign="end"
             >
-              <PasswordInput
-                id="current"
-                autoComplete="current-password"
-                required
-                value={currentPassword}
-                onChange={(e) => {
-                  setCurrentPassword(e.target.value);
-                  setPwStatus("idle");
-                  setPwError("");
-                }}
-              />
+              <div className="w-full @2xl:max-w-sm">
+                <PasswordInput
+                  id="current"
+                  autoComplete="current-password"
+                  required
+                  value={currentPassword}
+                  onChange={(e) => {
+                    setCurrentPassword(e.target.value);
+                    setPwStatus("idle");
+                    setPwError("");
+                  }}
+                />
+              </div>
             </SettingsRow>
 
             <SettingsRow
@@ -167,19 +172,22 @@ export function AccountForm({
               description="Use at least 8 characters."
               htmlFor="new"
               align="center"
+              controlAlign="end"
             >
-              <PasswordInput
-                id="new"
-                autoComplete="new-password"
-                required
-                minLength={8}
-                value={newPassword}
-                onChange={(e) => {
-                  setNewPassword(e.target.value);
-                  setPwStatus("idle");
-                  setPwError("");
-                }}
-              />
+              <div className="w-full @2xl:max-w-sm">
+                <PasswordInput
+                  id="new"
+                  autoComplete="new-password"
+                  required
+                  minLength={8}
+                  value={newPassword}
+                  onChange={(e) => {
+                    setNewPassword(e.target.value);
+                    setPwStatus("idle");
+                    setPwError("");
+                  }}
+                />
+              </div>
             </SettingsRow>
           </SettingsSection>
 

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -3,9 +3,15 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { PasswordInput } from "@/components/ui/password-input";
 import { authClient } from "@/lib/auth/client";
+import {
+  SettingsActions,
+  SettingsNotice,
+  SettingsPageHeader,
+  SettingsRow,
+  SettingsSection,
+} from "../_components/SettingsRows";
 
 export function AccountForm({
   email,
@@ -31,7 +37,7 @@ export function AccountForm({
     e.preventDefault();
     const trimmed = name.trim();
     if (!trimmed) {
-      setProfileError("Name is required");
+      setProfileError("Name is required.");
       return;
     }
     setProfileStatus("submitting");
@@ -65,42 +71,53 @@ export function AccountForm({
   }
 
   return (
-    <div className="max-w-xl space-y-10">
-      <header>
-        <h1 className="text-xl font-semibold tracking-tight">
-          Account
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Signed in as <span className="text-foreground">{email}</span>.
-        </p>
-      </header>
+    <div className="max-w-3xl space-y-8">
+      <SettingsPageHeader
+        title="Account"
+        description={
+          <>
+            Signed in as <span className="text-foreground">{email}</span>.
+          </>
+        }
+      />
 
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-sm font-medium">Profile</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Shown in the sidebar and on chats.
-          </p>
-        </div>
-
+      <div className="space-y-10">
         <form onSubmit={saveProfile} className="space-y-4">
-          <div className="space-y-1.5">
-            <Label htmlFor="name">Name</Label>
-            <Input
-              id="name"
-              type="text"
-              autoComplete="name"
-              required
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
+          <SettingsSection
+            title="Profile"
+            description="Shown in the sidebar and around chats."
+          >
+            <SettingsRow
+              title="Name"
+              description="Use the name people should recognize on this server."
+              htmlFor="name"
+              align="center"
+            >
+              <Input
+                id="name"
+                type="text"
+                autoComplete="name"
+                required
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setProfileStatus("idle");
+                  setProfileError("");
+                }}
+              />
+            </SettingsRow>
+          </SettingsSection>
 
           {profileError && (
-            <p className="text-sm text-destructive">{profileError}</p>
+            <SettingsNotice tone="error">{profileError}</SettingsNotice>
           )}
 
-          <div className="flex items-center gap-3">
+          <SettingsActions>
+            {profileStatus === "ok" && (
+              <SettingsNotice tone="success" className="mr-auto">
+                Profile updated
+              </SettingsNotice>
+            )}
             <Button
               type="submit"
               disabled={
@@ -109,20 +126,8 @@ export function AccountForm({
             >
               {profileStatus === "submitting" ? "Saving…" : "Save"}
             </Button>
-            {profileStatus === "ok" && (
-              <span className="text-sm text-ring">Saved</span>
-            )}
-          </div>
+          </SettingsActions>
         </form>
-      </section>
-
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-sm font-medium">Change password</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Signs you out of all other sessions.
-          </p>
-        </div>
 
         <form onSubmit={changePassword} className="space-y-4">
           {/* Hidden username anchor so password managers associate this
@@ -135,40 +140,63 @@ export function AccountForm({
             readOnly
             hidden
           />
-          <div className="space-y-1.5">
-            <Label htmlFor="current">Current password</Label>
-            <PasswordInput
-              id="current"
-              autoComplete="current-password"
-              required
-              value={currentPassword}
-              onChange={(e) => setCurrentPassword(e.target.value)}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="new">New password</Label>
-            <PasswordInput
-              id="new"
-              autoComplete="new-password"
-              required
-              minLength={8}
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-            />
-          </div>
+          <SettingsSection
+            title="Password"
+            description="Changing your password signs you out of all other sessions."
+          >
+            <SettingsRow
+              title="Current password"
+              htmlFor="current"
+              align="center"
+            >
+              <PasswordInput
+                id="current"
+                autoComplete="current-password"
+                required
+                value={currentPassword}
+                onChange={(e) => {
+                  setCurrentPassword(e.target.value);
+                  setPwStatus("idle");
+                  setPwError("");
+                }}
+              />
+            </SettingsRow>
 
-          {pwError && <p className="text-sm text-destructive">{pwError}</p>}
+            <SettingsRow
+              title="New password"
+              description="Use at least 8 characters."
+              htmlFor="new"
+              align="center"
+            >
+              <PasswordInput
+                id="new"
+                autoComplete="new-password"
+                required
+                minLength={8}
+                value={newPassword}
+                onChange={(e) => {
+                  setNewPassword(e.target.value);
+                  setPwStatus("idle");
+                  setPwError("");
+                }}
+              />
+            </SettingsRow>
+          </SettingsSection>
 
-          <div className="flex items-center gap-3">
+          {pwError && <SettingsNotice tone="error">{pwError}</SettingsNotice>}
+
+          <SettingsActions>
+            {pwStatus === "ok" && (
+              <SettingsNotice tone="success" className="mr-auto">
+                Password updated
+              </SettingsNotice>
+            )}
             <Button type="submit" disabled={pwStatus === "submitting"}>
               {pwStatus === "submitting" ? "Saving…" : "Change password"}
             </Button>
-            {pwStatus === "ok" && (
-              <span className="text-sm text-ring">Password updated</span>
-            )}
-          </div>
+          </SettingsActions>
         </form>
-      </section>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -5,6 +5,12 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Download, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { chatKeys, projectKeys } from "@/lib/queries/keys";
+import {
+  SettingsNotice,
+  SettingsPageHeader,
+  SettingsRow,
+  SettingsSection,
+} from "../_components/SettingsRows";
 
 type ImportResult = {
   format: string;
@@ -58,78 +64,78 @@ export function DataForm() {
   }
 
   return (
-    <div className="max-w-xl space-y-10">
-      <header>
-        <h1 className="text-xl font-semibold tracking-tight">
-          Data
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Import chats from other platforms, or export your own.
-        </p>
-      </header>
+    <div className="max-w-3xl space-y-8">
+      <SettingsPageHeader
+        title="Data"
+        description="Import chats from other platforms, or export your own."
+      />
 
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-sm font-medium">Import chats</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Supports ChatGPT, Claude.ai, OpenWebUI, and overtchat exports.
-            Drop the downloaded JSON or ZIP; we&apos;ll detect the format.
-          </p>
-        </div>
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".json,.zip,application/json,application/zip"
+        hidden
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void handleFile(f);
+        }}
+      />
 
-        <input
-          ref={fileRef}
-          type="file"
-          accept=".json,.zip,application/json,application/zip"
-          hidden
-          onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) void handleFile(f);
-          }}
-        />
+      <SettingsSection
+        title="Import"
+        description="Supports ChatGPT, Claude.ai, OpenWebUI, and overtchat exports."
+      >
+        <SettingsRow
+          title="Import file"
+          description="Choose a downloaded JSON or ZIP file. The format is detected automatically."
+          align="center"
+        >
+          <div className="space-y-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={importing}
+              onClick={() => fileRef.current?.click()}
+            >
+              <Upload data-icon="inline-start" />
+              {importing ? "Importing…" : "Choose file"}
+            </Button>
 
-        <div className="flex items-center gap-3">
-          <Button
-            type="button"
-            variant="outline"
-            disabled={importing}
-            onClick={() => fileRef.current?.click()}
-          >
-            <Upload data-icon="inline-start" />
-            {importing ? "Importing…" : "Choose file"}
+            {importResult && (
+              <SettingsNotice tone="success">
+                Imported {importResult.importedChats} chat
+                {importResult.importedChats === 1 ? "" : "s"} from{" "}
+                {FORMAT_LABELS[importResult.format] ?? importResult.format}.
+              </SettingsNotice>
+            )}
+
+            {importError && (
+              <SettingsNotice tone="error">{importError}</SettingsNotice>
+            )}
+
+            <SettingsNotice tone="muted" className="text-xs">
+              Imports preserve visible conversation text and reasoning.
+              Attachments, images, and branches are not preserved.
+            </SettingsNotice>
+          </div>
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Export"
+        description="Download every conversation as a single overtchat JSON file."
+      >
+        <SettingsRow
+          title="Export file"
+          description="Use this file for backup or a lossless re-import."
+          align="center"
+        >
+          <Button type="button" variant="outline" render={<a href="/api/export" />}>
+            <Download data-icon="inline-start" />
+            Download export
           </Button>
-          {importResult && (
-            <span className="text-sm text-ring">
-              Imported {importResult.importedChats} chat
-              {importResult.importedChats === 1 ? "" : "s"} from{" "}
-              {FORMAT_LABELS[importResult.format] ?? importResult.format}.
-            </span>
-          )}
-        </div>
-
-        {importError && (
-          <p className="text-sm text-destructive">{importError}</p>
-        )}
-
-        <p className="text-xs text-muted-foreground">
-          Attachments, images, and branches aren&apos;t preserved — only text
-          and reasoning from the visible conversation.
-        </p>
-      </section>
-
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-sm font-medium">Export all chats</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Downloads every conversation as a single JSON file. Lossless
-            round-trip — re-import with the &ldquo;Choose file&rdquo; button above.
-          </p>
-        </div>
-        <Button type="button" variant="outline" render={<a href="/api/export" />}>
-          <Download data-icon="inline-start" />
-          Download export
-        </Button>
-      </section>
+        </SettingsRow>
+      </SettingsSection>
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -87,10 +87,11 @@ export function DataForm() {
       >
         <SettingsRow
           title="Import file"
-          description="Choose a downloaded JSON or ZIP file. The format is detected automatically."
+          description="Choose a downloaded JSON or ZIP file. Imports preserve visible conversation text and reasoning, but not attachments, images, or branches."
           align="center"
+          controlAlign="end"
         >
-          <div className="space-y-2">
+          <div className="flex flex-col gap-2 @2xl:items-end @2xl:text-right">
             <Button
               type="button"
               variant="outline"
@@ -112,11 +113,6 @@ export function DataForm() {
             {importError && (
               <SettingsNotice tone="error">{importError}</SettingsNotice>
             )}
-
-            <SettingsNotice tone="muted" className="text-xs">
-              Imports preserve visible conversation text and reasoning.
-              Attachments, images, and branches are not preserved.
-            </SettingsNotice>
           </div>
         </SettingsRow>
       </SettingsSection>
@@ -129,6 +125,7 @@ export function DataForm() {
           title="Export file"
           description="Use this file for backup or a lossless re-import."
           align="center"
+          controlAlign="end"
         >
           <Button type="button" variant="outline" render={<a href="/api/export" />}>
             <Download data-icon="inline-start" />

--- a/apps/web/app/(app)/settings/general/GeneralForm.tsx
+++ b/apps/web/app/(app)/settings/general/GeneralForm.tsx
@@ -15,6 +15,11 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import {
+  SettingsPageHeader,
+  SettingsRow,
+  SettingsSection,
+} from "../_components/SettingsRows";
+import {
   DEFAULT_FONT_ID,
   FONT_OPTIONS,
   FONT_STORAGE_KEY,
@@ -23,7 +28,7 @@ import {
 
 type ThemeValue = "light" | "dark" | "system";
 
-const STATS_FOR_NERDS_STORAGE_KEY = "overtchat_stats_for_nerds";
+const MESSAGE_STATS_STORAGE_KEY = "overtchat_stats_for_nerds";
 
 const OPTIONS: Array<{ value: ThemeValue; label: string; icon: typeof Sun }> = [
   { value: "light", label: "Light", icon: Sun },
@@ -39,8 +44,8 @@ export function GeneralForm() {
   const { theme, setTheme } = useTheme();
   const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const current = (mounted ? theme : undefined) as ThemeValue | undefined;
-  const [statsForNerds, setStatsForNerds] = useLocalStorage<boolean>(
-    STATS_FOR_NERDS_STORAGE_KEY,
+  const [messageStatsEnabled, setMessageStatsEnabled] = useLocalStorage<boolean>(
+    MESSAGE_STATS_STORAGE_KEY,
     false,
   );
   const [fontId, setFontId] = useLocalStorage<FontId>(FONT_STORAGE_KEY, DEFAULT_FONT_ID);
@@ -56,90 +61,82 @@ export function GeneralForm() {
   }
 
   return (
-    <div className="max-w-xl space-y-8">
-      <header>
-        <h1 className="text-xl font-semibold tracking-tight">General</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Personal preferences for this browser.
-        </p>
-      </header>
+    <div className="max-w-3xl space-y-8">
+      <SettingsPageHeader
+        title="General"
+        description="Personal preferences for this browser."
+      />
 
-      <section className="space-y-3">
-        <div>
-          <h2 className="text-sm font-medium">Appearance</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Choose how overtchat looks to you.
-          </p>
-        </div>
-        <RadioGroup
-          aria-label="Theme"
-          value={current}
-          onValueChange={(next) => setTheme(next as ThemeValue)}
-          className="grid grid-cols-3 gap-2"
+      <SettingsSection
+        title="Appearance"
+        description="Choose how overtchat looks and reads."
+      >
+        <SettingsRow
+          title="Theme"
+          description="Use a fixed theme or follow the system setting."
+          align="center"
         >
-          {OPTIONS.map(({ value, label, icon: Icon }) => (
-            <Label
-              key={value}
-              className="flex cursor-pointer flex-col items-center gap-2 rounded-lg border bg-card px-3 py-4 text-sm font-normal transition-colors outline-none has-data-[checked]:border-ring has-data-[checked]:ring-1 has-data-[checked]:ring-ring has-focus-visible:border-ring has-focus-visible:ring-3 has-focus-visible:ring-ring/50 not-has-data-[checked]:hover:bg-accent/50"
-            >
-              <RadioGroupItem value={value} className="sr-only" />
-              <Icon className="size-4 text-muted-foreground" />
-              <span>{label}</span>
-            </Label>
-          ))}
-        </RadioGroup>
-      </section>
-
-      <section className="space-y-3">
-        <div>
-          <h2 className="text-sm font-medium">Font</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Choose the font used in the app.
-          </p>
-        </div>
-        <Select value={currentFont} onValueChange={(next) => selectFont(next as FontId)}>
-          <SelectTrigger aria-label="Font" className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {FONT_OPTIONS.map(({ id, label, cssValue }) => (
-              <SelectItem
-                key={id}
-                value={id}
-                style={{ fontFamily: cssValue ?? "var(--font-plus-jakarta-sans)" }}
+          <RadioGroup
+            aria-label="Theme"
+            value={current}
+            onValueChange={(next) => setTheme(next as ThemeValue)}
+            className="grid grid-cols-3 gap-1 rounded-lg border bg-muted/30 p-1"
+          >
+            {OPTIONS.map(({ value, label, icon: Icon }) => (
+              <Label
+                key={value}
+                className="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-md px-2 text-sm font-medium text-muted-foreground transition-colors outline-none has-data-[checked]:bg-background has-data-[checked]:text-foreground has-data-[checked]:shadow-xs has-focus-visible:ring-3 has-focus-visible:ring-ring/50 not-has-data-[checked]:hover:text-foreground"
               >
-                {label}
-              </SelectItem>
+                <RadioGroupItem value={value} className="sr-only" />
+                <Icon className="size-3.5" />
+                <span>{label}</span>
+              </Label>
             ))}
-          </SelectContent>
-        </Select>
-      </section>
+          </RadioGroup>
+        </SettingsRow>
 
-      <section className="space-y-3">
-        <div>
-          <h2 className="text-sm font-medium">Messages</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Browser-only message display preferences.
-          </p>
-        </div>
-        <Label
-          htmlFor="stats-for-nerds"
-          className="flex cursor-pointer items-start justify-between gap-3 rounded-lg border bg-card px-3 py-3 text-sm font-normal"
+        <SettingsRow
+          title="Chat font"
+          description="Choose the font used throughout the app."
+          align="center"
         >
-          <span>
-            <span className="block font-medium">Stats for nerds</span>
-            <span className="mt-0.5 block text-xs text-muted-foreground">
-              Show token and speed stats on assistant messages.
-            </span>
-          </span>
+          <Select value={currentFont} onValueChange={(next) => selectFont(next as FontId)}>
+            <SelectTrigger aria-label="Chat font" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FONT_OPTIONS.map(({ id, label, cssValue }) => (
+                <SelectItem
+                  key={id}
+                  value={id}
+                  style={{ fontFamily: cssValue ?? "var(--font-plus-jakarta-sans)" }}
+                >
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Messages"
+        description="Browser-only message display preferences."
+      >
+        <SettingsRow
+          title="Message stats"
+          description="Show token counts and speed stats on assistant messages."
+          htmlFor="message-stats"
+          align="center"
+        >
           <Switch
-            id="stats-for-nerds"
-            checked={statsForNerds}
-            onCheckedChange={(next) => setStatsForNerds(next)}
-            className="mt-0.5"
+            id="message-stats"
+            checked={messageStatsEnabled}
+            onCheckedChange={(next) => setMessageStatsEnabled(next)}
+            aria-label="Show message stats"
           />
-        </Label>
-      </section>
+        </SettingsRow>
+      </SettingsSection>
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/general/GeneralForm.tsx
+++ b/apps/web/app/(app)/settings/general/GeneralForm.tsx
@@ -75,12 +75,13 @@ export function GeneralForm() {
           title="Theme"
           description="Use a fixed theme or follow the system setting."
           align="center"
+          controlAlign="end"
         >
           <RadioGroup
             aria-label="Theme"
             value={current}
             onValueChange={(next) => setTheme(next as ThemeValue)}
-            className="grid grid-cols-3 gap-1 rounded-lg border bg-muted/30 p-1"
+            className="grid w-full grid-cols-3 gap-1 rounded-lg border bg-muted/30 p-1 @2xl:max-w-xs"
           >
             {OPTIONS.map(({ value, label, icon: Icon }) => (
               <Label
@@ -99,9 +100,10 @@ export function GeneralForm() {
           title="Chat font"
           description="Choose the font used throughout the app."
           align="center"
+          controlAlign="end"
         >
           <Select value={currentFont} onValueChange={(next) => selectFont(next as FontId)}>
-            <SelectTrigger aria-label="Chat font" className="w-full">
+            <SelectTrigger aria-label="Chat font" className="w-full @2xl:w-64">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -128,6 +130,7 @@ export function GeneralForm() {
           description="Show token counts and speed stats on assistant messages."
           htmlFor="message-stats"
           align="center"
+          controlAlign="end"
         >
           <Switch
             id="message-stats"

--- a/apps/web/app/(app)/settings/layout.tsx
+++ b/apps/web/app/(app)/settings/layout.tsx
@@ -28,7 +28,9 @@ export default function SettingsLayout({
         <aside className="shrink-0 overflow-y-auto border-b p-3 md:w-56 md:border-r md:border-b-0">
           <SettingsNav />
         </aside>
-        <div className="flex-1 overflow-y-auto p-4 md:p-8">{children}</div>
+        <div className="min-w-0 flex-1 overflow-y-auto p-4 md:p-8">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -196,7 +196,7 @@ export function ConnectionFields({
         htmlFor="p-model"
       >
         <div className="space-y-2">
-          <div className="flex flex-col gap-2 lg:flex-row">
+          <div className="flex flex-col gap-2 @lg:flex-row">
             {showList ? (
               <Select
                 value={draft.model}
@@ -237,7 +237,7 @@ export function ConnectionFields({
               size="sm"
               disabled={!canProbe || probing}
               onClick={() => void probe(draft.baseUrl, draft.apiKey)}
-              className="lg:w-auto"
+              className="@lg:w-auto"
             >
               {probing ? <Loader2 className="animate-spin" /> : <RefreshCw />}
               {models.length > 0 ? "Refresh" : "Fetch"}

--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -228,7 +228,7 @@ export function ConnectionFields({
             ) : (
               <Input
                 id="p-model"
-                className="min-w-0 flex-1 font-mono text-xs md:text-xs"
+                className="min-w-0 flex-1 font-mono text-xs"
                 placeholder={presetMeta.modelPlaceholder}
                 required
                 value={draft.model}

--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -124,6 +124,7 @@ export function ConnectionFields({
         description="Sets endpoint defaults and picker grouping."
         htmlFor="p-preset"
         align="center"
+        controlAlign="end"
       >
         <Select
           value={preset}
@@ -133,7 +134,7 @@ export function ConnectionFields({
             clearProbeState();
           }}
         >
-          <SelectTrigger id="p-preset" className="w-full">
+          <SelectTrigger id="p-preset" className="w-full @2xl:max-w-xl">
             <ModelBrandIcon iconId={presetIconId} />
             <SelectValue />
           </SelectTrigger>
@@ -153,9 +154,11 @@ export function ConnectionFields({
         description="Base URL for the model API."
         htmlFor="p-base-url"
         align="center"
+        controlAlign="end"
       >
         <Input
           id="p-base-url"
+          className="w-full @2xl:max-w-xl"
           placeholder="https://api.openai.com/v1"
           required
           autoFocus={preset === "custom"}
@@ -176,26 +179,30 @@ export function ConnectionFields({
         }
         htmlFor="p-api-key"
         align="center"
+        controlAlign="end"
       >
-        <PasswordInput
-          id="p-api-key"
-          autoComplete="new-password"
-          placeholder={requiresKey ? "Required" : "Optional"}
-          required={requiresKey}
-          value={draft.apiKey}
-          onChange={(e) => {
-            onChange({ apiKey: e.target.value });
-            clearProbeState();
-          }}
-        />
+        <div className="w-full @2xl:max-w-xl">
+          <PasswordInput
+            id="p-api-key"
+            autoComplete="new-password"
+            placeholder={requiresKey ? "Required" : "Optional"}
+            required={requiresKey}
+            value={draft.apiKey}
+            onChange={(e) => {
+              onChange({ apiKey: e.target.value });
+              clearProbeState();
+            }}
+          />
+        </div>
       </SettingsRow>
 
       <SettingsRow
         title="Model"
         description="Choose a fetched model or enter an id."
         htmlFor="p-model"
+        controlAlign="end"
       >
-        <div className="space-y-2">
+        <div className="w-full space-y-2 @2xl:max-w-xl">
           <div className="flex flex-col gap-2 @lg:flex-row">
             {showList ? (
               <Select

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -193,6 +193,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
           <SettingsRow
             title="Test connection"
             description="Send a short request with the current connection settings."
+            controlAlign="end"
           >
             <ConnectionTester
               key={`${draft.baseUrl}|${draft.apiKey}|${draft.model}|${extraBodyText}`}
@@ -211,9 +212,11 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
             description="Shown in the chat model picker."
             htmlFor="p-label"
             align="center"
+            controlAlign="end"
           >
             <Input
               id="p-label"
+              className="w-full @2xl:max-w-xl"
               placeholder={
                 draft.model ? defaultLabelFor(draft.model) : "Shown in the picker"
               }
@@ -228,6 +231,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
             title="Available in chat"
             description="Turn off to keep the config without showing it in the picker."
             align="center"
+            controlAlign="end"
           >
             <Switch
               checked={draft.enabled}

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -21,7 +21,12 @@ import { PRESETS, presetFor, type PresetId } from "@/lib/providers/meta";
 import { AdvancedFields } from "./AdvancedFields";
 import { ConnectionFields } from "./ConnectionFields";
 import { ConnectionTester } from "./ConnectionTester";
-import { SettingsRow, SettingsSection } from "../_components/SettingsRows";
+import {
+  SettingsActions,
+  SettingsPageHeader,
+  SettingsRow,
+  SettingsSection,
+} from "../_components/SettingsRows";
 
 export interface ModelEditorProps {
   /** When provided, editor loads the existing config from cache; otherwise a new one is being created. */
@@ -144,24 +149,21 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
 
   return (
     <div className="max-w-4xl">
-      <div className="mb-6 flex items-center gap-2">
-        <Button
-          render={<Link href="/settings/models" />}
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Back to models"
-        >
-          <ArrowLeft />
-        </Button>
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">
-            {isEditing ? "Edit model" : "Add model"}
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Configure a model that everyone on this server can use.
-          </p>
-        </div>
-      </div>
+      <SettingsPageHeader
+        className="mb-6"
+        title={isEditing ? "Edit model" : "Add model"}
+        description="Configure a model that everyone on this server can use."
+        leading={
+          <Button
+            render={<Link href="/settings/models" />}
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Back to models"
+          >
+            <ArrowLeft />
+          </Button>
+        }
+      />
 
       <form onSubmit={submit} className="space-y-8">
         <SettingsSection
@@ -257,7 +259,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
           </div>
         )}
 
-        <div className="flex items-center justify-end gap-2 border-t pt-4">
+        <SettingsActions>
           <Button
             type="button"
             variant="ghost"
@@ -269,7 +271,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
           <Button type="submit" size="sm" disabled={!canSave}>
             {saving ? "Saving…" : isEditing ? "Save" : "Create"}
           </Button>
-        </div>
+        </SettingsActions>
       </form>
     </div>
   );

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -164,7 +164,7 @@ export function ModelsPanel() {
               <div
                 key={m.id}
                 className={cn(
-                  "grid gap-3 py-3 @3xl:grid-cols-[minmax(0,1fr)_auto] @3xl:items-center",
+                  "grid gap-3 py-3 @xl:grid-cols-[minmax(0,1fr)_auto] @xl:items-center",
                   !m.enabled && "opacity-65",
                 )}
               >
@@ -192,9 +192,9 @@ export function ModelsPanel() {
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center gap-3 justify-self-start @3xl:justify-self-end">
-                  <div className="flex min-w-16 items-center justify-end gap-2">
-                    <span className="hidden text-xs text-muted-foreground sm:inline">
+                <div className="flex flex-wrap items-center gap-2 justify-self-end @xl:flex-nowrap">
+                  <div className="flex items-center justify-end gap-2 @2xl:min-w-16">
+                    <span className="hidden text-xs text-muted-foreground @2xl:inline">
                       {m.enabled ? "On" : "Off"}
                     </span>
                     <Switch

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -19,6 +19,10 @@ import {
   useUpdateModelConfig,
 } from "@/lib/queries/modelConfigs";
 import { cn } from "@/lib/utils";
+import {
+  SettingsNotice,
+  SettingsPageHeader,
+} from "../_components/SettingsRows";
 import { HealthBadge } from "./HealthBadge";
 
 export function ModelsPanel() {
@@ -27,7 +31,8 @@ export function ModelsPanel() {
   const updateMut = useUpdateModelConfig();
 
   const [query, setQuery] = useState("");
-  const [pendingDelete, setPendingDelete] = useState<AdminModelConfig | null>(null);
+  const [pendingDelete, setPendingDelete] =
+    useState<AdminModelConfig | null>(null);
   const [deleteError, setDeleteError] = useState("");
   const [actionError, setActionError] = useState("");
   const [togglingId, setTogglingId] = useState<string | null>(null);
@@ -70,7 +75,9 @@ export function ModelsPanel() {
         },
       });
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : "Failed to update model");
+      setActionError(
+        err instanceof Error ? err.message : "Failed to update model",
+      );
     } finally {
       setTogglingId(null);
     }
@@ -90,27 +97,21 @@ export function ModelsPanel() {
   }
 
   return (
-    <div className="max-w-4xl space-y-6">
-      <header className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">Models</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Configure the model endpoints available in chat.
-          </p>
-        </div>
-        {models.length > 0 && (
-          <Button
-            render={<Link href="/settings/models/new" />}
-            size="sm"
-            className="self-start lg:self-auto"
-          >
-            <Plus /> Add model
-          </Button>
-        )}
-      </header>
+    <div className="@container max-w-4xl space-y-6">
+      <SettingsPageHeader
+        title="Models"
+        description="Configure the model endpoints available in chat."
+        action={
+          models.length > 0 ? (
+            <Button render={<Link href="/settings/models/new" />} size="sm">
+              <Plus /> Add model
+            </Button>
+          ) : undefined
+        }
+      />
 
       {models.length > 0 && (
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-3 @2xl:flex-row @2xl:items-center @2xl:justify-between">
           <div className="relative max-w-md flex-1">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -128,9 +129,12 @@ export function ModelsPanel() {
       )}
 
       {actionError && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+        <SettingsNotice
+          tone="error"
+          className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2"
+        >
           {actionError}
-        </div>
+        </SettingsNotice>
       )}
 
       {models.length === 0 ? (
@@ -151,7 +155,7 @@ export function ModelsPanel() {
           </p>
         </div>
       ) : (
-        <div className="divide-y divide-border/70 border-y">
+        <div className="@container divide-y divide-border/70 border-y">
           {filteredModels.map((m) => {
             const provider = providerIdentityForBaseUrl(m.baseUrl);
             const host = hostnameOf(m.baseUrl);
@@ -160,7 +164,7 @@ export function ModelsPanel() {
               <div
                 key={m.id}
                 className={cn(
-                  "grid gap-3 py-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center",
+                  "grid gap-3 py-3 @3xl:grid-cols-[minmax(0,1fr)_auto] @3xl:items-center",
                   !m.enabled && "opacity-65",
                 )}
               >
@@ -188,7 +192,7 @@ export function ModelsPanel() {
                   </div>
                 </div>
 
-                <div className="flex items-center gap-3 justify-self-start lg:justify-self-end">
+                <div className="flex flex-wrap items-center gap-3 justify-self-start @3xl:justify-self-end">
                   <div className="flex min-w-16 items-center justify-end gap-2">
                     <span className="hidden text-xs text-muted-foreground sm:inline">
                       {m.enabled ? "On" : "Off"}
@@ -201,20 +205,21 @@ export function ModelsPanel() {
                     />
                   </div>
                   <div className="h-6 w-px bg-border" aria-hidden="true" />
-                  <div className="flex items-center gap-0.5 rounded-lg border bg-background/80 p-0.5">
+                  <div className="flex items-center gap-1.5">
                     <Button
                       render={<Link href={`/settings/models/${m.id}`} />}
-                      variant="ghost"
-                      size="icon-sm"
+                      variant="outline"
+                      size="sm"
                       aria-label={`Edit ${m.label}`}
                       title={`Edit ${m.label}`}
                     >
-                      <Pencil />
+                      <Pencil data-icon="inline-start" />
+                      Edit
                     </Button>
                     <Button
                       type="button"
                       variant="ghost"
-                      size="icon-sm"
+                      size="sm"
                       onClick={() => {
                         setDeleteError("");
                         setPendingDelete(m);
@@ -223,7 +228,8 @@ export function ModelsPanel() {
                       title={`Delete ${m.label}`}
                       className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                     >
-                      <Trash2 />
+                      <Trash2 data-icon="inline-start" />
+                      Delete
                     </Button>
                   </div>
                 </div>
@@ -256,7 +262,9 @@ export function ModelsPanel() {
               their messages.
             </AlertDialog.Description>
             {deleteError && (
-              <p className="mt-3 text-xs text-destructive">{deleteError}</p>
+              <SettingsNotice tone="error" className="mt-3 text-xs">
+                {deleteError}
+              </SettingsNotice>
             )}
             <div className="mt-5 flex justify-end gap-2">
               <Button

--- a/apps/web/app/(app)/settings/users/AddUserDialog.tsx
+++ b/apps/web/app/(app)/settings/users/AddUserDialog.tsx
@@ -13,6 +13,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { authClient } from "@/lib/auth/client";
+import {
+  SettingsActions,
+  SettingsNotice,
+} from "../_components/SettingsRows";
 
 type Role = "user" | "admin";
 
@@ -71,7 +75,7 @@ export function AddUserDialog({
     >
       <Dialog.Portal>
         <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity" />
-        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity">
+        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
           <Dialog.Title className="text-lg font-semibold tracking-tight">
             Add user
           </Dialog.Title>
@@ -87,7 +91,10 @@ export function AddUserDialog({
                 type="text"
                 required
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setError("");
+                }}
               />
             </div>
             <div className="space-y-1.5">
@@ -97,7 +104,10 @@ export function AddUserDialog({
                 type="email"
                 required
                 value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setError("");
+                }}
               />
             </div>
             <div className="space-y-1.5">
@@ -108,25 +118,34 @@ export function AddUserDialog({
                 required
                 minLength={8}
                 value={password}
-                onChange={(e) => setPassword(e.target.value)}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setError("");
+                }}
               />
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="new-role">Role</Label>
-              <Select value={role} onValueChange={(next) => setRole(next as Role)}>
+              <Select
+                value={role}
+                onValueChange={(next) => {
+                  setRole(next as Role);
+                  setError("");
+                }}
+              >
                 <SelectTrigger id="new-role" aria-label="Role" className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="user">user</SelectItem>
-                  <SelectItem value="admin">admin</SelectItem>
+                  <SelectItem value="user">User</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && <SettingsNotice tone="error">{error}</SettingsNotice>}
 
-            <div className="flex items-center justify-end gap-2 pt-2">
+            <SettingsActions bordered={false} className="pt-2">
               <Button
                 type="button"
                 variant="ghost"
@@ -138,7 +157,7 @@ export function AddUserDialog({
               <Button type="submit" size="sm" disabled={submitting}>
                 {submitting ? "Creating…" : "Create"}
               </Button>
-            </div>
+            </SettingsActions>
           </form>
         </Dialog.Popup>
       </Dialog.Portal>

--- a/apps/web/app/(app)/settings/users/UsersPanel.tsx
+++ b/apps/web/app/(app)/settings/users/UsersPanel.tsx
@@ -1,73 +1,102 @@
 "use client";
 
 import { useState } from "react";
+import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth/client";
 import { useInvalidateUsers, useUsers } from "@/lib/queries/users";
+import type { UserRow } from "@/lib/queries/users";
+import {
+  SettingsNotice,
+  SettingsPageHeader,
+  SettingsSection,
+} from "../_components/SettingsRows";
 import { AddUserDialog } from "./AddUserDialog";
 
 export function UsersPanel({ currentUserId }: { currentUserId: string }) {
   const { data: users = [] } = useUsers();
   const invalidateUsers = useInvalidateUsers();
   const [addOpen, setAddOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<UserRow | null>(null);
+  const [deleteError, setDeleteError] = useState("");
+  const [deleting, setDeleting] = useState(false);
 
-  async function removeUser(id: string) {
-    if (id === currentUserId) return;
-    if (!confirm("Delete this user? This cannot be undone.")) return;
-    const { error } = await authClient.admin.removeUser({ userId: id });
+  async function confirmDelete() {
+    if (!pendingDelete || pendingDelete.id === currentUserId) return;
+    setDeleting(true);
+    setDeleteError("");
+    const { error } = await authClient.admin.removeUser({
+      userId: pendingDelete.id,
+    });
     if (error) {
-      alert(error.message ?? "Failed to delete user");
+      setDeleteError(error.message ?? "Failed to delete user.");
+      setDeleting(false);
       return;
     }
     invalidateUsers();
+    setPendingDelete(null);
+    setDeleting(false);
   }
 
   return (
-    <div className="max-w-3xl space-y-6">
-      <header className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">Users</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Manage who can sign in.
-          </p>
-        </div>
-        <Button size="sm" onClick={() => setAddOpen(true)}>
-          <Plus /> Add user
-        </Button>
-      </header>
+    <div className="max-w-4xl space-y-6">
+      <SettingsPageHeader
+        title="Users"
+        description="Manage who can sign in to this server."
+        action={
+          <Button size="sm" onClick={() => setAddOpen(true)}>
+            <Plus /> Add user
+          </Button>
+        }
+      />
 
-      <div className="overflow-hidden rounded-lg border">
-        <table className="w-full text-sm">
-          <thead className="border-b bg-muted/40 text-xs text-muted-foreground uppercase tracking-wide">
+      <SettingsSection
+        title="People"
+        description={`${users.length} user${users.length === 1 ? "" : "s"} configured.`}
+        contentClassName="overflow-x-auto divide-y-0"
+      >
+        <table className="w-full min-w-[42rem] text-sm">
+          <thead className="border-b bg-muted/30 text-xs text-muted-foreground uppercase tracking-wide">
             <tr>
-              <th className="px-3 py-2 text-left font-medium">Name</th>
-              <th className="px-3 py-2 text-left font-medium">Email</th>
-              <th className="px-3 py-2 text-left font-medium">Role</th>
-              <th className="px-3 py-2 text-left font-medium">Created</th>
-              <th className="w-10 px-3 py-2"></th>
+              <th className="px-3 py-2.5 text-left font-medium">Name</th>
+              <th className="px-3 py-2.5 text-left font-medium">Email</th>
+              <th className="px-3 py-2.5 text-left font-medium">Role</th>
+              <th className="px-3 py-2.5 text-left font-medium">Created</th>
+              <th className="px-3 py-2.5 text-right font-medium">Actions</th>
             </tr>
           </thead>
           <tbody>
             {users.map((u) => (
               <tr key={u.id} className="border-b last:border-0">
-                <td className="px-3 py-2">{u.name}</td>
-                <td className="px-3 py-2">{u.email}</td>
-                <td className="px-3 py-2 text-muted-foreground">
-                  {u.role ?? "user"}
+                <td className="px-3 py-3 font-medium text-foreground">
+                  {u.name}
                 </td>
-                <td className="px-3 py-2 text-muted-foreground">
+                <td className="px-3 py-3 text-muted-foreground">{u.email}</td>
+                <td className="px-3 py-3 text-muted-foreground">
+                  {formatRole(u.role)}
+                </td>
+                <td className="px-3 py-3 text-muted-foreground">
                   {new Date(u.createdAt).toLocaleDateString()}
                 </td>
-                <td className="px-3 py-2 text-right">
-                  {u.id !== currentUserId && (
+                <td className="px-3 py-3 text-right">
+                  {u.id === currentUserId ? (
+                    <span className="text-xs text-muted-foreground">
+                      Current user
+                    </span>
+                  ) : (
                     <Button
+                      type="button"
                       variant="ghost"
-                      size="icon-sm"
-                      onClick={() => removeUser(u.id)}
-                      aria-label={`Delete ${u.email}`}
+                      size="sm"
+                      onClick={() => {
+                        setDeleteError("");
+                        setPendingDelete(u);
+                      }}
+                      className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                     >
-                      <Trash2 />
+                      <Trash2 data-icon="inline-start" />
+                      Delete
                     </Button>
                   )}
                 </td>
@@ -75,13 +104,66 @@ export function UsersPanel({ currentUserId }: { currentUserId: string }) {
             ))}
           </tbody>
         </table>
-      </div>
+      </SettingsSection>
 
       <AddUserDialog
         open={addOpen}
         onOpenChange={setAddOpen}
         onCreated={invalidateUsers}
       />
+
+      <AlertDialog.Root
+        open={pendingDelete !== null}
+        onOpenChange={(next) => {
+          if (!next && !deleting) {
+            setPendingDelete(null);
+            setDeleteError("");
+          }
+        }}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
+            <AlertDialog.Title className="text-base font-semibold tracking-tight">
+              Delete user?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {pendingDelete?.email}
+              </span>{" "}
+              will no longer be able to sign in. Existing chats and projects are
+              not deleted.
+            </AlertDialog.Description>
+            {deleteError && (
+              <SettingsNotice tone="error" className="mt-3 text-xs">
+                {deleteError}
+              </SettingsNotice>
+            )}
+            <div className="mt-5 flex justify-end gap-2">
+              <AlertDialog.Close
+                render={
+                  <Button variant="ghost" size="sm" disabled={deleting} />
+                }
+              >
+                Cancel
+              </AlertDialog.Close>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={deleting}
+                onClick={confirmDelete}
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </Button>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
     </div>
   );
+}
+
+function formatRole(role: string | null | undefined): string {
+  if (role === "admin") return "Admin";
+  return "User";
 }

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -29,7 +29,7 @@ import { MessageList } from "./MessageList";
 import { MiniSpeechPlayer } from "./MiniSpeechPlayer";
 
 const SEARCH_STORAGE_KEY = "overtchat_search_enabled";
-const STATS_FOR_NERDS_STORAGE_KEY = "overtchat_stats_for_nerds";
+const MESSAGE_STATS_STORAGE_KEY = "overtchat_stats_for_nerds";
 
 interface Props {
   chatId: string;
@@ -60,8 +60,8 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
     SEARCH_STORAGE_KEY,
     false,
   );
-  const [statsForNerds] = useLocalStorage<boolean>(
-    STATS_FOR_NERDS_STORAGE_KEY,
+  const [messageStatsEnabled] = useLocalStorage<boolean>(
+    MESSAGE_STATS_STORAGE_KEY,
     false,
   );
 
@@ -299,7 +299,7 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
             error={error}
             configured={configured}
             speech={speech}
-            showStats={statsForNerds}
+            showStats={messageStatsEnabled}
             storedStats={storedStats}
             onRegenerate={handleRegenerate}
             onEdit={handleEdit}

--- a/apps/web/components/chat/StatsPopover.tsx
+++ b/apps/web/components/chat/StatsPopover.tsx
@@ -58,8 +58,8 @@ export function StatsPopover({ stats }: { stats: MessageStats }) {
     <Popover.Root>
       <Popover.Trigger
         type="button"
-        aria-label="Stats for nerds"
-        title="Stats for nerds"
+        aria-label="Message stats"
+        title="Message stats"
         className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground max-md:p-2.5"
       >
         <Info className="size-3.5" />

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.9.5}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.9.7}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add shared settings page header, action, notice, and container-aware row primitives.
- Apply the refreshed settings structure across General, Account, Data, Models, and Users.
- Replace Users native delete confirmation with a consistent destructive dialog.
- Align model list actions, settings navigation, responsive pane behavior, and message stats terminology.
- Bump the default app image in compose to `0.9.7` for this release.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`
