### PR TITLE
fix(web): bypass reasoning trace in title generation

### DIFF
--- a/apps/web/lib/providers/server/registry.test.ts
+++ b/apps/web/lib/providers/server/registry.test.ts
@@ -42,6 +42,7 @@ describe("provider registry", () => {
     expect(configured.providerOptions).toEqual({
       openai: { forceReasoning: true, reasoningEffort: "high" },
     });
+    expect(configured.providerOptionsKey).toBe("openai");
     expect(configured.promptCacheStrategy).toEqual({ kind: "openai" });
   });
 
@@ -157,6 +158,54 @@ describe("provider registry", () => {
         expect.objectContaining({ role: "developer" }),
         expect.objectContaining({ role: "user" }),
       ],
+    });
+  });
+
+  it("serializes disabled reasoning for custom OpenAI-compatible models", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "intentional test response",
+              type: "invalid_request_error",
+              param: null,
+              code: null,
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }),
+    );
+    const configured = createConfiguredLanguageModel({
+      ...baseConfig,
+      providerId: "custom",
+      apiFormat: "openai-chat",
+    });
+    const providerOptions = {
+      ...configured.providerOptions,
+      [configured.providerOptionsKey]: {
+        ...configured.providerOptions?.[configured.providerOptionsKey],
+        reasoningEffort: "none",
+      },
+    };
+
+    await expect(
+      generateText({
+        model: configured.model,
+        prompt: "Generate a title",
+        providerOptions,
+      }),
+    ).rejects.toThrow("intentional test response");
+
+    expect(requestBody).toMatchObject({
+      reasoning_effort: "none",
     });
   });
 

--- a/apps/web/lib/providers/server/registry.ts
+++ b/apps/web/lib/providers/server/registry.ts
@@ -32,6 +32,7 @@ const PROVIDER_REGISTRY: Record<ProviderId, ProviderAdapter> = {
 export interface ConfiguredLanguageModel {
   model: LanguageModelV4;
   providerOptions: Record<string, Record<string, JSONValue>> | undefined;
+  providerOptionsKey: string;
   promptCacheStrategy: PromptCacheStrategy | undefined;
 }
 
@@ -70,6 +71,7 @@ export function createConfiguredLanguageModel(
             [resolved.providerOptionsKey]: options as Record<string, JSONValue>,
           }
         : undefined,
+    providerOptionsKey: resolved.providerOptionsKey,
     promptCacheStrategy: resolvePromptCacheStrategy(
       resolved.promptCacheKind,
       options,

--- a/apps/web/lib/title.test.ts
+++ b/apps/web/lib/title.test.ts
@@ -63,7 +63,8 @@ describe("title helpers", () => {
     vi.clearAllMocks();
     mocks.createConfiguredLanguageModel.mockReturnValue({
       model: "model",
-      providerOptions: { custom: {} },
+      providerOptions: undefined,
+      providerOptionsKey: "custom",
     });
     mocks.generateText.mockResolvedValue({ text: "Server Owned Titles" });
     mocks.setTitleIfNull.mockImplementation(async (_chatId, title) => title);
@@ -137,6 +138,7 @@ describe("title helpers", () => {
       expect.objectContaining({
         maxRetries: 0,
         prompt: expect.stringContaining("<user_message>"),
+        providerOptions: { custom: { reasoningEffort: "none" } },
       }),
     );
     expect(mocks.generateText.mock.calls[0][0]).not.toHaveProperty(
@@ -147,6 +149,28 @@ describe("title helpers", () => {
       "Dependency Cleanup",
     );
     expect(title).toBe("Dependency Cleanup");
+  });
+
+  it("preserves saved provider options while disabling reasoning", async () => {
+    mocks.createConfiguredLanguageModel.mockReturnValue({
+      model: "model",
+      providerOptions: { custom: { user: "saved-user" } },
+      providerOptionsKey: "custom",
+    });
+
+    await generateChatTitle({
+      chatId: "chat",
+      modelConfig,
+      userParts: firstUserParts,
+    });
+
+    expect(mocks.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: {
+          custom: { user: "saved-user", reasoningEffort: "none" },
+        },
+      }),
+    );
   });
 
   it("does not persist anything when generation fails", async () => {

--- a/apps/web/lib/title.ts
+++ b/apps/web/lib/title.ts
@@ -42,6 +42,7 @@ export async function generateChatTitle({
     const { text } = await generateText({
       model,
       prompt,
+      reasoningEffort: "low",
       providerOptions,
       // Do not cap title-task output tokens here. Some reasoning models spend
       // the first output budget on thoughts before emitting final text.

--- a/apps/web/lib/title.ts
+++ b/apps/web/lib/title.ts
@@ -31,19 +31,25 @@ export async function generateChatTitle({
     const prompt = buildTitlePromptText(userParts);
     if (!prompt) return null;
 
-    const { model, providerOptions } = createConfiguredLanguageModel({
-      providerId: modelConfig.providerId,
-      apiFormat: modelConfig.apiFormat,
-      baseUrl: modelConfig.baseUrl,
-      apiKey: modelConfig.apiKey,
-      model: modelConfig.model,
-      providerOptions: modelConfig.providerOptions,
-    });
+    const { model, providerOptions, providerOptionsKey } =
+      createConfiguredLanguageModel({
+        providerId: modelConfig.providerId,
+        apiFormat: modelConfig.apiFormat,
+        baseUrl: modelConfig.baseUrl,
+        apiKey: modelConfig.apiKey,
+        model: modelConfig.model,
+        providerOptions: modelConfig.providerOptions,
+      });
     const { text } = await generateText({
       model,
       prompt,
-      reasoningEffort: "low",
-      providerOptions,
+      providerOptions: {
+        ...providerOptions,
+        [providerOptionsKey]: {
+          ...providerOptions?.[providerOptionsKey],
+          reasoningEffort: "none",
+        },
+      },
       // Do not cap title-task output tokens here. Some reasoning models spend
       // the first output budget on thoughts before emitting final text.
       maxRetries: 0,


### PR DESCRIPTION
## Summary

- Disable reasoning for automatic chat-title generation with `reasoningEffort: "none"`.
- Mount the override under the language model's resolved provider-options key, including when the model has no saved provider options.
- Preserve existing provider options, the 15-second timeout, zero retries, and uncapped output tokens.

## Root cause

OpenAI-compatible local models can spend most of the title-generation window producing a verbose reasoning trace before emitting a short title. The original implementation placed `reasoningEffort` directly on `generateText`, but that is not a valid top-level AI SDK option and caused TypeScript/build failures.

The provider registry now exposes the resolved provider-options key so title generation can add the best-effort reasoning override without hardcoding a provider or guessing from existing options. For OpenAI-compatible transports, the SDK serializes this as `reasoning_effort: "none"`.

Providers that do not support the option retain the existing best-effort title behavior and 15-second safety boundary.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 198 web tests and 8 site tests passed
- CI-equivalent production build with the workflow environment
- Playwright E2E with Gemini — 3 tests passed, including signup, Gemini configuration, and streamed response
- Transport regression test confirms the outgoing OpenAI-compatible request contains `reasoning_effort: "none"`