### PR TITLE
fix(web): restructure chat title generation prompt

### DIFF
--- a/apps/web/lib/title.test.ts
+++ b/apps/web/lib/title.test.ts
@@ -104,7 +104,9 @@ describe("title helpers", () => {
       text("More detail"),
     ]);
 
-    expect(prompt).toContain("User:\nReal question More detail");
+    expect(prompt).toContain(
+      "<user_message>\nReal question More detail\n</user_message>",
+    );
     expect(prompt).not.toContain("Assistant:");
     expect(prompt).not.toContain("private thought");
     expect(prompt).not.toContain("hidden query");
@@ -134,7 +136,7 @@ describe("title helpers", () => {
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
         maxRetries: 0,
-        prompt: expect.stringContaining("User:"),
+        prompt: expect.stringContaining("<user_message>"),
       }),
     );
     expect(mocks.generateText.mock.calls[0][0]).not.toHaveProperty(

--- a/apps/web/lib/title.ts
+++ b/apps/web/lib/title.ts
@@ -63,12 +63,22 @@ export function buildTitlePromptText(
   if (!userText) return null;
 
   return [
-    "Generate a concise chat title in 3 to 6 words.",
-    "No quotes, no trailing punctuation, no emoji.",
-    "Base it on the user's first message.",
+    "### Task:",
+    "Generate a short chat title (2-5 words) summarizing the user's message.",
     "",
-    "User:",
+    "### Guidelines:",
+    "- Output ONLY the title text. No prefixes, no markdown formatting elements.",
+    '- Never output hashtags, prefixes like "Title:", or quotes.',
+    "",
+    "### Examples:",
+    '- "what\'s the weather in nyc" → Weather in NYC',
+    '- "help me write an essay about space" → Space Essay Help',
+    '- "hi" → Greeting',
+    "",
+    "### User Message:",
+    "<user_message>",
     userText,
+    "</user_message>",
   ].join("\n");
 }
 


### PR DESCRIPTION
Generated titles sometimes contained markdown formatting, and short messages occasionally got a conversational reply as the title instead of a summary.

Restructures the prompt as a single labelled task with the user's message fenced at the end, following the shape Open WebUI uses, with the wording and 2-5 word target from Vercel's ai-chatbot. Keeping the message in the same turn as the instructions is what fixes the conversational replies.

Prompt string only — `buildTitlePromptText` keeps its signature, so the call site in `app/api/chat/route.ts` is unchanged. No new dependencies.
