### PR TITLE
fix: align cross-platform copy

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -473,7 +473,7 @@ function ChatSurface({
                 { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
               ]}
             >
-              An admin needs to add one in Settings → Models on the web app.
+              An admin can add one in Settings → Models on the web.
             </Text>
           )}
           {modelsError && (

--- a/apps/mobile/src/app/(authed)/projects/[id].tsx
+++ b/apps/mobile/src/app/(authed)/projects/[id].tsx
@@ -441,7 +441,7 @@ function ProjectScreenInner({ projectId }: { projectId: string }) {
         title="Delete project?"
         message={
           project
-            ? `"${project.name}" will be deleted. Chats inside it will move to your main list.`
+            ? `${project.name} will be deleted. Chats inside it will move to your main list.`
             : ""
         }
         confirmLabel="Delete"

--- a/apps/mobile/src/app/(authed)/settings.tsx
+++ b/apps/mobile/src/app/(authed)/settings.tsx
@@ -119,19 +119,19 @@ export default function SettingsScreen() {
           </Section>
 
           <Section
-            title="Manage on web"
-            description="Open server settings in your browser."
+            title="Settings on the web"
+            description="Open settings that are managed on the web."
           >
             <LinkRow
               label="Account"
-              sub="Name, email, password, and sessions."
+              sub="Name and password."
               onPress={() => openOnWeb("/settings/account")}
               colors={colors}
               fonts={fonts}
             />
             <LinkRow
               label="Data"
-              sub="Export data and delete chats."
+              sub="Import and export chats."
               onPress={() => openOnWeb("/settings/data")}
               colors={colors}
               fonts={fonts}
@@ -140,14 +140,14 @@ export default function SettingsScreen() {
               <>
                 <LinkRow
                   label="Models"
-                  sub="Provider config and model access."
+                  sub="Models available in chat."
                   onPress={() => openOnWeb("/settings/models")}
                   colors={colors}
                   fonts={fonts}
                 />
                 <LinkRow
                   label="Users"
-                  sub="Invite and manage members."
+                  sub="Add and manage users."
                   onPress={() => openOnWeb("/settings/users")}
                   colors={colors}
                   fonts={fonts}
@@ -165,7 +165,7 @@ export default function SettingsScreen() {
                     },
                   ]}
                 >
-                  Opens {serverHost} in your browser.
+                  Opens {serverHost} on the web.
                 </Text>
               </View>
             ) : null}

--- a/apps/mobile/src/components/chat/Composer.tsx
+++ b/apps/mobile/src/components/chat/Composer.tsx
@@ -232,9 +232,7 @@ export function Composer({
             onChangeText={setInput}
             editable={configured && dictation.status !== "transcribing"}
             multiline
-            placeholder={
-              configured ? "Message…" : "No models available — ask an admin to add one"
-            }
+            placeholder={configured ? "Message…" : "No models configured"}
             placeholderTextColor={colors.mutedForeground}
             style={[
               styles.input,

--- a/apps/mobile/src/components/chat/MessageList.tsx
+++ b/apps/mobile/src/components/chat/MessageList.tsx
@@ -82,6 +82,8 @@ export function MessageList({
       })}
       {!error && status === "submitted" && lastIsUser && (
         <Text
+          accessibilityLabel="Assistant is responding"
+          accessibilityLiveRegion="polite"
           style={[
             styles.pending,
             { color: colors.mutedForeground, fontFamily: fonts.sansRegular },

--- a/apps/mobile/src/components/chat/ModelPickerSheet.tsx
+++ b/apps/mobile/src/components/chat/ModelPickerSheet.tsx
@@ -145,19 +145,19 @@ export const ModelPickerSheet = forwardRef<
           />
         ) : error ? (
           <StatusState
-            title="Couldn't load models."
+            title="Couldn't load models"
             message={error.message}
             tone="error"
           />
         ) : models.length === 0 ? (
           <StatusState
-            title="No models configured."
-            message="An admin needs to add one in Settings → Models."
+            title="No models configured"
+            message="An admin can add one in Settings → Models on the web."
           />
         ) : filteredModels.length === 0 ? (
           <StatusState
-            title={`No models match "${searchTerm}".`}
-            message="Try a model, provider, or deployment name."
+            title={`No models match "${searchTerm}"`}
+            message="Try a model, provider, or endpoint name."
           />
         ) : (
           <View style={styles.list}>

--- a/apps/mobile/src/components/drawer/AppDrawer.tsx
+++ b/apps/mobile/src/components/drawer/AppDrawer.tsx
@@ -350,7 +350,7 @@ export function AppDrawer(props: DrawerContentComponentProps) {
                 { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
               ]}
             >
-              No conversations yet
+              No chats yet
             </Text>
           </View>
         ) : (
@@ -515,8 +515,8 @@ export function AppDrawer(props: DrawerContentComponentProps) {
         title="Delete chat?"
         message={
           deleteTarget?.title?.trim()
-            ? `"${deleteTarget.title.trim()}" will be permanently deleted.`
-            : "This conversation will be permanently deleted."
+            ? `${deleteTarget.title.trim()} will be permanently deleted.`
+            : "This chat will be permanently deleted."
         }
         confirmLabel="Delete"
         destructive

--- a/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
+++ b/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
+import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Menu } from "@base-ui/react/menu";
 import { MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,8 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
 
   const savedInstructions = project?.instructions ?? "";
   const [renaming, setRenaming] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
   const [name, setName] = useState(project?.name ?? "");
   const [instructionsDraft, setInstructionsDraft] = useState<string | null>(
     null,
@@ -37,7 +40,8 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
   }
 
   const instructions = instructionsDraft ?? savedInstructions;
-  const dirty = instructionsDraft !== null && instructionsDraft !== savedInstructions;
+  const dirty =
+    instructionsDraft !== null && instructionsDraft !== savedInstructions;
 
   const projectChats = useMemo(
     () => chats.filter((c) => c.projectId === projectId),
@@ -67,18 +71,23 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
     );
   }
 
-  function confirmDelete() {
+  function requestDelete() {
+    setDeleteError("");
+    setDeleteOpen(true);
+  }
+
+  async function confirmDelete() {
     if (!project) return;
-    if (
-      !window.confirm(
-        `Delete "${project.name}"? Chats inside it will move to the main list.`,
-      )
-    ) {
-      return;
+    setDeleteError("");
+    try {
+      await deleteMut.mutateAsync(project.id);
+      setDeleteOpen(false);
+      router.push("/");
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error ? err.message : "Failed to delete project.",
+      );
     }
-    deleteMut.mutate(project.id, {
-      onSuccess: () => router.push("/"),
-    });
   }
 
   if (!project) {
@@ -141,7 +150,7 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
                   <span>Rename</span>
                 </Menu.Item>
                 <Menu.Item
-                  onClick={confirmDelete}
+                  onClick={requestDelete}
                   className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-destructive outline-none data-[highlighted]:bg-accent"
                 >
                   <Trash2 className="size-3.5 shrink-0" />
@@ -184,9 +193,7 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
 
           <section className="space-y-3">
             <div className="flex items-center justify-between">
-              <h2 className="text-base font-semibold tracking-tight">
-                Chats
-              </h2>
+              <h2 className="text-base font-semibold tracking-tight">Chats</h2>
               <Button
                 size="sm"
                 render={<Link href={`/?projectId=${project.id}`} />}
@@ -215,6 +222,57 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
           </section>
         </div>
       </div>
+
+      <AlertDialog.Root
+        open={deleteOpen}
+        onOpenChange={(next) => {
+          if (next) {
+            setDeleteOpen(true);
+          } else if (!deleteMut.isPending) {
+            setDeleteOpen(false);
+            setDeleteError("");
+          }
+        }}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop className="fixed inset-0 z-50 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
+          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
+            <AlertDialog.Title className="text-base font-semibold tracking-tight">
+              Delete project?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {project.name}
+              </span>{" "}
+              will be deleted. Chats inside it will move to your main list.
+            </AlertDialog.Description>
+            {deleteError && (
+              <p className="mt-3 text-xs text-destructive">{deleteError}</p>
+            )}
+            <div className="mt-5 flex justify-end gap-2">
+              <AlertDialog.Close
+                render={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={deleteMut.isPending}
+                  />
+                }
+              >
+                Cancel
+              </AlertDialog.Close>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={deleteMut.isPending}
+                onClick={confirmDelete}
+              >
+                {deleteMut.isPending ? "Deleting…" : "Delete"}
+              </Button>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/SettingsNav.tsx
+++ b/apps/web/app/(app)/settings/SettingsNav.tsx
@@ -36,7 +36,7 @@ export function SettingsNav() {
       className="-mx-1 flex gap-1 overflow-x-auto md:mx-0 md:flex-col md:gap-0 md:space-y-5 md:overflow-visible"
     >
       <Section
-        label="User settings"
+        label="Personal settings"
         items={USER_ITEMS}
         pathname={pathname}
         className="hidden md:block"

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -87,7 +87,7 @@ export function DataForm() {
       >
         <SettingsRow
           title="Import file"
-          description="Choose a downloaded JSON or ZIP file. Imports preserve visible conversation text and reasoning, but not attachments, images, or branches."
+          description="Choose a downloaded JSON or ZIP file. Imports preserve visible chat text and reasoning, but not attachments, images, or branches."
           align="center"
           controlAlign="end"
         >
@@ -119,7 +119,7 @@ export function DataForm() {
 
       <SettingsSection
         title="Export"
-        description="Download every conversation as a single overtchat JSON file."
+        description="Download every chat as a single overtchat JSON file."
       >
         <SettingsRow
           title="Export file"

--- a/apps/web/app/(app)/settings/general/GeneralForm.tsx
+++ b/apps/web/app/(app)/settings/general/GeneralForm.tsx
@@ -64,7 +64,7 @@ export function GeneralForm() {
     <div className="max-w-3xl space-y-8">
       <SettingsPageHeader
         title="General"
-        description="Personal preferences for this browser."
+        description="Preferences saved for this browser."
       />
 
       <SettingsSection
@@ -123,7 +123,7 @@ export function GeneralForm() {
 
       <SettingsSection
         title="Messages"
-        description="Browser-only message display preferences."
+        description="Message display preferences saved for this browser."
       >
         <SettingsRow
           title="Message stats"

--- a/apps/web/app/(app)/settings/models/AdvancedFields.tsx
+++ b/apps/web/app/(app)/settings/models/AdvancedFields.tsx
@@ -82,7 +82,7 @@ export function AdvancedFields({
         <>
           <SettingsRow
             title="System prompt"
-            description="Optional instructions sent before each conversation."
+            description="Optional instructions sent before each chat."
             htmlFor="p-system-prompt"
           >
             <Textarea

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -229,7 +229,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
 
           <SettingsRow
             title="Available in chat"
-            description="Turn off to keep the config without showing it in the picker."
+            description="Turn off to keep this model saved without showing it in chat."
             align="center"
             controlAlign="end"
           >

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -100,7 +100,7 @@ export function ModelsPanel() {
     <div className="@container max-w-4xl space-y-6">
       <SettingsPageHeader
         title="Models"
-        description="Configure the model endpoints available in chat."
+        description="Manage the models available in chat."
         action={
           models.length > 0 ? (
             <Button render={<Link href="/settings/models/new" />} size="sm">
@@ -139,7 +139,7 @@ export function ModelsPanel() {
 
       {models.length === 0 ? (
         <div className="border-y border-dashed px-6 py-14 text-center">
-          <p className="text-sm text-muted-foreground">No models configured yet.</p>
+          <p className="text-sm text-muted-foreground">No models configured.</p>
           <Button
             render={<Link href="/settings/models/new" />}
             className="mt-4"
@@ -258,8 +258,7 @@ export function ModelsPanel() {
               <span className="font-medium text-foreground">
                 {pendingDelete?.label}
               </span>{" "}
-              will be removed from the picker. Existing chats that used it keep
-              their messages.
+              will be removed from chat. Existing chats keep their messages.
             </AlertDialog.Description>
             {deleteError && (
               <SettingsNotice tone="error" className="mt-3 text-xs">

--- a/apps/web/components/ModelPicker.tsx
+++ b/apps/web/components/ModelPicker.tsx
@@ -28,8 +28,8 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
     : selected
       ? selected.label
       : models && models.length > 0
-        ? "Select a model"
-        : "No models";
+        ? "Select model"
+        : "No models configured";
 
   const filteredModels = useMemo(() => {
     const list = models ?? [];

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -50,7 +50,7 @@ export function SidebarChatList({
           Recents
         </div>
         <p className="px-2 py-1 text-xs text-muted-foreground">
-          No conversations yet
+          No chats yet
         </p>
       </>
     );
@@ -274,10 +274,16 @@ export function SidebarItem({
               Delete chat?
             </AlertDialog.Title>
             <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">
-              <span className="font-medium text-foreground">
-                {chat.title ?? "Untitled"}
-              </span>{" "}
-              will be permanently deleted.
+              {chat.title?.trim() ? (
+                <>
+                  <span className="font-medium text-foreground">
+                    {chat.title.trim()}
+                  </span>{" "}
+                  will be permanently deleted.
+                </>
+              ) : (
+                "This chat will be permanently deleted."
+              )}
             </AlertDialog.Description>
             {deleteError && (
               <p className="mt-3 text-xs text-destructive">{deleteError}</p>

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -278,7 +278,7 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
               </h1>
               {!configured && (
                 <p className="mb-6 text-center text-sm text-muted-foreground">
-                  No models configured yet. An admin needs to add one in Settings → Models.
+                  No models configured. An admin can add one in Settings → Models.
                 </p>
               )}
               {configured && temporary && (

--- a/apps/web/components/chat/Composer.tsx
+++ b/apps/web/components/chat/Composer.tsx
@@ -161,9 +161,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           ref={textareaRef}
           rows={1}
           placeholder={
-            configured
-              ? "Message…"
-              : "No models available — ask an admin to add one"
+            configured ? "Message…" : "No models configured"
           }
           className="max-h-48 min-h-10 resize-none border-0 bg-transparent px-1 py-0 shadow-none focus-visible:ring-0 md:text-sm dark:bg-transparent"
           value={input}

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -89,7 +89,7 @@ test("signup, configure Gemini, stream a response", async ({ page }) => {
     await page.waitForURL("**/");
     await page.getByLabel("Open sidebar").click();
     await expect(
-      page.getByText("No conversations yet").filter({ visible: true }),
+      page.getByText("No chats yet").filter({ visible: true }),
     ).toBeVisible();
   });
 });

--- a/apps/web/lib/import/chatgpt.ts
+++ b/apps/web/lib/import/chatgpt.ts
@@ -144,7 +144,7 @@ function convertOne(conv: ChatGPTConversation): ImportedChat | null {
   if (!messages.length) return null;
 
   return {
-    title: (conv.title ?? "").toString().slice(0, 200) || "ChatGPT conversation",
+    title: (conv.title ?? "").toString().slice(0, 200) || "ChatGPT chat",
     createdAt: chatCreated,
     messages,
   };
@@ -159,6 +159,6 @@ export function importChatGPT(data: unknown): ImportedChat[] {
     const chat = convertOne(conv);
     if (chat) out.push(chat);
   }
-  if (!out.length) throw new ImportError("No usable conversations in ChatGPT export.");
+  if (!out.length) throw new ImportError("No usable chats in ChatGPT export.");
   return out;
 }

--- a/apps/web/lib/import/claude.ts
+++ b/apps/web/lib/import/claude.ts
@@ -109,7 +109,7 @@ function convertOne(conv: ClaudeConversation): ImportedChat | null {
   if (!messages.length) return null;
 
   return {
-    title: (conv.name ?? "").toString().slice(0, 200) || "Claude conversation",
+    title: (conv.name ?? "").toString().slice(0, 200) || "Claude chat",
     createdAt: chatCreated,
     messages,
   };
@@ -124,6 +124,6 @@ export function importClaude(data: unknown): ImportedChat[] {
     const chat = convertOne(conv);
     if (chat) out.push(chat);
   }
-  if (!out.length) throw new ImportError("No usable conversations in Claude export.");
+  if (!out.length) throw new ImportError("No usable chats in Claude export.");
   return out;
 }

--- a/apps/web/lib/import/openwebui.ts
+++ b/apps/web/lib/import/openwebui.ts
@@ -104,7 +104,7 @@ function convertOne(raw: OWUIChat): ImportedChat | null {
 
   const title =
     (raw.title ?? inner.title ?? "").toString().slice(0, 200) ||
-    "OpenWebUI conversation";
+    "OpenWebUI chat";
 
   return { title, createdAt: chatCreated, messages };
 }
@@ -118,6 +118,6 @@ export function importOpenWebUI(data: unknown): ImportedChat[] {
     const chat = convertOne(c);
     if (chat) out.push(chat);
   }
-  if (!out.length) throw new ImportError("No usable conversations in OpenWebUI export.");
+  if (!out.length) throw new ImportError("No usable chats in OpenWebUI export.");
   return out;
 }


### PR DESCRIPTION
## Summary

- Align web and mobile product copy for model empty states, settings handoff language, pending status, and destructive confirmations.
- Replace the web project delete browser confirm with the app's alert dialog pattern.
- Normalize chat terminology across sidebar empty states, data settings, model help, and import fallback/errors.

## Impact

This makes copy consistent across web and mobile while preserving platform-specific UI conventions such as mobile bottom sheets and web alert dialogs.

## Validation

- `npm run lint -w apps/web --`
- `npm run lint` from `apps/mobile`
- `npm run test -w apps/web --`