### PR TITLE
Wrap long user messages

### DIFF
--- a/apps/web/components/chat/MessageBubble.tsx
+++ b/apps/web/components/chat/MessageBubble.tsx
@@ -101,7 +101,7 @@ export function MessageBubble({
           </div>
         )}
         {text && (
-          <div className="max-w-[80%] rounded-2xl bg-secondary px-4 py-2.5 text-sm whitespace-pre-wrap text-secondary-foreground">
+          <div className="min-w-0 max-w-[80%] rounded-2xl bg-secondary px-4 py-2.5 text-sm whitespace-pre-wrap wrap-anywhere text-secondary-foreground">
             {text}
           </div>
         )}


### PR DESCRIPTION
## Summary

- Allow user message bubbles to wrap long unbroken text such as URLs.
- Add the flex sizing constraint needed for bubbles to respect the chat column width.

## Root Cause

Long tokens in pre-wrapped user message text did not have an internal break opportunity, and the flex item kept a content-based minimum width.

## Validation

- `npm run lint --workspace apps/web`