### PR TITLE
chore(site): finish Cloudflare migration

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,8 +1,23 @@
-name: Deploy project site
+name: Project site
 
 on:
   push:
     branches: [main]
+    paths:
+      - ".github/workflows/site.yml"
+      - "apps/site/**"
+      - "packages/shared/**"
+      - "package.json"
+      - "package-lock.json"
+      - "wrangler.jsonc"
+  pull_request:
+    paths:
+      - ".github/workflows/site.yml"
+      - "apps/site/**"
+      - "packages/shared/**"
+      - "package.json"
+      - "package-lock.json"
+      - "wrangler.jsonc"
   release:
     types: [published, edited, deleted]
   workflow_dispatch:
@@ -10,20 +25,19 @@ on:
 permissions: {}
 
 concurrency:
-  group: pages
+  group: project-site-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build:
+  validate:
+    if: github.event_name != 'release'
     permissions:
       contents: read
-      pages: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: main
           persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -42,33 +56,25 @@ jobs:
           npm run lint -w apps/site --
           npm run test -w apps/site --
 
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-
       - name: Build static site
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEXT_PUBLIC_BASE_PATH: /overtchat
-          NEXT_PUBLIC_SITE_ORIGIN: https://yoloyash.github.io
+          NEXT_PUBLIC_SITE_ORIGIN: https://overtchat.com
           NEXT_TELEMETRY_DISABLED: "1"
         run: npm run build -w apps/site --
 
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        with:
-          path: apps/site/out
-
-  deploy:
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  rebuild-releases:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: build
+    timeout-minutes: 5
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+      - name: Rebuild Cloudflare site from main
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.CLOUDFLARE_SITE_DEPLOY_HOOK }}
+        run: |
+          test -n "$DEPLOY_HOOK_URL"
+          curl --fail --silent --show-error \
+            --retry 2 \
+            --retry-all-errors \
+            --request POST \
+            "$DEPLOY_HOOK_URL"

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 </p>
 
 <p align="center">
-  <a href="https://yoloyash.github.io/overtchat/"><img src="https://img.shields.io/badge/Website-overtchat-0D9488" alt="Project website" valign="middle"></a>&nbsp; • &nbsp;
+  <a href="https://overtchat.com/"><img src="https://img.shields.io/badge/Website-overtchat-0D9488" alt="Project website" valign="middle"></a>&nbsp; • &nbsp;
   <a href="docs/android-testing.md"><img src="https://img.shields.io/badge/Android-Google_Play-22C55E?logo=googleplay&logoColor=white" alt="Android on Google Play" valign="middle"></a>&nbsp; • &nbsp;
-  <a href="https://yoloyash.github.io/overtchat/privacy/"><img src="https://img.shields.io/badge/Privacy-No_Usage_Analytics-teal?color=0D9488" alt="Privacy Policy" valign="middle"></a>&nbsp; • &nbsp;
+  <a href="https://overtchat.com/privacy/"><img src="https://img.shields.io/badge/Privacy-No_Usage_Analytics-teal?color=0D9488" alt="Privacy Policy" valign="middle"></a>&nbsp; • &nbsp;
   <a href=".github/actions/repo-tokens/README.md"><img src=".github/badges/tokens.svg" alt="source tokens" valign="middle"></a>
 </p>
 
@@ -86,7 +86,7 @@ Multilingual (25 languages, auto-detected). All processing stays on your machine
 
 No usage analytics, no advertising. The server sends model requests only to endpoints you configure and sends web searches through its configured SearXNG instance. Stored application data lives in a single SQLite file you can copy, back up, or delete.
 
-The Android client can send crash diagnostics to Sentry. These may include technical request metadata; the app does not intentionally attach chat content, attachments, or credentials. Details are in the [privacy policy](https://yoloyash.github.io/overtchat/privacy/).
+The Android client can send crash diagnostics to Sentry. These may include technical request metadata; the app does not intentionally attach chat content, attachments, or credentials. Details are in the [privacy policy](https://overtchat.com/privacy/).
 
 ## Requirements
 

--- a/apps/site/app/privacy/page.tsx
+++ b/apps/site/app/privacy/page.tsx
@@ -4,7 +4,7 @@ import { createPageMetadata } from "@/lib/metadata";
 export const metadata: Metadata = createPageMetadata({
   title: "Privacy Policy",
   description:
-    "How the OvertChat mobile client handles data, permissions, and crash reports.",
+    "How the OvertChat app and project website handle data, permissions, and diagnostics.",
   path: "/privacy/",
 });
 
@@ -22,9 +22,9 @@ export default function PrivacyPage() {
           <p className="legal-updated">Last updated 23 July 2026</p>
           <p className="page-lede">
             OvertChat is an open-source chat client that connects to a server you
-            choose. The short version: the app is a client, we do not run a
-            server for you, and the server you point it at is governed by whoever
-            operates it—which may be you.
+            choose. The short version: we do not operate a hosted chat service,
+            and the server you point the app at is governed by whoever operates
+            it—which may be you.
           </p>
         </header>
 
@@ -36,7 +36,7 @@ export default function PrivacyPage() {
               URL—usually one you self-host, but it can be any compatible
               deployment. Your chats, messages, projects, and uploaded files live
               on that server, not on our infrastructure. We do not operate a
-              hosted backend.
+              hosted chat backend.
             </p>
           </section>
 
@@ -92,13 +92,34 @@ export default function PrivacyPage() {
             <h2>What we collect</h2>
             <p>
               We—the publisher of the app—do not operate a hosted OvertChat
-              backend, and the app does not include usage analytics or
-              advertising SDKs.
+              backend. The app and project website do not include usage analytics
+              or advertising SDKs.
             </p>
             <p>
               We receive limited crash diagnostics through Sentry when crash
               reporting is configured in the distributed app, as described
               next.
+            </p>
+          </section>
+
+          <section>
+            <h2>Project website hosting</h2>
+            <p>
+              The project website at overtchat.com is delivered through{" "}
+              <a href="https://www.cloudflare.com/privacypolicy/">Cloudflare</a>.
+              When you visit, Cloudflare processes ordinary web request data
+              such as your IP address, browser and device information, requested
+              URL, and request time to deliver and protect the site.
+            </p>
+            <p>
+              We do not add web analytics, advertising trackers, or analytics
+              cookies to the site. Cloudflare handles request data under its own{" "}
+              <a href="https://www.cloudflare.com/privacypolicy/">
+                privacy policy
+              </a>
+              . This website hosting is separate from your chats: visiting the
+              project website does not send your conversations, account
+              credentials, or configured OvertChat server URL to us.
             </p>
           </section>
 

--- a/apps/site/lib/site.ts
+++ b/apps/site/lib/site.ts
@@ -3,7 +3,7 @@ const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
 export const SITE_BASE_PATH =
   rawBasePath === "/" ? "" : rawBasePath.replace(/\/$/, "");
 export const SITE_ORIGIN = (
-  process.env.NEXT_PUBLIC_SITE_ORIGIN ?? "https://yoloyash.github.io"
+  process.env.NEXT_PUBLIC_SITE_ORIGIN ?? "https://overtchat.com"
 ).replace(/\/$/, "");
 
 export function sitePath(path = "/"): string {


### PR DESCRIPTION
## Summary
- replace the GitHub Pages deployment workflow with Cloudflare release rebuilds
- update project and privacy links to `https://overtchat.com`
- document Cloudflare website delivery separately from OvertChat chat hosting
- default generated site metadata to the production domain

## Infrastructure
- created a branch-scoped Cloudflare Deploy Hook for `main`
- stored the hook URL as the `CLOUDFLARE_SITE_DEPLOY_HOOK` GitHub Actions secret
- retain site lint, tests, and static build validation in GitHub Actions

## Validation
- `npm run lint -w apps/site --`
- `npm run test -w apps/site --`
- `NEXT_PUBLIC_SITE_ORIGIN=https://overtchat.com NEXT_TELEMETRY_DISABLED=1 npm run build -w apps/site --`
- workflow YAML parse
- stale GitHub Pages URL scan