### PR TITLE
feat: add ?q= URL parameter for omnibar search auto-submission

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -3,16 +3,17 @@ import { ChatArea } from "@/components/chat/ChatArea";
 export default async function Home({
   searchParams,
 }: {
-  searchParams: Promise<{ projectId?: string; q?: string }>;
+  searchParams: Promise<{ projectId?: string; q?: string | string[] }>;
 }) {
   const { projectId, q } = await searchParams;
+  const initialQuery = Array.isArray(q) ? q[0] : q;
   const chatId = crypto.randomUUID();
   return (
     <ChatArea
       key={chatId}
       chatId={chatId}
       projectId={projectId ?? null}
-      initialQuery={q}
+      initialQuery={initialQuery}
       isNew
     />
   );

--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -3,15 +3,16 @@ import { ChatArea } from "@/components/chat/ChatArea";
 export default async function Home({
   searchParams,
 }: {
-  searchParams: Promise<{ projectId?: string }>;
+  searchParams: Promise<{ projectId?: string; q?: string }>;
 }) {
-  const { projectId } = await searchParams;
+  const { projectId, q } = await searchParams;
   const chatId = crypto.randomUUID();
   return (
     <ChatArea
       key={chatId}
       chatId={chatId}
       projectId={projectId ?? null}
+      initialQuery={q}
       isNew
     />
   );

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -221,10 +221,15 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId, initialQue
 
   const initialQueryFiredRef = useRef(false);
   useEffect(() => {
-    if (!initialQuery || initialQueryFiredRef.current || !configured) return;
+    const query = initialQuery?.trim();
+    const selectedModelReady = models?.some(
+      (model) => model.id === selectedId,
+    );
+    if (!query || initialQueryFiredRef.current || !selectedModelReady) return;
     initialQueryFiredRef.current = true;
-    handleSubmit(initialQuery, []);
-  }, [initialQuery, configured]);
+    handleSubmit(query, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialQuery, models, selectedId]);
 
   function handleRegenerate(messageId: string) {
     if (streaming || !configured) return;

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -41,9 +41,10 @@ interface Props {
   initialMessages?: UIMessage[];
   isNew?: boolean;
   projectId?: string | null;
+  initialQuery?: string;
 }
 
-export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
+export function ChatArea({ chatId, initialMessages, isNew, projectId, initialQuery }: Props) {
   const qc = useQueryClient();
   const { data: chats } = useChats();
 
@@ -217,6 +218,13 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId }: Props) {
     }
     sendMessage({ text, files: attachments }, { body: requestBody() });
   }
+
+  const initialQueryFiredRef = useRef(false);
+  useEffect(() => {
+    if (!initialQuery || initialQueryFiredRef.current || !configured) return;
+    initialQueryFiredRef.current = true;
+    handleSubmit(initialQuery, []);
+  }, [initialQuery, configured]);
 
   function handleRegenerate(messageId: string) {
     if (streaming || !configured) return;


### PR DESCRIPTION
Enables starting a new chat directly via URL by passing a `q` query parameter (e.g., `/?q=Why is the sky blue`). It allows users to set up a custom search engine shortcut directly in their browser's address bar. 

- Parses the `q` parameter in the root page component and passes it as `initialQuery`.
- Adds a `useEffect` in `ChatArea` to automatically submit the query once models are configured.
- Relies on the existing `handleSubmit` logic to cleanly replace the `?q=` URL with the new chat ID route, preventing duplicate submissions on page reload.