### PR TITLE
fix(mobile): repair crash reporting and ship to the production track

### DIFF
--- a/.github/workflows/mobile-eas.yml
+++ b/.github/workflows/mobile-eas.yml
@@ -48,6 +48,26 @@ jobs:
             echo "expected_tag=$EXPECTED_TAG"
           } >> "$GITHUB_OUTPUT"
 
+      # A secret-visibility DSN is unreadable here and ships crash reporting
+      # silently disabled, which is how 1.2.3 went out.
+      - name: Check crash reporting is configured
+        working-directory: apps/mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        # `env:exec` runs this through `sh`, so keep it POSIX.
+        run: |
+          npx eas-cli@20 env:exec production '
+            if [ -z "$EXPO_PUBLIC_SENTRY_DSN" ]; then
+              echo "::error::EXPO_PUBLIC_SENTRY_DSN is not readable in the production environment. It must have plain-text visibility; local builds cannot read secret variables."
+              exit 1
+            fi
+            if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+              echo "::error::SENTRY_AUTH_TOKEN is not readable in the production environment. Source maps would upload unsymbolicated."
+              exit 1
+            fi
+            echo "Crash reporting is configured."
+          '
+
       - name: Install local Android credentials
         run: |
           if [[ -f apps/mobile/credentials.json ]]; then

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -7,6 +7,7 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "environment": "development",
       "android": {
         "buildType": "apk",
         "withoutCredentials": true
@@ -17,18 +18,21 @@
     },
     "preview": {
       "distribution": "internal",
+      "environment": "preview",
       "android": {
         "buildType": "apk",
         "credentialsSource": "local"
       }
     },
     "production": {
+      "environment": "production",
       "android": {
         "buildType": "app-bundle",
         "credentialsSource": "local"
       }
     },
     "production-apk": {
+      "environment": "production",
       "android": {
         "buildType": "apk",
         "credentialsSource": "local"
@@ -38,8 +42,8 @@
   "submit": {
     "production": {
       "android": {
-        "track": "alpha",
-        "releaseStatus": "draft"
+        "track": "production",
+        "releaseStatus": "completed"
       }
     }
   }

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -50,13 +50,22 @@ import { useTheme } from "@/lib/theme";
 
 SplashScreen.preventAutoHideAsync();
 
+// Must be stored in EAS with plain-text visibility: releases build with
+// `eas build --local`, which never receives secret-visibility variables.
 const SENTRY_DSN = process.env.EXPO_PUBLIC_SENTRY_DSN;
 if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
     debug: __DEV__,
     sendDefaultPii: false,
+    environment:
+      process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT ??
+      (__DEV__ ? "development" : "production"),
   });
+} else if (__DEV__) {
+  console.warn(
+    "[sentry] EXPO_PUBLIC_SENTRY_DSN is unset — crash reporting is disabled.",
+  );
 }
 
 function RootLayout() {


### PR DESCRIPTION
Crash reporting has never worked in a shipped build. `EXPO_PUBLIC_SENTRY_DSN` was stored as an EAS variable with **secret** visibility, and secret variables are withheld from `eas build --local` — which is how `mobile-eas.yml` builds every release. The variable resolved to `undefined`, `Sentry.init` was skipped by its own guard, and 1.2.3 has been in the Play Store reporting nothing.

The failure was invisible because `SENTRY_AUTH_TOKEN` is only *sensitive*, which **is** readable locally. Source maps kept uploading on schedule, so the Sentry project looked healthy while receiving zero events. The 1.2.3 build log:

```
Environment variables with visibility "Plain text" and "Sensitive"
loaded from the "production" environment on EAS: SENTRY_AUTH_TOKEN.
```

`EXPO_PUBLIC_SENTRY_DSN` is absent from that line. After the fix, the same line from a local release build reads `EXPO_PUBLIC_SENTRY_DSN, SENTRY_AUTH_TOKEN`.

## What's changed

- **Preflight the Sentry variables** on `mobile-v*` tags, before spending ~15 minutes on a build that would ship blind.
- **Tag events with an `environment`** so dev-client crashes stop sharing an issue stream with store builds. Overridable via `EXPO_PUBLIC_SENTRY_ENVIRONMENT`.
- **Warn in dev when the DSN is missing.** Silence is what hid this for two releases.
- **Submit to the track the app actually lives on.** `alpha` + `releaseStatus: draft` dated from closed testing; the listing is public now, so `production` + `completed` removes a manual promote step.
- **Name each build profile's `environment` explicitly.** EAS already inferred these correctly from profile shape — this is readability, not a fix.

## Upgrade note

The repair itself is an EAS-side change, already applied: the variable was deleted and recreated with plain-text visibility in `production`, `preview`, and `development`. EAS rejects converting a secret in place — both `env:update` and `env:create --force` fail, because it cannot decrypt the value to re-store it — so delete-and-recreate is the only path. A DSN is not a credential; it only permits event submission, never reads, so plain text is the correct storage class per [Sentry's DSN docs](https://docs.sentry.io/concepts/key-terms/dsn-explainer/).

`SENTRY_AUTH_TOKEN` is unchanged and stays *sensitive*. It is a real credential, and sensitive is already readable by local builds.

## Validation

Verified end to end against a real release build and a physical device, rather than by inspection:

- A local `production`-env release APK loaded **both** Sentry variables, where 1.2.3 loaded only the auth token.
- The DSN is present in `assets/index.android.bundle` inside the built APK. A 1.2.3 APK does not contain it.
- Installed on-device (production-signed, `versionCode=9`): the app resolves the Sentry ingest host on launch, confirming `Sentry.init` runs rather than being skipped.
- All three capture paths fire — unhandled JS exception, `captureMessage`, and `nativeCrash` — observed in logcat and delivered to the project.
- Source maps upload during the build (debug ID recorded against `com.overtchat.mobile@1.2.3+9`).
- The tag preflight was exercised in both directions: exit 1 with a named cause before the EAS fix, exit 0 after.

`npm run typecheck -w apps/mobile` passes. The temporary crash triggers used for the device pass were never committed.
