### PR TITLE
Standardize web motion and interaction polish

### DIFF
--- a/apps/web/MOTION.md
+++ b/apps/web/MOTION.md
@@ -1,0 +1,59 @@
+# Motion Standard
+
+Overtchat uses CSS-first motion. Reach for Tailwind 4 utilities, the app motion classes in `app/globals.css`, `tw-animate-css`, Base UI state attributes, and Next/React View Transitions. Do not add a runtime animation library for ordinary interface motion.
+
+## Tone
+
+Motion should feel like a quiet work app: fast, useful, and hard to notice unless it is missing. Animate to clarify state changes, preserve spatial context, or show progress. Do not animate streaming message text, typing output, long lists, or decorative loops.
+
+## Tokens
+
+Use the CSS variables instead of ad hoc durations/easing:
+
+- `--motion-duration-instant`: `0ms`
+- `--motion-duration-fast`: `120ms`
+- `--motion-duration-base`: `180ms`
+- `--motion-duration-slow`: `240ms`
+- `--motion-duration-deliberate`: `320ms`
+- `--motion-ease-standard`, `--motion-ease-enter`, `--motion-ease-exit`, `--motion-ease-emphasized`
+
+Prefer the shared classes:
+
+- `motion-colors` for hover/focus color changes
+- `motion-opacity` for reveal/hide affordances
+- `motion-transform` for small spatial changes
+- `motion-surface` for popup/menu/dialog movement and fade
+- `motion-overlay` for backdrops
+- `motion-collapse` for grid-row/opacity disclosure panels
+- `motion-disable` to opt a subtree out of nonessential motion
+
+## Routes
+
+Navigation should pass a transition type, either via `MotionLink` or `useMotionRouter`.
+
+- `/chat/*`: `route-chat`
+- `/projects/*`: `route-project`
+- `/settings/*`: `route-settings`
+- `/login`, `/signup`: `route-auth`
+- `/`: `route-home`
+- Same-pane or unknown navigation: `route-same-pane`
+
+Route transitions are deliberately subtle: short crossfades and tiny axis shifts only. Avoid full-page slides, springy motion, or anything that competes with streaming chat.
+
+## Reduced Motion
+
+`prefers-reduced-motion: reduce` must disable nonessential transitions and infinite decorative animations. Progress indicators may still communicate loading, but shimmer, bounce, and transform-heavy movement should stop or become instant.
+
+Any JavaScript-driven animation must check reduced motion and complete immediately when the user requests it.
+
+## When Not To Animate
+
+Do not animate:
+
+- streamed assistant tokens or Markdown layout while tokens arrive
+- text selection, cursor movement, or editable input height changes
+- security/auth redirects
+- destructive confirmation consequences after the user confirms
+- table/list churn where many rows can change at once
+
+Use static loading skeletons and stable dimensions before adding motion.

--- a/apps/web/app/(app)/chat/[id]/loading.tsx
+++ b/apps/web/app/(app)/chat/[id]/loading.tsx
@@ -1,0 +1,18 @@
+export default function ChatLoading() {
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
+        <div className="size-8 rounded-md motion-skeleton" />
+        <div className="h-4 w-48 rounded motion-skeleton" />
+      </div>
+      <div className="mx-auto w-full max-w-3xl flex-1 space-y-6 px-4 pt-10 pb-8">
+        <div className="ml-auto h-16 w-2/3 rounded-lg motion-skeleton" />
+        <div className="h-28 w-5/6 rounded-lg motion-skeleton" />
+        <div className="ml-auto h-14 w-1/2 rounded-lg motion-skeleton" />
+      </div>
+      <div className="px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
+        <div className="mx-auto h-24 max-w-3xl rounded-3xl motion-skeleton" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/loading.tsx
+++ b/apps/web/app/(app)/loading.tsx
@@ -1,0 +1,16 @@
+export default function AppLoading() {
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
+        <div className="size-8 rounded-md motion-skeleton" />
+        <div className="h-4 w-36 rounded motion-skeleton" />
+      </div>
+      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col justify-end gap-6 px-4 py-8">
+        <div className="h-20 w-4/5 rounded-lg motion-skeleton" />
+        <div className="ml-auto h-14 w-2/3 rounded-lg motion-skeleton" />
+        <div className="h-24 w-5/6 rounded-lg motion-skeleton" />
+        <div className="h-24 rounded-3xl motion-skeleton" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
+++ b/apps/web/app/(app)/projects/[id]/ProjectPanel.tsx
@@ -1,24 +1,26 @@
 "use client";
 
-import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Menu } from "@base-ui/react/menu";
 import { MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { MotionLink } from "@/components/ui/motion-link";
 import { toast } from "@/components/ui/toast";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import { useChats } from "@/lib/queries/chats";
 import { getErrorMessage } from "@/lib/errors";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 import {
   useDeleteProject,
   useProject,
   useUpdateProject,
 } from "@/lib/queries/projects";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 
 export function ProjectPanel({ projectId }: { projectId: string }) {
-  const router = useRouter();
+  const router = useMotionRouter();
   const { data: project } = useProject(projectId);
   const { data: chats = [] } = useChats();
   const updateMut = useUpdateProject(projectId);
@@ -153,7 +155,7 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
           <button
             type="button"
             onClick={startRename}
-            className="truncate rounded-md px-1 py-0.5 text-sm font-semibold tracking-tight hover:bg-accent"
+            className="truncate rounded-md px-1 py-0.5 text-sm font-semibold tracking-tight motion-colors hover:bg-accent"
             title="Rename"
           >
             {project.name}
@@ -163,23 +165,28 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
         <Menu.Root>
           <Menu.Trigger
             aria-label="Project actions"
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            className="rounded-md p-1.5 text-muted-foreground motion-colors hover:bg-accent hover:text-foreground"
           >
             <MoreHorizontal className="size-4" />
           </Menu.Trigger>
           <Menu.Portal>
             <Menu.Positioner side="bottom" align="end" sideOffset={6}>
-              <Menu.Popup className="z-50 w-44 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
+              <Menu.Popup
+                className={cn(
+                  "z-50 w-44 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+                  motionClasses.popup,
+                )}
+              >
                 <Menu.Item
                   onClick={startRename}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
                 >
                   <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
                   <span>Rename</span>
                 </Menu.Item>
                 <Menu.Item
                   onClick={requestDelete}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-destructive outline-none data-[highlighted]:bg-accent"
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-destructive outline-none motion-colors data-[highlighted]:bg-accent"
                 >
                   <Trash2 className="size-3.5 shrink-0" />
                   <span>Delete project</span>
@@ -224,7 +231,7 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
               <h2 className="text-base font-semibold tracking-tight">Chats</h2>
               <Button
                 size="sm"
-                render={<Link href={`/?projectId=${project.id}`} />}
+                render={<MotionLink href={`/?projectId=${project.id}`} />}
               >
                 <Plus /> New chat
               </Button>
@@ -237,12 +244,12 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
               <ul className="divide-y rounded-lg border">
                 {projectChats.map((c) => (
                   <li key={c.id}>
-                    <Link
+                    <MotionLink
                       href={`/chat/${c.id}`}
-                      className="block truncate px-3 py-2.5 text-sm hover:bg-accent"
+                      className="block truncate px-3 py-2.5 text-sm motion-colors hover:bg-accent"
                     >
                       {c.title ?? "Untitled"}
-                    </Link>
+                    </MotionLink>
                   </li>
                 ))}
               </ul>
@@ -263,8 +270,15 @@ export function ProjectPanel({ projectId }: { projectId: string }) {
         }}
       >
         <AlertDialog.Portal>
-          <AlertDialog.Backdrop className="fixed inset-0 z-50 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
+          <AlertDialog.Backdrop
+            className={cn("fixed inset-0 z-50 bg-black/40", motionClasses.overlay)}
+          />
+          <AlertDialog.Popup
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none",
+              motionClasses.dialog,
+            )}
+          >
             <AlertDialog.Title className="text-base font-semibold tracking-tight">
               Delete project?
             </AlertDialog.Title>

--- a/apps/web/app/(app)/projects/[id]/loading.tsx
+++ b/apps/web/app/(app)/projects/[id]/loading.tsx
@@ -1,0 +1,21 @@
+export default function ProjectLoading() {
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex h-12 shrink-0 items-center gap-3 border-b px-3">
+        <div className="size-8 rounded-md motion-skeleton" />
+        <div className="h-4 w-44 rounded motion-skeleton" />
+      </div>
+      <div className="mx-auto w-full max-w-3xl space-y-8 px-4 py-8 md:px-8">
+        <section className="space-y-3">
+          <div className="h-5 w-32 rounded motion-skeleton" />
+          <div className="h-32 rounded-lg motion-skeleton" />
+        </section>
+        <section className="space-y-3">
+          <div className="h-5 w-24 rounded motion-skeleton" />
+          <div className="h-12 rounded-lg motion-skeleton" />
+          <div className="h-12 rounded-lg motion-skeleton" />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/settings/SettingsNav.tsx
+++ b/apps/web/app/(app)/settings/SettingsNav.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Cpu, Database, Settings2, User, Users } from "lucide-react";
+import { MotionLink } from "@/components/ui/motion-link";
 import { cn } from "@/lib/utils";
 import { authClient } from "@/lib/auth/client";
 
@@ -87,10 +87,11 @@ function NavLink({ item, pathname }: { item: Item; pathname: string }) {
   const active = pathname === item.href;
   const Icon = item.icon;
   return (
-    <Link
+    <MotionLink
       href={item.href}
+      pendingHint
       className={cn(
-        "flex shrink-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+        "flex shrink-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors",
         active
           ? "bg-accent text-accent-foreground"
           : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
@@ -98,6 +99,6 @@ function NavLink({ item, pathname }: { item: Item; pathname: string }) {
     >
       <Icon className="size-3.5 shrink-0" />
       <span>{item.label}</span>
-    </Link>
+    </MotionLink>
   );
 }

--- a/apps/web/app/(app)/settings/general/GeneralForm.tsx
+++ b/apps/web/app/(app)/settings/general/GeneralForm.tsx
@@ -86,7 +86,7 @@ export function GeneralForm() {
             {OPTIONS.map(({ value, label, icon: Icon }) => (
               <Label
                 key={value}
-                className="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-md px-2 text-sm font-medium text-muted-foreground transition-colors outline-none has-data-[checked]:bg-background has-data-[checked]:text-foreground has-data-[checked]:shadow-xs has-focus-visible:ring-3 has-focus-visible:ring-ring/50 not-has-data-[checked]:hover:text-foreground"
+                className="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-md px-2 text-sm font-medium text-muted-foreground motion-colors outline-none has-data-[checked]:bg-background has-data-[checked]:text-foreground has-data-[checked]:shadow-xs has-focus-visible:ring-3 has-focus-visible:ring-ring/50 not-has-data-[checked]:hover:text-foreground"
               >
                 <RadioGroupItem value={value} className="sr-only" />
                 <Icon className="size-3.5" />

--- a/apps/web/app/(app)/settings/layout.tsx
+++ b/apps/web/app/(app)/settings/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SidebarToggle } from "@/components/SidebarToggle";
+import { routeTransitionTypes } from "@/lib/motion";
 import { SettingsNav } from "./SettingsNav";
 
 export default function SettingsLayout({
@@ -16,7 +17,7 @@ export default function SettingsLayout({
         <span className="text-sm font-semibold tracking-tight">Settings</span>
         <div className="flex-1" />
         <Button
-          render={<Link href="/" />}
+          render={<Link href="/" transitionTypes={[routeTransitionTypes.home]} />}
           variant="ghost"
           size="icon-sm"
           aria-label="Close settings"

--- a/apps/web/app/(app)/settings/loading.tsx
+++ b/apps/web/app/(app)/settings/loading.tsx
@@ -1,0 +1,16 @@
+export default function SettingsLoading() {
+  return (
+    <div className="max-w-4xl space-y-6">
+      <div className="space-y-2">
+        <div className="h-6 w-40 rounded motion-skeleton" />
+        <div className="h-4 w-72 max-w-full rounded motion-skeleton" />
+      </div>
+      <div className="space-y-4 rounded-lg border p-4">
+        <div className="h-5 w-32 rounded motion-skeleton" />
+        <div className="h-10 rounded-lg motion-skeleton" />
+        <div className="h-10 rounded-lg motion-skeleton" />
+        <div className="h-10 rounded-lg motion-skeleton" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/settings/models/AdvancedFields.tsx
+++ b/apps/web/app/(app)/settings/models/AdvancedFields.tsx
@@ -71,7 +71,7 @@ export function AdvancedFields({
           {open ? "Hide" : "Show"}
           <ChevronDown
             className={cn(
-              "transition-transform duration-200",
+              "motion-transform",
               open && "rotate-180",
             )}
           />
@@ -103,7 +103,7 @@ export function AdvancedFields({
             <div className="space-y-2">
               <div
                 className={cn(
-                  "rounded-lg border border-input bg-transparent transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 dark:bg-input/30",
+                  "rounded-lg border border-input bg-transparent motion-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 dark:bg-input/30",
                   extraBodyError &&
                     "border-destructive focus-within:border-destructive focus-within:ring-destructive/20",
                 )}

--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { fetchModelsForEndpoint } from "@/lib/config";
+import { motionClasses } from "@/lib/motion";
 import {
   modelIconForModel,
   PRESETS,
@@ -246,7 +247,7 @@ export function ConnectionFields({
               onClick={() => void probe(draft.baseUrl, draft.apiKey)}
               className="@lg:w-auto"
             >
-              {probing ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+              {probing ? <Loader2 className={motionClasses.spinner} /> : <RefreshCw />}
               {models.length > 0 ? "Refresh" : "Fetch"}
             </Button>
           </div>
@@ -254,7 +255,7 @@ export function ConnectionFields({
           <div className="flex min-h-5 flex-wrap items-center gap-x-3 gap-y-1 text-xs">
             {probing ? (
               <span className="inline-flex items-center gap-1 text-muted-foreground">
-                <Loader2 className="size-3 animate-spin" />
+                <Loader2 className={`size-3 ${motionClasses.spinner}`} />
                 Fetching available models
               </span>
             ) : models.length > 0 ? (

--- a/apps/web/app/(app)/settings/models/ConnectionTester.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionTester.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { motionClasses } from "@/lib/motion";
 
 export interface PingArgs {
   baseUrl: string;
@@ -75,7 +76,7 @@ export function ConnectionTester({ args, disabled }: ConnectionTesterProps) {
       >
         {pinging ? (
           <>
-            <Loader2 className="size-3 animate-spin" /> Testing…
+            <Loader2 className={`size-3 ${motionClasses.spinner}`} /> Testing…
           </>
         ) : (
           "Test connection"

--- a/apps/web/app/(app)/settings/models/HealthBadge.tsx
+++ b/apps/web/app/(app)/settings/models/HealthBadge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import { motionClasses } from "@/lib/motion";
 import { useModelHealth } from "@/lib/queries/modelConfigs";
 
 export interface HealthBadgeProps {
@@ -41,10 +42,10 @@ export function HealthBadge({ id, enabled }: HealthBadgeProps) {
       disabled={!enabled || isFetching}
       title={title}
       aria-label={title}
-      className="inline-flex shrink-0 items-center gap-1 rounded-full border bg-card/60 px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none text-muted-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+      className="inline-flex shrink-0 items-center gap-1 rounded-full border bg-card/60 px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none text-muted-foreground motion-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
     >
       {isFetching ? (
-        <Loader2 className="size-2.5 animate-spin" />
+        <Loader2 className={`size-2.5 ${motionClasses.spinner}`} />
       ) : (
         <span className={`size-1.5 rounded-full ${dotClass}`} aria-hidden />
       )}

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { ArrowLeft, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MotionLink } from "@/components/ui/motion-link";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/toast";
 import {
@@ -29,6 +28,7 @@ import {
   SettingsRow,
   SettingsSection,
 } from "../_components/SettingsRows";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 
 export interface ModelEditorProps {
   /** When provided, editor loads the existing config from cache; otherwise a new one is being created. */
@@ -36,7 +36,7 @@ export interface ModelEditorProps {
 }
 
 export function ModelEditor({ modelId }: ModelEditorProps) {
-  const router = useRouter();
+  const router = useMotionRouter();
   const { data: list = [] } = useAdminModelConfigs();
   const existing: AdminModelConfig | undefined = modelId
     ? list.find((m) => m.id === modelId)
@@ -166,7 +166,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
         description="Configure a model that everyone on this server can use."
         leading={
           <Button
-            render={<Link href="/settings/models" />}
+            render={<MotionLink href="/settings/models" />}
             variant="ghost"
             size="icon-sm"
             aria-label="Back to models"
@@ -279,7 +279,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
             type="button"
             variant="ghost"
             size="sm"
-            render={<Link href="/settings/models" />}
+            render={<MotionLink href="/settings/models" />}
           >
             Cancel
           </Button>

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MotionLink } from "@/components/ui/motion-link";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/toast";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
@@ -26,6 +26,7 @@ import {
   SettingsPageHeader,
 } from "../_components/SettingsRows";
 import { HealthBadge } from "./HealthBadge";
+import { motionClasses } from "@/lib/motion";
 
 export function ModelsPanel() {
   const { data: models = [] } = useAdminModelConfigs();
@@ -108,7 +109,7 @@ export function ModelsPanel() {
         description="Manage the models available in chat."
         action={
           models.length > 0 ? (
-            <Button render={<Link href="/settings/models/new" />} size="sm">
+            <Button render={<MotionLink href="/settings/models/new" />} size="sm">
               <Plus /> Add model
             </Button>
           ) : undefined
@@ -137,7 +138,7 @@ export function ModelsPanel() {
         <div className="border-y border-dashed px-6 py-14 text-center">
           <p className="text-sm text-muted-foreground">No models configured.</p>
           <Button
-            render={<Link href="/settings/models/new" />}
+            render={<MotionLink href="/settings/models/new" />}
             className="mt-4"
             size="sm"
           >
@@ -203,7 +204,7 @@ export function ModelsPanel() {
                   <div className="h-6 w-px bg-border" aria-hidden="true" />
                   <div className="flex items-center gap-1.5">
                     <Button
-                      render={<Link href={`/settings/models/${m.id}`} />}
+                      render={<MotionLink href={`/settings/models/${m.id}`} />}
                       variant="outline"
                       size="sm"
                       aria-label={`Edit ${m.label}`}
@@ -245,8 +246,15 @@ export function ModelsPanel() {
         }}
       >
         <AlertDialog.Portal>
-          <AlertDialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
+          <AlertDialog.Backdrop
+            className={cn("fixed inset-0 z-40 bg-black/40", motionClasses.overlay)}
+          />
+          <AlertDialog.Popup
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none",
+              motionClasses.dialog,
+            )}
+          >
             <AlertDialog.Title className="text-base font-semibold tracking-tight">
               Delete model?
             </AlertDialog.Title>

--- a/apps/web/app/(app)/settings/users/AddUserDialog.tsx
+++ b/apps/web/app/(app)/settings/users/AddUserDialog.tsx
@@ -6,6 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/toast";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 import {
   Select,
   SelectContent,
@@ -79,8 +81,15 @@ export function AddUserDialog({
       }}
     >
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity" />
-        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
+        <Dialog.Backdrop
+          className={cn("fixed inset-0 z-40 bg-black/40", motionClasses.overlay)}
+        />
+        <Dialog.Popup
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none",
+            motionClasses.dialog,
+          )}
+        >
           <Dialog.Title className="text-lg font-semibold tracking-tight">
             Add user
           </Dialog.Title>

--- a/apps/web/app/(app)/settings/users/UsersPanel.tsx
+++ b/apps/web/app/(app)/settings/users/UsersPanel.tsx
@@ -8,6 +8,8 @@ import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
 import { useInvalidateUsers, useUsers } from "@/lib/queries/users";
 import type { UserRow } from "@/lib/queries/users";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 import {
   SettingsNotice,
   SettingsPageHeader,
@@ -128,8 +130,15 @@ export function UsersPanel({ currentUserId }: { currentUserId: string }) {
         }}
       >
         <AlertDialog.Portal>
-          <AlertDialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
+          <AlertDialog.Backdrop
+            className={cn("fixed inset-0 z-40 bg-black/40", motionClasses.overlay)}
+          />
+          <AlertDialog.Popup
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none",
+              motionClasses.dialog,
+            )}
+          >
             <AlertDialog.Title className="text-base font-semibold tracking-tight">
               Delete user?
             </AlertDialog.Title>

--- a/apps/web/app/(auth)/login/LoginForm.tsx
+++ b/apps/web/app/(auth)/login/LoginForm.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PasswordInput } from "@/components/ui/password-input";
 import { authClient } from "@/lib/auth/client";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 
 export function LoginForm() {
-  const router = useRouter();
+  const router = useMotionRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");

--- a/apps/web/app/(auth)/signup/SignupForm.tsx
+++ b/apps/web/app/(auth)/signup/SignupForm.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PasswordInput } from "@/components/ui/password-input";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 import { bootstrapSignUp } from "./actions";
 
 export function SignupForm() {
-  const router = useRouter();
+  const router = useMotionRouter();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -55,6 +55,10 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+@theme {
+  --animate-text-shimmer: text-shimmer 2.5s linear infinite;
+}
+
 /*
  * Olive palette (hue 120°). Source of truth lives in
  * `packages/shared/src/theme/tokens.ts`; the imported file is generated.
@@ -63,6 +67,18 @@
 @import "@overtchat/shared/theme.css";
 
 @layer base {
+  :root {
+    --motion-duration-instant: 0ms;
+    --motion-duration-fast: 120ms;
+    --motion-duration-base: 180ms;
+    --motion-duration-slow: 240ms;
+    --motion-duration-deliberate: 320ms;
+    --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+    --motion-ease-enter: cubic-bezier(0, 0, 0.2, 1);
+    --motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
+    --motion-ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  }
+
   * {
     @apply border-border outline-ring/50;
   }
@@ -96,6 +112,56 @@
   }
 }
 
+@layer utilities {
+  .motion-colors {
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, box-shadow;
+    transition-duration: var(--motion-duration-fast);
+    transition-timing-function: var(--motion-ease-standard);
+  }
+
+  .motion-opacity {
+    transition-property: opacity;
+    transition-duration: var(--motion-duration-fast);
+    transition-timing-function: var(--motion-ease-standard);
+  }
+
+  .motion-transform {
+    transition-property: transform;
+    transition-duration: var(--motion-duration-base);
+    transition-timing-function: var(--motion-ease-standard);
+  }
+
+  .motion-surface {
+    transition-property: opacity, transform, scale;
+    transition-duration: var(--motion-duration-base);
+    transition-timing-function: var(--motion-ease-standard);
+  }
+
+  .motion-overlay {
+    transition-property: opacity;
+    transition-duration: var(--motion-duration-base);
+    transition-timing-function: var(--motion-ease-standard);
+  }
+
+  .motion-collapse {
+    transition-property: grid-template-rows, opacity;
+    transition-duration: var(--motion-duration-base);
+    transition-timing-function: var(--motion-ease-standard);
+  }
+
+  .motion-disable,
+  .motion-disable * {
+    transition-duration: var(--motion-duration-instant) !important;
+    animation-duration: var(--motion-duration-instant) !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
+
+  .motion-skeleton {
+    background-color: color-mix(in oklch, var(--muted) 82%, var(--foreground) 8%);
+  }
+}
+
 @media (forced-colors: active) {
   * {
     scrollbar-color: auto;
@@ -121,4 +187,73 @@
   -webkit-background-clip: text;
   color: transparent;
   animation: text-shimmer 2.5s linear infinite;
+}
+
+@supports (view-transition-name: root) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: var(--motion-duration-slow);
+    animation-timing-function: var(--motion-ease-standard);
+  }
+
+  :root:active-view-transition-type(route-chat)::view-transition-old(root),
+  :root:active-view-transition-type(route-project)::view-transition-old(root),
+  :root:active-view-transition-type(route-settings)::view-transition-old(root) {
+    animation-name: overtchat-route-out;
+  }
+
+  :root:active-view-transition-type(route-chat)::view-transition-new(root),
+  :root:active-view-transition-type(route-project)::view-transition-new(root),
+  :root:active-view-transition-type(route-settings)::view-transition-new(root),
+  :root:active-view-transition-type(route-home)::view-transition-new(root) {
+    animation-name: overtchat-route-in;
+  }
+}
+
+@keyframes overtchat-route-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes overtchat-route-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: var(--motion-duration-instant) !important;
+    animation-duration: var(--motion-duration-instant) !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .animate-text-shimmer {
+    background-image: none;
+    color: currentColor;
+  }
+
+  @supports (view-transition-name: root) {
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+      animation: none;
+    }
+  }
 }

--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -1,17 +1,19 @@
 "use client";
 
-import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Menu } from "@base-ui/react/menu";
 import { ChevronUp, LogOut, Settings, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { MotionLink } from "@/components/ui/motion-link";
 import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
 import { getErrorMessage } from "@/lib/errors";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 import { useSidebar } from "@/components/sidebar-context";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 
 export function AccountMenu() {
-  const router = useRouter();
+  const router = useMotionRouter();
   const { data: session, isPending } = authClient.useSession();
   // Portal the menu into the drawer's Dialog.Popup on mobile so the Dialog's
   // dismiss logic recognizes menu-item taps as "inside" events. On desktop
@@ -73,17 +75,22 @@ export function AccountMenu() {
       </Menu.Trigger>
       <Menu.Portal container={drawerRef}>
         <Menu.Positioner side="top" align="start" sideOffset={6}>
-          <Menu.Popup className="z-50 w-56 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
+          <Menu.Popup
+            className={cn(
+              "z-50 w-56 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+              motionClasses.popup,
+            )}
+          >
             <Menu.Item
-              render={<Link href="/settings" />}
-              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              render={<MotionLink href="/settings" />}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
             >
               <Settings className="size-3.5 shrink-0 text-muted-foreground" />
               <span>Settings</span>
             </Menu.Item>
             <Menu.Item
               onClick={logOut}
-              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
             >
               <LogOut className="size-3.5 shrink-0 text-muted-foreground" />
               <span>Log out</span>

--- a/apps/web/components/AdminOnboardingCard.tsx
+++ b/apps/web/components/AdminOnboardingCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { Check, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { MotionLink } from "@/components/ui/motion-link";
 import { AddUserDialog } from "@/app/(app)/settings/users/AddUserDialog";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import { cn } from "@/lib/utils";
@@ -41,7 +41,7 @@ export function AdminOnboardingCard({
             title="Add your first model"
             description="Anthropic, Google Gemini, or any OpenAI-compatible endpoint."
             action={
-              <Button render={<Link href="/settings/models/new" />} size="sm">
+              <Button render={<MotionLink href="/settings/models/new" />} size="sm">
                 <Plus /> {modelDone ? "Add another" : "Add model"}
               </Button>
             }

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { Dialog } from "@base-ui/react/dialog";
 import { SidebarContext } from "@/components/sidebar-context";
 import { SearchChatsPalette } from "@/components/SearchChatsPalette";
 import { useLocalStorage } from "@/lib/useLocalStorage";
+import { motionClasses } from "@/lib/motion";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 
 export function AppShell({
   sidebar,
@@ -14,7 +16,7 @@ export function AppShell({
   sidebar: React.ReactNode;
   children: React.ReactNode;
 }) {
-  const router = useRouter();
+  const router = useMotionRouter();
   const [openMobile, setOpenMobile] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [collapsed, setCollapsed] = useLocalStorage<boolean>(
@@ -64,10 +66,12 @@ export function AppShell({
         <div className="box-border flex h-dvh overflow-hidden bg-background pt-[env(safe-area-inset-top)]">
           {!collapsed && <div className="hidden md:flex">{sidebar}</div>}
           <Dialog.Portal>
-            <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 md:hidden" />
+            <Dialog.Backdrop
+              className={`fixed inset-0 z-40 bg-black/40 md:hidden ${motionClasses.overlay}`}
+            />
             <Dialog.Popup
               ref={drawerRef as React.RefObject<HTMLDivElement>}
-              className="fixed inset-y-0 left-0 z-50 box-border flex bg-sidebar pt-[env(safe-area-inset-top)] transition-transform duration-200 data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full md:hidden"
+              className="fixed inset-y-0 left-0 z-50 box-border flex bg-sidebar pt-[env(safe-area-inset-top)] motion-transform data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full md:hidden"
             >
               {sidebar}
             </Dialog.Popup>

--- a/apps/web/components/ModelPicker.tsx
+++ b/apps/web/components/ModelPicker.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import { cn } from "@/lib/utils";
 import type { PublicModelConfig } from "@/lib/config";
+import { motionClasses } from "@/lib/motion";
 
 interface Props {
   models: PublicModelConfig[] | null;
@@ -70,6 +71,7 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
           <Menu.Popup
             className={cn(
               "z-50 max-h-96 w-80 overflow-y-auto rounded-lg border bg-popover text-sm text-popover-foreground shadow-md outline-none",
+              motionClasses.popup,
               showSearch ? "p-0" : "p-1",
             )}
           >
@@ -105,7 +107,7 @@ export function ModelPicker({ models, selectedId, onSelect }: Props) {
                       setSearch("");
                     }}
                     className={cn(
-                      "flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+                      "flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
                       m.id === selectedId && "bg-accent text-accent-foreground",
                     )}
                   >

--- a/apps/web/components/SearchChatsPalette.tsx
+++ b/apps/web/components/SearchChatsPalette.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Dialog } from "@base-ui/react/dialog";
 import { Pencil, Search, X } from "lucide-react";
@@ -8,6 +7,8 @@ import { cn } from "@/lib/utils";
 import { groupByDate, type DateBucket } from "@/lib/dateGroups";
 import { useChats } from "@/lib/queries/chats";
 import { useChatsSearch, type SearchHit } from "@/lib/queries/search";
+import { motionClasses } from "@/lib/motion";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 
 type Chat = { id: string; title: string | null; updatedAt: number };
 
@@ -40,7 +41,7 @@ export function SearchChatsPalette({
   open: boolean;
   onOpenChange: (v: boolean) => void;
 }) {
-  const router = useRouter();
+  const router = useMotionRouter();
   const { data: allChats = [] } = useChats();
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -145,8 +146,15 @@ export function SearchChatsPalette({
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[starting-style]:opacity-0 data-[ending-style]:opacity-0" />
-        <Dialog.Popup className="fixed left-1/2 top-[20%] z-50 w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 rounded-xl border bg-popover text-popover-foreground shadow-xl outline-none transition-opacity data-[starting-style]:opacity-0 data-[ending-style]:opacity-0">
+        <Dialog.Backdrop
+          className={cn("fixed inset-0 z-40 bg-black/40", motionClasses.overlay)}
+        />
+        <Dialog.Popup
+          className={cn(
+            "fixed left-1/2 top-[20%] z-50 w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 rounded-xl border bg-popover text-popover-foreground shadow-xl outline-none",
+            motionClasses.palette,
+          )}
+        >
           <Dialog.Title className="sr-only">Search chats</Dialog.Title>
           <div className="flex items-center gap-2 border-b px-3 py-2.5">
             <Search className="size-4 shrink-0 text-muted-foreground" />
@@ -174,7 +182,7 @@ export function SearchChatsPalette({
               type="button"
               onClick={() => handleOpenChange(false)}
               aria-label="Close"
-              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              className="rounded p-1 text-muted-foreground motion-colors hover:bg-muted hover:text-foreground"
             >
               <X className="size-4" />
             </button>

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Menu } from "@base-ui/react/menu";
@@ -22,7 +21,11 @@ import {
 import { getErrorMessage } from "@/lib/errors";
 import { useSidebar } from "@/components/sidebar-context";
 import { Button } from "@/components/ui/button";
+import { MotionLink } from "@/components/ui/motion-link";
 import { toast } from "@/components/ui/toast";
+import { motionClasses } from "@/lib/motion";
+import { useMotionRouter } from "@/lib/useMotionRouter";
+import { useReducedMotion } from "@/lib/useReducedMotion";
 
 interface Chat {
   id: string;
@@ -85,7 +88,7 @@ export function SidebarItem({
   projects: ProjectOption[];
   currentProjectId?: string | null;
 }) {
-  const router = useRouter();
+  const router = useMotionRouter();
   const pathname = usePathname();
   const active = pathname === `/chat/${chat.id}`;
   // See AccountMenu for the full explanation; mobile drawer needs in-subtree portaling.
@@ -180,10 +183,10 @@ export function SidebarItem({
   return (
     <>
       <li className="group flex items-center">
-        <Link
+        <MotionLink
           href={`/chat/${chat.id}`}
           className={cn(
-            "flex-1 truncate rounded-md px-2 py-1.5 text-sm hover:bg-sidebar-accent",
+            "flex-1 truncate rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
             active && "bg-sidebar-accent",
           )}
         >
@@ -197,41 +200,54 @@ export function SidebarItem({
           ) : (
             "Untitled"
           )}
-        </Link>
+        </MotionLink>
         <Menu.Root>
           <Menu.Trigger
             aria-label="Chat actions"
-            className="mr-0.5 rounded p-1 opacity-0 transition-opacity hover:bg-sidebar-accent group-hover:opacity-100 data-[popup-open]:opacity-100 max-md:p-2 [@media(hover:none)]:opacity-100"
+            className={cn(
+              "mr-0.5 rounded p-1 hover:bg-sidebar-accent max-md:p-2",
+              motionClasses.hoverReveal,
+            )}
           >
             <MoreHorizontal className="size-3.5 text-muted-foreground" />
           </Menu.Trigger>
           <Menu.Portal container={drawerRef}>
             <Menu.Positioner side="right" align="start" sideOffset={6}>
-              <Menu.Popup className="z-50 w-44 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
+              <Menu.Popup
+                className={cn(
+                  "z-50 w-44 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+                  motionClasses.popup,
+                )}
+              >
                 <Menu.Item
                   onClick={() => {
                     setDraft(chat.title ?? "");
                     setRenaming(true);
                   }}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
                 >
                   <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
                   <span>Rename</span>
                 </Menu.Item>
                 <Menu.SubmenuRoot>
-                  <Menu.SubmenuTrigger className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[popup-open]:bg-accent">
+                  <Menu.SubmenuTrigger className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[popup-open]:bg-accent">
                     <FolderInput className="size-3.5 shrink-0 text-muted-foreground" />
                     <span>Move to</span>
                     <span className="ml-auto text-muted-foreground">›</span>
                   </Menu.SubmenuTrigger>
                   <Menu.Portal container={drawerRef}>
                     <Menu.Positioner side="right" align="start" sideOffset={6}>
-                      <Menu.Popup className="z-50 max-h-64 w-48 overflow-y-auto rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none">
+                      <Menu.Popup
+                        className={cn(
+                          "z-50 max-h-64 w-48 overflow-y-auto rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+                          motionClasses.popup,
+                        )}
+                      >
                         <Menu.Item
                           onClick={() => moveTo(null)}
                           disabled={currentProjectId === null}
                           className={cn(
-                            "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+                            "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
                             currentProjectId === null &&
                               "text-muted-foreground",
                           )}
@@ -247,7 +263,7 @@ export function SidebarItem({
                             onClick={() => moveTo(p.id)}
                             disabled={p.id === currentProjectId}
                             className={cn(
-                              "flex cursor-pointer items-center gap-2 truncate rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+                              "flex cursor-pointer items-center gap-2 truncate rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
                               p.id === currentProjectId &&
                                 "text-muted-foreground",
                             )}
@@ -261,14 +277,14 @@ export function SidebarItem({
                 </Menu.SubmenuRoot>
                 <Menu.Item
                   render={<a href={`/api/chat/${chat.id}/export`} download />}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
                 >
                   <Download className="size-3.5 shrink-0 text-muted-foreground" />
                   <span>Export</span>
                 </Menu.Item>
                 <Menu.Item
                   onClick={requestDelete}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-destructive outline-none data-[highlighted]:bg-accent"
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-destructive outline-none motion-colors data-[highlighted]:bg-accent"
                 >
                   <Trash2 className="size-3.5 shrink-0" />
                   <span>Delete</span>
@@ -291,8 +307,15 @@ export function SidebarItem({
         }}
       >
         <AlertDialog.Portal>
-          <AlertDialog.Backdrop className="fixed inset-0 z-50 bg-black/40 transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0" />
-          <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-5 text-card-foreground shadow-lg outline-none transition-opacity data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
+          <AlertDialog.Backdrop
+            className={cn("fixed inset-0 z-50 bg-black/40", motionClasses.overlay)}
+          />
+          <AlertDialog.Popup
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-5 text-card-foreground shadow-lg outline-none",
+              motionClasses.dialog,
+            )}
+          >
             <AlertDialog.Title className="text-base font-semibold tracking-tight">
               Delete chat?
             </AlertDialog.Title>
@@ -349,12 +372,17 @@ function RevealedTitle({
   onComplete: () => void;
 }) {
   const chars = Array.from(title);
+  const reducedMotion = useReducedMotion();
   const [length, setLength] = useState(() =>
     reveal ? Math.min(1, chars.length) : chars.length,
   );
 
   useEffect(() => {
     if (!reveal) return;
+    if (reducedMotion) {
+      onComplete();
+      return;
+    }
 
     let nextLength = Math.min(1, chars.length);
 
@@ -368,7 +396,7 @@ function RevealedTitle({
     }, 24);
 
     return () => window.clearInterval(interval);
-  }, [chars.length, onComplete, reveal]);
+  }, [chars.length, onComplete, reducedMotion, reveal]);
 
-  return <>{reveal ? chars.slice(0, length).join("") : title}</>;
+  return <>{reveal && !reducedMotion ? chars.slice(0, length).join("") : title}</>;
 }

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
 import { FolderPlus, PanelLeft, Pencil, Search } from "lucide-react";
 import { SidebarChatList } from "@/components/SidebarChatList";
@@ -12,11 +11,13 @@ import {
 import { useSidebar } from "@/components/sidebar-context";
 import { useChats } from "@/lib/queries/chats";
 import { useProjects } from "@/lib/queries/projects";
+import { MotionLink } from "@/components/ui/motion-link";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 
 export function SidebarClient() {
   const { setOpenMobile, setCollapsed, openPalette } = useSidebar();
   const [creatingProject, setCreatingProject] = useState(false);
-  const router = useRouter();
+  const router = useMotionRouter();
   const pathname = usePathname();
 
   const { data: chats = [] } = useChats();
@@ -72,7 +73,7 @@ export function SidebarClient() {
 
       <div className="flex-1 overflow-y-auto px-2 pb-2">
         <nav className="flex flex-col gap-0.5 py-1">
-          <Link
+          <MotionLink
             href="/"
             onClick={(e) => {
               setOpenMobile(false);
@@ -81,16 +82,17 @@ export function SidebarClient() {
                 router.refresh();
               }
             }}
-            className="group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-sidebar-accent"
+            pendingHint
+            className="group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent"
           >
             <Pencil className="size-4 shrink-0 text-muted-foreground" />
             <span className="flex-1">New chat</span>
             <Shortcut keys={["Ctrl", "Shift", "O"]} />
-          </Link>
+          </MotionLink>
           <button
             type="button"
             onClick={openPalette}
-            className="group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-sidebar-accent"
+            className="group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent"
           >
             <Search className="size-4 shrink-0 text-muted-foreground" />
             <span className="flex-1 text-left">Search chats</span>
@@ -103,7 +105,7 @@ export function SidebarClient() {
         <button
           type="button"
           onClick={() => setCreatingProject(true)}
-          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground motion-colors hover:bg-sidebar-accent hover:text-foreground"
         >
           <FolderPlus className="size-4 shrink-0" />
           <span>New project</span>
@@ -130,7 +132,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 function Shortcut({ keys }: { keys: string[] }) {
   return (
-    <span className="flex shrink-0 items-center gap-0.5 text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
+    <span className="flex shrink-0 items-center gap-0.5 text-[10px] text-muted-foreground opacity-0 motion-opacity group-hover:opacity-100">
       {keys.map((k) => (
         <kbd
           key={k}

--- a/apps/web/components/SidebarProjects.tsx
+++ b/apps/web/components/SidebarProjects.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { Dialog } from "@base-ui/react/dialog";
 import { ChevronRight, Plus } from "lucide-react";
@@ -9,9 +8,12 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { MotionLink } from "@/components/ui/motion-link";
 import { toast } from "@/components/ui/toast";
 import { getErrorMessage } from "@/lib/errors";
+import { motionClasses } from "@/lib/motion";
 import { useCreateProject } from "@/lib/queries/projects";
+import { useMotionRouter } from "@/lib/useMotionRouter";
 import {
   SidebarItem,
   type ProjectOption,
@@ -67,31 +69,34 @@ function ProjectNode({
           type="button"
           onClick={() => setOpen((o) => !o)}
           aria-label={open ? "Collapse" : "Expand"}
-          className="rounded p-1 text-muted-foreground hover:bg-sidebar-accent max-md:p-2"
+          className="rounded p-1 text-muted-foreground motion-colors hover:bg-sidebar-accent max-md:p-2"
         >
           <ChevronRight
             className={cn(
-              "size-3.5 transition-transform",
+              "size-3.5 motion-transform",
               open && "rotate-90",
             )}
           />
         </button>
-        <Link
+        <MotionLink
           href={`/projects/${project.id}`}
           className={cn(
-            "flex-1 truncate rounded-md px-1 py-1 text-sm hover:bg-sidebar-accent",
+            "flex-1 truncate rounded-md px-1 py-1 text-sm motion-colors hover:bg-sidebar-accent",
             active && "bg-sidebar-accent",
           )}
         >
           {project.name}
-        </Link>
-        <Link
+        </MotionLink>
+        <MotionLink
           href={`/?projectId=${project.id}`}
           aria-label={`New chat in ${project.name}`}
-          className="mr-0.5 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-foreground group-hover:opacity-100 max-md:p-2 [@media(hover:none)]:opacity-100"
+          className={cn(
+            "mr-0.5 rounded p-1 text-muted-foreground hover:bg-sidebar-accent hover:text-foreground max-md:p-2",
+            motionClasses.hoverReveal,
+          )}
         >
           <Plus className="size-3.5" />
-        </Link>
+        </MotionLink>
       </div>
       {open && (
         <ul className="ml-5 flex flex-col gap-0.5 border-l pl-1">
@@ -122,7 +127,7 @@ export function CreateProjectDialog({
   open: boolean;
   onClose: () => void;
 }) {
-  const router = useRouter();
+  const router = useMotionRouter();
   const createMut = useCreateProject();
   const [name, setName] = useState("");
   const [error, setError] = useState("");
@@ -171,8 +176,15 @@ export function CreateProjectDialog({
       }}
     >
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-40 bg-black/40 transition-opacity data-[starting-style]:opacity-0 data-[ending-style]:opacity-0" />
-        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none transition-opacity data-[starting-style]:opacity-0 data-[ending-style]:opacity-0">
+        <Dialog.Backdrop
+          className={cn("fixed inset-0 z-40 bg-black/40", motionClasses.overlay)}
+        />
+        <Dialog.Popup
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none",
+            motionClasses.dialog,
+          )}
+        >
           <Dialog.Title className="text-lg font-semibold tracking-tight">
             New project
           </Dialog.Title>

--- a/apps/web/components/chat/ChainOfThought.tsx
+++ b/apps/web/components/chat/ChainOfThought.tsx
@@ -10,6 +10,7 @@ import {
   Search,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { motionClasses } from "@/lib/motion";
 import { cleanDomain, faviconUrl } from "@/lib/web-client";
 import type {
   FetchUrlPart,
@@ -86,22 +87,22 @@ export function ChainOfThought({
         type="button"
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
-        className="group/cot flex w-full items-center gap-2 py-1 text-left text-muted-foreground transition-colors hover:text-foreground"
+        className="group/cot flex w-full items-center gap-2 py-1 text-left text-muted-foreground motion-colors hover:text-foreground"
       >
         <StatusIcon
-          className={cn("size-4 shrink-0", active && "animate-spin")}
+          className={cn("size-4 shrink-0", active && motionClasses.spinner)}
         />
         <span
           className={cn(
             "min-w-0 truncate font-medium",
-            active ? "animate-text-shimmer text-foreground" : "text-foreground",
+            active ? `${motionClasses.shimmer} text-foreground` : "text-foreground",
           )}
         >
           {label}
         </span>
         <ChevronDown
           className={cn(
-            "size-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-200",
+            "size-3.5 shrink-0 text-muted-foreground/60 motion-transform",
             open && "rotate-180",
           )}
         />
@@ -110,7 +111,8 @@ export function ChainOfThought({
       {/* Timeline — typed step nodes on a left rail, in original order. */}
       <div
         className={cn(
-          "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+          "grid",
+          motionClasses.collapse,
           open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
         )}
       >
@@ -202,7 +204,7 @@ function ResultRow({ result }: { result: WebSearchResult }) {
         href={result.link}
         target="_blank"
         rel="noreferrer"
-        className="flex items-center gap-2.5 px-2.5 py-2 transition-colors hover:bg-accent/60"
+        className="flex items-center gap-2.5 px-2.5 py-2 motion-colors hover:bg-accent/60"
       >
         <Favicon domain={domain} className="size-4 shrink-0 rounded-sm" />
         <span className="min-w-0 flex-1 truncate text-foreground">
@@ -237,10 +239,10 @@ function FetchStep({ part }: { part: FetchUrlPart }) {
       href={page?.url ?? url ?? "#"}
       target="_blank"
       rel="noreferrer"
-      className="flex items-center gap-2.5 rounded-lg border bg-background/40 px-2.5 py-2 transition-colors hover:bg-accent/60"
+      className="flex items-center gap-2.5 rounded-lg border bg-background/40 px-2.5 py-2 motion-colors hover:bg-accent/60"
     >
       {running ? (
-        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+        <Loader2 className={cn("size-4 shrink-0 text-muted-foreground", motionClasses.spinner)} />
       ) : (
         <Favicon domain={domain} className="size-4 shrink-0 rounded-sm" />
       )}

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -11,6 +11,7 @@ import { chatKeys } from "@/lib/queries/keys";
 import { useChats, type ChatListItem } from "@/lib/queries/chats";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import { useSpeech } from "@/lib/useSpeech";
+import { motionClasses } from "@/lib/motion";
 import { authClient } from "@/lib/auth/client";
 import {
   readMessageStats,
@@ -263,9 +264,9 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
       <MiniSpeechPlayer speech={speech} />
 
       {dropActive && (
-        <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center bg-background/70 backdrop-blur-[2px]">
+        <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center bg-background/70 backdrop-blur-[2px] motion-overlay">
           <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-ring bg-background/90 px-8 py-6 text-center shadow-lg ring-1 ring-ring/20">
-            <div className="flex size-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm animate-in zoom-in-95">
+            <div className={`flex size-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm ${motionClasses.dropIcon}`}>
               <FileUp className="size-6" />
             </div>
             <div>

--- a/apps/web/components/chat/Citation.tsx
+++ b/apps/web/components/chat/Citation.tsx
@@ -35,7 +35,7 @@ function CitationPill({ source, n }: { source: WebSearchResult; n: number }) {
       target="_blank"
       rel="noopener noreferrer"
       title={`${source.title} — ${domain}`}
-      className="ml-0.5 inline-flex h-[18px] items-center gap-1 rounded-full border bg-muted px-1.5 align-baseline text-[10px] font-medium leading-none text-muted-foreground no-underline transition-colors hover:bg-accent hover:text-foreground"
+      className="ml-0.5 inline-flex h-[18px] items-center gap-1 rounded-full border bg-muted px-1.5 align-baseline text-[10px] font-medium leading-none text-muted-foreground no-underline motion-colors hover:bg-accent hover:text-foreground"
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img

--- a/apps/web/components/chat/Composer.tsx
+++ b/apps/web/components/chat/Composer.tsx
@@ -27,6 +27,7 @@ import {
   getDataTransferFiles,
 } from "@/lib/chat/attachments";
 import { dictationErrorMessage } from "@/lib/chat/message";
+import { motionClasses } from "@/lib/motion";
 import { useDictation } from "@/lib/useDictation";
 import { CategoryIcon } from "./attachment-icons";
 import {
@@ -145,7 +146,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       )}
       <div
         className={cn(
-          "flex flex-col gap-2 rounded-3xl border bg-background px-3.5 pt-3.5 pb-2.5 shadow-sm transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
+          "flex flex-col gap-2 rounded-3xl border bg-background px-3.5 pt-3.5 pb-2.5 shadow-sm motion-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
           dropActive && "border-ring bg-accent/20 ring-2 ring-ring/30",
         )}
       >
@@ -240,7 +241,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
               aria-pressed={dictation.status === "recording"}
             >
               {dictation.status === "transcribing" ? (
-                <Loader2 className="animate-spin" />
+                <Loader2 className={motionClasses.spinner} />
               ) : dictation.status === "recording" ? (
                 <Square className="size-3 fill-current" />
               ) : (
@@ -269,7 +270,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
                 onClick={submit}
                 aria-label="Send message"
               >
-                {uploading ? <Loader2 className="animate-spin" /> : <ArrowUp />}
+                {uploading ? <Loader2 className={motionClasses.spinner} /> : <ArrowUp />}
               </Button>
             )}
           </div>
@@ -297,7 +298,7 @@ function AttachmentChip({
       type="button"
       onClick={onRemove}
       aria-label={`Remove ${label}`}
-      className="absolute top-0.5 right-0.5 rounded-full bg-foreground/70 p-0.5 text-background shadow-sm hover:bg-foreground max-md:p-1"
+      className="absolute top-0.5 right-0.5 rounded-full bg-foreground/70 p-0.5 text-background shadow-sm motion-colors hover:bg-foreground max-md:p-1"
     >
       <X className="size-3" />
     </button>
@@ -315,7 +316,7 @@ function AttachmentChip({
         )}
         {status === "uploading" && (
           <div className="absolute inset-0 flex items-center justify-center bg-background/50">
-            <Loader2 className="size-4 animate-spin text-foreground" />
+            <Loader2 className={`size-4 text-foreground ${motionClasses.spinner}`} />
           </div>
         )}
         {removeButton}
@@ -342,7 +343,7 @@ function AttachmentChip({
     >
       <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
         {status === "uploading" ? (
-          <Loader2 className="size-4 animate-spin" />
+          <Loader2 className={`size-4 ${motionClasses.spinner}`} />
         ) : status === "error" ? (
           <AlertCircle className="size-4 text-destructive" />
         ) : (

--- a/apps/web/components/chat/MessageBubble.tsx
+++ b/apps/web/components/chat/MessageBubble.tsx
@@ -27,6 +27,7 @@ import { groupMessageParts } from "@/lib/chat/parts";
 import { stripCitationMarkers, type CitationRefType } from "@/lib/citations";
 import { unicodeCitation } from "@/lib/citations-remark";
 import type { MessageStats } from "@/lib/chat/stats";
+import { motionClasses } from "@/lib/motion";
 import type { useSpeech } from "@/lib/useSpeech";
 import {
   Citation,
@@ -391,7 +392,7 @@ function MessageActions({
 }) {
   if (!show) return null;
   return (
-    <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100">
+    <div className="flex items-center gap-0.5 opacity-0 motion-opacity group-hover:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100">
       {children}
     </div>
   );
@@ -412,7 +413,7 @@ function ActionButton({
       onClick={onClick}
       aria-label={label}
       title={label}
-      className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground max-md:p-2.5"
+      className="rounded-md p-1.5 text-muted-foreground motion-colors hover:bg-accent hover:text-foreground max-md:p-2.5"
     >
       {icon}
     </button>
@@ -463,7 +464,7 @@ function SpeakButton({
   const live = active && (speech.status === "playing" || speech.status === "paused");
   const label = live ? "Stop" : loading ? "Loading…" : "Speak";
   const icon = loading ? (
-    <Loader2 className="size-3.5 animate-spin" />
+    <Loader2 className={`size-3.5 ${motionClasses.spinner}`} />
   ) : live ? (
     <Square className="size-3 fill-current" />
   ) : (

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -6,6 +6,7 @@ import { useStickToBottom } from "use-stick-to-bottom";
 import { Button } from "@/components/ui/button";
 import { chatErrorMessage } from "@/lib/chat/message";
 import { readMessageStats, type StoredMessageStats } from "@/lib/chat/stats";
+import { motionClasses } from "@/lib/motion";
 import type { useSpeech } from "@/lib/useSpeech";
 import { MessageBubble } from "./MessageBubble";
 
@@ -95,9 +96,9 @@ function PendingIndicator() {
       role="status"
       aria-label="Assistant is responding"
     >
-      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70 [animation-delay:-0.3s]" />
-      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70 [animation-delay:-0.15s]" />
-      <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/70" />
+      <span className={`size-1.5 rounded-full bg-muted-foreground/70 [animation-delay:-0.3s] ${motionClasses.pendingDot}`} />
+      <span className={`size-1.5 rounded-full bg-muted-foreground/70 [animation-delay:-0.15s] ${motionClasses.pendingDot}`} />
+      <span className={`size-1.5 rounded-full bg-muted-foreground/70 ${motionClasses.pendingDot}`} />
     </div>
   );
 }

--- a/apps/web/components/chat/MiniSpeechPlayer.tsx
+++ b/apps/web/components/chat/MiniSpeechPlayer.tsx
@@ -42,7 +42,7 @@ export function MiniSpeechPlayer({
             type="button"
             onClick={() => stop()}
             aria-label="Dismiss"
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            className="rounded-md p-1.5 text-muted-foreground motion-colors hover:bg-accent hover:text-foreground"
           >
             <X className="size-4" />
           </button>
@@ -74,7 +74,7 @@ export function MiniSpeechPlayer({
           type="button"
           onClick={() => stop()}
           aria-label="Close player"
-          className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          className="rounded-md p-2 text-muted-foreground motion-colors hover:bg-accent hover:text-foreground"
         >
           <X className="size-4" />
         </button>

--- a/apps/web/components/chat/Sources.tsx
+++ b/apps/web/components/chat/Sources.tsx
@@ -32,7 +32,7 @@ export function Sources({ message }: { message: UIMessage }) {
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-2 rounded-md py-1 text-muted-foreground transition-colors hover:text-foreground"
+        className="flex items-center gap-2 rounded-md py-1 text-muted-foreground motion-colors hover:text-foreground"
       >
         <div className="flex -space-x-1">
           {preview.map((r) => {
@@ -52,7 +52,7 @@ export function Sources({ message }: { message: UIMessage }) {
         <span className="font-medium">{all.length} Sources</span>
         <ChevronRight
           className={cn(
-            "size-3.5 transition-transform",
+            "size-3.5 motion-transform",
             open && "rotate-90",
           )}
         />

--- a/apps/web/components/chat/StatsPopover.tsx
+++ b/apps/web/components/chat/StatsPopover.tsx
@@ -9,6 +9,8 @@ import {
   type MessageStats,
 } from "@/lib/chat/stats";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 
 export function StatsPopover({ stats }: { stats: MessageStats }) {
   const rows = [
@@ -60,13 +62,18 @@ export function StatsPopover({ stats }: { stats: MessageStats }) {
         type="button"
         aria-label="Message stats"
         title="Message stats"
-        className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground max-md:p-2.5"
+        className="rounded-md p-1.5 text-muted-foreground motion-colors hover:bg-accent hover:text-foreground max-md:p-2.5"
       >
         <Info className="size-3.5" />
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Positioner side="top" align="start" sideOffset={6}>
-          <Popover.Popup className="z-50 w-56 rounded-lg border bg-popover p-3 text-xs text-popover-foreground shadow-md outline-none">
+          <Popover.Popup
+            className={cn(
+              "z-50 w-56 rounded-lg border bg-popover p-3 text-xs text-popover-foreground shadow-md outline-none",
+              motionClasses.popup,
+            )}
+          >
             <div className="space-y-2">
               {rows.map(({ iconId, label, value }) => (
                 <div key={label} className="flex items-center justify-between gap-4">

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap motion-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base motion-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/apps/web/components/ui/motion-link.tsx
+++ b/apps/web/components/ui/motion-link.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link, { useLinkStatus } from "next/link";
+import { forwardRef, type ComponentProps } from "react";
+import { cn } from "@/lib/utils";
+import { motionClasses, transitionTypesForUrl } from "@/lib/motion";
+
+type MotionLinkProps = ComponentProps<typeof Link> & {
+  pendingHint?: boolean;
+  pendingHintClassName?: string;
+};
+
+export const MotionLink = forwardRef<HTMLAnchorElement, MotionLinkProps>(
+  function MotionLink(
+    {
+      href,
+      transitionTypes,
+      pendingHint = false,
+      pendingHintClassName,
+      children,
+      ...props
+    },
+    ref,
+  ) {
+    return (
+      <Link
+        ref={ref}
+        href={href}
+        transitionTypes={transitionTypes ?? transitionTypesForUrl(href)}
+        {...props}
+      >
+        {children}
+        {pendingHint && <LinkPendingHint className={pendingHintClassName} />}
+      </Link>
+    );
+  },
+);
+
+function LinkPendingHint({ className }: { className?: string }) {
+  const { pending } = useLinkStatus();
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "ml-auto size-1.5 shrink-0 rounded-full bg-current opacity-0 motion-opacity",
+        pending && `opacity-60 ${motionClasses.linkPending}`,
+        className,
+      )}
+    />
+  );
+}

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -5,6 +5,7 @@ import { Select as SelectPrimitive } from "@base-ui/react/select"
 
 import { cn } from "@/lib/utils"
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+import { motionClasses } from "@/lib/motion"
 
 const Select = SelectPrimitive.Root
 
@@ -41,7 +42,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap motion-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -83,7 +84,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10", motionClasses.selectPopup, className )}
           {...props}
         >
           <SelectScrollUpButton />

--- a/apps/web/components/ui/switch.tsx
+++ b/apps/web/components/ui/switch.tsx
@@ -16,14 +16,14 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent motion-colors outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+        className="pointer-events-none block rounded-full bg-background ring-0 motion-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
       />
     </SwitchPrimitive.Root>
   )

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base motion-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { Toast as ToastPrimitive } from "@base-ui/react/toast";
 import { CheckCircle2, X, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { motionClasses } from "@/lib/motion";
 
 type ToastInput =
   | string
@@ -58,8 +59,8 @@ function ToastList() {
       toast={item}
       swipeDirection="right"
       className={cn(
-        "pointer-events-auto w-full rounded-lg border bg-popover text-popover-foreground shadow-lg outline-none transition-all duration-200",
-        "data-[swiping]:transition-none data-[starting-style]:translate-x-6 data-[starting-style]:opacity-0 data-[ending-style]:translate-x-6 data-[ending-style]:opacity-0",
+        "pointer-events-auto w-full rounded-lg border bg-popover text-popover-foreground shadow-lg outline-none",
+        motionClasses.toast,
         item.type === "success" && "border-ring/30",
         item.type === "error" && "border-destructive/35",
       )}
@@ -74,7 +75,7 @@ function ToastList() {
         </div>
         <ToastPrimitive.Close
           aria-label="Dismiss notification"
-          className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+          className="rounded-md p-1 text-muted-foreground outline-none motion-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
         >
           <X className="size-3.5" />
         </ToastPrimitive.Close>

--- a/apps/web/e2e/motion.spec.ts
+++ b/apps/web/e2e/motion.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+import Database from "better-sqlite3";
+import path from "node:path";
+
+const TEST_DB_PATH = path.resolve(__dirname, "../data/test.db");
+
+function resetE2eDatabase() {
+  const db = new Database(TEST_DB_PATH);
+  db.pragma("foreign_keys = ON");
+  db.pragma("busy_timeout = 5000");
+  db.transaction(() => {
+    db.prepare("DELETE FROM messages").run();
+    db.prepare("DELETE FROM messages_fts").run();
+    db.prepare("DELETE FROM chats").run();
+    db.prepare("DELETE FROM projects").run();
+    db.prepare("DELETE FROM uploads").run();
+    db.prepare("DELETE FROM account").run();
+    db.prepare("DELETE FROM session").run();
+    db.prepare("DELETE FROM verification").run();
+    db.prepare("DELETE FROM user").run();
+    db.prepare("DELETE FROM model_configs").run();
+  })();
+  db.close();
+}
+
+function seedModelConfig() {
+  const db = new Database(TEST_DB_PATH);
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO model_configs
+      (id, label, base_url, api_key, model, system_prompt, extra_body, enabled, sort_order, created_at, updated_at)
+     VALUES
+      (@id, @label, @baseUrl, @apiKey, @model, NULL, NULL, 1, 0, @now, @now)`,
+  ).run({
+    id: "motion-model",
+    label: "Local Motion Model",
+    baseUrl: "https://example.invalid/v1",
+    apiKey: "test-key",
+    model: "motion-test-model",
+    now,
+  });
+  db.close();
+}
+
+test.beforeEach(() => {
+  resetE2eDatabase();
+});
+
+test("motion surfaces work without an upstream model", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+
+  await test.step("admin signup", async () => {
+    await page.goto("/signup");
+    await page.locator("#name").fill("Motion Admin");
+    await page.locator("#email").fill("motion-admin@overtchat-test.local");
+    await page.locator("#password").fill("test-password-123");
+    await page.getByRole("button", { name: "Create account" }).click();
+    await page.waitForURL("**/", { timeout: 15000 });
+    seedModelConfig();
+    await page.reload();
+  });
+
+  await test.step("model picker and command palette", async () => {
+    await page.getByRole("button", { name: /Local Motion Model/ }).click();
+    await expect(page.getByRole("menu")).toContainText("Local Motion Model");
+    await page.keyboard.press("Escape");
+
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+K" : "Control+K");
+    await expect(page.getByRole("dialog", { name: "Search chats" })).toBeVisible();
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page.getByRole("dialog", { name: "Search chats" })).toBeHidden();
+  });
+
+  await test.step("project dialog and motion router navigation", async () => {
+    await page.getByRole("button", { name: "New project" }).click();
+    await expect(page.getByRole("dialog", { name: "New project" })).toBeVisible();
+    await page.locator("#project-name").fill("Motion Project");
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+    await page.waitForURL("**/projects/**");
+    await expect(page.getByRole("heading", { name: "Instructions" })).toBeVisible();
+  });
+
+  await test.step("settings links, add-user dialog, and alert dialog", async () => {
+    await page.goto("/");
+    await page.getByText("Motion Admin").click();
+    await page.getByRole("menuitem", { name: "Settings" }).click();
+    await page.waitForURL("**/settings");
+
+    await page.getByRole("link", { name: /Users/ }).click();
+    await page.waitForURL("**/settings/users");
+    await page.getByRole("button", { name: "Add user" }).click();
+    await expect(page.getByRole("dialog", { name: "Add user" })).toBeVisible();
+    await page.locator("#new-name").fill("Motion Guest");
+    await page.locator("#new-email").fill("motion-guest@overtchat-test.local");
+    await page.locator("#new-password").fill("test-password-123");
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+    await expect(
+      page.getByRole("cell", { name: "motion-guest@overtchat-test.local" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByRole("alertdialog", { name: "Delete user?" })).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByRole("alertdialog", { name: "Delete user?" })).toBeHidden();
+  });
+
+  await test.step("mobile drawer opens under reduced motion", async () => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    await page.getByLabel("Open sidebar").click();
+    await expect(page.getByRole("button", { name: "New project" })).toBeVisible();
+  });
+
+  await test.step("logout and auth redirect", async () => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await page.getByText("Motion Admin").click();
+    await page.getByRole("menuitem", { name: "Log out" }).click();
+    await page.waitForURL("**/login", { timeout: 15000 });
+    await expect(page.locator("h1")).toContainText("Welcome back");
+
+    await page.goto("/");
+    await page.waitForURL("**/login", { timeout: 15000 });
+  });
+});

--- a/apps/web/lib/motion.ts
+++ b/apps/web/lib/motion.ts
@@ -1,0 +1,109 @@
+export const routeTransitionTypes = {
+  chat: "route-chat",
+  project: "route-project",
+  settings: "route-settings",
+  auth: "route-auth",
+  home: "route-home",
+  samePane: "route-same-pane",
+} as const;
+
+export type RouteTransitionType =
+  (typeof routeTransitionTypes)[keyof typeof routeTransitionTypes];
+
+export type MotionNavigateOptions = {
+  scroll?: boolean;
+  transitionTypes?: string[];
+};
+
+export const motionClasses = {
+  interactive: "motion-colors",
+  opacity: "motion-opacity",
+  transform: "motion-transform",
+  hoverReveal:
+    "opacity-0 motion-opacity group-hover:opacity-100 focus-within:opacity-100 data-[popup-open]:opacity-100 [@media(hover:none)]:opacity-100",
+  overlay:
+    "motion-overlay data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+  dialog:
+    "motion-surface data-[starting-style]:scale-[0.98] data-[starting-style]:opacity-0 data-[ending-style]:scale-[0.98] data-[ending-style]:opacity-0",
+  palette:
+    "motion-surface data-[starting-style]:translate-y-1 data-[starting-style]:opacity-0 data-[ending-style]:translate-y-1 data-[ending-style]:opacity-0",
+  drawer:
+    "motion-transform data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full",
+  popup:
+    "origin-(--transform-origin) motion-surface data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+  selectPopup:
+    "origin-(--transform-origin) duration-(--motion-duration-fast) data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+  toast:
+    "motion-surface data-[swiping]:transition-none data-[starting-style]:translate-x-6 data-[starting-style]:opacity-0 data-[ending-style]:translate-x-6 data-[ending-style]:opacity-0",
+  collapse: "motion-collapse",
+  spinner: "animate-spin motion-reduce:animate-none",
+  shimmer: "animate-text-shimmer motion-reduce:animate-none",
+  pendingDot: "animate-bounce motion-reduce:animate-none",
+  dropIcon: "animate-in zoom-in-95 motion-reduce:animate-none",
+  linkPending: "animate-pulse motion-reduce:animate-none",
+} as const;
+
+export function transitionTypesForHref(href: string): RouteTransitionType[] {
+  if (href === "/" || href.startsWith("/?")) return [routeTransitionTypes.home];
+  if (href.startsWith("/chat/")) return [routeTransitionTypes.chat];
+  if (href.startsWith("/projects/")) return [routeTransitionTypes.project];
+  if (href === "/settings" || href.startsWith("/settings/")) {
+    return [routeTransitionTypes.settings];
+  }
+  if (href === "/login" || href === "/signup") {
+    return [routeTransitionTypes.auth];
+  }
+  return [routeTransitionTypes.samePane];
+}
+
+type UrlLike = {
+  pathname?: string | null;
+  query?:
+    | string
+    | Record<
+        string,
+        string | string[] | number | boolean | null | undefined
+      >
+    | null;
+  hash?: string | null;
+};
+
+export function transitionTypesForUrl(
+  href: unknown,
+): RouteTransitionType[] {
+  if (typeof href === "string") return transitionTypesForHref(href);
+  if (href instanceof URL) {
+    return transitionTypesForHref(`${href.pathname}${href.search}${href.hash}`);
+  }
+
+  const url = (href ?? {}) as UrlLike;
+  const pathname = url.pathname ?? "/";
+  const hash = url.hash ? `#${url.hash.replace(/^#/, "")}` : "";
+  if (typeof url.query === "string") {
+    const query = url.query ? `?${url.query.replace(/^\?/, "")}` : "";
+    return transitionTypesForHref(`${pathname}${query}${hash}`);
+  }
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(url.query ?? {})) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, item);
+    } else {
+      params.set(key, String(value));
+    }
+  }
+
+  const query = params.size ? `?${params.toString()}` : "";
+  return transitionTypesForHref(`${pathname}${query}${hash}`);
+}
+
+export function motionNavigateOptions(
+  href: string,
+  options?: MotionNavigateOptions,
+): MotionNavigateOptions {
+  return {
+    ...options,
+    transitionTypes: options?.transitionTypes ?? transitionTypesForHref(href),
+  };
+}

--- a/apps/web/lib/useMotionRouter.ts
+++ b/apps/web/lib/useMotionRouter.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { motionNavigateOptions, type MotionNavigateOptions } from "@/lib/motion";
+
+export function useMotionRouter() {
+  const router = useRouter();
+
+  const push = useCallback(
+    (href: string, options?: MotionNavigateOptions) => {
+      router.push(href, motionNavigateOptions(href, options));
+    },
+    [router],
+  );
+
+  const replace = useCallback(
+    (href: string, options?: MotionNavigateOptions) => {
+      router.replace(href, motionNavigateOptions(href, options));
+    },
+    [router],
+  );
+
+  return useMemo(
+    () => ({
+      ...router,
+      push,
+      replace,
+    }),
+    [push, replace, router],
+  );
+}

--- a/apps/web/lib/useReducedMotion.ts
+++ b/apps/web/lib/useReducedMotion.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return reduced;
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,9 @@ import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
   output: "standalone",
   outputFileTracingRoot: path.join(__dirname, "../../"),
   outputFileTracingIncludes: {

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.9.8}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.9.11}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add a CSS-first web motion system with shared duration/easing tokens, reusable surface classes, and reduced-motion behavior
- Add typed route transitions through `MotionLink` and `useMotionRouter`, plus lightweight App Router loading skeletons
- Standardize dialogs, drawers, menus, popovers, selects, toasts, controls, and chat affordances around the shared motion primitives
- Keep streamed message tokens unanimated while polishing pending, reasoning, upload, scroll, and title state changes
- Set the default Compose app image to `0.9.11` for the release

## Why
Motion behavior had grown across many one-off class strings, which made timing, easing, accessibility, and interaction quality inconsistent. This establishes one documented web standard without adding a runtime animation library.

## User impact
Navigation and state changes feel faster and more consistent, loading routes show stable skeletons, mobile and overlay surfaces transition cleanly, and users requesting reduced motion get instant nonessential transitions.

## Validation
- `npm run lint -w apps/web`
- `npm run test -w apps/web` (48 tests)
- `npm run build -w apps/web`
- `npm run test:e2e -w apps/web --` (motion coverage and live Gemini streaming)
- `docker compose config --quiet`
- Manual interaction pass across chat, projects, settings, dialogs, menus, and mobile sidebar