### PR TITLE
fix(mobile): replace vulnerable syntax highlighter

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -70,9 +70,9 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-svg": "15.15.4",
-    "react-native-syntax-highlighter": "^2.1.0",
     "react-native-web": "~0.21.0",
-    "react-native-worklets": "0.8.3"
+    "react-native-worklets": "0.8.3",
+    "refractor": "^5.0.0"
   },
   "devDependencies": {
     "@types/react": "~19.2.2",

--- a/apps/mobile/src/components/chat/CodeBlock.tsx
+++ b/apps/mobile/src/components/chat/CodeBlock.tsx
@@ -1,10 +1,92 @@
 import * as Clipboard from "expo-clipboard";
 import { Feather } from "@expo/vector-icons";
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
-import SyntaxHighlighter from "react-native-syntax-highlighter";
-import { atomDark, vs } from "react-syntax-highlighter/styles/prism";
+import { refractor } from "refractor/all";
 import { useTheme } from "@/lib/theme";
+
+type HighlightNode = ReturnType<
+  typeof refractor.highlight
+>["children"][number];
+
+const LANGUAGE_ALIASES: Record<string, string> = {
+  "c#": "csharp",
+  "c++": "cpp",
+  "javascriptreact": "jsx",
+  "objective-c": "objectivec",
+  "shellscript": "bash",
+  "typescriptreact": "tsx",
+};
+
+const DARK_TOKEN_COLORS: Record<string, string> = {
+  comment: "#7c7c7c",
+  prolog: "#7c7c7c",
+  doctype: "#7c7c7c",
+  cdata: "#7c7c7c",
+  punctuation: "#c5c8c6",
+  property: "#96cbfe",
+  keyword: "#96cbfe",
+  tag: "#96cbfe",
+  "class-name": "#ffffb6",
+  boolean: "#99cc99",
+  constant: "#99cc99",
+  symbol: "#f92672",
+  deleted: "#f92672",
+  number: "#ff73fd",
+  selector: "#a8ff60",
+  "attr-name": "#a8ff60",
+  string: "#a8ff60",
+  char: "#a8ff60",
+  builtin: "#a8ff60",
+  inserted: "#a8ff60",
+  variable: "#c6c5fe",
+  operator: "#ededed",
+  entity: "#ffffb6",
+  url: "#96cbfe",
+  atrule: "#f9ee98",
+  "attr-value": "#f9ee98",
+  function: "#dad085",
+  regex: "#e9c062",
+  important: "#fd971f",
+};
+
+const LIGHT_TOKEN_COLORS: Record<string, string> = {
+  comment: "#008000",
+  prolog: "#008000",
+  doctype: "#008000",
+  cdata: "#008000",
+  punctuation: "#393a34",
+  property: "#36acaa",
+  tag: "#36acaa",
+  boolean: "#36acaa",
+  number: "#36acaa",
+  constant: "#36acaa",
+  symbol: "#36acaa",
+  deleted: "#36acaa",
+  selector: "#e3116c",
+  "attr-name": "#e3116c",
+  string: "#e3116c",
+  char: "#e3116c",
+  builtin: "#e3116c",
+  inserted: "#e3116c",
+  operator: "#393a34",
+  entity: "#393a34",
+  url: "#393a34",
+  variable: "#36acaa",
+  atrule: "#00a4db",
+  "attr-value": "#00a4db",
+  keyword: "#00a4db",
+  function: "#d73a49",
+  "class-name": "#d73a49",
+  regex: "#36acaa",
+  important: "#36acaa",
+};
 
 export function CodeBlock({
   code,
@@ -16,7 +98,22 @@ export function CodeBlock({
   const { colors, fonts, radii, scheme } = useTheme();
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lang = language.trim();
+  const languageLabel = language.trim().split(/\s+/, 1)[0] ?? "";
+  const grammar = normalizeLanguage(languageLabel);
+  const codeContent = useMemo<ReactNode>(() => {
+    if (!grammar || !refractor.registered(grammar)) return code;
+
+    try {
+      const tree = refractor.highlight(code, grammar);
+      const tokenColors =
+        scheme === "dark" ? DARK_TOKEN_COLORS : LIGHT_TOKEN_COLORS;
+      return tree.children.map((node, index) =>
+        renderHighlightNode(node, String(index), tokenColors),
+      );
+    } catch {
+      return code;
+    }
+  }, [code, grammar, scheme]);
 
   useEffect(() => {
     return () => {
@@ -41,14 +138,14 @@ export function CodeBlock({
   return (
     <View style={[styles.container, containerStyle]}>
       <View style={[styles.header, { borderBottomColor: colors.border }]}>
-        {lang ? (
+        {languageLabel ? (
           <Text
             style={[
               styles.lang,
               { color: colors.mutedForeground, fontFamily: fonts.mono },
             ]}
           >
-            {lang}
+            {languageLabel}
           </Text>
         ) : (
           <View />
@@ -75,32 +172,50 @@ export function CodeBlock({
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.codeScroll}
       >
-        {lang ? (
-          <SyntaxHighlighter
-            language={lang}
-            highlighter="prism"
-            style={scheme === "dark" ? atomDark : vs}
-            fontFamily={fonts.mono}
-            fontSize={13}
-            customStyle={{ backgroundColor: "transparent", padding: 0 }}
-          >
-            {code}
-          </SyntaxHighlighter>
-        ) : (
-          <Text
-            style={{
-              color: colors.foreground,
-              fontFamily: fonts.mono,
-              fontSize: 13,
-              lineHeight: 19,
-            }}
-          >
-            {code}
-          </Text>
-        )}
+        <Text
+          style={[
+            styles.code,
+            { color: colors.foreground, fontFamily: fonts.mono },
+          ]}
+        >
+          {codeContent}
+        </Text>
       </ScrollView>
     </View>
   );
+}
+
+function normalizeLanguage(language: string): string {
+  const normalized = language.toLowerCase().replace(/^language-/, "");
+  return LANGUAGE_ALIASES[normalized] ?? normalized;
+}
+
+function renderHighlightNode(
+  node: HighlightNode,
+  key: string,
+  tokenColors: Record<string, string>,
+): ReactNode {
+  if (node.type === "text") return node.value;
+  if (node.type !== "element") return null;
+
+  const classNames = normalizeClassNames(node.properties.className);
+  const color = classNames
+    .map((className) => tokenColors[className])
+    .find(Boolean);
+
+  return (
+    <Text key={key} style={color ? { color } : undefined}>
+      {node.children.map((child, index) =>
+        renderHighlightNode(child, `${key}.${index}`, tokenColors),
+      )}
+    </Text>
+  );
+}
+
+function normalizeClassNames(value: unknown): string[] {
+  if (typeof value === "string") return value.split(/\s+/);
+  if (!Array.isArray(value)) return [];
+  return value.map(String);
 }
 
 const styles = StyleSheet.create({
@@ -119,5 +234,6 @@ const styles = StyleSheet.create({
   lang: { fontSize: 11 },
   copyBtn: { flexDirection: "row", alignItems: "center", gap: 4 },
   copyLabel: { fontSize: 11 },
+  code: { fontSize: 13, lineHeight: 19 },
   codeScroll: { paddingHorizontal: 12, paddingVertical: 10 },
 });

--- a/apps/mobile/src/types/modules.d.ts
+++ b/apps/mobile/src/types/modules.d.ts
@@ -14,30 +14,3 @@ declare module "markdown-it" {
   function MarkdownIt(options?: MarkdownItOptions): MarkdownItInstance;
   export default MarkdownIt;
 }
-
-declare module "react-native-syntax-highlighter" {
-  import type { ComponentType, ReactNode } from "react";
-  import type { TextStyle } from "react-native";
-
-  interface SyntaxHighlighterProps {
-    language?: string;
-    style?: Record<string, unknown>;
-    highlighter?: "hljs" | "prism";
-    fontFamily?: string;
-    fontSize?: number;
-    customStyle?: TextStyle;
-    children?: ReactNode;
-  }
-
-  const SyntaxHighlighter: ComponentType<SyntaxHighlighterProps>;
-  export default SyntaxHighlighter;
-}
-
-declare module "react-syntax-highlighter/styles/prism" {
-  const styles: Record<string, Record<string, unknown>>;
-  export const atomDark: Record<string, unknown>;
-  export const vs: Record<string, unknown>;
-  export const tomorrow: Record<string, unknown>;
-  export const prism: Record<string, unknown>;
-  export default styles;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-svg": "15.15.4",
-        "react-native-syntax-highlighter": "^2.1.0",
         "react-native-web": "~0.21.0",
-        "react-native-worklets": "0.8.3"
+        "react-native-worklets": "0.8.3",
+        "refractor": "^5.0.0"
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
@@ -370,6 +370,22 @@
         "react": "*",
         "react-native": "*",
         "react-native-reanimated": ">=3.0.0"
+      }
+    },
+    "apps/mobile/node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "apps/site": {
@@ -9731,6 +9747,12 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
@@ -11164,22 +11186,6 @@
         }
       }
     },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "license": "MIT"
-    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -11825,18 +11831,6 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/clipboard": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "node_modules/clipboard-polyfill": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-4.1.1.tgz",
@@ -12098,14 +12092,6 @@
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -13129,13 +13115,6 @@
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -15481,19 +15460,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fault": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-      "license": "MIT",
-      "dependencies": {
-        "format": "^0.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
@@ -15749,14 +15715,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -16124,16 +16082,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "delegate": "^3.1.2"
       }
     },
     "node_modules/gopd": {
@@ -16539,16 +16487,6 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.33.3"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha512-qNnYpBDO/FQwYVur1+sQBQw7v0cxso1nOYLklqWh6af8ROwwTVoII5+kf/BVa8354WL4ad6rURHYGUXCbD9mMg==",
-      "deprecated": "Version no longer supported. Upgrade to @latest",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -18468,16 +18406,6 @@
         "duck": "^0.1.12",
         "option": "~0.2.1",
         "underscore": "^1.13.1"
-      }
-    },
-    "node_modules/lowlight": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
-      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fault": "^1.0.2",
-        "highlight.js": "~9.12.0"
       }
     },
     "node_modules/lru-cache": {
@@ -21727,15 +21655,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/proc-log": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -22282,18 +22201,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-syntax-highlighter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-syntax-highlighter/-/react-native-syntax-highlighter-2.1.0.tgz",
-      "integrity": "sha512-upu8gpKT2ZeslXn2d763KwtzzhM9OUHGgJjIKKIUw1JnFAzVwQmKCaFGoI6PkQa7T1LVggBW5k5VoaLFhZDb+g==",
-      "license": "MIT",
-      "dependencies": {
-        "react-syntax-highlighter": "^6.0.4"
-      },
-      "peerDependencies": {
-        "react-syntax-highlighter": "^6.0.4"
-      }
-    },
     "node_modules/react-native-web": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
@@ -22484,22 +22391,6 @@
         }
       }
     },
-    "node_modules/react-syntax-highlighter": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-6.1.2.tgz",
-      "integrity": "sha512-ahNwcZ0FhUd8U5TQYcmAqC/pec6Q308mUAATKMcLFmNYkvGhN9wfmoqxzjACcccGb2e85d5ZnGpOiCIIzGO3yA==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.18.0",
-        "highlight.js": "~9.12.0",
-        "lowlight": "~1.9.1",
-        "prismjs": "^1.8.4",
-        "refractor": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -22596,177 +22487,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/refractor": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
-      "license": "MIT",
-      "dependencies": {
-        "hastscript": "^5.0.0",
-        "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/comma-separated-tokens": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/hast-util-parse-selector": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/refractor/node_modules/hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/refractor/node_modules/is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "clipboard": "^2.0.0"
-      }
-    },
-    "node_modules/refractor/node_modules/property-information": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
-      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/space-separated-tokens": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/regenerate": {
@@ -23430,13 +23150,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
-    },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -25058,13 +24771,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -27626,6 +27332,8 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }


### PR DESCRIPTION
## Summary

- replace the abandoned `react-native-syntax-highlighter` wrapper with Refractor 5
- render highlighted tokens as native nested `Text` elements while preserving copy and horizontal scrolling
- keep broad language coverage and fall back to plain monospace text for unknown language labels
- remove the obsolete wrapper type shims and vulnerable Prism/Highlight.js dependency chain

## Root cause

`react-native-syntax-highlighter@2.1.0` constrained the app to `react-syntax-highlighter@6`, which pulled `refractor@2.10.1`, `prismjs@1.17.1`, and `highlight.js@9.12.0`. Those versions cannot be upgraded cleanly within the wrapper's dependency ranges.

## Validation

- clean `npm ci` using npm 10.9.8
- dependency guard and targeted dependency-tree/audit checks
- mobile and full-workspace lint/typecheck
- 116 unit tests
- web and site production builds
- Android production export through Expo/Metro
- physical Android device smoke test: TSX highlighting, unknown-language fallback, copy, and scrolling