### PR TITLE
ci: simplify source token badge

### DIFF
--- a/.github/actions/repo-tokens/LICENSE
+++ b/.github/actions/repo-tokens/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gavriel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/repo-tokens/README.md
+++ b/.github/actions/repo-tokens/README.md
@@ -5,10 +5,10 @@ This is a token-count-only adaptation of NanoClaw's
 composite action. It keeps NanoClaw's `tiktoken` counting and SVG badge layout,
 but deliberately omits the model-dependent “percentage of context window.”
 
-The workflow counts the repository's system-understanding surface: production
-web, mobile, and shared source; maintenance scripts; core runtime/build
-configuration; and the agent guidance that documents the architecture. Tests,
-generated output, dependencies, and database migrations are excluded.
+The workflow counts production web, mobile, and shared source, including the
+web runtime entry point and Next.js configuration. Tests, documentation,
+maintenance scripts, infrastructure, generated output, dependencies, and
+database migrations are excluded.
 
 The tokenizer is pinned and the action lives in this repository so the metric
 cannot change because an upstream branch moved. See [LICENSE](LICENSE) for the

--- a/.github/actions/repo-tokens/README.md
+++ b/.github/actions/repo-tokens/README.md
@@ -1,0 +1,15 @@
+# Source Tokens
+
+This is a token-count-only adaptation of NanoClaw's
+[Repo Tokens](https://github.com/nanocoai/nanoclaw/tree/main/repo-tokens)
+composite action. It keeps NanoClaw's `tiktoken` counting and SVG badge layout,
+but deliberately omits the model-dependent “percentage of context window.”
+
+The workflow counts the repository's system-understanding surface: production
+web, mobile, and shared source; maintenance scripts; core runtime/build
+configuration; and the agent guidance that documents the architecture. Tests,
+generated output, dependencies, and database migrations are excluded.
+
+The tokenizer is pinned and the action lives in this repository so the metric
+cannot change because an upstream branch moved. See [LICENSE](LICENSE) for the
+upstream MIT license.

--- a/.github/actions/repo-tokens/action.yml
+++ b/.github/actions/repo-tokens/action.yml
@@ -1,0 +1,168 @@
+# Adapted from NanoClaw's Repo Tokens action:
+# https://github.com/nanocoai/nanoclaw/tree/main/repo-tokens
+# Copyright (c) 2026 Gavriel. Licensed under the MIT License in this directory.
+
+name: Source Tokens
+description: Count source tokens with tiktoken and update a token-count badge
+
+inputs:
+  include:
+    description: 'Glob patterns for files to count (space-separated)'
+    required: true
+  exclude:
+    description: 'Glob patterns to exclude (space-separated)'
+    required: false
+    default: ''
+  readme:
+    description: 'Path to README file'
+    required: false
+    default: 'README.md'
+  encoding:
+    description: 'Tiktoken encoding name'
+    required: false
+    default: 'cl100k_base'
+  marker:
+    description: 'HTML comment marker name'
+    required: false
+    default: 'token-count'
+  badge-path:
+    description: 'Path to write SVG badge (empty = no SVG)'
+    required: false
+    default: ''
+
+outputs:
+  tokens:
+    description: 'Total token count'
+    value: ${{ steps.count.outputs.tokens }}
+  badge:
+    description: 'Formatted token count'
+    value: ${{ steps.count.outputs.badge }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install tiktoken
+      shell: bash
+      run: pip install tiktoken==0.13.0
+
+    - name: Count tokens and update README
+      id: count
+      shell: python
+      env:
+        INPUT_INCLUDE: ${{ inputs.include }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_README: ${{ inputs.readme }}
+        INPUT_ENCODING: ${{ inputs.encoding }}
+        INPUT_MARKER: ${{ inputs.marker }}
+        INPUT_BADGE_PATH: ${{ inputs.badge-path }}
+      run: |
+        import glob, os, re, tiktoken
+
+        include_patterns = os.environ["INPUT_INCLUDE"].split()
+        exclude_patterns = os.environ["INPUT_EXCLUDE"].split()
+        readme_path = os.environ["INPUT_README"]
+        encoding_name = os.environ["INPUT_ENCODING"]
+        marker = os.environ["INPUT_MARKER"]
+        badge_path = os.environ.get("INPUT_BADGE_PATH", "").strip()
+
+        # Expand globs
+        included = set()
+        for pattern in include_patterns:
+            included.update(glob.glob(pattern, recursive=True))
+
+        excluded = set()
+        for pattern in exclude_patterns:
+            excluded.update(glob.glob(pattern, recursive=True))
+
+        files = sorted(included - excluded)
+        files = [f for f in files if os.path.isfile(f)]
+
+        # Count tokens
+        enc = tiktoken.get_encoding(encoding_name)
+        total = 0
+        for path in files:
+            try:
+                with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                    total += len(enc.encode(f.read()))
+            except Exception as e:
+                print(f"Skipping {path}: {e}")
+
+        # Format
+        if total >= 100000:
+            display = f"{round(total / 1000)}k"
+        elif total >= 1000:
+            display = f"{total / 1000:.1f}k"
+        else:
+            display = str(total)
+
+        badge = f"{display} tokens"
+        print(f"Files: {len(files)}, Tokens: {total}, Badge: {badge}")
+
+        # Update README text between optional markers
+        marker_re = re.compile(
+            rf"(<!--\s*{re.escape(marker)}\s*-->).*?(<!--\s*/{re.escape(marker)}\s*-->)",
+            re.DOTALL,
+        )
+
+        with open(readme_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        methodology_url = "https://github.com/yoloyash/overtchat/tree/main/.github/actions/repo-tokens"
+        linked_badge = f'<a href="{methodology_url}">{badge}</a>'
+        new_content = marker_re.sub(rf"\1{linked_badge}\2", content)
+
+        if new_content != content:
+            with open(readme_path, "w", encoding="utf-8") as f:
+                f.write(new_content)
+            print("README updated")
+        else:
+            print("No change to README")
+
+        # Generate SVG badge using NanoClaw's badge layout
+        if badge_path:
+            label_text = "tokens"
+            value_text = display
+            full_desc = f"{display} source tokens"
+
+            cw = 7.0
+            label_w = round(len(label_text) * cw) + 10
+            value_w = round(len(value_text) * cw) + 10
+            total_w = label_w + value_w
+            color = "#4c1"
+
+            lx = label_w // 2
+            vx = label_w + value_w // 2
+
+            svg = f'''<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{total_w}" height="20" role="img" aria-label="{full_desc}">
+          <title>{full_desc}</title>
+          <linearGradient id="s" x2="0" y2="100%">
+            <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+            <stop offset="1" stop-opacity=".1"/>
+          </linearGradient>
+          <clipPath id="r">
+            <rect width="{total_w}" height="20" rx="3" fill="#fff"/>
+          </clipPath>
+          <a xlink:href="{methodology_url}">
+            <g clip-path="url(#r)">
+              <rect width="{label_w}" height="20" fill="#555"/>
+              <rect x="{label_w}" width="{value_w}" height="20" fill="{color}"/>
+              <rect width="{total_w}" height="20" fill="url(#s)"/>
+              <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+                <text aria-hidden="true" x="{lx}" y="15" fill="#010101" fill-opacity=".3">{label_text}</text>
+                <text x="{lx}" y="14">{label_text}</text>
+                <text aria-hidden="true" x="{vx}" y="15" fill="#010101" fill-opacity=".3">{value_text}</text>
+                <text x="{vx}" y="14">{value_text}</text>
+              </g>
+            </g>
+          </a>
+        </svg>'''
+
+            os.makedirs(os.path.dirname(badge_path) or ".", exist_ok=True)
+            with open(badge_path, "w", encoding="utf-8") as f:
+                f.write(svg)
+            print(f"Badge SVG written to {badge_path}")
+
+        # Set outputs
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"tokens={total}\n")
+            f.write(f"badge={badge}\n")

--- a/.github/badges/tokens.svg
+++ b/.github/badges/tokens.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="90" height="20" role="img" aria-label="138k tokens, 14% of context window">
-  <title>138k tokens, 14% of context window</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="90" height="20" role="img" aria-label="183k source tokens">
+  <title>183k source tokens</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -7,7 +7,7 @@
   <clipPath id="r">
     <rect width="90" height="20" rx="3" fill="#fff"/>
   </clipPath>
-  <a xlink:href="https://github.com/nanocoai/nanoclaw/tree/main/repo-tokens">
+  <a xlink:href="https://github.com/yoloyash/overtchat/tree/main/.github/actions/repo-tokens">
     <g clip-path="url(#r)">
       <rect width="52" height="20" fill="#555"/>
       <rect x="52" width="38" height="20" fill="#4c1"/>
@@ -15,8 +15,8 @@
       <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
         <text aria-hidden="true" x="26" y="15" fill="#010101" fill-opacity=".3">tokens</text>
         <text x="26" y="14">tokens</text>
-        <text aria-hidden="true" x="71" y="15" fill="#010101" fill-opacity=".3">138k</text>
-        <text x="71" y="14">138k</text>
+        <text aria-hidden="true" x="71" y="15" fill="#010101" fill-opacity=".3">183k</text>
+        <text x="71" y="14">183k</text>
       </g>
     </g>
   </a>

--- a/.github/badges/tokens.svg
+++ b/.github/badges/tokens.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="90" height="20" role="img" aria-label="183k source tokens">
-  <title>183k source tokens</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="90" height="20" role="img" aria-label="173k source tokens">
+  <title>173k source tokens</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,8 +15,8 @@
       <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
         <text aria-hidden="true" x="26" y="15" fill="#010101" fill-opacity=".3">tokens</text>
         <text x="26" y="14">tokens</text>
-        <text aria-hidden="true" x="71" y="15" fill="#010101" fill-opacity=".3">183k</text>
-        <text x="71" y="14">183k</text>
+        <text aria-hidden="true" x="71" y="15" fill="#010101" fill-opacity=".3">173k</text>
+        <text x="71" y="14">173k</text>
       </g>
     </g>
   </a>

--- a/.github/workflows/tokens.yml
+++ b/.github/workflows/tokens.yml
@@ -1,4 +1,4 @@
-name: Update token count
+name: Update source token count
 
 on:
   push:
@@ -6,6 +6,11 @@ on:
     paths:
       - 'apps/**'
       - 'packages/**'
+      - 'AGENTS.md'
+      - 'Dockerfile'
+      - 'compose.yml'
+      - '.github/actions/repo-tokens/**'
+      - '.github/workflows/tokens.yml'
   workflow_dispatch:
 
 permissions:
@@ -21,11 +26,39 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: nanocoai/nanoclaw/repo-tokens@main
+      - uses: ./.github/actions/repo-tokens
         id: tokens
         with:
-          include: 'apps/web/app/**/*.ts apps/web/app/**/*.tsx apps/web/lib/**/*.ts apps/web/lib/**/*.tsx apps/mobile/src/**/*.ts apps/mobile/src/**/*.tsx packages/shared/src/**/*.ts packages/shared/src/**/*.tsx'
-          exclude: '**/*.test.ts **/*.test.tsx **/*.spec.ts **/*.spec.tsx **/node_modules/** **/dist/**'
+          include: >-
+            apps/web/app/**/*.ts
+            apps/web/app/**/*.tsx
+            apps/web/components/**/*.ts
+            apps/web/components/**/*.tsx
+            apps/web/lib/**/*.ts
+            apps/web/lib/**/*.tsx
+            apps/web/instrumentation.ts
+            apps/web/next.config.ts
+            apps/web/scripts/**/*.ts
+            apps/mobile/src/**/*.ts
+            apps/mobile/src/**/*.tsx
+            apps/mobile/scripts/**/*.mjs
+            apps/mobile/app.json
+            apps/mobile/eas.json
+            packages/shared/src/**/*.ts
+            packages/shared/src/**/*.tsx
+            packages/shared/scripts/**/*.ts
+            AGENTS.md
+            apps/web/AGENTS.md
+            apps/mobile/AGENTS.md
+            Dockerfile
+            compose.yml
+          exclude: >-
+            **/*.test.ts
+            **/*.test.tsx
+            **/*.spec.ts
+            **/*.spec.tsx
+            **/node_modules/**
+            **/dist/**
           badge-path: '.github/badges/tokens.svg'
 
       - name: Commit if changed
@@ -34,5 +67,6 @@ jobs:
           git diff --cached --quiet && exit 0
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "docs: update token count to ${{ steps.tokens.outputs.badge }}"
+          git commit -m "docs: update source token count to ${{ steps.tokens.outputs.badge }}"
+          git pull --rebase
           git push

--- a/.github/workflows/tokens.yml
+++ b/.github/workflows/tokens.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'apps/**'
-      - 'packages/**'
-      - 'AGENTS.md'
-      - 'Dockerfile'
-      - 'compose.yml'
+      - 'apps/web/app/**'
+      - 'apps/web/components/**'
+      - 'apps/web/lib/**'
+      - 'apps/web/instrumentation.ts'
+      - 'apps/web/next.config.ts'
+      - 'apps/mobile/src/**'
+      - 'packages/shared/src/**'
       - '.github/actions/repo-tokens/**'
       - '.github/workflows/tokens.yml'
   workflow_dispatch:
@@ -38,20 +40,10 @@ jobs:
             apps/web/lib/**/*.tsx
             apps/web/instrumentation.ts
             apps/web/next.config.ts
-            apps/web/scripts/**/*.ts
             apps/mobile/src/**/*.ts
             apps/mobile/src/**/*.tsx
-            apps/mobile/scripts/**/*.mjs
-            apps/mobile/app.json
-            apps/mobile/eas.json
             packages/shared/src/**/*.ts
             packages/shared/src/**/*.tsx
-            packages/shared/scripts/**/*.ts
-            AGENTS.md
-            apps/web/AGENTS.md
-            apps/mobile/AGENTS.md
-            Dockerfile
-            compose.yml
           exclude: >-
             **/*.test.ts
             **/*.test.tsx

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="docs/android-testing.md"><img src="https://img.shields.io/badge/Android-Google_Play-22C55E?logo=googleplay&logoColor=white" alt="Android on Google Play" valign="middle"></a>&nbsp; • &nbsp;
   <a href="https://yoloyash.github.io/overtchat/privacy.html"><img src="https://img.shields.io/badge/Privacy-Zero_Telemetry-teal?color=0D9488" alt="Privacy Policy" valign="middle"></a>&nbsp; • &nbsp;
-  <a href="https://github.com/yoloyash/overtchat"><img src=".github/badges/tokens.svg" alt="repo tokens" valign="middle"></a>
+  <a href=".github/actions/repo-tokens/README.md"><img src=".github/badges/tokens.svg" alt="source tokens" valign="middle"></a>
 </p>
 
 https://github.com/user-attachments/assets/8d135eac-ae55-40eb-934c-e0d88395bb5b


### PR DESCRIPTION
## Summary

- keep the source token-count badge while removing the model-dependent context-window percentage
- adapt NanoClaw's MIT-licensed Repo Tokens action locally and pin `tiktoken`
- count production source consistently, including the previously omitted web components
- link the README badge to the local methodology and use a source-token-only bot commit message

## Why

The workflow consumed `nanocoai/nanoclaw/repo-tokens@main`, so NanoClaw's default context-window change silently changed Overtchat from 68% to 14% without changing its source count. The percentage was model-dependent, while the mutable action reference made the metric non-deterministic.

Keeping the small token badge is still a useful codebase-size signal. Owning the tiny upstream-derived action makes its meaning and update behavior explicit.

## Impact

The badge now reports `173k` source tokens with no context-window claim. The count increases from `138k` because the old scope omitted the 38 source files in `apps/web/components`. Documentation, infrastructure, build metadata, maintenance scripts, generated output, dependencies, tests, and database migrations remain excluded.

## Validation

- parsed the workflow and composite-action YAML
- executed the composite action's actual inline Python in a temporary Python 3 environment with `tiktoken==0.13.0`
- counted 232 files and 172,707 tokens
- ran the generator twice and confirmed the SVG hash is stable
- confirmed the badge and workflow contain no context-window percentage
- ran `git diff --check`
