### PR TITLE
chore(deps): group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          # Better Auth and its Expo client must stay version-aligned. Review
+          # those updates separately because 1.6.13 currently fails type-check.
+          - better-auth
+          - "@better-auth/*"


### PR DESCRIPTION
## Summary

- group npm security updates into one Dependabot pull request
- disable routine version-update pull requests
- keep Better Auth updates separate because the current 1.6.13 proposal fails the repository's production type-check

## Why

Enabling Dependabot security updates caused GitHub to drain the existing advisory backlog in waves of individual pull requests. Grouping keeps security automation enabled while reducing review and CI noise.

`open-pull-requests-limit: 0` applies to routine version updates; GitHub maintains a separate security-update limit, so security alerts and grouped remediation pull requests remain enabled.

## Validation

- parsed `.github/dependabot.yml` with `js-yaml`
- reviewed against GitHub's grouped security update configuration
