### PR TITLE
chore(site): configure Cloudflare static deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "overtchat-site",
+  "compatibility_date": "2026-07-23",
+  "assets": {
+    "directory": "./apps/site/out",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
## Summary

- add a Wrangler manifest for the `overtchat-site` Worker
- deploy the existing Next.js static export from `apps/site/out`
- preserve GitHub Pages until the Cloudflare deployment and custom domain are verified

## Why

Cloudflare Workers Builds requires the repository configuration name to match the Worker project. Committing the static-assets directory explicitly avoids framework autoconfiguration choosing the wrong app in this monorepo.

## Validation

- `npm run lint -w apps/site --`
- `npm run test -w apps/site --`
- `NEXT_PUBLIC_SITE_ORIGIN=https://overtchat.com NEXT_TELEMETRY_DISABLED=1 npm run build -w apps/site --`
- `npx --yes wrangler@4.114.0 deploy --dry-run` (84 assets, no runtime bindings)