### PR TITLE
fix(web): smooth sidebar motion

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -131,7 +131,7 @@
   }
 
   .motion-transform {
-    transition-property: transform;
+    transition-property: transform, translate, scale, rotate;
     transition-duration: var(--motion-duration-base);
     transition-timing-function: var(--motion-ease-standard);
   }
@@ -174,6 +174,10 @@
 
   html[data-sidebar-collapsed] [data-desktop-sidebar] {
     width: 0;
+  }
+
+  html[data-sidebar-collapsed] [data-desktop-sidebar-panel] {
+    translate: -100% 0;
   }
 }
 

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -121,11 +121,19 @@ export function AppShell({
             aria-hidden={collapsed}
             inert={collapsed}
             className={cn(
-              "hidden h-full shrink-0 overflow-hidden motion-width md:flex",
+              "relative hidden h-full shrink-0 motion-width md:block",
               collapsed ? "w-0" : "w-64",
             )}
           >
-            {sidebar}
+            <div
+              data-desktop-sidebar-panel
+              className={cn(
+                "absolute inset-y-0 left-0 flex w-64 motion-transform",
+                collapsed && "-translate-x-full",
+              )}
+            >
+              {sidebar}
+            </div>
           </div>
           <Dialog.Portal>
             <Dialog.Backdrop

--- a/apps/web/e2e/sidebar.spec.ts
+++ b/apps/web/e2e/sidebar.spec.ts
@@ -1,14 +1,28 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { resetE2eDatabase } from "./helpers/database";
 
 const SIDEBAR_STORAGE_KEY = "overtchat_sidebar_collapsed";
 
 test.beforeEach(resetE2eDatabase);
 
+async function getTransitionProperties(page: Page) {
+  await page.evaluate(() => new Promise(requestAnimationFrame));
+  return page.evaluate(() =>
+    document
+      .getAnimations()
+      .filter(
+        (animation): animation is CSSTransition =>
+          animation instanceof CSSTransition,
+      )
+      .map((transition) => transition.transitionProperty),
+  );
+}
+
 test("sidebar behavior stays consistent across desktop and mobile", async ({
   page,
 }) => {
   test.setTimeout(60_000);
+  await page.emulateMedia({ reducedMotion: "no-preference" });
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.goto("/signup");
   await page.locator("#name").fill("Sidebar Admin");
@@ -18,16 +32,26 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
   await page.waitForURL("**/");
 
   const desktopSidebar = page.locator("[data-desktop-sidebar]");
+  const desktopPanel = page.locator("[data-desktop-sidebar-panel]");
   await expect(desktopSidebar).toHaveCSS("width", "256px");
+  await expect(desktopPanel).toHaveCSS(
+    "transition-property",
+    "transform, translate, scale, rotate",
+  );
 
   await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  expect(await getTransitionProperties(page)).toEqual(
+    expect.arrayContaining(["translate", "width"]),
+  );
   await expect(desktopSidebar).toHaveCSS("width", "0px");
+  await expect(desktopPanel).toHaveCSS("translate", "-100%");
   await expect
     .poll(() => page.evaluate((key) => localStorage.getItem(key), SIDEBAR_STORAGE_KEY))
     .toBe("true");
 
   await page.getByRole("button", { name: "Open sidebar" }).click();
   await expect(desktopSidebar).toHaveCSS("width", "256px");
+  await expect(desktopPanel).toHaveCSS("translate", "none");
   await expect(page.getByRole("dialog", { name: "Navigation" })).toHaveCount(0);
   await page.locator("main").click({ position: { x: 20, y: 20 } });
   await expect
@@ -41,8 +65,13 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
 
   await page.setViewportSize({ width: 390, height: 844 });
   await page.getByRole("button", { name: "Open sidebar" }).click();
+  expect(await getTransitionProperties(page)).toContain("translate");
   const drawer = page.getByRole("dialog", { name: "Navigation" });
   await expect(drawer).toBeVisible();
+  await expect(drawer).toHaveCSS(
+    "transition-property",
+    "transform, translate, scale, rotate",
+  );
 
   await drawer.getByRole("link", { name: "Sidebar Project", exact: true }).click();
   await expect(drawer).toBeHidden();


### PR DESCRIPTION
## Summary

- animate the desktop sidebar panel independently from its layout gap so content slides without being compressed
- include Tailwind 4 individual transform properties in the shared CSS motion utility, fixing the mobile drawer transition too
- cover active desktop and mobile CSS transitions in the sidebar browser test

## Why

Tailwind 4 translate utilities update the individual `translate` property, while the shared utility only transitioned `transform`, so translate-driven motion snapped. On desktop, animating and clipping the sidebar wrapper also squeezed its contents during the width transition. This follows the current shadcn sidebar structure and Base UI CSS-transition guidance without adding a runtime animation dependency.

## Validation

- `npm run lint -w apps/web --`
- `npm run typecheck -w apps/web --`
- `npm run test -w apps/web --` (278 tests)
- `E2E_PORT=4731 npm exec -w apps/web playwright test e2e/sidebar.spec.ts`