### PR TITLE
Harden web e2e smoke test

### DIFF
--- a/apps/web/app/api/chat/[id]/stream/route.ts
+++ b/apps/web/app/api/chat/[id]/stream/route.ts
@@ -24,7 +24,20 @@ export async function GET(
   const streamId = await getActiveStreamId(id);
   if (!streamId) return withCors(req, new Response(null, { status: 204 }));
 
-  const replay = await getStreamContext().resumeExistingStream(streamId);
+  const streamContext = getStreamContext();
+  if (!streamContext) {
+    await setActiveStreamId(id, null);
+    return withCors(req, new Response(null, { status: 204 }));
+  }
+
+  let replay: Awaited<ReturnType<typeof streamContext.resumeExistingStream>>;
+  try {
+    replay = await streamContext.resumeExistingStream(streamId);
+  } catch (err) {
+    console.warn("[resumable-stream] failed to resume stream", err);
+    await setActiveStreamId(id, null);
+    return withCors(req, new Response(null, { status: 204 }));
+  }
   if (!replay) {
     await setActiveStreamId(id, null);
     return withCors(req, new Response(null, { status: 204 }));

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -190,8 +190,15 @@ export async function POST(req: Request) {
     consumeSseStream: temporary
       ? undefined
       : async ({ stream }) => {
-          await getStreamContext().createNewResumableStream(streamId, () => stream);
-          await setActiveStreamId(chatId, streamId);
+          const streamContext = getStreamContext();
+          if (!streamContext) return;
+
+          try {
+            await streamContext.createNewResumableStream(streamId, () => stream);
+            await setActiveStreamId(chatId, streamId);
+          } catch (err) {
+            console.warn("[resumable-stream] failed to buffer stream", err);
+          }
         },
     messageMetadata: ({ part }) => {
       if (part.type !== "finish") return undefined;

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,4 +1,31 @@
 import { test, expect } from "@playwright/test";
+import Database from "better-sqlite3";
+import path from "node:path";
+
+const TEST_DB_PATH = path.resolve(__dirname, "../data/test.db");
+
+function resetE2eDatabase() {
+  const db = new Database(TEST_DB_PATH);
+  db.pragma("foreign_keys = ON");
+  db.pragma("busy_timeout = 5000");
+  db.transaction(() => {
+    db.prepare("DELETE FROM messages").run();
+    db.prepare("DELETE FROM messages_fts").run();
+    db.prepare("DELETE FROM chats").run();
+    db.prepare("DELETE FROM projects").run();
+    db.prepare("DELETE FROM uploads").run();
+    db.prepare("DELETE FROM account").run();
+    db.prepare("DELETE FROM session").run();
+    db.prepare("DELETE FROM verification").run();
+    db.prepare("DELETE FROM user").run();
+    db.prepare("DELETE FROM model_configs").run();
+  })();
+  db.close();
+}
+
+test.beforeEach(() => {
+  resetE2eDatabase();
+});
 
 test("signup, configure Gemini, stream a response", async ({ page }) => {
   if (!process.env.GEMINI_API_KEY) {

--- a/apps/web/lib/streams/context.ts
+++ b/apps/web/lib/streams/context.ts
@@ -6,8 +6,19 @@ import {
 } from "resumable-stream";
 
 let cached: ResumableStreamContext | null = null;
+let didWarnMissingRedis = false;
 
-export function getStreamContext(): ResumableStreamContext {
+export function getStreamContext(): ResumableStreamContext | null {
+  if (!process.env.REDIS_URL?.trim()) {
+    if (!didWarnMissingRedis) {
+      didWarnMissingRedis = true;
+      console.warn(
+        "[resumable-stream] REDIS_URL is not set; stream resumption is disabled.",
+      );
+    }
+    return null;
+  }
+
   if (!cached) {
     cached = createResumableStreamContext({ waitUntil: after });
   }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -5,6 +5,9 @@ import path from "node:path";
 dotenv.config({ path: path.resolve(__dirname, ".env.local") });
 
 const isCI = !!process.env.CI;
+const port = process.env.E2E_PORT ?? "4717";
+const baseURL = `http://localhost:${port}`;
+const redisUrl = process.env.REDIS_URL?.trim();
 
 export default defineConfig({
   testDir: "./e2e",
@@ -14,7 +17,7 @@ export default defineConfig({
   workers: 1,
   reporter: "line",
   use: {
-    baseURL: "http://localhost:4717",
+    baseURL,
     trace: "retain-on-failure",
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
@@ -24,15 +27,16 @@ export default defineConfig({
     command: isCI
       ? "mkdir -p .next/standalone/apps/web/.next && cp -r .next/static .next/standalone/apps/web/.next/static && node .next/standalone/apps/web/server.js"
       : "npm run build && mkdir -p .next/standalone/apps/web/.next && cp -r .next/static .next/standalone/apps/web/.next/static && node .next/standalone/apps/web/server.js",
-    url: "http://localhost:4717",
+    url: baseURL,
     reuseExistingServer: !isCI,
     timeout: 180 * 1000,
     env: {
-      PORT: "4717",
+      PORT: port,
       DATABASE_URL: path.resolve(__dirname, "data/test.db"),
       MIGRATIONS_FOLDER: path.resolve(__dirname, "drizzle"),
       BETTER_AUTH_SECRET: "testsecret1234567890123456789012",
-      BETTER_AUTH_URL: "http://localhost:4717",
+      BETTER_AUTH_URL: baseURL,
+      ...(redisUrl ? { REDIS_URL: redisUrl } : {}),
     },
   },
 });


### PR DESCRIPTION
## Summary
- make resumable stream storage optional when REDIS_URL is absent so normal chat streaming keeps working
- handle resumable stream buffer/resume failures as a disabled-resume fallback instead of an unhandled rejection
- reset the E2E SQLite database before each smoke-test attempt so retries start from a first-user state
- let Playwright run the standalone server on E2E_PORT for local validation without colliding with dev servers

## Why
The main-branch E2E failure was caused by the standalone smoke server missing REDIS_URL. Previous passing runs had logged the same error but recovered quickly enough to pass.

## Validation
- npm run lint
- npm run test
- npm run build
- CI=true E2E_PORT=4727 REDIS_URL= npm run test:e2e -w apps/web --