### PR TITLE
fix(site): clarify model data flow

### DIFF
--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -63,7 +63,7 @@ const steps: Array<{
   {
     number: "03",
     title: "Chat from anywhere",
-    body: "Use the responsive web app or connect the native mobile client to the server you control. Your data stays there.",
+    body: "Use the responsive web app or connect the native mobile client to the server you control. Your account, chat history, and files stay on that server.",
   },
 ];
 

--- a/apps/site/components/HeroVignette.tsx
+++ b/apps/site/components/HeroVignette.tsx
@@ -90,7 +90,7 @@ export function HeroVignette() {
 
           <div className="vignette-messages">
             <div className="vignette-message vignette-message-user">
-              Why run my own chat instead of just using ChatGPT?
+              How do hosted and local models differ for privacy?
             </div>
             <div className="vignette-tool">
               <Search />
@@ -98,20 +98,15 @@ export function HeroVignette() {
               <span className="vignette-tool-time">1.4s</span>
             </div>
             <div className="vignette-message vignette-message-assistant">
-              <p>
-                Mostly privacy. With hosted assistants, your conversations
-                aren&rsquo;t really yours:
-              </p>
+              <p>Mostly in where requests go:</p>
               <ul>
-                <li>They live on servers you don&rsquo;t control</li>
-                <li>They can be read by human reviewers</li>
-                <li>They&rsquo;re often used to train the next model</li>
+                <li>A hosted model receives prompts at its API</li>
+                <li>A local model can process them on your hardware</li>
+                <li>OvertChat stores chat history on your server</li>
               </ul>
-              <p>
-                Self-hosting keeps everything on hardware you own.
-              </p>
+              <p>You choose the endpoint for each conversation.</p>
               <div className="vignette-citations">
-                <span><Globe /> futurism.com</span>
+                <span><Globe /> ollama.com</span>
                 <span><FileText /> openai.com</span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replace the last broad “your data stays there” statement with the specific data stored on the OvertChat server.
- Rewrite the hero chat mock to distinguish hosted-model requests from local-model processing.
- Remove claims that all self-hosted usage stays on local hardware.

## Why
The production smoke test after #78 found two remaining lines that undercut the clearer hosted-versus-local data-flow language added during review.

## Validation
- `npm run lint -w apps/site --`
- `npm run test -w apps/site --` (8/8)
- GitHub Pages production build with `NEXT_PUBLIC_BASE_PATH=/overtchat` and `NEXT_PUBLIC_SITE_ORIGIN=https://yoloyash.github.io`