### PR TITLE
feat(mobile): add a device-level web search toggle

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -44,6 +44,7 @@ import { useChatMessages } from "@/lib/queries/chatMessages";
 import { useModelConfigs } from "@/lib/queries/modelConfigs";
 import type { ChatListItem } from "@/lib/queries/chats";
 import { queryKeys } from "@/lib/queries/keys";
+import { useWebSearchEnabled } from "@/lib/toolPreferences";
 import { useSpeech } from "@/lib/useSpeech";
 import { useTheme } from "@/lib/theme";
 import { toastError } from "@/lib/toast";
@@ -171,6 +172,7 @@ function ChatSurface({
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [searchRequested, setSearchRequested] = useState(false);
+  const webSearchEnabled = useWebSearchEnabled();
   const pickerRef = useRef<BottomSheetModal>(null);
   const addSheetRef = useRef<BottomSheetModal>(null);
 
@@ -231,7 +233,11 @@ function ChatSurface({
   const streaming = status === "streaming" || status === "submitted";
   const configured = Boolean(selectedId);
   const selectedModel = models?.find((m) => m.id === selectedId) ?? null;
-  const searchAvailable = modelSupportsToolCalling(selectedModel);
+  const searchAvailable =
+    webSearchEnabled && modelSupportsToolCalling(selectedModel);
+  const searchUnavailableReason = !webSearchEnabled
+    ? "Web search is disabled in Settings → Tools"
+    : "Unavailable for this model";
 
   const {
     attachments,
@@ -375,6 +381,7 @@ function ChatSurface({
     const requested = searchAvailable && forceSearch;
     return {
       modelConfigId: selectedId,
+      webSearchEnabled,
       forceSearch: requested,
       // Older self-hosted servers only understand the persisted-toggle name.
       // New servers give `forceSearch` precedence and discard this alias.
@@ -569,6 +576,7 @@ function ChatSurface({
       <AddToChatSheet
         ref={addSheetRef}
         searchAvailable={searchAvailable}
+        searchUnavailableReason={searchUnavailableReason}
         searchRequested={searchAvailable && searchRequested}
         onToggleSearchRequested={setSearchRequested}
         onPickTool={onPickTool}

--- a/apps/mobile/src/app/(authed)/settings.tsx
+++ b/apps/mobile/src/app/(authed)/settings.tsx
@@ -6,6 +6,7 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   View,
 } from "react-native";
@@ -16,6 +17,7 @@ import { FONT_OPTIONS, FONT_SANS } from "@/lib/fonts";
 import { setFontPref, useFontPref } from "@/lib/fontPref";
 import { getServerUrl } from "@/lib/server-url";
 import { useTheme } from "@/lib/theme";
+import { setWebSearchEnabled, useWebSearchEnabled } from "@/lib/toolPreferences";
 
 export default function SettingsScreen() {
   const { colors, radii, fonts } = useTheme();
@@ -27,6 +29,7 @@ export default function SettingsScreen() {
 
   const themePref = useThemePref();
   const fontPref = useFontPref();
+  const webSearchEnabled = useWebSearchEnabled();
   const [signingOut, setSigningOut] = useState(false);
   const serverUrl = getServerUrl();
   const serverHost = serverUrl ? safeHost(serverUrl) : null;
@@ -116,6 +119,19 @@ export default function SettingsScreen() {
                 onPress={() => setFontPref(opt.id)}
               />
             ))}
+          </Section>
+
+          <Section
+            title="Tools"
+            description="Control which capabilities models can use on this device."
+          >
+            <SwitchRow
+              label="Web search"
+              sub="Allow supported models to search the web and fetch pages. Disabling this also turns off the Search action in chat."
+              value={webSearchEnabled}
+              onValueChange={setWebSearchEnabled}
+              accessibilityLabel="Enable web search"
+            />
           </Section>
 
           <Section
@@ -316,6 +332,51 @@ function RadioRow({
         ) : null}
       </View>
     </Pressable>
+  );
+}
+
+function SwitchRow({
+  label,
+  sub,
+  value,
+  onValueChange,
+  accessibilityLabel,
+}: {
+  label: string;
+  sub: string;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+  accessibilityLabel: string;
+}) {
+  const { colors, fonts } = useTheme();
+  return (
+    <View style={styles.row}>
+      <View style={styles.rowText}>
+        <Text
+          style={[
+            styles.rowLabel,
+            { color: colors.foreground, fontFamily: fonts.sansRegular },
+          ]}
+        >
+          {label}
+        </Text>
+        <Text
+          style={[
+            styles.rowSub,
+            { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
+          ]}
+        >
+          {sub}
+        </Text>
+      </View>
+      <Switch
+        value={value}
+        onValueChange={onValueChange}
+        accessibilityLabel={accessibilityLabel}
+        trackColor={{ true: colors.primary, false: colors.border }}
+        thumbColor={colors.background}
+      />
+    </View>
   );
 }
 

--- a/apps/mobile/src/components/chat/AddToChatSheet.tsx
+++ b/apps/mobile/src/components/chat/AddToChatSheet.tsx
@@ -24,6 +24,7 @@ export const AddToChatSheet = forwardRef<
   AddToChatSheetRef,
   {
     searchAvailable: boolean;
+    searchUnavailableReason: string;
     searchRequested: boolean;
     onToggleSearchRequested: (next: boolean) => void;
     onPickTool?: (tool: ToolKey) => void;
@@ -31,6 +32,7 @@ export const AddToChatSheet = forwardRef<
 >(function AddToChatSheet(
   {
     searchAvailable,
+    searchUnavailableReason,
     searchRequested,
     onToggleSearchRequested,
     onPickTool,
@@ -144,7 +146,7 @@ export const AddToChatSheet = forwardRef<
                   },
                 ]}
               >
-                Unavailable for this model
+                {searchUnavailableReason}
               </Text>
             ) : null}
           </View>
@@ -155,7 +157,7 @@ export const AddToChatSheet = forwardRef<
             accessibilityLabel={
               searchAvailable
                 ? "Search the web for this message"
-                : "Web search unavailable for this model"
+                : searchUnavailableReason
             }
             trackColor={{ true: colors.primary, false: colors.border }}
             thumbColor={colors.background}

--- a/apps/mobile/src/lib/toolPreferences.ts
+++ b/apps/mobile/src/lib/toolPreferences.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from "react";
+import * as SecureStore from "expo-secure-store";
+import {
+  DEFAULT_WEB_SEARCH_ENABLED,
+  WEB_SEARCH_ENABLED_STORAGE_KEY,
+} from "@overtchat/shared";
+
+const KEY = WEB_SEARCH_ENABLED_STORAGE_KEY;
+
+function read(): boolean {
+  const v = SecureStore.getItem(KEY);
+  if (v === "1") return true;
+  if (v === "0") return false;
+  return DEFAULT_WEB_SEARCH_ENABLED;
+}
+
+const listeners = new Set<() => void>();
+let cached: boolean = read();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+function getSnapshot() {
+  return cached;
+}
+
+export function useWebSearchEnabled(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function setWebSearchEnabled(enabled: boolean) {
+  if (enabled === cached) return;
+  cached = enabled;
+  // The default needs no stored value — a fresh/cleared device resolves to it.
+  if (enabled === DEFAULT_WEB_SEARCH_ENABLED) {
+    SecureStore.deleteItemAsync(KEY).catch(() => {});
+  } else {
+    SecureStore.setItem(KEY, enabled ? "1" : "0");
+  }
+  listeners.forEach((cb) => cb());
+}
+
+export function getWebSearchEnabled(): boolean {
+  return cached;
+}

--- a/apps/web/lib/tool-preferences.ts
+++ b/apps/web/lib/tool-preferences.ts
@@ -1,4 +1,4 @@
-export const WEB_SEARCH_ENABLED_STORAGE_KEY =
-  "overtchat_web_search_enabled";
-
-export const DEFAULT_WEB_SEARCH_ENABLED = true;
+export {
+  DEFAULT_WEB_SEARCH_ENABLED,
+  WEB_SEARCH_ENABLED_STORAGE_KEY,
+} from "@overtchat/shared";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./models";
 export * from "./model-icons";
 export * from "./chat";
 export * from "./tools";
+export * from "./tool-preferences";
 export * from "./citations";
 export * from "./search";
 export * from "./theme/tokens";

--- a/packages/shared/src/tool-preferences.ts
+++ b/packages/shared/src/tool-preferences.ts
@@ -1,0 +1,7 @@
+/**
+ * Device-local web search preference. Web persists it in localStorage and
+ * mobile in SecureStore, so the key is shared but the storage is not.
+ */
+export const WEB_SEARCH_ENABLED_STORAGE_KEY = "overtchat_web_search_enabled";
+
+export const DEFAULT_WEB_SEARCH_ENABLED = true;


### PR DESCRIPTION
Supersedes the mobile half of #75, cut fresh off `main` instead of rebasing it.

v0.11.0 gave web a persistent web search disable under **Settings → Tools**. Mobile never got one, so the only lever there was the one-message Search action — a tool-capable model would still search on its own.

## What's changed

- Added a **Tools** section to mobile settings with a **Web search** switch, mirroring web's copy.
- Moved `WEB_SEARCH_ENABLED_STORAGE_KEY` / `DEFAULT_WEB_SEARCH_ENABLED` into `@overtchat/shared` so the two clients can't drift on the key or the default. `apps/web/lib/tool-preferences.ts` is now a re-export, so its consumers are untouched.
- The mobile preference is a module-level store read through `useSyncExternalStore`, matching `lib/appearance.ts` and `lib/fontPref.ts`. Toggling it in settings reaches an already-mounted chat screen, which a per-component hook would not.
- Mobile now sends `webSearchEnabled` in the chat request body as web does. Without it the server falls back to its default of `true` and keeps attaching web tools, which would make the toggle cosmetic.
- Split the two reasons the Search action can be unavailable. "Unavailable for this model" was shown even when the user had disabled search themselves; that case now points at Settings → Tools.

## Notes

Web behaviour is unchanged — the only web edit is the re-export shim.

No mobile version bump here. This is groundwork for the next `mobile-v*` release rather than the release itself.

`#75` is left for separate closing. Its web-side commits are already in v0.11.0 via #74/#76/#98, and its remaining mobile diff would revert the #106 syntax-highlighter fix, so rebasing it was the wrong move.

## Validation

`npm run typecheck` (web, site, mobile), `npm run lint`, `npm run test` (166), `npm run build`.

Not yet exercised on a device — the switch, its persistence across app restart, and the disabled-state copy in the add sheet still want a manual pass on the dev client before this leaves draft.
