### PR TITLE
Add toast notifications for key web actions

### DIFF
--- a/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
+++ b/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
@@ -7,8 +7,10 @@ import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Menu } from "@base-ui/react/menu";
 import { MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import { useChats } from "@/lib/queries/chats";
+import { getErrorMessage } from "@/lib/errors";
 import {
   useDeleteProject,
   useProject,
@@ -59,7 +61,17 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
     const next = name.trim();
     setRenaming(false);
     if (!next || next === project.name) return;
-    updateMut.mutate({ name: next });
+    updateMut.mutate(
+      { name: next },
+      {
+        onError: (err) => {
+          toast.error({
+            title: "Failed to rename project",
+            description: getErrorMessage(err, "The project name was not changed."),
+          });
+        },
+      },
+    );
   }
 
   function saveInstructions() {
@@ -67,7 +79,21 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
     const value = instructionsDraft;
     updateMut.mutate(
       { instructions: value.trim() ? value : null },
-      { onSuccess: () => setInstructionsDraft(null) },
+      {
+        onSuccess: () => {
+          setInstructionsDraft(null);
+          toast.success("Project instructions saved");
+        },
+        onError: (err) => {
+          toast.error({
+            title: "Failed to save instructions",
+            description: getErrorMessage(
+              err,
+              "The project instructions were not changed.",
+            ),
+          });
+        },
+      },
     );
   }
 
@@ -82,6 +108,10 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
     try {
       await deleteMut.mutateAsync(project.id);
       setDeleteOpen(false);
+      toast.success({
+        title: "Project deleted",
+        description: "Chats from the project moved to your main list.",
+      });
       router.push("/");
     } catch (err) {
       setDeleteError(

--- a/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
+++ b/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
@@ -114,9 +114,7 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
       });
       router.push("/");
     } catch (err) {
-      setDeleteError(
-        err instanceof Error ? err.message : "Failed to delete project.",
-      );
+      setDeleteError(getErrorMessage(err, "Failed to delete project."));
     }
   }
 

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
+import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
 import {
   SettingsActions,
@@ -49,6 +50,7 @@ export function AccountForm({
       return;
     }
     setProfileStatus("ok");
+    toast.success("Profile updated");
   }
 
   async function changePassword(e: React.FormEvent) {
@@ -68,6 +70,7 @@ export function AccountForm({
     setPwStatus("ok");
     setCurrentPassword("");
     setNewPassword("");
+    toast.success("Password updated");
   }
 
   return (

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
-import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
 import {
   SettingsActions,
@@ -50,7 +49,6 @@ export function AccountForm({
       return;
     }
     setProfileStatus("ok");
-    toast.success("Profile updated");
   }
 
   async function changePassword(e: React.FormEvent) {
@@ -70,7 +68,6 @@ export function AccountForm({
     setPwStatus("ok");
     setCurrentPassword("");
     setNewPassword("");
-    toast.success("Password updated");
   }
 
   return (

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Download, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/toast";
+import { getErrorMessage } from "@/lib/errors";
 import { chatKeys, projectKeys } from "@/lib/queries/keys";
 import {
   SettingsNotice,
@@ -31,12 +32,10 @@ export function DataForm() {
   const fileRef = useRef<HTMLInputElement>(null);
 
   const [importing, setImporting] = useState(false);
-  const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [importError, setImportError] = useState("");
 
   async function handleFile(file: File) {
     setImporting(true);
-    setImportResult(null);
     setImportError("");
 
     const form = new FormData();
@@ -52,7 +51,6 @@ export function DataForm() {
         return;
       }
       const result = body as ImportResult;
-      setImportResult(result);
       qc.invalidateQueries({ queryKey: chatKeys.list() });
       qc.invalidateQueries({ queryKey: projectKeys.list() });
       toast.success({
@@ -62,9 +60,7 @@ export function DataForm() {
         } from ${FORMAT_LABELS[result.format] ?? result.format}.`,
       });
     } catch (err) {
-      setImportError(
-        err instanceof Error ? err.message : "Import failed.",
-      );
+      setImportError(getErrorMessage(err, "Import failed."));
     } finally {
       setImporting(false);
       if (fileRef.current) fileRef.current.value = "";
@@ -109,14 +105,6 @@ export function DataForm() {
               <Upload data-icon="inline-start" />
               {importing ? "Importing…" : "Choose file"}
             </Button>
-
-            {importResult && (
-              <SettingsNotice tone="success">
-                Imported {importResult.importedChats} chat
-                {importResult.importedChats === 1 ? "" : "s"} from{" "}
-                {FORMAT_LABELS[importResult.format] ?? importResult.format}.
-              </SettingsNotice>
-            )}
 
             {importError && (
               <SettingsNotice tone="error">{importError}</SettingsNotice>

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Download, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
 import { chatKeys, projectKeys } from "@/lib/queries/keys";
 import {
   SettingsNotice,
@@ -50,9 +51,16 @@ export function DataForm() {
         );
         return;
       }
-      setImportResult(body as ImportResult);
+      const result = body as ImportResult;
+      setImportResult(result);
       qc.invalidateQueries({ queryKey: chatKeys.list() });
       qc.invalidateQueries({ queryKey: projectKeys.list() });
+      toast.success({
+        title: "Import complete",
+        description: `Imported ${result.importedChats} chat${
+          result.importedChats === 1 ? "" : "s"
+        } from ${FORMAT_LABELS[result.format] ?? result.format}.`,
+      });
     } catch (err) {
       setImportError(
         err instanceof Error ? err.message : "Import failed.",

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -13,6 +13,7 @@ import {
   type AdminModelConfig,
   type ModelConfigInput,
 } from "@/lib/config";
+import { getErrorMessage } from "@/lib/errors";
 import {
   useAdminModelConfigs,
   useCreateModelConfig,
@@ -117,9 +118,10 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
         extraBody = JSON.parse(extraBodyText);
       } catch (err) {
         setSaveError(
-          `Extra body must be valid JSON object: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `Extra body must be valid JSON object: ${getErrorMessage(
+            err,
+            "Invalid JSON",
+          )}`,
         );
         return;
       }
@@ -152,7 +154,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
       }
       router.push("/settings/models");
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : String(err));
+      setSaveError(getErrorMessage(err, "Failed to save model"));
     }
   }
 

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { toast } from "@/components/ui/toast";
 import {
   ModelConfigSchema,
   type AdminModelConfig,
@@ -138,8 +139,16 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
     try {
       if (modelId) {
         await updateMut.mutateAsync({ id: modelId, input });
+        toast.success({
+          title: "Model saved",
+          description: input.label,
+        });
       } else {
         await createMut.mutateAsync(input);
+        toast.success({
+          title: "Model created",
+          description: input.label,
+        });
       }
       router.push("/settings/models");
     } catch (err) {

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -7,8 +7,10 @@ import { Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { toast } from "@/components/ui/toast";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import type { AdminModelConfig } from "@/lib/config";
+import { getErrorMessage } from "@/lib/errors";
 import {
   modelIconForModel,
   providerIdentityForBaseUrl,
@@ -75,9 +77,12 @@ export function ModelsPanel() {
         },
       });
     } catch (err) {
-      setActionError(
-        err instanceof Error ? err.message : "Failed to update model",
-      );
+      const message = getErrorMessage(err, "Failed to update model");
+      setActionError(message);
+      toast.error({
+        title: `Failed to ${next ? "enable" : "disable"} model`,
+        description: message,
+      });
     } finally {
       setTogglingId(null);
     }
@@ -85,10 +90,15 @@ export function ModelsPanel() {
 
   async function confirmDelete() {
     if (!pendingDelete) return;
+    const label = pendingDelete.label;
     setDeleteError("");
     try {
       await deleteMut.mutateAsync(pendingDelete.id);
       setPendingDelete(null);
+      toast.success({
+        title: "Model deleted",
+        description: label,
+      });
     } catch (err) {
       setDeleteError(
         err instanceof Error ? err.message : "Failed to delete model",

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -36,7 +36,6 @@ export function ModelsPanel() {
   const [pendingDelete, setPendingDelete] =
     useState<AdminModelConfig | null>(null);
   const [deleteError, setDeleteError] = useState("");
-  const [actionError, setActionError] = useState("");
   const [togglingId, setTogglingId] = useState<string | null>(null);
 
   const filteredModels = useMemo(() => {
@@ -61,7 +60,6 @@ export function ModelsPanel() {
 
   async function toggleEnabled(m: AdminModelConfig, next: boolean) {
     setTogglingId(m.id);
-    setActionError("");
     try {
       await updateMut.mutateAsync({
         id: m.id,
@@ -78,7 +76,6 @@ export function ModelsPanel() {
       });
     } catch (err) {
       const message = getErrorMessage(err, "Failed to update model");
-      setActionError(message);
       toast.error({
         title: `Failed to ${next ? "enable" : "disable"} model`,
         description: message,
@@ -100,9 +97,7 @@ export function ModelsPanel() {
         description: label,
       });
     } catch (err) {
-      setDeleteError(
-        err instanceof Error ? err.message : "Failed to delete model",
-      );
+      setDeleteError(getErrorMessage(err, "Failed to delete model"));
     }
   }
 
@@ -136,15 +131,6 @@ export function ModelsPanel() {
             {models.length} configured
           </p>
         </div>
-      )}
-
-      {actionError && (
-        <SettingsNotice
-          tone="error"
-          className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2"
-        >
-          {actionError}
-        </SettingsNotice>
       )}
 
       {models.length === 0 ? (

--- a/apps/web/app/(app)/settings/users/AddUserDialog.tsx
+++ b/apps/web/app/(app)/settings/users/AddUserDialog.tsx
@@ -5,6 +5,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { toast } from "@/components/ui/toast";
 import {
   Select,
   SelectContent,
@@ -63,6 +64,10 @@ export function AddUserDialog({
     reset();
     onOpenChange(false);
     onCreated();
+    toast.success({
+      title: "User created",
+      description: email,
+    });
   }
 
   return (

--- a/apps/web/app/(app)/settings/users/UsersPanel.tsx
+++ b/apps/web/app/(app)/settings/users/UsersPanel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
 import { useInvalidateUsers, useUsers } from "@/lib/queries/users";
 import type { UserRow } from "@/lib/queries/users";
@@ -24,6 +25,7 @@ export function UsersPanel({ currentUserId }: { currentUserId: string }) {
 
   async function confirmDelete() {
     if (!pendingDelete || pendingDelete.id === currentUserId) return;
+    const email = pendingDelete.email;
     setDeleting(true);
     setDeleteError("");
     const { error } = await authClient.admin.removeUser({
@@ -37,6 +39,10 @@ export function UsersPanel({ currentUserId }: { currentUserId: string }) {
     invalidateUsers();
     setPendingDelete(null);
     setDeleting(false);
+    toast.success({
+      title: "User deleted",
+      description: email,
+    });
   }
 
   return (

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,6 +11,7 @@ import {
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { QueryProvider } from "@/components/QueryProvider";
+import { ToastProvider } from "@/components/ui/toast";
 import { FONT_STORAGE_KEY, fontCssValueById } from "@/lib/fonts";
 
 const sans = Plus_Jakarta_Sans({
@@ -92,7 +93,9 @@ export default function RootLayout({
       <body className="h-full">
         <script dangerouslySetInnerHTML={{ __html: fontScript }} />
         <QueryProvider>
-          <ThemeProvider>{children}</ThemeProvider>
+          <ThemeProvider>
+            <ToastProvider>{children}</ToastProvider>
+          </ThemeProvider>
         </QueryProvider>
       </body>
     </html>

--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Menu } from "@base-ui/react/menu";
 import { ChevronUp, LogOut, Settings, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
 import { useSidebar } from "@/components/sidebar-context";
 
@@ -18,9 +19,23 @@ export function AccountMenu() {
   const { drawerRef } = useSidebar();
 
   async function logOut() {
-    await authClient.signOut();
-    router.replace("/login");
-    router.refresh();
+    try {
+      const { error } = await authClient.signOut();
+      if (error) {
+        toast.error({
+          title: "Failed to log out",
+          description: error.message ?? "Try again in a moment.",
+        });
+        return;
+      }
+      router.replace("/login");
+      router.refresh();
+    } catch (err) {
+      toast.error({
+        title: "Failed to log out",
+        description: err instanceof Error ? err.message : "Try again in a moment.",
+      });
+    }
   }
 
   return (

--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -7,6 +7,7 @@ import { ChevronUp, LogOut, Settings, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
+import { getErrorMessage } from "@/lib/errors";
 import { useSidebar } from "@/components/sidebar-context";
 
 export function AccountMenu() {
@@ -24,7 +25,7 @@ export function AccountMenu() {
       if (error) {
         toast.error({
           title: "Failed to log out",
-          description: error.message ?? "Try again in a moment.",
+          description: getErrorMessage(error, "Try again in a moment."),
         });
         return;
       }
@@ -33,7 +34,7 @@ export function AccountMenu() {
     } catch (err) {
       toast.error({
         title: "Failed to log out",
-        description: err instanceof Error ? err.message : "Try again in a moment.",
+        description: getErrorMessage(err, "Try again in a moment."),
       });
     }
   }

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -134,7 +134,7 @@ export function SidebarItem({
       toast.success("Chat deleted");
       if (active) router.push("/");
     } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : "Failed to delete");
+      setDeleteError(getErrorMessage(err, "Failed to delete"));
     }
   }
 

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -19,8 +19,10 @@ import {
   useMoveChat,
   useRenameChat,
 } from "@/lib/queries/chats";
+import { getErrorMessage } from "@/lib/errors";
 import { useSidebar } from "@/components/sidebar-context";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
 
 interface Chat {
   id: string;
@@ -106,7 +108,17 @@ export function SidebarItem({
     const next = draft.trim();
     setRenaming(false);
     if (!next || next === (chat.title ?? "")) return;
-    renameMut.mutate({ id: chat.id, title: next });
+    renameMut.mutate(
+      { id: chat.id, title: next },
+      {
+        onError: (err) => {
+          toast.error({
+            title: "Failed to rename chat",
+            description: getErrorMessage(err, "The chat title was not changed."),
+          });
+        },
+      },
+    );
   }
 
   function requestDelete() {
@@ -119,6 +131,7 @@ export function SidebarItem({
     try {
       await deleteMut.mutateAsync(chat.id);
       setDeleteOpen(false);
+      toast.success("Chat deleted");
       if (active) router.push("/");
     } catch (err) {
       setDeleteError(err instanceof Error ? err.message : "Failed to delete");
@@ -127,7 +140,17 @@ export function SidebarItem({
 
   function moveTo(projectId: string | null) {
     if (projectId === currentProjectId) return;
-    moveMut.mutate({ id: chat.id, projectId });
+    moveMut.mutate(
+      { id: chat.id, projectId },
+      {
+        onError: (err) => {
+          toast.error({
+            title: "Failed to move chat",
+            description: getErrorMessage(err, "The chat stayed where it was."),
+          });
+        },
+      },
+    );
   }
 
   if (renaming) {

--- a/apps/web/components/SidebarProjects.tsx
+++ b/apps/web/components/SidebarProjects.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { toast } from "@/components/ui/toast";
 import { useCreateProject } from "@/lib/queries/projects";
 import {
   SidebarItem,
@@ -143,6 +144,10 @@ export function CreateProjectDialog({
         onSuccess: ({ id }) => {
           reset();
           onClose();
+          toast.success({
+            title: "Project created",
+            description: trimmed,
+          });
           router.push(`/projects/${id}`);
         },
         onError: (err) => {

--- a/apps/web/components/SidebarProjects.tsx
+++ b/apps/web/components/SidebarProjects.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/toast";
+import { getErrorMessage } from "@/lib/errors";
 import { useCreateProject } from "@/lib/queries/projects";
 import {
   SidebarItem,
@@ -151,7 +152,7 @@ export function CreateProjectDialog({
           router.push(`/projects/${id}`);
         },
         onError: (err) => {
-          setError(err instanceof Error ? err.message : String(err));
+          setError(getErrorMessage(err, "Failed to create project."));
         },
       },
     );

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -12,7 +12,6 @@ import { useChats, type ChatListItem } from "@/lib/queries/chats";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import { useSpeech } from "@/lib/useSpeech";
 import { authClient } from "@/lib/auth/client";
-import { toast } from "@/components/ui/toast";
 import {
   readMessageStats,
   readStoredMessageStats,
@@ -177,17 +176,9 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   function handleStop() {
     stop();
     if (!temporary) {
-      void fetch(`/api/chat/${chatId}/stream/cancel`, { method: "POST" })
-        .then((res) => {
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        })
-        .catch((err) => {
-          toast.error({
-            title: "Failed to cancel server stream",
-            description:
-              err instanceof Error ? err.message : "The local stream was stopped.",
-          });
-        });
+      void fetch(`/api/chat/${chatId}/stream/cancel`, { method: "POST" }).catch(
+        () => undefined,
+      );
     }
   }
 

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -12,6 +12,7 @@ import { useChats, type ChatListItem } from "@/lib/queries/chats";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import { useSpeech } from "@/lib/useSpeech";
 import { authClient } from "@/lib/auth/client";
+import { toast } from "@/components/ui/toast";
 import {
   readMessageStats,
   readStoredMessageStats,
@@ -176,7 +177,17 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
   function handleStop() {
     stop();
     if (!temporary) {
-      void fetch(`/api/chat/${chatId}/stream/cancel`, { method: "POST" });
+      void fetch(`/api/chat/${chatId}/stream/cancel`, { method: "POST" })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        })
+        .catch((err) => {
+          toast.error({
+            title: "Failed to cancel server stream",
+            description:
+              err instanceof Error ? err.message : "The local stream was stopped.",
+          });
+        });
     }
   }
 

--- a/apps/web/components/chat/MessageBubble.tsx
+++ b/apps/web/components/chat/MessageBubble.tsx
@@ -437,11 +437,10 @@ function CopyButton({ text }: { text: string }) {
             setCopied(true);
             setTimeout(() => setCopied(false), 1200);
           })
-          .catch((err) => {
+          .catch(() => {
             toast.error({
               title: "Failed to copy",
-              description:
-                err instanceof Error ? err.message : "Clipboard access was denied.",
+              description: "Clipboard access was denied by the browser.",
             });
           });
       }}

--- a/apps/web/components/chat/MessageBubble.tsx
+++ b/apps/web/components/chat/MessageBubble.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { toast } from "@/components/ui/toast";
 import { humanMediaLabel } from "@/lib/chat/attachments";
 import {
   STREAMDOWN_DEFAULT_REMARK_PLUGINS,
@@ -431,10 +432,18 @@ function CopyButton({ text }: { text: string }) {
         )
       }
       onClick={() => {
-        void clipboardWriteText(text).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1200);
-        });
+        void clipboardWriteText(text)
+          .then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          })
+          .catch((err) => {
+            toast.error({
+              title: "Failed to copy",
+              description:
+                err instanceof Error ? err.message : "Clipboard access was denied.",
+            });
+          });
       }}
     />
   );

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Toast as ToastPrimitive } from "@base-ui/react/toast";
+import { CheckCircle2, X, XCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type ToastInput =
+  | string
+  | {
+      title: ReactNode;
+      description?: ReactNode;
+      timeout?: number;
+    };
+type ToastOptions = Exclude<ToastInput, string>;
+
+const toastManager = ToastPrimitive.createToastManager();
+
+export const toast = {
+  success(input: ToastInput) {
+    const options = normalizeInput(input);
+    toastManager.add({
+      ...options,
+      type: "success",
+      timeout: options.timeout ?? 4500,
+    });
+  },
+  error(input: ToastInput) {
+    const options = normalizeInput(input);
+    toastManager.add({
+      ...options,
+      type: "error",
+      priority: "high",
+      timeout: options.timeout ?? 7000,
+    });
+  },
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  return (
+    <ToastPrimitive.Provider toastManager={toastManager} limit={4}>
+      {children}
+      <ToastPrimitive.Portal>
+        <ToastPrimitive.Viewport className="fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-[100] flex w-[calc(100vw-2rem)] max-w-sm flex-col gap-2 outline-none max-sm:right-4 max-sm:left-4">
+          <ToastList />
+        </ToastPrimitive.Viewport>
+      </ToastPrimitive.Portal>
+    </ToastPrimitive.Provider>
+  );
+}
+
+function ToastList() {
+  const { toasts } = ToastPrimitive.useToastManager();
+
+  return toasts.map((item) => (
+    <ToastPrimitive.Root
+      key={item.id}
+      toast={item}
+      swipeDirection="right"
+      className={cn(
+        "pointer-events-auto w-full rounded-lg border bg-popover text-popover-foreground shadow-lg outline-none transition-all duration-200",
+        "data-[swiping]:transition-none data-[starting-style]:translate-x-6 data-[starting-style]:opacity-0 data-[ending-style]:translate-x-6 data-[ending-style]:opacity-0",
+        item.type === "success" && "border-ring/30",
+        item.type === "error" && "border-destructive/35",
+      )}
+    >
+      <ToastPrimitive.Content className="flex gap-3 p-3">
+        <ToastIcon type={item.type} />
+        <div className="min-w-0 flex-1">
+          <ToastPrimitive.Title className="text-sm font-medium text-foreground" />
+          {item.description != null && (
+            <ToastPrimitive.Description className="mt-0.5 text-xs leading-relaxed text-muted-foreground" />
+          )}
+        </div>
+        <ToastPrimitive.Close
+          aria-label="Dismiss notification"
+          className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          <X className="size-3.5" />
+        </ToastPrimitive.Close>
+      </ToastPrimitive.Content>
+    </ToastPrimitive.Root>
+  ));
+}
+
+function ToastIcon({ type }: { type?: string }) {
+  if (type === "error") {
+    return <XCircle className="mt-0.5 size-4 shrink-0 text-destructive" />;
+  }
+
+  return <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-ring" />;
+}
+
+function normalizeInput(input: ToastInput): ToastOptions {
+  if (typeof input === "string") return { title: input };
+  return input;
+}

--- a/apps/web/lib/errors.ts
+++ b/apps/web/lib/errors.ts
@@ -1,0 +1,5 @@
+export function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error) return error;
+  return fallback;
+}

--- a/apps/web/lib/errors.ts
+++ b/apps/web/lib/errors.ts
@@ -1,5 +1,14 @@
 export function getErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error && error.message) return error.message;
   if (typeof error === "string" && error) return error;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    error.message
+  ) {
+    return error.message;
+  }
   return fallback;
 }


### PR DESCRIPTION
## Summary
- Add a global Base UI toast provider and reusable toast helpers for success and error states.
- Add error toasts for previously silent chat rename, chat move, project update, and model toggle failures.
- Add success receipts for destructive/import/admin actions while keeping inline form and dialog errors where users need retry context.
- Centralize user-facing error extraction with `getErrorMessage`.

## Testing
- `npm run lint -w apps/web --`
- `npm run test -w apps/web --`
- `npm run build -w apps/web --`
