### PR TITLE
chore(site): route domain through Cloudflare

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "db:generate": "npm run db:generate -w apps/web --",
     "db:migrate": "npm run db:migrate -w apps/web --",
     "db:studio": "npm run db:studio -w apps/web --",
-    "auth:generate": "npm run auth:generate -w apps/web --"
+    "auth:generate": "npm run auth:generate -w apps/web --",
+    "site:deploy": "npx --yes wrangler@4.114.0 deploy",
+    "site:preview": "npx --yes wrangler@4.114.0 versions upload"
   },
   "devDependencies": {
     "turbo": "^2.9.6"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,14 @@
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "overtchat",
   "compatibility_date": "2026-07-23",
+  "workers_dev": false,
+  "preview_urls": true,
+  "routes": [
+    {
+      "pattern": "overtchat.com",
+      "custom_domain": true
+    }
+  ],
   "assets": {
     "directory": "./apps/site/out",
     "not_found_handling": "404-page"


### PR DESCRIPTION
## Summary

- route `overtchat.com` directly to the `overtchat` Worker as a Cloudflare Custom Domain
- disable the duplicate production `workers.dev` hostname
- keep unique version preview URLs enabled for non-production branch builds

## Impact

The project site is now served at `https://overtchat.com`. GitHub Pages remains configured as a rollback while the remaining URL and workflow cleanup is handled separately.

## Validation

- root-domain Next.js static export completed successfully
- `wrangler deploy --dry-run` read all 84 assets with no runtime bindings
- authenticated Wrangler deployment created the custom domain and certificate
- `/`, `/privacy/`, `/releases/`, `/robots.txt`, and `/sitemap.xml` return 200
- `/privacy.html` redirects to `/privacy`
- an unknown route returns the custom 404
- canonical metadata and sitemap use `https://overtchat.com`