### PR TITLE
feat(web): add slash commands to the chat composer

### DIFF
--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useChat } from "@ai-sdk/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai";
@@ -29,6 +30,7 @@ import {
   hasDataTransferFiles,
 } from "@/lib/chat/attachments";
 import { AdminOnboardingCard } from "@/components/AdminOnboardingCard";
+import { useSidebar } from "@/components/sidebar-context";
 import { ChatHeader } from "./ChatHeader";
 import { Composer, type ComposerHandle } from "./Composer";
 import { MessageList } from "./MessageList";
@@ -50,6 +52,8 @@ interface Props {
 
 export function ChatArea({ chatId, initialMessages, isNew, projectId, initialQuery }: Props) {
   const qc = useQueryClient();
+  const router = useRouter();
+  const { openPalette } = useSidebar();
   const { data: chats } = useChats();
 
   const { data: modelsData, isError: modelsError } = useModelConfigs();
@@ -263,6 +267,17 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId, initialQue
     sendMessage({ text, files, messageId }, { body: requestBody() });
   }
 
+  // A per-message search request is scoped to the model that supports it, so
+  // switching models drops it.
+  function handleSelectModel(modelId: string) {
+    setSearchRequested(false);
+    setSelectedId(modelId);
+  }
+
+  // Temporary mode is only switchable before the first message, matching the
+  // header toggle's visibility rule.
+  const canToggleTemporary = Boolean(isNew) && messages.length === 0;
+
   const composer = (
     <Composer
       ref={composerRef}
@@ -272,6 +287,17 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId, initialQue
       searchUnavailableReason={searchUnavailableReason}
       searchRequested={searchAvailable && searchRequested}
       dropActive={dropActive}
+      models={models}
+      selectedModelId={selectedId}
+      commandActions={{
+        temporary: canToggleTemporary
+          ? { active: temporary, onToggle: () => setTemporary((t) => !t) }
+          : undefined,
+        onNewChat: () => router.push("/"),
+        onSearchChats: openPalette,
+        onOpenSettings: () => router.push("/settings"),
+        onSelectModel: handleSelectModel,
+      }}
       onToggleSearch={() => {
         if (searchAvailable) setSearchRequested((selected) => !selected);
       }}
@@ -292,11 +318,8 @@ export function ChatArea({ chatId, initialMessages, isNew, projectId, initialQue
       <ChatHeader
         models={models}
         selectedId={selectedId}
-        onSelectModel={(modelId) => {
-          setSearchRequested(false);
-          setSelectedId(modelId);
-        }}
-        showTempToggle={Boolean(isNew) && messages.length === 0}
+        onSelectModel={handleSelectModel}
+        showTempToggle={canToggleTemporary}
         temporary={temporary}
         onToggleTemporary={() => setTemporary((t) => !t)}
       />

--- a/apps/web/components/chat/Composer.tsx
+++ b/apps/web/components/chat/Composer.tsx
@@ -3,7 +3,9 @@
 import {
   forwardRef,
   useEffect,
+  useId,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -12,11 +14,16 @@ import {
   AlertCircle,
   ArrowUp,
   Check,
+  Cpu,
+  Ghost,
   Globe,
   Loader2,
   Mic,
   Paperclip,
+  Pencil,
   Plus,
+  Search,
+  Settings2,
   Square,
   X,
 } from "lucide-react";
@@ -32,7 +39,22 @@ import {
 import { dictationErrorMessage } from "@/lib/chat/message";
 import { motionClasses } from "@/lib/motion";
 import { useDictation } from "@/lib/useDictation";
+import {
+  filterSlashCommandModels,
+  filterSlashCommands,
+  isSlashCommandAvailable,
+  parseSlashCommandQuery,
+  resolveSlashCommand,
+  type SlashCommand,
+} from "@/lib/chat/slash-commands";
+import type { PublicModelConfig } from "@/lib/model-config/schema";
 import { CategoryIcon } from "./attachment-icons";
+import {
+  SlashCommandMenu,
+  toSlashCommandModelRows,
+  toSlashCommandRows,
+  type SlashCommandRow,
+} from "./SlashCommandMenu";
 import {
   type ChatAttachment,
   useChatAttachments,
@@ -43,6 +65,19 @@ export interface ComposerHandle {
   focus: (options?: FocusOptions) => void;
 }
 
+/**
+ * Commands the composer owns itself (attach, dictate) are appended by the
+ * composer; everything that mutates chat-level state is declared by `ChatArea`.
+ */
+export interface ComposerCommandActions {
+  /** Runs `/temporary`; omitted once the chat has messages. */
+  temporary?: { active: boolean; onToggle: () => void };
+  onNewChat: () => void;
+  onSearchChats: () => void;
+  onOpenSettings: () => void;
+  onSelectModel: (modelId: string) => void;
+}
+
 interface ComposerProps {
   configured: boolean;
   streaming: boolean;
@@ -50,6 +85,9 @@ interface ComposerProps {
   searchUnavailableReason: string;
   searchRequested: boolean;
   dropActive: boolean;
+  models: PublicModelConfig[] | null;
+  selectedModelId: string;
+  commandActions: ComposerCommandActions;
   onToggleSearch: () => void;
   onSubmit: (input: string, attachments: FileUIPart[]) => void;
   onStop: () => void;
@@ -63,6 +101,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   searchUnavailableReason,
   searchRequested,
   dropActive,
+  models,
+  selectedModelId,
+  commandActions,
   onToggleSearch,
   onSubmit,
   onStop,
@@ -114,6 +155,234 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     el.style.height = `${el.scrollHeight}px`;
   }, [input]);
 
+  function startDictation() {
+    if (dictation.status === "idle") void dictation.start();
+  }
+
+  const [dismissedQuery, setDismissedQuery] = useState<string | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listboxId = useId();
+  const optionIdPrefix = useId();
+
+  const commands = useMemo<SlashCommand[]>(() => {
+    const list: SlashCommand[] = [
+      {
+        name: "search",
+        title: "Web search",
+        description: "Search the web for this message",
+        group: "actions",
+        icon: Globe,
+        keywords: ["web", "browse"],
+        toggle: {
+          active: searchRequested,
+          unavailableReason: searchAvailable
+            ? undefined
+            : searchUnavailableReason,
+        },
+        run: onToggleSearch,
+      },
+      {
+        name: "attach",
+        title: "Add photos & files",
+        description: "Upload from your device",
+        group: "actions",
+        icon: Paperclip,
+        keywords: ["file", "upload", "image", "photo", "pdf"],
+        action: "attach",
+      },
+      {
+        name: "dictate",
+        title: "Dictate",
+        description: "Record and transcribe speech",
+        group: "actions",
+        icon: Mic,
+        keywords: ["voice", "speak", "microphone", "transcribe"],
+        action: "dictate",
+      },
+    ];
+
+    if (commandActions.temporary) {
+      list.push({
+        name: "temporary",
+        title: "Temporary chat",
+        description: "Chat without saving to history",
+        group: "actions",
+        icon: Ghost,
+        keywords: ["incognito", "private", "unsaved"],
+        toggle: { active: commandActions.temporary.active },
+        run: commandActions.temporary.onToggle,
+      });
+    }
+
+    list.push(
+      {
+        name: "model",
+        title: "Switch model",
+        description: "Choose which model answers",
+        group: "actions",
+        icon: Cpu,
+        keywords: ["models", "switch"],
+        submenu: "model",
+      },
+      {
+        name: "new",
+        title: "New chat",
+        description: "Start a fresh conversation",
+        group: "navigate",
+        icon: Pencil,
+        shortcut: ["Ctrl", "Shift", "O"],
+        run: commandActions.onNewChat,
+      },
+      {
+        name: "chats",
+        title: "Search chats",
+        description: "Find an earlier conversation",
+        group: "navigate",
+        icon: Search,
+        keywords: ["history", "find"],
+        shortcut: ["Ctrl", "K"],
+        run: commandActions.onSearchChats,
+      },
+      {
+        name: "settings",
+        title: "Settings",
+        description: "Models, tools, and preferences",
+        group: "navigate",
+        icon: Settings2,
+        keywords: ["preferences", "config"],
+        run: commandActions.onOpenSettings,
+      },
+    );
+
+    return list;
+  }, [
+    commandActions,
+    searchAvailable,
+    searchRequested,
+    searchUnavailableReason,
+    onToggleSearch,
+  ]);
+
+  const query = parseSlashCommandQuery(input);
+  const exactCommand = query
+    ? (commands.find((command) => command.name === query.name) ?? null)
+    : null;
+  // `/model foo` filters the model list; any other command with an argument is
+  // a finished invocation, so the menu closes.
+  const submenu = query?.hasArgument ? exactCommand?.submenu ?? null : null;
+
+  const commandQuery = query && !submenu ? query.name : null;
+  const filteredCommands = useMemo(
+    () =>
+      commandQuery === null ? [] : filterSlashCommands(commands, commandQuery),
+    [commands, commandQuery],
+  );
+  const submenuModels = useMemo(
+    () =>
+      submenu === "model"
+        ? filterSlashCommandModels(models ?? [], query?.argument ?? "")
+        : null,
+    [models, query?.argument, submenu],
+  );
+
+  const rows = submenuModels
+    ? toSlashCommandModelRows(submenuModels)
+    : toSlashCommandRows(filteredCommands);
+  const menuOpen =
+    query !== null &&
+    input !== dismissedQuery &&
+    (submenu !== null || !query.hasArgument);
+  // Filtering shrinks the list under the cursor, so clamp on read rather than
+  // syncing an effect against the row count.
+  const activeRow = Math.min(activeIndex, Math.max(0, rows.length - 1));
+
+  function closeMenu() {
+    setDismissedQuery(input);
+    setActiveIndex(0);
+  }
+
+  function replaceDraft(next: string) {
+    setInput(next);
+    setDismissedQuery(null);
+    setActiveIndex(0);
+    textareaRef.current?.focus({ preventScroll: true });
+  }
+
+  function runCommand(command: SlashCommand) {
+    if (!isSlashCommandAvailable(command)) return;
+    if (command.submenu) {
+      replaceDraft(`/${command.name} `);
+      return;
+    }
+    // Clear the draft before running: navigation unmounts the composer, and a
+    // toggle should leave an empty box ready for the real message.
+    replaceDraft("");
+    if (command.action === "attach") fileInputRef.current?.click();
+    else if (command.action === "dictate") startDictation();
+    else command.run?.();
+  }
+
+  function selectRow(row: SlashCommandRow) {
+    if (row.kind === "model") {
+      replaceDraft("");
+      commandActions.onSelectModel(row.model.id);
+      return;
+    }
+    runCommand(row.command);
+  }
+
+  /** Returns true when the menu consumed the key. */
+  function handleMenuKeyDown(
+    e: React.KeyboardEvent<HTMLTextAreaElement>,
+  ): boolean {
+    if (!query) return false;
+
+    if (e.key === "Escape" && menuOpen) {
+      e.preventDefault();
+      // Back out of the submenu one level before closing the menu.
+      if (submenu) replaceDraft(`/${query.name}`);
+      else closeMenu();
+      return true;
+    }
+
+    if (e.key === "Enter" && !e.shiftKey) {
+      if (menuOpen && rows.length > 0) {
+        e.preventDefault();
+        selectRow(rows[activeRow]);
+        return true;
+      }
+      // With the menu closed, a fully typed command still runs on Enter instead
+      // of sending "/temporary" as a message.
+      if (!submenu) {
+        const command = resolveSlashCommand(commands, query);
+        if (command && isSlashCommandAvailable(command) && !command.submenu) {
+          e.preventDefault();
+          runCommand(command);
+          return true;
+        }
+      }
+      return false;
+    }
+
+    if (!menuOpen || rows.length === 0) return false;
+
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const delta = e.key === "ArrowDown" ? 1 : -1;
+      setActiveIndex((activeRow + delta + rows.length) % rows.length);
+      return true;
+    }
+
+    if (e.key === "Tab" && !e.shiftKey && !submenu) {
+      e.preventDefault();
+      const command = filteredCommands[activeRow];
+      if (command) replaceDraft(`/${command.name}${command.submenu ? " " : ""}`);
+      return true;
+    }
+
+    return false;
+  }
+
   function submit() {
     const text = input.trim();
     if (streaming || uploading) return;
@@ -121,6 +390,8 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     if (!configured) return;
     onSubmit(text, readyParts);
     setInput("");
+    setDismissedQuery(null);
+    setActiveIndex(0);
     clearAttachments();
   }
 
@@ -131,6 +402,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (handleMenuKeyDown(e)) return;
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       submit();
@@ -151,179 +423,208 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           {dictationErrorMessage(dictation.error, isAdmin)}
         </p>
       )}
-      <div
-        className={cn(
-          "flex flex-col gap-2 rounded-3xl border bg-background px-3.5 pt-3.5 pb-2.5 shadow-sm motion-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
-          dropActive && "border-ring bg-accent/20 ring-2 ring-ring/30",
+      <div className="relative">
+        {menuOpen && query && (
+          <SlashCommandMenu
+            id={listboxId}
+            optionIdPrefix={optionIdPrefix}
+            commands={filteredCommands}
+            models={submenuModels}
+            selectedModelId={selectedModelId}
+            activeIndex={activeRow}
+            query={query.name}
+            onActiveIndexChange={setActiveIndex}
+            onSelect={selectRow}
+          />
         )}
-      >
-        {attachments.length > 0 && (
-          <div className="flex flex-wrap gap-2 px-1 pt-1">
-            {attachments.map((att) => (
-              <AttachmentChip
-                key={att.id}
-                attachment={att}
-                onRemove={() => removeAttachment(att.id)}
+        <div
+          className={cn(
+            "flex flex-col gap-2 rounded-3xl border bg-background px-3.5 pt-3.5 pb-2.5 shadow-sm motion-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
+            dropActive && "border-ring bg-accent/20 ring-2 ring-ring/30",
+          )}
+        >
+          {attachments.length > 0 && (
+            <div className="flex flex-wrap gap-2 px-1 pt-1">
+              {attachments.map((att) => (
+                <AttachmentChip
+                  key={att.id}
+                  attachment={att}
+                  onRemove={() => removeAttachment(att.id)}
+                />
+              ))}
+            </div>
+          )}
+          <Textarea
+            ref={textareaRef}
+            rows={1}
+            placeholder={
+              configured ? "Message… or / for commands" : "No models configured"
+            }
+            className="max-h-48 min-h-10 resize-none border-0 bg-transparent px-1 py-0 shadow-none focus-visible:ring-0 md:text-sm dark:bg-transparent"
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              setActiveIndex(0);
+            }}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            // The textarea stays focused and owns the keyboard; the menu below is
+            // the listbox it controls.
+            role="combobox"
+            aria-expanded={menuOpen}
+            aria-controls={menuOpen ? listboxId : undefined}
+            aria-activedescendant={
+              menuOpen && rows.length > 0
+                ? `${optionIdPrefix}-${activeRow}`
+                : undefined
+            }
+            aria-autocomplete="list"
+          />
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={ATTACH_ACCEPT}
+                multiple
+                className="hidden"
+                onChange={(e) => void handleFiles(e.target.files)}
               />
-            ))}
-          </div>
-        )}
-        <Textarea
-          ref={textareaRef}
-          rows={1}
-          placeholder={
-            configured ? "Message…" : "No models configured"
-          }
-          className="max-h-48 min-h-10 resize-none border-0 bg-transparent px-1 py-0 shadow-none focus-visible:ring-0 md:text-sm dark:bg-transparent"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onPaste={handlePaste}
-        />
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-1">
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={ATTACH_ACCEPT}
-              multiple
-              className="hidden"
-              onChange={(e) => void handleFiles(e.target.files)}
-            />
-            <Menu.Root>
-              <Menu.Trigger
-                render={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    className="rounded-full"
-                    aria-label="Add to message"
-                  />
-                }
-              >
-                <Plus />
-              </Menu.Trigger>
-              <Menu.Portal>
-                <Menu.Positioner side="top" align="start" sideOffset={8}>
-                  <Menu.Popup
-                    className={cn(
-                      "z-50 w-72 rounded-xl border bg-popover p-1.5 text-sm text-popover-foreground shadow-md outline-none",
-                      motionClasses.popup,
-                    )}
-                  >
-                    <Menu.Item
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={uploading}
-                      className="flex min-h-12 cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              <Menu.Root>
+                <Menu.Trigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="rounded-full"
+                      aria-label="Add to message"
+                    />
+                  }
+                >
+                  <Plus />
+                </Menu.Trigger>
+                <Menu.Portal>
+                  <Menu.Positioner side="top" align="start" sideOffset={8}>
+                    <Menu.Popup
+                      className={cn(
+                        "z-50 w-72 rounded-xl border bg-popover p-1.5 text-sm text-popover-foreground shadow-md outline-none",
+                        motionClasses.popup,
+                      )}
                     >
-                      <Paperclip className="size-4 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-medium">
-                          Add photos &amp; files
+                      <Menu.Item
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={uploading}
+                        className="flex min-h-12 cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                      >
+                        <Paperclip className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-medium">
+                            Add photos &amp; files
+                          </span>
+                          <span className="block text-xs text-muted-foreground">
+                            Upload from your device
+                          </span>
                         </span>
-                        <span className="block text-xs text-muted-foreground">
-                          Upload from your device
+                      </Menu.Item>
+                      <Menu.CheckboxItem
+                        checked={searchRequested}
+                        onCheckedChange={onToggleSearch}
+                        closeOnClick
+                        disabled={!searchAvailable}
+                        className="flex min-h-12 cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                      >
+                        <Globe className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-medium">Web search</span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {searchAvailable
+                              ? "Always search for this message"
+                              : searchUnavailableReason}
+                          </span>
                         </span>
-                      </span>
-                    </Menu.Item>
-                    <Menu.CheckboxItem
-                      checked={searchRequested}
-                      onCheckedChange={onToggleSearch}
-                      closeOnClick
-                      disabled={!searchAvailable}
-                      className="flex min-h-12 cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
-                    >
-                      <Globe className="size-4 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-medium">Web search</span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {searchAvailable
-                            ? "Always search for this message"
-                            : searchUnavailableReason}
+                        <span className="flex size-4 shrink-0 items-center justify-center">
+                          {searchRequested ? <Check className="size-3.5" /> : null}
                         </span>
-                      </span>
-                      <span className="flex size-4 shrink-0 items-center justify-center">
-                        {searchRequested ? <Check className="size-3.5" /> : null}
-                      </span>
-                    </Menu.CheckboxItem>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
-            {searchRequested && (
-              <button
+                      </Menu.CheckboxItem>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+              {searchRequested && (
+                <button
+                  type="button"
+                  onClick={onToggleSearch}
+                  className="flex h-7 items-center gap-1.5 rounded-full bg-accent px-2.5 text-xs font-medium text-accent-foreground outline-none motion-colors hover:bg-accent/80 focus-visible:ring-3 focus-visible:ring-ring/50 max-md:h-10 max-md:px-3"
+                  aria-label="Remove Web search from this message"
+                >
+                  <Globe className="size-3.5" />
+                  <span>Web search</span>
+                  <X className="size-3" />
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
                 type="button"
-                onClick={onToggleSearch}
-                className="flex h-7 items-center gap-1.5 rounded-full bg-accent px-2.5 text-xs font-medium text-accent-foreground outline-none motion-colors hover:bg-accent/80 focus-visible:ring-3 focus-visible:ring-ring/50 max-md:h-10 max-md:px-3"
-                aria-label="Remove Web search from this message"
-              >
-                <Globe className="size-3.5" />
-                <span>Web search</span>
-                <X className="size-3" />
-              </button>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              className={cn(
-                "rounded-full",
-                dictation.status === "recording" &&
-                  "bg-destructive text-destructive-foreground hover:bg-destructive hover:text-destructive-foreground",
-              )}
-              onClick={() => {
-                if (dictation.status === "recording") {
-                  dictation.stop();
-                } else if (dictation.status === "idle") {
-                  void dictation.start();
+                variant="ghost"
+                size="icon-sm"
+                className={cn(
+                  "rounded-full",
+                  dictation.status === "recording" &&
+                    "bg-destructive text-destructive-foreground hover:bg-destructive hover:text-destructive-foreground",
+                )}
+                onClick={() => {
+                  if (dictation.status === "recording") {
+                    dictation.stop();
+                  } else if (dictation.status === "idle") {
+                    void dictation.start();
+                  }
+                }}
+                disabled={dictation.status === "transcribing"}
+                aria-label={
+                  dictation.status === "recording"
+                    ? "Stop dictation"
+                    : dictation.status === "transcribing"
+                      ? "Transcribing"
+                      : "Dictate"
                 }
-              }}
-              disabled={dictation.status === "transcribing"}
-              aria-label={
-                dictation.status === "recording"
-                  ? "Stop dictation"
-                  : dictation.status === "transcribing"
-                    ? "Transcribing"
-                    : "Dictate"
-              }
-              aria-pressed={dictation.status === "recording"}
-            >
-              {dictation.status === "transcribing" ? (
-                <Loader2 className={motionClasses.spinner} />
-              ) : dictation.status === "recording" ? (
-                <Square className="size-3 fill-current" />
+                aria-pressed={dictation.status === "recording"}
+              >
+                {dictation.status === "transcribing" ? (
+                  <Loader2 className={motionClasses.spinner} />
+                ) : dictation.status === "recording" ? (
+                  <Square className="size-3 fill-current" />
+                ) : (
+                  <Mic />
+                )}
+              </Button>
+              {streaming ? (
+                <Button
+                  size="icon-sm"
+                  variant="secondary"
+                  className="shrink-0 rounded-full"
+                  onClick={onStop}
+                  aria-label="Stop generating"
+                >
+                  <Square className="size-3 fill-current" />
+                </Button>
               ) : (
-                <Mic />
+                <Button
+                  size="icon-sm"
+                  className="shrink-0 rounded-full"
+                  disabled={
+                    uploading ||
+                    (!input.trim() &&
+                      readyParts.length === 0)
+                  }
+                  onClick={submit}
+                  aria-label="Send message"
+                >
+                  {uploading ? <Loader2 className={motionClasses.spinner} /> : <ArrowUp />}
+                </Button>
               )}
-            </Button>
-            {streaming ? (
-              <Button
-                size="icon-sm"
-                variant="secondary"
-                className="shrink-0 rounded-full"
-                onClick={onStop}
-                aria-label="Stop generating"
-              >
-                <Square className="size-3 fill-current" />
-              </Button>
-            ) : (
-              <Button
-                size="icon-sm"
-                className="shrink-0 rounded-full"
-                disabled={
-                  uploading ||
-                  (!input.trim() &&
-                    readyParts.length === 0)
-                }
-                onClick={submit}
-                aria-label="Send message"
-              >
-                {uploading ? <Loader2 className={motionClasses.spinner} /> : <ArrowUp />}
-              </Button>
-            )}
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/components/chat/SlashCommandMenu.tsx
+++ b/apps/web/components/chat/SlashCommandMenu.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { Check } from "lucide-react";
+import { ModelBrandIcon } from "@/components/ModelBrandIcon";
+import { cn } from "@/lib/utils";
+import { motionClasses } from "@/lib/motion";
+import {
+  groupSlashCommands,
+  isSlashCommandAvailable,
+  type SlashCommand,
+} from "@/lib/chat/slash-commands";
+import type { PublicModelConfig } from "@/lib/model-config/schema";
+
+// Rows are flat so the active index is a single number shared by keyboard
+// navigation, `aria-activedescendant`, and scroll-into-view.
+export type SlashCommandRow =
+  | { kind: "command"; command: SlashCommand }
+  | { kind: "model"; model: PublicModelConfig };
+
+export function toSlashCommandRows(
+  commands: readonly SlashCommand[],
+): SlashCommandRow[] {
+  return commands.map((command) => ({ kind: "command", command }));
+}
+
+export function toSlashCommandModelRows(
+  models: readonly PublicModelConfig[],
+): SlashCommandRow[] {
+  return models.map((model) => ({ kind: "model", model }));
+}
+
+interface Props {
+  id: string;
+  /** Owned by the composer, which points `aria-activedescendant` at a row. */
+  optionIdPrefix: string;
+  /** Already filtered. Ignored while `models` is set. */
+  commands: readonly SlashCommand[];
+  /** Non-null while the `/model` submenu is open. */
+  models: readonly PublicModelConfig[] | null;
+  selectedModelId: string;
+  activeIndex: number;
+  /** Typed command name, for the empty state. */
+  query: string;
+  onActiveIndexChange: (index: number) => void;
+  onSelect: (row: SlashCommandRow) => void;
+}
+
+export function SlashCommandMenu({
+  id,
+  optionIdPrefix,
+  commands,
+  models,
+  selectedModelId,
+  activeIndex,
+  query,
+  onActiveIndexChange,
+  onSelect,
+}: Props) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const groups = useMemo(
+    () => (models ? [] : groupSlashCommands(commands)),
+    [commands, models],
+  );
+
+  // Indexed in render order so `data-index` matches the composer's cursor.
+  const rowIndexes = useMemo(() => {
+    const map = new Map<string, number>();
+    let index = 0;
+    if (models) {
+      for (const model of models) map.set(`model:${model.id}`, index++);
+    } else {
+      for (const group of groups) {
+        for (const command of group.commands) {
+          map.set(`command:${command.name}`, index++);
+        }
+      }
+    }
+    return map;
+  }, [groups, models]);
+
+  useEffect(() => {
+    const row = listRef.current?.querySelector<HTMLElement>(
+      `[data-index="${activeIndex}"]`,
+    );
+    row?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  const isEmpty = models ? models.length === 0 : commands.length === 0;
+
+  return (
+    <div
+      className={cn(
+        "absolute bottom-full left-0 z-50 mb-2 w-full max-w-lg overflow-hidden rounded-xl border bg-popover text-sm text-popover-foreground shadow-md",
+        motionClasses.palette,
+      )}
+    >
+      <div
+        ref={listRef}
+        id={id}
+        role="listbox"
+        aria-label={models ? "Select model" : "Commands"}
+        className="max-h-72 overflow-y-auto p-1.5"
+      >
+        {isEmpty && (
+          <p className="px-2.5 py-4 text-center text-xs text-muted-foreground">
+            {models
+              ? "No models match this search."
+              : `No commands match ${query ? `“/${query}”` : "your search"}.`}
+          </p>
+        )}
+
+        {models?.map((model) => {
+          const index = rowIndexes.get(`model:${model.id}`) ?? 0;
+          return (
+            <Row
+              key={model.id}
+              id={`${optionIdPrefix}-${index}`}
+              index={index}
+              active={index === activeIndex}
+              disabled={false}
+              icon={
+                <ModelBrandIcon
+                  iconId={model.modelIconId ?? model.providerIconId}
+                  className="size-4"
+                />
+              }
+              title={model.label}
+              description={model.displayProvider}
+              trailing={
+                model.id === selectedModelId ? (
+                  <Check className="size-3.5 text-muted-foreground" />
+                ) : null
+              }
+              onActivate={() => onSelect({ kind: "model", model })}
+              onHover={() => onActiveIndexChange(index)}
+            />
+          );
+        })}
+
+        {groups.map((group) => (
+          <div key={group.group} className="not-first:mt-1">
+            <div
+              aria-hidden
+              className="px-2.5 pt-1.5 pb-1 text-xs font-medium tracking-wide text-muted-foreground uppercase"
+            >
+              {group.label}
+            </div>
+            {group.commands.map((command) => {
+              const index = rowIndexes.get(`command:${command.name}`) ?? 0;
+              const available = isSlashCommandAvailable(command);
+              const Icon = command.icon;
+              return (
+                <Row
+                  key={command.name}
+                  id={`${optionIdPrefix}-${index}`}
+                  index={index}
+                  active={index === activeIndex}
+                  disabled={!available}
+                  icon={<Icon className="size-4" />}
+                  title={command.title}
+                  hint={`/${command.name}`}
+                  description={
+                    command.toggle?.unavailableReason ?? command.description
+                  }
+                  trailing={
+                    command.toggle?.active ? (
+                      <Check className="size-3.5 text-muted-foreground" />
+                    ) : command.shortcut ? (
+                      <Shortcut keys={command.shortcut} />
+                    ) : null
+                  }
+                  selected={command.toggle?.active}
+                  onActivate={() => onSelect({ kind: "command", command })}
+                  onHover={() => onActiveIndexChange(index)}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  id,
+  index,
+  active,
+  disabled,
+  selected,
+  icon,
+  title,
+  hint,
+  description,
+  trailing,
+  onActivate,
+  onHover,
+}: {
+  id: string;
+  index: number;
+  active: boolean;
+  disabled: boolean;
+  selected?: boolean;
+  icon: React.ReactNode;
+  title: string;
+  hint?: string;
+  description?: string;
+  trailing?: React.ReactNode;
+  onActivate: () => void;
+  onHover: () => void;
+}) {
+  return (
+    <div
+      id={id}
+      role="option"
+      aria-selected={selected ?? active}
+      aria-disabled={disabled || undefined}
+      data-index={index}
+      data-active={active || undefined}
+      // The textarea keeps DOM focus, so pointer interaction must not steal it.
+      onPointerDown={(event) => event.preventDefault()}
+      onClick={() => {
+        if (!disabled) onActivate();
+      }}
+      onPointerMove={onHover}
+      className={cn(
+        "flex min-h-11 cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2 motion-colors",
+        active && "bg-accent text-accent-foreground",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      <span className="shrink-0 text-muted-foreground">{icon}</span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-baseline gap-1.5">
+          <span className="truncate font-medium">{title}</span>
+          {hint && (
+            <span className="shrink-0 font-mono text-xs text-muted-foreground">
+              {hint}
+            </span>
+          )}
+        </span>
+        {description && (
+          <span className="block truncate text-xs text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </span>
+      {trailing && (
+        <span className="flex shrink-0 items-center justify-center">
+          {trailing}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function Shortcut({ keys }: { keys: readonly string[] }) {
+  return (
+    <span className="flex items-center gap-0.5">
+      {keys.map((key) => (
+        <kbd
+          key={key}
+          className="rounded border bg-muted px-1 py-0.5 font-sans text-[10px] leading-none text-muted-foreground"
+        >
+          {key}
+        </kbd>
+      ))}
+    </span>
+  );
+}

--- a/apps/web/lib/chat/slash-commands.test.ts
+++ b/apps/web/lib/chat/slash-commands.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterSlashCommandModels,
+  filterSlashCommands,
+  groupSlashCommands,
+  isSlashCommandAvailable,
+  parseSlashCommandQuery,
+  resolveSlashCommand,
+  type SlashCommand,
+} from "@/lib/chat/slash-commands";
+
+const Icon = () => null;
+
+function command(
+  name: string,
+  overrides: Partial<SlashCommand> = {},
+): SlashCommand {
+  return {
+    name,
+    title: `/${name}`,
+    description: "",
+    group: "actions",
+    icon: Icon,
+    ...overrides,
+  };
+}
+
+const COMMANDS: SlashCommand[] = [
+  command("search", { keywords: ["web"] }),
+  command("attach", { keywords: ["file", "upload"] }),
+  command("dictate", { keywords: ["voice"] }),
+  command("temporary", { keywords: ["incognito"] }),
+  command("model", { submenu: "model" }),
+  command("new", { group: "navigate" }),
+  command("chats", { group: "navigate" }),
+  command("settings", { group: "navigate" }),
+];
+
+describe("parseSlashCommandQuery", () => {
+  it("parses a bare slash as an empty query", () => {
+    expect(parseSlashCommandQuery("/")).toEqual({
+      name: "",
+      argument: "",
+      hasArgument: false,
+    });
+  });
+
+  it("parses a partial command name", () => {
+    expect(parseSlashCommandQuery("/sea")).toEqual({
+      name: "sea",
+      argument: "",
+      hasArgument: false,
+    });
+  });
+
+  it("lowercases the command name so matching is case-insensitive", () => {
+    expect(parseSlashCommandQuery("/Model")?.name).toBe("model");
+  });
+
+  it("splits an argument off the command name", () => {
+    expect(parseSlashCommandQuery("/model gpt-5")).toEqual({
+      name: "model",
+      argument: "gpt-5",
+      hasArgument: true,
+    });
+  });
+
+  it("preserves argument case and inner spacing", () => {
+    expect(parseSlashCommandQuery("/model  GPT 5 Pro")?.argument).toBe(
+      "GPT 5 Pro",
+    );
+  });
+
+  it("reports a trailing space as an empty argument", () => {
+    expect(parseSlashCommandQuery("/model ")).toEqual({
+      name: "model",
+      argument: "",
+      hasArgument: true,
+    });
+  });
+
+  it("tolerates leading whitespace from a paste", () => {
+    expect(parseSlashCommandQuery("  /search")?.name).toBe("search");
+  });
+
+  it("returns null for prose that merely contains a slash", () => {
+    expect(parseSlashCommandQuery("what lives in /etc/hosts?")).toBeNull();
+    expect(parseSlashCommandQuery("Read /etc/hosts")).toBeNull();
+  });
+
+  it("returns null once the draft is no longer a command", () => {
+    // A path is a single token but has a slash inside the name.
+    expect(parseSlashCommandQuery("/etc/hosts")).toBeNull();
+    expect(parseSlashCommandQuery("")).toBeNull();
+    expect(parseSlashCommandQuery("hello")).toBeNull();
+  });
+
+  it("returns null for a multi-line draft", () => {
+    expect(parseSlashCommandQuery("/search\nsecond line")).toBeNull();
+    expect(parseSlashCommandQuery("/search extra\nmore")).toBeNull();
+  });
+});
+
+describe("filterSlashCommands", () => {
+  it("returns every command for an empty name", () => {
+    expect(filterSlashCommands(COMMANDS, "")).toHaveLength(COMMANDS.length);
+  });
+
+  it("prefix-matches command names", () => {
+    expect(filterSlashCommands(COMMANDS, "se").map((c) => c.name)).toEqual([
+      "search",
+      "settings",
+    ]);
+  });
+
+  it("matches declared keywords", () => {
+    expect(filterSlashCommands(COMMANDS, "voice").map((c) => c.name)).toEqual([
+      "dictate",
+    ]);
+  });
+
+  it("does not match on a substring that isn't a prefix", () => {
+    expect(filterSlashCommands(COMMANDS, "ttings")).toEqual([]);
+  });
+
+  it("preserves declaration order", () => {
+    expect(filterSlashCommands(COMMANDS, "").map((c) => c.name)).toEqual(
+      COMMANDS.map((c) => c.name),
+    );
+  });
+});
+
+describe("resolveSlashCommand", () => {
+  it("resolves an exact name even when it prefixes another command", () => {
+    // "new" is a prefix of nothing here, but the exact-match branch must win
+    // over the ambiguity check in general.
+    const commands = [command("new"), command("newsletter")];
+    const resolved = resolveSlashCommand(commands, {
+      name: "new",
+      argument: "",
+      hasArgument: false,
+    });
+    expect(resolved?.name).toBe("new");
+  });
+
+  it("resolves an unambiguous prefix", () => {
+    expect(
+      resolveSlashCommand(COMMANDS, {
+        name: "att",
+        argument: "",
+        hasArgument: false,
+      })?.name,
+    ).toBe("attach");
+  });
+
+  it("returns null for an ambiguous prefix", () => {
+    expect(
+      resolveSlashCommand(COMMANDS, {
+        name: "se",
+        argument: "",
+        hasArgument: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unknown name", () => {
+    expect(
+      resolveSlashCommand(COMMANDS, {
+        name: "zzz",
+        argument: "",
+        hasArgument: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for a bare slash", () => {
+    expect(
+      resolveSlashCommand(COMMANDS, {
+        name: "",
+        argument: "",
+        hasArgument: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("isSlashCommandAvailable", () => {
+  it("treats a command without a toggle as available", () => {
+    expect(isSlashCommandAvailable(command("attach"))).toBe(true);
+  });
+
+  it("treats an enabled toggle as available", () => {
+    expect(
+      isSlashCommandAvailable(
+        command("search", { toggle: { active: false } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a toggle with an unavailable reason as unavailable", () => {
+    expect(
+      isSlashCommandAvailable(
+        command("search", {
+          toggle: { active: false, unavailableReason: "Disabled in settings" },
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("groupSlashCommands", () => {
+  it("groups commands in the declared group order", () => {
+    const groups = groupSlashCommands(COMMANDS);
+    expect(groups.map((g) => g.group)).toEqual(["actions", "navigate"]);
+    expect(groups[0].commands.map((c) => c.name)).toEqual([
+      "search",
+      "attach",
+      "dictate",
+      "temporary",
+      "model",
+    ]);
+  });
+
+  it("omits groups with no matches", () => {
+    const groups = groupSlashCommands(filterSlashCommands(COMMANDS, "att"));
+    expect(groups).toHaveLength(1);
+    expect(groups[0].group).toBe("actions");
+  });
+
+  it("returns nothing when no command matches", () => {
+    expect(groupSlashCommands([])).toEqual([]);
+  });
+});
+
+describe("filterSlashCommandModels", () => {
+  const models = [
+    { label: "Sonnet 5", model: "claude-sonnet-5", displayProvider: "Anthropic" },
+    { label: "GPT 5", model: "gpt-5", displayProvider: "OpenAI" },
+    { label: "Local Llama", model: "llama-4", displayProvider: "vLLM" },
+  ];
+
+  it("returns every model for an empty query", () => {
+    expect(filterSlashCommandModels(models, "")).toHaveLength(3);
+  });
+
+  it("matches on label, model id, and provider", () => {
+    expect(filterSlashCommandModels(models, "sonnet").map((m) => m.label)).toEqual(
+      ["Sonnet 5"],
+    );
+    expect(filterSlashCommandModels(models, "gpt-5").map((m) => m.label)).toEqual(
+      ["GPT 5"],
+    );
+    expect(filterSlashCommandModels(models, "vllm").map((m) => m.label)).toEqual(
+      ["Local Llama"],
+    );
+  });
+
+  it("matches a substring anywhere in the haystack", () => {
+    expect(filterSlashCommandModels(models, "llama").map((m) => m.label)).toEqual(
+      ["Local Llama"],
+    );
+  });
+
+  it("does not mutate the input array", () => {
+    const filtered = filterSlashCommandModels(models, "");
+    filtered.pop();
+    expect(models).toHaveLength(3);
+  });
+});

--- a/apps/web/lib/chat/slash-commands.ts
+++ b/apps/web/lib/chat/slash-commands.ts
@@ -1,0 +1,136 @@
+// A command is recognized only while the whole draft is a leading-slash token
+// (plus an optional argument), so prose mentioning "/etc/hosts" never opens the
+// menu and the menu closes as soon as the draft becomes a real message.
+
+import type { ComponentType } from "react";
+
+export interface SlashCommandToggleState {
+  active: boolean;
+  /** Disables the row and replaces its description when set. */
+  unavailableReason?: string;
+}
+
+export interface SlashCommand {
+  /** Name without the leading slash, e.g. `"search"`. */
+  name: string;
+  title: string;
+  description: string;
+  group: SlashCommandGroup;
+  icon: ComponentType<{ className?: string }>;
+  /** Extra terms the filter should match. */
+  keywords?: readonly string[];
+  /**
+   * Set when the command opens a nested picker instead of running immediately.
+   * The trailing argument becomes the picker's query.
+   */
+  submenu?: "model";
+  toggle?: SlashCommandToggleState;
+  shortcut?: readonly string[];
+  /** Handled by the composer, which owns the file input and recorder. */
+  action?: "attach" | "dictate";
+  run?: () => void;
+}
+
+export type SlashCommandGroup = "actions" | "navigate";
+
+export const SLASH_COMMAND_GROUP_LABELS: Record<SlashCommandGroup, string> = {
+  actions: "Actions",
+  navigate: "Navigate",
+};
+
+export const SLASH_COMMAND_GROUP_ORDER: readonly SlashCommandGroup[] = [
+  "actions",
+  "navigate",
+];
+
+export interface SlashCommandQuery {
+  /** Name typed so far, lowercased. */
+  name: string;
+  /** Text after the first whitespace run, verbatim. */
+  argument: string;
+  hasArgument: boolean;
+}
+
+// `[^\S\n]` keeps newlines out of the separator, so a multi-line draft is prose.
+const COMMAND_PATTERN = /^\/([a-z0-9-]*)(?:([^\S\n]+)([^\n]*))?$/i;
+
+/** Returns `null` when the draft isn't a command invocation. */
+export function parseSlashCommandQuery(value: string): SlashCommandQuery | null {
+  // Tolerate leading whitespace a paste might add.
+  const match = COMMAND_PATTERN.exec(value.replace(/^[^\S\n]+/, ""));
+  if (!match) return null;
+  const [, name, separator, argument] = match;
+  return {
+    name: name.toLowerCase(),
+    argument: argument ?? "",
+    hasArgument: separator !== undefined,
+  };
+}
+
+function matches(command: SlashCommand, name: string): boolean {
+  if (!name) return true;
+  if (command.name.startsWith(name)) return true;
+  return (command.keywords ?? []).some((keyword) =>
+    keyword.toLowerCase().startsWith(name),
+  );
+}
+
+/** Prefix-matches name and keywords, preserving declaration order. */
+export function filterSlashCommands(
+  commands: readonly SlashCommand[],
+  name: string,
+): SlashCommand[] {
+  return commands.filter((command) => matches(command, name));
+}
+
+/**
+ * The command a draft resolves to, or `null` when ambiguous or unknown. Lets
+ * Enter run a fully typed command even with the menu closed.
+ */
+export function resolveSlashCommand(
+  commands: readonly SlashCommand[],
+  query: SlashCommandQuery,
+): SlashCommand | null {
+  if (!query.name) return null;
+  const exact = commands.find((command) => command.name === query.name);
+  if (exact) return exact;
+  const candidates = filterSlashCommands(commands, query.name);
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+export function isSlashCommandAvailable(command: SlashCommand): boolean {
+  return !command.toggle?.unavailableReason;
+}
+
+/** Mirrors `ModelPicker`'s substring match so both surfaces rank alike. */
+export function filterSlashCommandModels<
+  T extends { label: string; model: string; displayProvider: string },
+>(models: readonly T[], query: string): T[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...models];
+  return models.filter((model) =>
+    [model.label, model.model, model.displayProvider]
+      .join(" ")
+      .toLowerCase()
+      .includes(q),
+  );
+}
+
+export interface SlashCommandGroupView {
+  group: SlashCommandGroup;
+  label: string;
+  commands: SlashCommand[];
+}
+
+/** Groups commands for rendering, dropping empty groups. */
+export function groupSlashCommands(
+  commands: readonly SlashCommand[],
+): SlashCommandGroupView[] {
+  return SLASH_COMMAND_GROUP_ORDER.flatMap((group) => {
+    const inGroup = commands.filter((command) => command.group === group);
+    if (inGroup.length === 0) return [];
+    return [
+      { group, label: SLASH_COMMAND_GROUP_LABELS[group], commands: inGroup },
+    ];
+  });
+}

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.11.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.11.1}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Adds a `/` slash-command palette to the web chat composer. Typing `/` opens a keyboard-navigable menu that filters commands by name and keyword.

Commands wrap existing chat capabilities: per-message web search, attachments, dictation, temporary chats, model selection, new chat, chat search, and settings navigation. Parsing, filtering, resolution, and grouping remain in a pure logic layer with unit coverage.

Updates the default Compose app image to `0.11.1` for the server release.

## Context

This supersedes #114. The original PR branch accumulated pre-squash `dev` history, which made GitHub report a 79-file diff and merge conflicts unrelated to the slash-command feature. This branch starts from current `main` and transplants only the original slash-command commit.

## Impact

This adds a keyboard-first interface for capabilities already available in the composer. It does not add new server behavior, database changes, dependencies, or migrations.

## Validation

- `npm run test -w apps/web` — 196 tests passed
- `npm run typecheck -w apps/web`
- `npm run lint -w apps/web`
- `npm run build -w apps/web`
- `docker compose config --quiet`