### PR TITLE
refactor(mobile): polish settings and model picker

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -287,7 +287,6 @@ function ChatSurface({
       headerTitle: () => (
         <Pressable
           onPress={() => pickerRef.current?.present()}
-          disabled={modelsPending}
           style={styles.headerTitle}
         >
           {modelsPending ? (
@@ -519,6 +518,8 @@ function ChatSurface({
         ref={pickerRef}
         models={models ?? []}
         selectedId={selectedId}
+        loading={modelsPending}
+        error={modelsError}
         onSelect={setSelectedId}
       />
 

--- a/apps/mobile/src/app/(authed)/settings.tsx
+++ b/apps/mobile/src/app/(authed)/settings.tsx
@@ -74,12 +74,19 @@ export default function SettingsScreen() {
         edges={["bottom", "left", "right"]}
       >
         <ScrollView contentContainerStyle={styles.content}>
-          <Section title="Account">
+          <Section title="Account" description="Signed in on this device.">
             <Row label="Name" right={user?.name ?? "—"} />
             <Row label="Email" right={user?.email ?? "—"} />
           </Section>
 
-          <Section title="Appearance">
+          <Section
+            title="Appearance"
+            description="Choose how overtchat looks and reads."
+          >
+            <GroupHeader
+              label="Theme"
+              sub="Use a fixed theme or follow the system setting."
+            />
             {(
               [
                 { key: "system", label: "System" },
@@ -87,98 +94,44 @@ export default function SettingsScreen() {
                 { key: "dark", label: "Dark" },
               ] as { key: ThemePref; label: string }[]
             ).map((opt) => (
-              <Pressable
+              <RadioRow
                 key={opt.key}
+                label={opt.label}
+                selected={themePref === opt.key}
                 onPress={() => setThemePref(opt.key)}
-                style={({ pressed }) => [
-                  styles.row,
-                  { opacity: pressed ? 0.7 : 1 },
-                ]}
-              >
-                <Text
-                  style={[
-                    styles.rowLabel,
-                    { color: colors.foreground, fontFamily: fonts.sansRegular },
-                  ]}
-                >
-                  {opt.label}
-                </Text>
-                <View
-                  style={[
-                    styles.radio,
-                    {
-                      borderColor:
-                        themePref === opt.key ? colors.primary : colors.border,
-                    },
-                  ]}
-                >
-                  {themePref === opt.key ? (
-                    <View
-                      style={[
-                        styles.radioDot,
-                        { backgroundColor: colors.primary },
-                      ]}
-                    />
-                  ) : null}
-                </View>
-              </Pressable>
+              />
             ))}
-          </Section>
 
-          <Section title="Font">
+            <Divider />
+            <GroupHeader
+              label="Chat font"
+              sub="Choose the font used throughout the app."
+            />
             {FONT_OPTIONS.map((opt) => (
-              <Pressable
+              <RadioRow
                 key={opt.id}
+                label={opt.label}
+                selected={fontPref === opt.id}
+                labelFont={FONT_SANS[opt.id].sansRegular}
                 onPress={() => setFontPref(opt.id)}
-                style={({ pressed }) => [
-                  styles.row,
-                  { opacity: pressed ? 0.7 : 1 },
-                ]}
-              >
-                <Text
-                  style={[
-                    styles.rowLabel,
-                    {
-                      color: colors.foreground,
-                      fontFamily: FONT_SANS[opt.id].sansRegular,
-                    },
-                  ]}
-                >
-                  {opt.label}
-                </Text>
-                <View
-                  style={[
-                    styles.radio,
-                    {
-                      borderColor:
-                        fontPref === opt.id ? colors.primary : colors.border,
-                    },
-                  ]}
-                >
-                  {fontPref === opt.id ? (
-                    <View
-                      style={[
-                        styles.radioDot,
-                        { backgroundColor: colors.primary },
-                      ]}
-                    />
-                  ) : null}
-                </View>
-              </Pressable>
+              />
             ))}
           </Section>
 
-          <Section title="Manage on web">
+          <Section
+            title="Manage on web"
+            description="Open server settings in your browser."
+          >
             <LinkRow
               label="Account"
-              sub="Name, email, password, sessions"
+              sub="Name, email, password, and sessions."
               onPress={() => openOnWeb("/settings/account")}
               colors={colors}
               fonts={fonts}
             />
             <LinkRow
               label="Data"
-              sub="Export, delete chats"
+              sub="Export data and delete chats."
               onPress={() => openOnWeb("/settings/data")}
               colors={colors}
               fonts={fonts}
@@ -187,14 +140,14 @@ export default function SettingsScreen() {
               <>
                 <LinkRow
                   label="Models"
-                  sub="Provider config and access"
+                  sub="Provider config and model access."
                   onPress={() => openOnWeb("/settings/models")}
                   colors={colors}
                   fonts={fonts}
                 />
                 <LinkRow
                   label="Users"
-                  sub="Invite and manage members"
+                  sub="Invite and manage members."
                   onPress={() => openOnWeb("/settings/users")}
                   colors={colors}
                   fonts={fonts}
@@ -212,7 +165,7 @@ export default function SettingsScreen() {
                     },
                   ]}
                 >
-                  Opens {serverHost} in your browser
+                  Opens {serverHost} in your browser.
                 </Text>
               </View>
             ) : null}
@@ -246,18 +199,38 @@ export default function SettingsScreen() {
   );
 }
 
-function Section({ title, children }: { title: string; children: ReactNode }) {
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
   const { colors, radii, fonts } = useTheme();
   return (
     <View style={styles.section}>
-      <Text
-        style={[
-          styles.sectionTitle,
-          { color: colors.mutedForeground, fontFamily: fonts.sansMedium },
-        ]}
-      >
-        {title.toUpperCase()}
-      </Text>
+      <View style={styles.sectionHeader}>
+        <Text
+          style={[
+            styles.sectionTitle,
+            { color: colors.foreground, fontFamily: fonts.sansSemiBold },
+          ]}
+        >
+          {title}
+        </Text>
+        {description ? (
+          <Text
+            style={[
+              styles.sectionDescription,
+              { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
+            ]}
+          >
+            {description}
+          </Text>
+        ) : null}
+      </View>
       <View
         style={[
           styles.sectionBody,
@@ -272,6 +245,83 @@ function Section({ title, children }: { title: string; children: ReactNode }) {
       </View>
     </View>
   );
+}
+
+function GroupHeader({ label, sub }: { label: string; sub: string }) {
+  const { colors, fonts } = useTheme();
+  return (
+    <View style={[styles.row, styles.groupHeaderRow]}>
+      <View style={styles.rowText}>
+        <Text
+          style={[
+            styles.rowLabel,
+            { color: colors.foreground, fontFamily: fonts.sansMedium },
+          ]}
+        >
+          {label}
+        </Text>
+        <Text
+          style={[
+            styles.rowSub,
+            { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
+          ]}
+        >
+          {sub}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function RadioRow({
+  label,
+  selected,
+  labelFont,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  labelFont?: string;
+  onPress: () => void;
+}) {
+  const { colors, fonts } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected }}
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, { opacity: pressed ? 0.7 : 1 }]}
+    >
+      <Text
+        style={[
+          styles.rowLabel,
+          {
+            color: colors.foreground,
+            fontFamily: labelFont ?? fonts.sansRegular,
+          },
+        ]}
+      >
+        {label}
+      </Text>
+      <View
+        style={[
+          styles.radio,
+          {
+            borderColor: selected ? colors.primary : colors.border,
+          },
+        ]}
+      >
+        {selected ? (
+          <View style={[styles.radioDot, { backgroundColor: colors.primary }]} />
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+function Divider() {
+  const { colors } = useTheme();
+  return <View style={[styles.divider, { backgroundColor: colors.border }]} />;
 }
 
 function LinkRow({
@@ -378,11 +428,14 @@ function Row({
 const styles = StyleSheet.create({
   root: { flex: 1 },
   content: { paddingHorizontal: 16, paddingVertical: 16, gap: 24, paddingBottom: 32 },
-  section: { gap: 8 },
+  section: { gap: 10 },
+  sectionHeader: { gap: 2, paddingHorizontal: 4 },
   sectionTitle: {
-    fontSize: 11,
-    letterSpacing: 0.8,
-    paddingHorizontal: 4,
+    fontSize: 15,
+  },
+  sectionDescription: {
+    fontSize: 12,
+    lineHeight: 18,
   },
   sectionBody: { borderWidth: StyleSheet.hairlineWidth, overflow: "hidden" },
   row: {
@@ -392,10 +445,12 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     gap: 12,
   },
+  groupHeaderRow: { paddingBottom: 6 },
   rowText: { flex: 1, gap: 2 },
   rowLabel: { fontSize: 15 },
-  rowSub: { fontSize: 12 },
+  rowSub: { fontSize: 12, lineHeight: 17 },
   rowRight: { fontSize: 14, maxWidth: "55%" },
+  divider: { height: StyleSheet.hairlineWidth },
   radio: {
     width: 20,
     height: 20,

--- a/apps/mobile/src/components/chat/ModelPickerSheet.tsx
+++ b/apps/mobile/src/components/chat/ModelPickerSheet.tsx
@@ -5,7 +5,6 @@ import {
   BottomSheetModal,
   BottomSheetScrollView,
   BottomSheetTextInput,
-  BottomSheetView,
 } from "@gorhom/bottom-sheet";
 import type { PublicModelConfig } from "@overtchat/shared";
 import { forwardRef, useCallback, useMemo, useState } from "react";
@@ -41,7 +40,7 @@ export const ModelPickerSheet = forwardRef<
   const insets = useSafeAreaInsets();
   const { height } = useWindowDimensions();
   const [search, setSearch] = useState("");
-  const sheetMaxHeight = Math.min(560, Math.round(height * 0.72));
+  const sheetMaxHeight = Math.min(640, Math.round(height * 0.86));
   const showSearch = !loading && !error && models.length > SEARCH_THRESHOLD;
   const searchTerm = search.trim();
 
@@ -52,8 +51,6 @@ export const ModelPickerSheet = forwardRef<
       [m.label, m.model, m.displayProvider].join(" ").toLowerCase().includes(q),
     );
   }, [models, searchTerm]);
-
-  const groups = useMemo(() => groupModels(filteredModels), [filteredModels]);
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -71,6 +68,7 @@ export const ModelPickerSheet = forwardRef<
     <BottomSheetModal
       ref={ref}
       enableDynamicSizing
+      maxDynamicContentSize={sheetMaxHeight}
       backdropComponent={renderBackdrop}
       onDismiss={() => setSearch("")}
       backgroundStyle={{
@@ -80,7 +78,14 @@ export const ModelPickerSheet = forwardRef<
       }}
       handleIndicatorStyle={{ backgroundColor: colors.mutedForeground }}
     >
-      <BottomSheetView style={styles.body}>
+      <BottomSheetScrollView
+        contentContainerStyle={[
+          styles.body,
+          { paddingBottom: 20 + insets.bottom },
+        ]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={models.length > SEARCH_THRESHOLD}
+      >
         <Text
           style={[
             styles.title,
@@ -132,67 +137,44 @@ export const ModelPickerSheet = forwardRef<
           </View>
         ) : null}
 
-        <BottomSheetScrollView
-          style={[styles.scroller, { maxHeight: sheetMaxHeight }]}
-          contentContainerStyle={[
-            styles.scrollerContent,
-            { paddingBottom: 16 + insets.bottom },
-          ]}
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={models.length > SEARCH_THRESHOLD}
-        >
-          {loading ? (
-            <StatusState
-              title="Loading models…"
-              icon={<ActivityIndicator color={colors.mutedForeground} />}
-            />
-          ) : error ? (
-            <StatusState
-              title="Couldn't load models."
-              message={error.message}
-              tone="error"
-            />
-          ) : models.length === 0 ? (
-            <StatusState
-              title="No models configured."
-              message="An admin needs to add one in Settings → Models."
-            />
-          ) : groups.length === 0 ? (
-            <StatusState
-              title={`No models match "${searchTerm}".`}
-              message="Try a model, provider, or deployment name."
-            />
-          ) : (
-            groups.map(([provider, items]) => (
-              <View key={provider} style={styles.group}>
-                <Text
-                  style={[
-                    styles.groupLabel,
-                    {
-                      color: colors.mutedForeground,
-                      fontFamily: fonts.sansMedium,
-                    },
-                  ]}
-                >
-                  {provider}
-                </Text>
-                {items.map((model) => (
-                  <ModelRow
-                    key={model.id}
-                    model={model}
-                    selected={model.id === selectedId}
-                    onPress={() => {
-                      onSelect(model.id);
-                      setSearch("");
-                      (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
-                    }}
-                  />
-                ))}
-              </View>
-            ))
-          )}
-        </BottomSheetScrollView>
-      </BottomSheetView>
+        {loading ? (
+          <StatusState
+            title="Loading models…"
+            icon={<ActivityIndicator color={colors.mutedForeground} />}
+          />
+        ) : error ? (
+          <StatusState
+            title="Couldn't load models."
+            message={error.message}
+            tone="error"
+          />
+        ) : models.length === 0 ? (
+          <StatusState
+            title="No models configured."
+            message="An admin needs to add one in Settings → Models."
+          />
+        ) : filteredModels.length === 0 ? (
+          <StatusState
+            title={`No models match "${searchTerm}".`}
+            message="Try a model, provider, or deployment name."
+          />
+        ) : (
+          <View style={styles.list}>
+            {filteredModels.map((model) => (
+              <ModelRow
+                key={model.id}
+                model={model}
+                selected={model.id === selectedId}
+                onPress={() => {
+                  onSelect(model.id);
+                  setSearch("");
+                  (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
+                }}
+              />
+            ))}
+          </View>
+        )}
+      </BottomSheetScrollView>
     </BottomSheetModal>
   );
 });
@@ -207,10 +189,6 @@ function ModelRow({
   onPress: () => void;
 }) {
   const { colors, radii, fonts } = useTheme();
-  const subtitle =
-    model.label === model.model
-      ? model.displayProvider
-      : `${model.displayProvider} / ${model.model}`;
 
   return (
     <Pressable
@@ -226,11 +204,6 @@ function ModelRow({
         },
       ]}
     >
-      <Ionicons
-        name="checkmark"
-        size={18}
-        color={selected ? colors.primary : "transparent"}
-      />
       <View style={styles.rowText}>
         <Text
           numberOfLines={1}
@@ -245,20 +218,15 @@ function ModelRow({
         >
           {model.label}
         </Text>
-        <Text
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          style={[
-            styles.sub,
-            {
-              color: colors.mutedForeground,
-              fontFamily: fonts.sansRegular,
-            },
-          ]}
-        >
-          {subtitle}
-        </Text>
       </View>
+      {selected ? (
+        <Ionicons
+          name="checkmark"
+          size={18}
+          color={colors.primary}
+          style={styles.rowCheck}
+        />
+      ) : null}
     </Pressable>
   );
 }
@@ -301,20 +269,8 @@ function StatusState({
   );
 }
 
-function groupModels(
-  models: PublicModelConfig[],
-): Array<[string, PublicModelConfig[]]> {
-  const groups = new Map<string, PublicModelConfig[]>();
-  for (const model of models) {
-    const items = groups.get(model.displayProvider) ?? [];
-    items.push(model);
-    groups.set(model.displayProvider, items);
-  }
-  return [...groups.entries()];
-}
-
 const styles = StyleSheet.create({
-  body: { paddingHorizontal: 12, paddingTop: 4 },
+  body: { paddingHorizontal: 12, paddingTop: 4, gap: 8 },
   title: { fontSize: 18, paddingHorizontal: 8, paddingBottom: 8 },
   searchBox: {
     minHeight: 42,
@@ -327,27 +283,18 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   searchInput: { flex: 1, fontSize: 15, paddingVertical: 8 },
-  scroller: { flexGrow: 0 },
-  scrollerContent: { gap: 8 },
-  group: { gap: 2 },
-  groupLabel: {
-    fontSize: 11,
-    letterSpacing: 0.7,
-    textTransform: "uppercase",
-    paddingHorizontal: 12,
-    paddingTop: 6,
-    paddingBottom: 3,
-  },
+  list: { gap: 2 },
   row: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
+    gap: 12,
+    minHeight: 48,
     paddingHorizontal: 12,
-    paddingVertical: 11,
+    paddingVertical: 12,
   },
-  rowText: { flex: 1, minWidth: 0, gap: 2 },
+  rowText: { flex: 1, minWidth: 0 },
   label: { fontSize: 15 },
-  sub: { fontSize: 12, lineHeight: 17 },
+  rowCheck: { marginLeft: "auto" },
   status: {
     alignItems: "center",
     justifyContent: "center",

--- a/apps/mobile/src/components/chat/ModelPickerSheet.tsx
+++ b/apps/mobile/src/components/chat/ModelPickerSheet.tsx
@@ -1,27 +1,59 @@
+import { Ionicons } from "@expo/vector-icons";
 import {
   BottomSheetBackdrop,
   type BottomSheetBackdropProps,
   BottomSheetModal,
+  BottomSheetScrollView,
+  BottomSheetTextInput,
   BottomSheetView,
 } from "@gorhom/bottom-sheet";
 import type { PublicModelConfig } from "@overtchat/shared";
-import { forwardRef, useCallback } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { forwardRef, useCallback, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@/lib/theme";
 
 export type ModelPickerSheetRef = BottomSheetModal;
+
+const SEARCH_THRESHOLD = 7;
 
 export const ModelPickerSheet = forwardRef<
   ModelPickerSheetRef,
   {
     models: PublicModelConfig[];
     selectedId: string | null;
+    loading?: boolean;
+    error?: Error | null;
     onSelect: (id: string) => void;
   }
->(function ModelPickerSheet({ models, selectedId, onSelect }, ref) {
+>(function ModelPickerSheet(
+  { models, selectedId, loading = false, error = null, onSelect },
+  ref,
+) {
   const { colors, radii, fonts } = useTheme();
   const insets = useSafeAreaInsets();
+  const { height } = useWindowDimensions();
+  const [search, setSearch] = useState("");
+  const sheetMaxHeight = Math.min(560, Math.round(height * 0.72));
+  const showSearch = !loading && !error && models.length > SEARCH_THRESHOLD;
+  const searchTerm = search.trim();
+
+  const filteredModels = useMemo(() => {
+    if (!searchTerm) return models;
+    const q = searchTerm.toLowerCase();
+    return models.filter((m) =>
+      [m.label, m.model, m.displayProvider].join(" ").toLowerCase().includes(q),
+    );
+  }, [models, searchTerm]);
+
+  const groups = useMemo(() => groupModels(filteredModels), [filteredModels]);
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -40,6 +72,7 @@ export const ModelPickerSheet = forwardRef<
       ref={ref}
       enableDynamicSizing
       backdropComponent={renderBackdrop}
+      onDismiss={() => setSearch("")}
       backgroundStyle={{
         backgroundColor: colors.popover,
         borderTopLeftRadius: radii.xl,
@@ -47,7 +80,7 @@ export const ModelPickerSheet = forwardRef<
       }}
       handleIndicatorStyle={{ backgroundColor: colors.mutedForeground }}
     >
-      <BottomSheetView style={[styles.body, { paddingBottom: 16 + insets.bottom }]}>
+      <BottomSheetView style={styles.body}>
         <Text
           style={[
             styles.title,
@@ -56,76 +89,272 @@ export const ModelPickerSheet = forwardRef<
         >
           Models
         </Text>
-        {models.length === 0 ? (
-          <Text
+
+        {showSearch ? (
+          <View
             style={[
-              styles.empty,
-              { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
+              styles.searchBox,
+              {
+                backgroundColor: colors.muted,
+                borderColor: colors.border,
+                borderRadius: radii.md,
+              },
             ]}
           >
-            No models configured. An admin needs to add one in Settings → Models.
-          </Text>
-        ) : (
-          <View style={styles.list}>
-            {models.map((m) => {
-              const selected = m.id === selectedId;
-              return (
-                <Pressable
-                  key={m.id}
-                  onPress={() => {
-                    onSelect(m.id);
-                    (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
-                  }}
-                  style={({ pressed }) => [
-                    styles.row,
+            <Ionicons name="search-outline" size={17} color={colors.mutedForeground} />
+            <BottomSheetTextInput
+              value={search}
+              onChangeText={setSearch}
+              placeholder="Search models"
+              placeholderTextColor={colors.mutedForeground}
+              autoCapitalize="none"
+              autoCorrect={false}
+              returnKeyType="search"
+              style={[
+                styles.searchInput,
+                { color: colors.foreground, fontFamily: fonts.sansRegular },
+              ]}
+            />
+            {search.length > 0 ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Clear model search"
+                hitSlop={8}
+                onPress={() => setSearch("")}
+              >
+                <Ionicons
+                  name="close-circle"
+                  size={18}
+                  color={colors.mutedForeground}
+                />
+              </Pressable>
+            ) : null}
+          </View>
+        ) : null}
+
+        <BottomSheetScrollView
+          style={[styles.scroller, { maxHeight: sheetMaxHeight }]}
+          contentContainerStyle={[
+            styles.scrollerContent,
+            { paddingBottom: 16 + insets.bottom },
+          ]}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={models.length > SEARCH_THRESHOLD}
+        >
+          {loading ? (
+            <StatusState
+              title="Loading models…"
+              icon={<ActivityIndicator color={colors.mutedForeground} />}
+            />
+          ) : error ? (
+            <StatusState
+              title="Couldn't load models."
+              message={error.message}
+              tone="error"
+            />
+          ) : models.length === 0 ? (
+            <StatusState
+              title="No models configured."
+              message="An admin needs to add one in Settings → Models."
+            />
+          ) : groups.length === 0 ? (
+            <StatusState
+              title={`No models match "${searchTerm}".`}
+              message="Try a model, provider, or deployment name."
+            />
+          ) : (
+            groups.map(([provider, items]) => (
+              <View key={provider} style={styles.group}>
+                <Text
+                  style={[
+                    styles.groupLabel,
                     {
-                      backgroundColor: selected ? colors.accent : "transparent",
-                      borderRadius: radii.md,
-                      opacity: pressed ? 0.85 : 1,
+                      color: colors.mutedForeground,
+                      fontFamily: fonts.sansMedium,
                     },
                   ]}
                 >
-                  <View style={styles.rowText}>
-                    <Text
-                      style={[
-                        styles.label,
-                        {
-                          color: colors.popoverForeground,
-                          fontFamily: fonts.sansSemiBold,
-                        },
-                      ]}
-                    >
-                      {m.label}
-                    </Text>
-                    <Text
-                      style={[
-                        styles.sub,
-                        {
-                          color: colors.mutedForeground,
-                          fontFamily: fonts.sansRegular,
-                        },
-                      ]}
-                    >
-                      {m.displayProvider} · {m.model}
-                    </Text>
-                  </View>
-                </Pressable>
-              );
-            })}
-          </View>
-        )}
+                  {provider}
+                </Text>
+                {items.map((model) => (
+                  <ModelRow
+                    key={model.id}
+                    model={model}
+                    selected={model.id === selectedId}
+                    onPress={() => {
+                      onSelect(model.id);
+                      setSearch("");
+                      (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
+                    }}
+                  />
+                ))}
+              </View>
+            ))
+          )}
+        </BottomSheetScrollView>
       </BottomSheetView>
     </BottomSheetModal>
   );
 });
 
+function ModelRow({
+  model,
+  selected,
+  onPress,
+}: {
+  model: PublicModelConfig;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  const { colors, radii, fonts } = useTheme();
+  const subtitle =
+    model.label === model.model
+      ? model.displayProvider
+      : `${model.displayProvider} / ${model.model}`;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.row,
+        {
+          backgroundColor: selected || pressed ? colors.accent : "transparent",
+          borderRadius: radii.md,
+          opacity: pressed ? 0.85 : 1,
+        },
+      ]}
+    >
+      <Ionicons
+        name="checkmark"
+        size={18}
+        color={selected ? colors.primary : "transparent"}
+      />
+      <View style={styles.rowText}>
+        <Text
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          style={[
+            styles.label,
+            {
+              color: colors.popoverForeground,
+              fontFamily: fonts.sansSemiBold,
+            },
+          ]}
+        >
+          {model.label}
+        </Text>
+        <Text
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          style={[
+            styles.sub,
+            {
+              color: colors.mutedForeground,
+              fontFamily: fonts.sansRegular,
+            },
+          ]}
+        >
+          {subtitle}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+function StatusState({
+  title,
+  message,
+  icon,
+  tone = "muted",
+}: {
+  title: string;
+  message?: string;
+  icon?: React.ReactNode;
+  tone?: "muted" | "error";
+}) {
+  const { colors, fonts } = useTheme();
+  const textColor = tone === "error" ? colors.destructive : colors.mutedForeground;
+  return (
+    <View style={styles.status}>
+      {icon}
+      <Text
+        style={[
+          styles.statusTitle,
+          { color: textColor, fontFamily: fonts.sansSemiBold },
+        ]}
+      >
+        {title}
+      </Text>
+      {message ? (
+        <Text
+          style={[
+            styles.statusMessage,
+            { color: textColor, fontFamily: fonts.sansRegular },
+          ]}
+        >
+          {message}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function groupModels(
+  models: PublicModelConfig[],
+): Array<[string, PublicModelConfig[]]> {
+  const groups = new Map<string, PublicModelConfig[]>();
+  for (const model of models) {
+    const items = groups.get(model.displayProvider) ?? [];
+    items.push(model);
+    groups.set(model.displayProvider, items);
+  }
+  return [...groups.entries()];
+}
+
 const styles = StyleSheet.create({
-  body: { paddingHorizontal: 16, paddingTop: 4 },
-  title: { fontSize: 18, marginBottom: 8, paddingHorizontal: 8 },
-  empty: { fontSize: 14, paddingHorizontal: 8, paddingVertical: 12 },
-  list: { gap: 4 },
-  row: { paddingHorizontal: 12, paddingVertical: 12 },
-  rowText: { gap: 2 },
+  body: { paddingHorizontal: 12, paddingTop: 4 },
+  title: { fontSize: 18, paddingHorizontal: 8, paddingBottom: 8 },
+  searchBox: {
+    minHeight: 42,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    marginHorizontal: 4,
+    marginBottom: 8,
+  },
+  searchInput: { flex: 1, fontSize: 15, paddingVertical: 8 },
+  scroller: { flexGrow: 0 },
+  scrollerContent: { gap: 8 },
+  group: { gap: 2 },
+  groupLabel: {
+    fontSize: 11,
+    letterSpacing: 0.7,
+    textTransform: "uppercase",
+    paddingHorizontal: 12,
+    paddingTop: 6,
+    paddingBottom: 3,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+  },
+  rowText: { flex: 1, minWidth: 0, gap: 2 },
   label: { fontSize: 15 },
-  sub: { fontSize: 12 },
+  sub: { fontSize: 12, lineHeight: 17 },
+  status: {
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingHorizontal: 20,
+    paddingVertical: 28,
+  },
+  statusTitle: { fontSize: 14, textAlign: "center" },
+  statusMessage: { fontSize: 13, lineHeight: 19, textAlign: "center" },
 });


### PR DESCRIPTION
## Summary
- Refresh mobile Settings copy and grouping to better match the updated web settings tone while keeping native mobile structure.
- Add loading, error, empty, and search-empty states to the mobile model picker.
- Simplify the mobile model picker into compact single-row model choices with a trailing selected checkmark and cleaner bottom-sheet sizing.

## Scope
- Mobile UI only.
- No schema, API, provider, query contract, auth/session, or chat-send behavior changes.
- Brand icons and web picker simplification are intentionally left for a follow-up.

## Validation
- `npm run lint` from `apps/mobile`
- `git diff --check`