### PR TITLE
fix(web): stabilize responsive sidebar

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -136,6 +136,12 @@
     transition-timing-function: var(--motion-ease-standard);
   }
 
+  .motion-width {
+    transition-property: width;
+    transition-duration: var(--motion-duration-base);
+    transition-timing-function: var(--motion-ease-standard);
+  }
+
   .motion-surface {
     transition-property: opacity, transform, scale;
     transition-duration: var(--motion-duration-base);
@@ -164,6 +170,10 @@
 
   .motion-skeleton {
     background-color: color-mix(in oklch, var(--muted) 82%, var(--foreground) 8%);
+  }
+
+  html[data-sidebar-collapsed] [data-desktop-sidebar] {
+    width: 0;
   }
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -13,6 +13,10 @@ import { ThemeProvider } from "@/components/ThemeProvider";
 import { QueryProvider } from "@/components/QueryProvider";
 import { ToastProvider } from "@/components/ui/toast";
 import { FONT_STORAGE_KEY, fontCssValueById } from "@/lib/fonts";
+import {
+  SIDEBAR_COLLAPSED_ATTRIBUTE,
+  SIDEBAR_COLLAPSED_STORAGE_KEY,
+} from "@/lib/sidebar";
 
 const sans = Plus_Jakarta_Sans({
   variable: "--font-plus-jakarta-sans",
@@ -59,6 +63,13 @@ const fontScript = `(function(){try{
   if(v){document.documentElement.style.setProperty("--app-font-sans",v);}
 }catch(e){}})();`;
 
+const sidebarScript = `(function(){try{
+  var raw=localStorage.getItem(${JSON.stringify(SIDEBAR_COLLAPSED_STORAGE_KEY)});
+  if(raw&&JSON.parse(raw)===true){
+    document.documentElement.setAttribute(${JSON.stringify(SIDEBAR_COLLAPSED_ATTRIBUTE)},"");
+  }
+}catch(e){}})();`;
+
 export const metadata: Metadata = {
   title: "overtchat",
   description: "Simple self-hosted chat UI for OpenAI-compatible endpoints",
@@ -91,7 +102,7 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="h-full">
-        <script dangerouslySetInnerHTML={{ __html: fontScript }} />
+        <script dangerouslySetInnerHTML={{ __html: fontScript + sidebarScript }} />
         <QueryProvider>
           <ThemeProvider>
             <ToastProvider>{children}</ToastProvider>

--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -20,7 +20,7 @@ export function AccountMenu() {
   // dismiss logic recognizes menu-item taps as "inside" events. On desktop
   // the drawer isn't mounted, ref.current is null, and base-ui falls back to
   // portaling into <body>. See sidebar-context.tsx for the full explanation.
-  const { drawerRef } = useSidebar();
+  const { closeMobile, drawerRef } = useSidebar();
 
   async function logOut() {
     try {
@@ -92,7 +92,7 @@ export function AccountMenu() {
             )}
           >
             <Menu.Item
-              render={<Link href="/settings" />}
+              render={<Link href="/settings" onClick={closeMobile} />}
               className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
             >
               <Settings className="size-3.5 shrink-0 text-muted-foreground" />

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -1,12 +1,24 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Dialog } from "@base-ui/react/dialog";
 import { SidebarContext } from "@/components/sidebar-context";
 import { SearchChatsPalette } from "@/components/SearchChatsPalette";
 import { useLocalStorage } from "@/lib/useLocalStorage";
+import {
+  SIDEBAR_COLLAPSED_ATTRIBUTE,
+  SIDEBAR_COLLAPSED_STORAGE_KEY,
+} from "@/lib/sidebar";
+import { useIsMobile } from "@/lib/useIsMobile";
 import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 
 export function AppShell({
   sidebar,
@@ -16,21 +28,56 @@ export function AppShell({
   children: React.ReactNode;
 }) {
   const router = useRouter();
-  const [openMobile, setOpenMobile] = useState(false);
+  const isMobile = useIsMobile();
+  const [openMobileRoute, setOpenMobileRoute] = useState<string | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
-  const [collapsed, setCollapsed] = useLocalStorage<boolean>(
-    "overtchat_sidebar_collapsed",
+  const [collapsed, setStoredCollapsed] = useLocalStorage<boolean>(
+    SIDEBAR_COLLAPSED_STORAGE_KEY,
     false,
   );
   const drawerRef = useRef<HTMLElement | null>(null);
   const pathname = usePathname();
-  const [lastPath, setLastPath] = useState(pathname);
-  if (pathname !== lastPath) {
-    setLastPath(pathname);
-    setOpenMobile(false);
-  }
+  const searchParams = useSearchParams();
+  const routeKey = `${pathname}?${searchParams.toString()}`;
+  const openMobile = isMobile && openMobileRoute === routeKey;
 
   const openPalette = useCallback(() => setPaletteOpen(true), []);
+  const closeMobile = useCallback(() => setOpenMobileRoute(null), []);
+  const setOpenMobile = useCallback(
+    (next: boolean) => setOpenMobileRoute(next ? routeKey : null),
+    [routeKey],
+  );
+  const setCollapsed = useCallback(
+    (next: boolean) => {
+      document.documentElement.toggleAttribute(
+        SIDEBAR_COLLAPSED_ATTRIBUTE,
+        next,
+      );
+      setStoredCollapsed(next);
+    },
+    [setStoredCollapsed],
+  );
+  const openSidebar = useCallback(() => {
+    if (isMobile) {
+      setOpenMobile(true);
+    } else {
+      setCollapsed(false);
+    }
+  }, [isMobile, setCollapsed, setOpenMobile]);
+  const closeSidebar = useCallback(() => {
+    if (isMobile) {
+      closeMobile();
+    } else {
+      setCollapsed(true);
+    }
+  }, [closeMobile, isMobile, setCollapsed]);
+
+  useLayoutEffect(() => {
+    document.documentElement.toggleAttribute(
+      SIDEBAR_COLLAPSED_ATTRIBUTE,
+      collapsed,
+    );
+  }, [collapsed]);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -42,28 +89,44 @@ export function AppShell({
         setPaletteOpen(true);
       } else if (key === "o" && e.shiftKey) {
         e.preventDefault();
-        setOpenMobile(false);
+        closeMobile();
         router.push("/");
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [router]);
+  }, [closeMobile, router]);
 
   return (
     <SidebarContext.Provider
       value={{
         collapsed,
-        setCollapsed,
-        openMobile,
-        setOpenMobile,
+        openSidebar,
+        closeSidebar,
+        closeMobile,
         openPalette,
         drawerRef,
       }}
     >
-      <Dialog.Root open={openMobile} onOpenChange={setOpenMobile}>
+      <Dialog.Root
+        open={openMobile}
+        onOpenChange={setOpenMobile}
+        onOpenChangeComplete={(open) => {
+          if (!open) setOpenMobileRoute(null);
+        }}
+      >
         <div className="box-border flex h-dvh overflow-hidden bg-background pt-[env(safe-area-inset-top)]">
-          {!collapsed && <div className="hidden md:flex">{sidebar}</div>}
+          <div
+            data-desktop-sidebar
+            aria-hidden={collapsed}
+            inert={collapsed}
+            className={cn(
+              "hidden h-full shrink-0 overflow-hidden motion-width md:flex",
+              collapsed ? "w-0" : "w-64",
+            )}
+          >
+            {sidebar}
+          </div>
           <Dialog.Portal>
             <Dialog.Backdrop
               className={`fixed inset-0 z-40 bg-black/40 md:hidden ${motionClasses.overlay}`}
@@ -72,6 +135,7 @@ export function AppShell({
               ref={drawerRef as React.RefObject<HTMLDivElement>}
               className="fixed inset-y-0 left-0 z-50 box-border flex bg-sidebar pt-[env(safe-area-inset-top)] motion-transform data-[ending-style]:-translate-x-full data-[starting-style]:-translate-x-full md:hidden"
             >
+              <Dialog.Title className="sr-only">Navigation</Dialog.Title>
               {sidebar}
             </Dialog.Popup>
           </Dialog.Portal>

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -91,7 +91,7 @@ export function SidebarItem({
   const pathname = usePathname();
   const active = pathname === `/chat/${chat.id}`;
   // See AccountMenu for the full explanation; mobile drawer needs in-subtree portaling.
-  const { drawerRef } = useSidebar();
+  const { closeMobile, drawerRef } = useSidebar();
 
   const renameMut = useRenameChat();
   const deleteMut = useDeleteChat();
@@ -184,6 +184,7 @@ export function SidebarItem({
       <li className="group flex items-center">
         <Link
           href={`/chat/${chat.id}`}
+          onClick={closeMobile}
           className={cn(
             "flex-1 truncate rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
             active && "bg-sidebar-accent",

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -16,7 +16,7 @@ import { LinkPendingIndicator } from "@/components/ui/link-pending-indicator";
 import { cn } from "@/lib/utils";
 
 export function SidebarClient() {
-  const { setOpenMobile, setCollapsed, openPalette } = useSidebar();
+  const { closeMobile, closeSidebar, openPalette } = useSidebar();
   const [creatingProject, setCreatingProject] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
@@ -61,10 +61,7 @@ export function SidebarClient() {
         <span className="font-brand text-sm font-semibold tracking-tight">overtchat</span>
         <button
           type="button"
-          onClick={() => {
-            setOpenMobile(false);
-            setCollapsed(true);
-          }}
+          onClick={closeSidebar}
           aria-label="Collapse sidebar"
           className="rounded-md p-1.5 text-muted-foreground hover:bg-sidebar-accent hover:text-foreground max-md:p-2.5"
         >
@@ -77,7 +74,7 @@ export function SidebarClient() {
           <Link
             href="/"
             onClick={(e) => {
-              setOpenMobile(false);
+              closeMobile();
               if (pathname === "/") {
                 e.preventDefault();
                 router.refresh();
@@ -92,7 +89,10 @@ export function SidebarClient() {
           </Link>
           <button
             type="button"
-            onClick={openPalette}
+            onClick={() => {
+              closeMobile();
+              openPalette();
+            }}
             className="group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent"
           >
             <Search className="size-4 shrink-0 text-muted-foreground" />
@@ -101,7 +101,7 @@ export function SidebarClient() {
           </button>
           <Link
             href="/activity"
-            onClick={() => setOpenMobile(false)}
+            onClick={closeMobile}
             className={cn(
               "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
               pathname.startsWith("/activity") && "bg-sidebar-accent",

--- a/apps/web/components/SidebarProjects.tsx
+++ b/apps/web/components/SidebarProjects.tsx
@@ -17,6 +17,7 @@ import {
   SidebarItem,
   type ProjectOption,
 } from "@/components/SidebarChatList";
+import { useSidebar } from "@/components/sidebar-context";
 
 interface ProjectWithChats extends ProjectOption {
   chats: { id: string; title: string | null }[];
@@ -55,6 +56,7 @@ function ProjectNode({
   projectOptions: ProjectOption[];
 }) {
   const pathname = usePathname();
+  const { closeMobile } = useSidebar();
   const active = pathname === `/projects/${project.id}`;
   const hasActiveChat = project.chats.some(
     (c) => pathname === `/chat/${c.id}`,
@@ -79,6 +81,7 @@ function ProjectNode({
         </button>
         <Link
           href={`/projects/${project.id}`}
+          onClick={closeMobile}
           className={cn(
             "flex-1 truncate rounded-md px-1 py-1 text-sm motion-colors hover:bg-sidebar-accent",
             active && "bg-sidebar-accent",
@@ -88,6 +91,7 @@ function ProjectNode({
         </Link>
         <Link
           href={`/?projectId=${project.id}`}
+          onClick={closeMobile}
           aria-label={`New chat in ${project.name}`}
           className={cn(
             "mr-0.5 rounded p-1 text-muted-foreground hover:bg-sidebar-accent hover:text-foreground max-md:p-2",

--- a/apps/web/components/SidebarToggle.tsx
+++ b/apps/web/components/SidebarToggle.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { useSidebar } from "@/components/sidebar-context";
 
 export function SidebarToggle({ className }: { className?: string }) {
-  const { collapsed, setCollapsed, setOpenMobile } = useSidebar();
+  const { collapsed, openSidebar } = useSidebar();
 
   return (
     <Button
@@ -14,10 +14,7 @@ export function SidebarToggle({ className }: { className?: string }) {
       size="icon-sm"
       aria-label="Open sidebar"
       className={cn(!collapsed && "md:hidden", className)}
-      onClick={() => {
-        if (collapsed) setCollapsed(false);
-        setOpenMobile(true);
-      }}
+      onClick={openSidebar}
     >
       <PanelLeft />
     </Button>

--- a/apps/web/components/sidebar-context.tsx
+++ b/apps/web/components/sidebar-context.tsx
@@ -4,9 +4,9 @@ import { createContext, useContext, type RefObject } from "react";
 
 interface SidebarCtx {
   collapsed: boolean;
-  setCollapsed: (v: boolean) => void;
-  openMobile: boolean;
-  setOpenMobile: (v: boolean) => void;
+  openSidebar: () => void;
+  closeSidebar: () => void;
+  closeMobile: () => void;
   openPalette: () => void;
   // Ref to the mobile drawer's Dialog.Popup element. Popups inside the sidebar
   // pass this to `Menu.Portal container` on mobile so their floating element

--- a/apps/web/e2e/sidebar.spec.ts
+++ b/apps/web/e2e/sidebar.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+import { resetE2eDatabase } from "./helpers/database";
+
+const SIDEBAR_STORAGE_KEY = "overtchat_sidebar_collapsed";
+
+test.beforeEach(resetE2eDatabase);
+
+test("sidebar behavior stays consistent across desktop and mobile", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/signup");
+  await page.locator("#name").fill("Sidebar Admin");
+  await page.locator("#email").fill("sidebar-admin@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+
+  const desktopSidebar = page.locator("[data-desktop-sidebar]");
+  await expect(desktopSidebar).toHaveCSS("width", "256px");
+
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(desktopSidebar).toHaveCSS("width", "0px");
+  await expect
+    .poll(() => page.evaluate((key) => localStorage.getItem(key), SIDEBAR_STORAGE_KEY))
+    .toBe("true");
+
+  await page.getByRole("button", { name: "Open sidebar" }).click();
+  await expect(desktopSidebar).toHaveCSS("width", "256px");
+  await expect(page.getByRole("dialog", { name: "Navigation" })).toHaveCount(0);
+  await page.locator("main").click({ position: { x: 20, y: 20 } });
+  await expect
+    .poll(() => page.evaluate(() => getComputedStyle(document.body).overflow))
+    .not.toBe("hidden");
+
+  await page.getByRole("button", { name: "New project" }).click();
+  await page.locator("#project-name").fill("Sidebar Project");
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.waitForURL("**/projects/**");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole("button", { name: "Open sidebar" }).click();
+  const drawer = page.getByRole("dialog", { name: "Navigation" });
+  await expect(drawer).toBeVisible();
+
+  await drawer.getByRole("link", { name: "Sidebar Project", exact: true }).click();
+  await expect(drawer).toBeHidden();
+
+  await page.getByRole("button", { name: "Open sidebar" }).click();
+  await drawer.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(drawer).toBeHidden();
+  await expect
+    .poll(() => page.evaluate((key) => localStorage.getItem(key), SIDEBAR_STORAGE_KEY))
+    .toBe("false");
+
+  await page.getByRole("button", { name: "Open sidebar" }).click();
+  await expect(drawer).toBeVisible();
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await expect(drawer).toBeHidden();
+  await expect
+    .poll(() => page.evaluate(() => getComputedStyle(document.body).overflow))
+    .not.toBe("hidden");
+  await expect(desktopSidebar).toHaveCSS("width", "256px");
+  await page.waitForTimeout(250);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(drawer).toBeHidden();
+  await page.setViewportSize({ width: 1280, height: 720 });
+
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(desktopSidebar).toHaveCSS("width", "0px");
+  await page.addInitScript(() => {
+    const samples: number[] = [];
+    Object.assign(window, { __sidebarWidthSamples: samples });
+    function sample() {
+      const sidebar = document.querySelector<HTMLElement>(
+        "[data-desktop-sidebar]",
+      );
+      if (sidebar) samples.push(sidebar.getBoundingClientRect().width);
+      if (samples.length < 10) requestAnimationFrame(sample);
+    }
+    requestAnimationFrame(sample);
+  });
+  await page.reload();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __sidebarWidthSamples?: number[];
+            }
+          ).__sidebarWidthSamples?.[0],
+      ),
+    )
+    .toBe(0);
+});

--- a/apps/web/lib/sidebar.ts
+++ b/apps/web/lib/sidebar.ts
@@ -1,0 +1,3 @@
+export const SIDEBAR_COLLAPSED_STORAGE_KEY = "overtchat_sidebar_collapsed";
+export const SIDEBAR_COLLAPSED_ATTRIBUTE = "data-sidebar-collapsed";
+export const MOBILE_SIDEBAR_QUERY = "(max-width: 767px)";

--- a/apps/web/lib/useIsMobile.ts
+++ b/apps/web/lib/useIsMobile.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { MOBILE_SIDEBAR_QUERY } from "@/lib/sidebar";
+
+let mediaQuery: MediaQueryList | undefined;
+
+function getMediaQuery() {
+  mediaQuery ??= window.matchMedia(MOBILE_SIDEBAR_QUERY);
+  return mediaQuery;
+}
+
+function subscribe(onStoreChange: () => void) {
+  const query = getMediaQuery();
+  query.addEventListener("change", onStoreChange);
+  return () => query.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot() {
+  return getMediaQuery().matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function useIsMobile() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## Summary

- separate desktop collapse state from the mobile drawer
- animate desktop resizing and restore persisted state before paint
- close and label the mobile drawer consistently

## Why

Sidebar controls could open an invisible desktop modal, leak state across breakpoints, and leave the mobile drawer open after navigation.

## Checks

- web lint
- web type-check
- 278 web unit tests
- production build
- focused Playwright sidebar regression
