### PR TITLE
fix(mobile): follow the Sentry project slug rename

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -59,7 +59,7 @@
         {
           "url": "https://sentry.io/",
           "organization": "yash-ge",
-          "project": "react-native"
+          "project": "overtchat-mobile"
         }
       ],
       [


### PR DESCRIPTION
The Sentry project was renamed off the scaffold default `react-native` to `overtchat-mobile`, but `apps/mobile/app.json` still named the old slug in the `@sentry/react-native/expo` plugin config.

Sentry 302-redirects the old slug for browsing, so the UI looks fine. The Gradle source-map upload resolves the project by slug at build time, so the next release would have kept uploading maps under the old identity — the same class of silent failure as #109, where everything looked healthy and nothing was wired up.

`android/sentry.properties` holds the same value and was updated locally, but `android/` is gitignored and regenerated from `app.json` during prebuild, so this one line is the whole fix.

Verified `overtchat-mobile` resolves against the API with the release auth token before changing it.

No version bump — this only affects where the next build uploads source maps, and 1.3.0 already shipped with maps correctly uploaded under the old slug.