### PR TITLE
Balance settings row layout

### DIFF
--- a/apps/web/app/(app)/settings/_components/SettingsRows.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsRows.tsx
@@ -108,7 +108,7 @@ export function SettingsRow({
   return (
     <div
       className={cn(
-        "grid gap-3 py-4 @2xl:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] @2xl:gap-6",
+        "grid gap-3 py-4 @2xl:grid-cols-[minmax(0,18rem)_minmax(0,1fr)] @2xl:gap-6",
         align === "center" && "@2xl:items-center",
         className,
       )}

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.9.7}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.9.8}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- widen the shared settings row label column so helper copy wraps less awkwardly
- bump the default app image tag in compose.yml to 0.9.8

## Validation
- npm run lint
- npm run test
- npm run build