### PR TITLE
chore(mobile): bump to 1.3.0

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "overtchat",
     "slug": "overtchat",
-    "version": "1.2.3",
+    "version": "1.3.0",
     "orientation": "portrait",
     "scheme": "overtchat",
     "userInterfaceStyle": "automatic",
@@ -10,11 +10,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.overtchat.mobile",
-      "buildNumber": "8"
+      "buildNumber": "9"
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 9,
+      "versionCode": 10,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@overtchat/mobile",
   "main": "expo-router/entry",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "expo start --host=lan",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/mobile": {
       "name": "@overtchat/mobile",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "dependencies": {
         "@ai-sdk/react": "^4.0.34",
         "@better-auth/expo": "1.6.23",


### PR DESCRIPTION
Mobile hasn't shipped since 1.2.3 on 2026-07-13. Six merged PRs of changes are sitting on `main` unreleased:

- #109 — crash reporting repaired (1.2.3 shipped with Sentry silently disabled) and submission repointed at the production track
- #108 — device-level web search toggle
- #106 — replaced a vulnerable syntax highlighter
- #107 — automatic web search, prompt caching, AI SDK v7
- #73 — provider architecture and Amazon Bedrock
- #99 — Better Auth package family aligned on 1.6.23

Minor bump rather than patch: the web search toggle is a user-visible feature.

`versionCode` 9 → 10 and `buildNumber` 8 → 9. `package.json`'s `version` moves in lockstep because `mobile-eas.yml` asserts it equals `expo.version` and that the tag is `mobile-v${expo.version}`. `package-lock.json` carries the workspace version, so it's regenerated with `--package-lock-only` — that one line is its only change.

## Before tagging

`releaseStatus: completed` now means the tag goes live with no draft to reject. A `workflow_dispatch` run of `mobile-eas.yml` builds the real production AAB and APK but skips both the Play submit and the release upload (each gated on `refs/tags/mobile-v`), so it's a full rehearsal of everything irreversible. That runs against `main` after this merges, and the resulting APK gets a smoke pass, before `mobile-v1.3.0` is tagged.
