### PR TITLE
fix: improve chat input ergonomics

### DIFF
--- a/apps/web/app/(app)/chat/[id]/page.tsx
+++ b/apps/web/app/(app)/chat/[id]/page.tsx
@@ -17,6 +17,7 @@ export default async function Page({
   const initialMessages = await getMessages(id);
   return (
     <ChatArea
+      key={id}
       chatId={id}
       projectId={chat.projectId ?? null}
       initialMessages={initialMessages}

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -31,6 +31,10 @@ import { MiniSpeechPlayer } from "./MiniSpeechPlayer";
 const SEARCH_STORAGE_KEY = "overtchat_search_enabled";
 const MESSAGE_STATS_STORAGE_KEY = "overtchat_stats_for_nerds";
 
+function shouldAutofocusComposer() {
+  return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+}
+
 interface Props {
   chatId: string;
   initialMessages?: UIMessage[];
@@ -82,6 +86,14 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
 
   const isNewRef = useRef(isNew ?? false);
   const composerRef = useRef<ComposerHandle>(null);
+
+  useEffect(() => {
+    if (!configured || !shouldAutofocusComposer()) return;
+    const id = window.setTimeout(() => {
+      composerRef.current?.focus({ preventScroll: true });
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [chatId, configured]);
 
   const [transport] = useState(
     () =>

--- a/apps/web/components/chat/Composer.tsx
+++ b/apps/web/components/chat/Composer.tsx
@@ -36,7 +36,7 @@ import {
 
 export interface ComposerHandle {
   addFiles: (files: readonly File[]) => void;
-  focus: () => void;
+  focus: (options?: FocusOptions) => void;
 }
 
 interface ComposerProps {
@@ -78,10 +78,13 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     () => ({
       addFiles(files) {
         addFiles(files);
-        setTimeout(() => textareaRef.current?.focus(), 0);
+        setTimeout(
+          () => textareaRef.current?.focus({ preventScroll: true }),
+          0,
+        );
       },
-      focus() {
-        textareaRef.current?.focus();
+      focus(options) {
+        textareaRef.current?.focus(options);
       },
     }),
     [addFiles],
@@ -93,7 +96,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       if (!trimmed) return text;
       return `${trimmed} ${text}`;
     });
-    setTimeout(() => textareaRef.current?.focus(), 0);
+    setTimeout(() => textareaRef.current?.focus({ preventScroll: true }), 0);
   });
 
   useEffect(() => {

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import type { ChatStatus, FileUIPart, UIMessage } from "ai";
 import { AlertTriangle, ChevronDown, RotateCcw } from "lucide-react";
+import { useStickToBottom } from "use-stick-to-bottom";
 import { Button } from "@/components/ui/button";
 import { chatErrorMessage } from "@/lib/chat/message";
 import { readMessageStats, type StoredMessageStats } from "@/lib/chat/stats";
 import type { useSpeech } from "@/lib/useSpeech";
 import { MessageBubble } from "./MessageBubble";
-
-const BOTTOM_THRESHOLD_PX = 80;
 
 export function MessageList({
   messages,
@@ -36,59 +34,16 @@ export function MessageList({
   onEdit: (id: string, text: string, files: FileUIPart[]) => void;
   onRetry: () => void;
 }) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const stickToBottomRef = useRef(true);
-  const [detachedFromBottom, setDetachedFromBottom] = useState(false);
-
-  function pinToBottom(el: HTMLDivElement) {
-    el.scrollTop = el.scrollHeight;
-    setDetachedFromBottom(false);
-  }
-
-  function updateStickiness(el: HTMLDivElement) {
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const isAtBottom = distanceFromBottom < BOTTOM_THRESHOLD_PX;
-    stickToBottomRef.current = isAtBottom;
-    setDetachedFromBottom(!isAtBottom);
-  }
-
-  function handleScroll() {
-    const el = scrollRef.current;
-    if (!el) return;
-    updateStickiness(el);
-  }
-
-  function scrollToBottom() {
-    const el = scrollRef.current;
-    if (!el) return;
-    stickToBottomRef.current = true;
-    pinToBottom(el);
-  }
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el || !stickToBottomRef.current) return;
-    pinToBottom(el);
-  }, [messages]);
-
-  useEffect(() => {
-    const scrollEl = scrollRef.current;
-    const contentEl = contentRef.current;
-    if (!scrollEl || !contentEl) return;
-
-    const observer = new ResizeObserver(() => {
-      if (stickToBottomRef.current) pinToBottom(scrollEl);
+  const { scrollRef, contentRef, isAtBottom, scrollToBottom } =
+    useStickToBottom({
+      initial: "instant",
+      resize: "instant",
     });
-    observer.observe(contentEl);
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
       <div
         ref={scrollRef}
-        onScroll={handleScroll}
         className="h-full overflow-y-auto overscroll-contain"
       >
         <div
@@ -115,14 +70,14 @@ export function MessageList({
         </div>
       </div>
 
-      {detachedFromBottom && (
+      {!isAtBottom && (
         <div className="pointer-events-none absolute inset-x-0 bottom-3 z-10 flex justify-center">
           <Button
             type="button"
             variant="outline"
             size="icon-sm"
             className="pointer-events-auto rounded-full bg-background/95 shadow-md backdrop-blur"
-            onClick={scrollToBottom}
+            onClick={() => void scrollToBottom()}
             aria-label="Scroll to bottom"
           >
             <ChevronDown />

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ChatStatus, FileUIPart, UIMessage } from "ai";
-import { AlertTriangle, RotateCcw } from "lucide-react";
+import { AlertTriangle, ChevronDown, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { chatErrorMessage } from "@/lib/chat/message";
 import { readMessageStats, type StoredMessageStats } from "@/lib/chat/stats";
 import type { useSpeech } from "@/lib/useSpeech";
 import { MessageBubble } from "./MessageBubble";
+
+const BOTTOM_THRESHOLD_PX = 80;
 
 export function MessageList({
   messages,
@@ -35,46 +37,98 @@ export function MessageList({
   onRetry: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
+  const [detachedFromBottom, setDetachedFromBottom] = useState(false);
+
+  function pinToBottom(el: HTMLDivElement) {
+    el.scrollTop = el.scrollHeight;
+    setDetachedFromBottom(false);
+  }
+
+  function updateStickiness(el: HTMLDivElement) {
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const isAtBottom = distanceFromBottom < BOTTOM_THRESHOLD_PX;
+    stickToBottomRef.current = isAtBottom;
+    setDetachedFromBottom(!isAtBottom);
+  }
 
   function handleScroll() {
     const el = scrollRef.current;
     if (!el) return;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    stickToBottomRef.current = distanceFromBottom < 80;
+    updateStickiness(el);
+  }
+
+  function scrollToBottom() {
+    const el = scrollRef.current;
+    if (!el) return;
+    stickToBottomRef.current = true;
+    pinToBottom(el);
   }
 
   useEffect(() => {
     const el = scrollRef.current;
     if (!el || !stickToBottomRef.current) return;
-    el.scrollTop = el.scrollHeight;
+    pinToBottom(el);
   }, [messages]);
 
+  useEffect(() => {
+    const scrollEl = scrollRef.current;
+    const contentEl = contentRef.current;
+    if (!scrollEl || !contentEl) return;
+
+    const observer = new ResizeObserver(() => {
+      if (stickToBottomRef.current) pinToBottom(scrollEl);
+    });
+    observer.observe(contentEl);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div
-      ref={scrollRef}
-      onScroll={handleScroll}
-      className="flex-1 overflow-y-auto overscroll-contain"
-    >
-      <div className="mx-auto w-full max-w-3xl space-y-6 px-4 pt-10 pb-8">
-        {messages.map((m, i) => (
-          <MessageBubble
-            key={m.id}
-            message={m}
-            streaming={streaming && i === messages.length - 1}
-            canAct={!streaming && configured}
-            onRegenerate={onRegenerate}
-            onEdit={onEdit}
-            speech={speech}
-            showStats={showStats}
-            stats={readMessageStats(m) ?? storedStats[m.id] ?? null}
-          />
-        ))}
-        {error && <ChatErrorBubble error={error} onRetry={onRetry} />}
-        {!error &&
-          status === "submitted" &&
-          messages.at(-1)?.role === "user" && <PendingIndicator />}
+    <div className="relative min-h-0 flex-1 overflow-hidden">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="h-full overflow-y-auto overscroll-contain"
+      >
+        <div
+          ref={contentRef}
+          className="mx-auto w-full max-w-3xl space-y-6 px-4 pt-10 pb-8"
+        >
+          {messages.map((m, i) => (
+            <MessageBubble
+              key={m.id}
+              message={m}
+              streaming={streaming && i === messages.length - 1}
+              canAct={!streaming && configured}
+              onRegenerate={onRegenerate}
+              onEdit={onEdit}
+              speech={speech}
+              showStats={showStats}
+              stats={readMessageStats(m) ?? storedStats[m.id] ?? null}
+            />
+          ))}
+          {error && <ChatErrorBubble error={error} onRetry={onRetry} />}
+          {!error &&
+            status === "submitted" &&
+            messages.at(-1)?.role === "user" && <PendingIndicator />}
+        </div>
       </div>
+
+      {detachedFromBottom && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-3 z-10 flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            className="pointer-events-auto rounded-full bg-background/95 shadow-md backdrop-blur"
+            onClick={scrollToBottom}
+            aria-label="Scroll to bottom"
+          >
+            <ChevronDown />
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "unpdf": "^1.6.2",
+    "use-stick-to-bottom": "^1.1.6",
     "xlsx": "^0.18.5",
     "zod": "^4.4.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "unpdf": "^1.6.2",
+        "use-stick-to-bottom": "^1.1.6",
         "xlsx": "^0.18.5",
         "zod": "^4.4.3"
       },
@@ -25570,6 +25571,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-stick-to-bottom": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/use-stick-to-bottom/-/use-stick-to-bottom-1.1.6.tgz",
+      "integrity": "sha512-z3Up8jYQGTkUCsGBnwg6/wj70KgXoW5Kz1AAc1j8MtQuYMBo6ZsdhrIXoegxa7gaMMilgQYyTohTrt3p94jHog==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/samdenty"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sync-external-store": {


### PR DESCRIPTION
## Summary

- Autofocus the chat composer on desktop when opening or switching chats.
- Preserve scroll position while focusing the composer after attach/dictation flows.
- Add `use-stick-to-bottom` for streaming-chat scroll anchoring, resize-aware bottom stickiness, and detached-state tracking.
- Render the floating scroll-to-bottom chevron from the hook's bottom state.
- Key existing-chat `ChatArea` instances by chat id so per-chat scroll, composer, and attachment state resets on client-side chat switches.

## Validation

- `npm run lint`
- `npm run test`
- `npm run build`
- `E2E_PORT=4728 npm run test:e2e`