### PR TITLE
feat(web): add Codex agent support

### DIFF
--- a/apps/web/app/(app)/settings/connections/AddConnectionDialog.tsx
+++ b/apps/web/app/(app)/settings/connections/AddConnectionDialog.tsx
@@ -13,6 +13,7 @@ import {
   TerminalSquare,
   Wifi,
 } from "lucide-react";
+import codexIcon from "@/assets/agent-providers/codex.png";
 import ompIcon from "@/assets/agent-providers/omp.svg";
 import piIcon from "@/assets/agent-providers/pi.svg";
 import { Button } from "@/components/ui/button";
@@ -63,6 +64,7 @@ const PROVIDER_ICONS: Record<
 > = {
   pi: { icon: piIcon },
   omp: { icon: ompIcon, darkSurface: true },
+  codex: { icon: codexIcon, darkSurface: true },
 };
 
 export function AddConnectionDialog({

--- a/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
+++ b/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
@@ -209,7 +209,7 @@ export function ConnectionsPanel({
             <span>Use OvertChat as a web interface for coding agents.</span>
             <span
               className="inline-flex items-center gap-1"
-              aria-label="Supported agents: Pi and Oh My Pi. Claude Code and Codex coming soon."
+              aria-label="Supported agents: Pi, Oh My Pi, and Codex. Claude Code coming soon."
             >
               <span
                 className="flex size-6 items-center justify-center rounded-md border bg-background"
@@ -234,8 +234,8 @@ export function ConnectionsPanel({
                 />
               </span>
               <span
-                className="flex size-6 items-center justify-center rounded-md border bg-background opacity-40 grayscale"
-                title="Codex · Coming soon"
+                className="flex size-6 items-center justify-center rounded-md border bg-zinc-950"
+                title="Codex"
               >
                 <Image
                   src={codexIcon}

--- a/apps/web/app/api/agent-sessions/[id]/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.ts
@@ -89,7 +89,7 @@ export async function POST(
         sessionId: created.sessionId,
       });
     }
-    await runtime.command(normalized);
+    const commandResult = await runtime.command(normalized);
     if (
       normalized.type === "prompt" ||
       normalized.type === "steer" ||
@@ -109,6 +109,9 @@ export async function POST(
     return Response.json({
       accepted: true,
       queuedMessages: runtime.snapshot().queuedMessages,
+      ...(normalized.type === "show_usage"
+        ? { usage: commandResult }
+        : {}),
     });
   } catch (error) {
     return Response.json(

--- a/apps/web/components/agents/AgentSessionDialogs.tsx
+++ b/apps/web/components/agents/AgentSessionDialogs.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea";
 import type {
   AgentInteractionValue,
   AgentRuntimeSnapshot,
+  AgentUsageSnapshot,
 } from "@/lib/agents/types";
 import { motionClasses } from "@/lib/motion";
 import { cn } from "@/lib/utils";
@@ -274,6 +275,156 @@ export function AgentInteractionDialog({
       onRespond={onRespond}
     />
   ) : null;
+}
+
+export function AgentUsageDialog({
+  open,
+  usage,
+  onOpenChange,
+}: {
+  open: boolean;
+  usage: AgentUsageSnapshot | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  if (!open || !usage) return null;
+  const activityRows = [
+    ["Lifetime tokens", usage.activity?.lifetimeTokens],
+    ["Current streak", usage.activity?.currentStreakDays],
+    ["Longest streak", usage.activity?.longestStreakDays],
+    ["Peak daily tokens", usage.activity?.peakDailyTokens],
+  ].filter((row): row is [string, number] => typeof row[1] === "number");
+
+  return (
+    <Dialog.Root open onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={dialogBackdrop} />
+        <Dialog.Popup className={dialogPopup}>
+          <Dialog.Title className="text-lg font-semibold tracking-tight">
+            Codex usage
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+            {usage.planType
+              ? `${formatPlanType(usage.planType)} plan`
+              : "Current account limits"}
+          </Dialog.Description>
+
+          <div className="mt-5 space-y-5">
+            {usage.windows.length > 0 && (
+              <div className="space-y-4">
+                {usage.windows.map((window) => (
+                  <div key={window.id} className="space-y-1.5">
+                    <div className="flex items-baseline justify-between gap-3 text-sm">
+                      <span className="min-w-0 truncate font-medium">
+                        {window.label}
+                        {window.windowDurationMins
+                          ? ` · ${formatDuration(window.windowDurationMins)}`
+                          : ""}
+                      </span>
+                      <span className="shrink-0 tabular-nums text-muted-foreground">
+                        {Math.round(window.usedPercent)}% used
+                      </span>
+                    </div>
+                    <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                      <div
+                        className="h-full rounded-full bg-primary"
+                        style={{
+                          width: `${Math.max(0, Math.min(100, window.usedPercent))}%`,
+                        }}
+                      />
+                    </div>
+                    {window.resetsAt && (
+                      <p className="text-xs text-muted-foreground">
+                        Resets {formatResetTime(window.resetsAt)}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {usage.credits && (
+              <div className="flex items-center justify-between border-t pt-4 text-sm">
+                <span className="text-muted-foreground">Credits</span>
+                <span className="font-medium tabular-nums">
+                  {usage.credits.unlimited
+                    ? "Unlimited"
+                    : usage.credits.balance ?? "Available"}
+                </span>
+              </div>
+            )}
+
+            {activityRows.length > 0 && (
+              <dl className="grid grid-cols-2 gap-x-5 gap-y-3 border-t pt-4 text-sm">
+                {activityRows.map(([label, value]) => (
+                  <div key={label}>
+                    <dt className="text-xs text-muted-foreground">{label}</dt>
+                    <dd className="mt-0.5 font-medium tabular-nums">
+                      {label.includes("streak")
+                        ? `${value.toLocaleString()} days`
+                        : value.toLocaleString()}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+
+            {usage.windows.length === 0 &&
+              !usage.credits &&
+              activityRows.length === 0 &&
+              !usage.unavailableReason && (
+                <p className="text-sm text-muted-foreground">
+                  Codex did not return usage details for this account.
+                </p>
+              )}
+            {usage.unavailableReason && (
+              <p className="text-sm text-muted-foreground">
+                {usage.unavailableReason}
+              </p>
+            )}
+          </div>
+
+          <DialogActions>
+            <Button type="button" size="sm" onClick={() => onOpenChange(false)}>
+              Done
+            </Button>
+          </DialogActions>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function formatPlanType(value: string): string {
+  return value
+    .replace(/_/gu, " ")
+    .replace(/\b\w/gu, (character) => character.toUpperCase());
+}
+
+function formatDuration(minutes: number): string {
+  if (minutes % (24 * 60) === 0) {
+    const days = minutes / (24 * 60);
+    return `${days} ${days === 1 ? "day" : "days"}`;
+  }
+  if (minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  return `${minutes} min`;
+}
+
+function formatResetTime(timestampSeconds: number): string {
+  const date = new Date(timestampSeconds * 1_000);
+  const delta = date.getTime() - Date.now();
+  if (delta > 0 && delta < 48 * 60 * 60 * 1_000) {
+    const hours = Math.max(1, Math.ceil(delta / (60 * 60 * 1_000)));
+    return `in ${hours}h`;
+  }
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 function InteractionDialogContent({

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -43,6 +43,7 @@ export function AgentSessionHeader({
   stats,
   running,
   commandPending,
+  readOnly,
   onSelectModel,
   onSelectThinking,
   onRename,
@@ -57,6 +58,7 @@ export function AgentSessionHeader({
   stats: AgentSessionStats;
   running: boolean;
   commandPending: boolean;
+  readOnly: boolean;
   onSelectModel: (model: AgentModel) => void;
   onSelectThinking: (level: AgentThinkingLevel) => void;
   onRename: () => void;
@@ -75,7 +77,7 @@ export function AgentSessionHeader({
         providerLabel={providerLabel}
         models={models}
         currentModel={currentModel}
-        disabled={running || commandPending}
+        disabled={readOnly || running || commandPending}
         onSelect={onSelectModel}
       />
       {thinkingLevels.length > 0 && thinkingLevel && (
@@ -84,7 +86,7 @@ export function AgentSessionHeader({
           onValueChange={(value) =>
             onSelectThinking(value as AgentThinkingLevel)
           }
-          disabled={running || commandPending}
+          disabled={readOnly || running || commandPending}
         >
           <SelectTrigger
             size="sm"
@@ -122,6 +124,7 @@ export function AgentSessionHeader({
                 size="icon-sm"
                 aria-label="Session actions"
                 title="Session actions"
+                disabled={readOnly}
               />
             }
           >
@@ -136,14 +139,15 @@ export function AgentSessionHeader({
                 )}
               >
                 <Menu.Item
+                  disabled={readOnly}
                   onClick={onRename}
-                  className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[highlighted]:bg-accent"
+                  className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent"
                 >
                   <Pencil className="size-3.5 text-muted-foreground" />
                   Rename session
                 </Menu.Item>
                 <Menu.Item
-                  disabled={running || commandPending}
+                  disabled={readOnly || running || commandPending}
                   onClick={onCompact}
                   className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent"
                 >

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import {
+  AlertTriangle,
+  Loader2,
+  LockKeyhole,
+  RefreshCw,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import { toast } from "@/components/ui/toast";
 import type {
@@ -193,6 +199,7 @@ export function AgentSessionView({
 
   const running = snapshot.status === "running";
   const exited = snapshot.status === "exited";
+  const readOnly = snapshot.readOnly;
   const model = currentModel(snapshot);
   const thinking = currentThinking(snapshot);
   const currentName = sessionName(snapshot) || initialSessionName;
@@ -230,6 +237,7 @@ export function AgentSessionView({
         stats={snapshot.stats}
         running={running}
         commandPending={command.isPending}
+        readOnly={Boolean(readOnly)}
         onSelectModel={(selected: AgentModel) =>
           void run({
             type: "set_model",
@@ -249,6 +257,38 @@ export function AgentSessionView({
           setCompactOpen(true);
         }}
       />
+
+      {readOnly && (
+        <section
+          aria-label={`Read-only ${providerLabel} session`}
+          className="border-b bg-muted/30 px-4 py-3"
+        >
+          <div className="mx-auto flex max-w-3xl items-start gap-3">
+            <LockKeyhole className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <p className="min-w-0 flex-1 text-sm text-muted-foreground">
+              {readOnly.reason}
+            </p>
+            {readOnly.retryable && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={command.isPending}
+                onClick={() => void run({ type: "retry_interactive" })}
+              >
+                <RefreshCw
+                  className={
+                    pendingCommand === "retry_interactive"
+                      ? motionClasses.spinner
+                      : undefined
+                  }
+                />
+                Retry
+              </Button>
+            )}
+          </div>
+        </section>
+      )}
 
       <AgentMessageList
         providerLabel={providerLabel}
@@ -270,7 +310,11 @@ export function AgentSessionView({
             running={running}
             pending={command.isPending}
             stopping={pendingCommand === "abort"}
-            disabled={exited || Boolean(snapshot.pendingInteraction)}
+            disabled={
+              exited ||
+              Boolean(readOnly) ||
+              Boolean(snapshot.pendingInteraction)
+            }
             onSubmit={submit}
             onStop={() => void run({ type: "abort" })}
             onEditQueued={(id) =>

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -17,6 +17,7 @@ import type {
   AgentRuntimeSnapshot,
   AgentSessionCommand,
   AgentThinkingLevel,
+  AgentUsageSnapshot,
 } from "@/lib/agents/types";
 import {
   buildAgentPromptCommand,
@@ -31,6 +32,7 @@ import { motionClasses } from "@/lib/motion";
 import { AgentComposer } from "./AgentComposer";
 import {
   AgentInteractionDialog,
+  AgentUsageDialog,
   CompactAgentSessionDialog,
   RenameAgentSessionDialog,
 } from "./AgentSessionDialogs";
@@ -88,6 +90,7 @@ export function AgentSessionView({
   const command = useAgentSessionCommand(sessionId);
   const [renameOpen, setRenameOpen] = useState(false);
   const [compactOpen, setCompactOpen] = useState(false);
+  const [usage, setUsage] = useState<AgentUsageSnapshot | null>(null);
   const [dialogError, setDialogError] = useState("");
   const snapshot = session.data;
 
@@ -107,6 +110,7 @@ export function AgentSessionView({
     setDialogError("");
     try {
       const result = await command.mutateAsync(input);
+      if (result.usage) setUsage(result.usage);
       if (input.type === "new_session") {
         if (!result.sessionId) {
           throw new Error(`${providerLabel} did not return the new session.`);
@@ -378,6 +382,13 @@ export function AgentSessionView({
             ...response,
           })
         }
+      />
+      <AgentUsageDialog
+        open={Boolean(usage)}
+        usage={usage}
+        onOpenChange={(open) => {
+          if (!open) setUsage(null);
+        }}
       />
     </div>
   );

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -178,6 +178,7 @@ test("shows durable turn activity without changing completed tool status", async
   const snapshot: ReturnType<typeof runtimeSnapshot> & {
     pendingInteraction?: Record<string, unknown>;
   } = runtimeSnapshot(startedAt);
+  let retryRequested = false;
   let interactionResponse: Record<string, unknown> | null = null;
   await page.route(
     new RegExp(`/api/agent-sessions/${SESSION_ID}$`),
@@ -192,6 +193,7 @@ test("shows durable turn activity without changing completed tool status", async
           interactionResponse = command;
           delete snapshot.pendingInteraction;
         }
+        if (command.type === "retry_interactive") retryRequested = true;
         if (
           command.type === "abort" ||
           command.type === "steer" ||
@@ -617,4 +619,41 @@ test("shows durable turn activity without changing completed tool status", async
     id: "mcp-url",
     confirmed: true,
   });
+
+  await page.evaluate((initialSnapshot) => {
+    const controls = (
+      window as unknown as {
+        __agentRuntimeControls: {
+          emit: (envelope: unknown) => void;
+        };
+      }
+    ).__agentRuntimeControls;
+    controls.emit({
+      sequence: 6,
+      type: "snapshot",
+      data: {
+        ...initialSnapshot,
+        status: "idle",
+        activeTurn: null,
+        state: {
+          ...initialSnapshot.state,
+          isStreaming: false,
+        },
+        readOnly: {
+          reason:
+            "This session is currently open in another Codex client. You can view it here, but close it there before continuing in OvertChat.",
+          retryable: true,
+        },
+      },
+    });
+  }, snapshot);
+  await expect(
+    page.getByRole("region", { name: "Read-only Pi session" }),
+  ).toBeVisible();
+  await expect(
+    page.getByPlaceholder("Message Pi or type / for commands"),
+  ).toBeDisabled();
+  await expect(page.getByLabel("Session actions")).toBeDisabled();
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect.poll(() => retryRequested).toBe(true);
 });

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -641,7 +641,7 @@ test("shows durable turn activity without changing completed tool status", async
         },
         readOnly: {
           reason:
-            "This session is currently open in another Codex client. You can view it here, but close it there before continuing in OvertChat.",
+            "Another Codex process currently owns this session. You can view it here and retry when it becomes available.",
           retryable: true,
         },
       },

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -796,6 +796,12 @@ test("connect local Codex and resume a native thread", async ({
   const composer = page.getByPlaceholder(
     "Message Codex or type / for commands",
   );
+  await composer.fill("/usage");
+  await composer.press("Enter");
+  const usageDialog = page.getByRole("dialog", { name: "Codex usage" });
+  await expect(usageDialog).toBeVisible({ timeout: 30_000 });
+  await usageDialog.getByRole("button", { name: "Done" }).click();
+
   const prompt =
     "Respond with exactly OVERTCHAT_CODEX_E2E_OK and nothing else.";
   await composer.fill(prompt);

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -53,9 +53,7 @@ async function startHostConnector(
   await expect(
     page.getByTitle("Claude Code · Coming soon", { exact: true }),
   ).toBeVisible();
-  await expect(
-    page.getByTitle("Codex · Coming soon", { exact: true }),
-  ).toBeVisible();
+  await expect(page.getByTitle("Codex", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Agent access" }),
   ).toBeVisible();
@@ -226,9 +224,7 @@ test("explains agent access before setup", async ({ page }, testInfo) => {
   await expect(
     page.getByTitle("Claude Code · Coming soon", { exact: true }),
   ).toBeVisible();
-  await expect(
-    page.getByTitle("Codex · Coming soon", { exact: true }),
-  ).toBeVisible();
+  await expect(page.getByTitle("Codex", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Agent access" }),
   ).toBeVisible();
@@ -730,6 +726,100 @@ test("connect local Oh My Pi and use its native commands", async ({
     { timeout: 30_000 },
   );
   await expect(page.getByText("New Oh My Pi session")).toBeVisible();
+  expect(browserErrors).toEqual([]);
+});
+
+test("connect local Codex and resume a native thread", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(240_000);
+  test.skip(
+    process.env.RUN_CODEX_E2E !== "1",
+    "Set RUN_CODEX_E2E=1 on a machine with Codex installed and signed in.",
+  );
+
+  const browserErrors: string[] = [];
+  page.on("pageerror", (error) => browserErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(message.text());
+  });
+
+  await page.goto("/signup");
+  await page.locator("#name").fill("Codex E2E Admin");
+  await page
+    .locator("#email")
+    .fill("codex-admin@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/", { timeout: 15_000 });
+
+  await startHostConnector(page, testInfo);
+  await page.getByRole("button", { name: "Add agent" }).click();
+  await expect(
+    page.getByRole("button", { name: "Add Codex", exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+  await page
+    .getByRole("button", { name: "Add Codex", exact: true })
+    .click();
+  await expect(page.getByText("Codex added")).toBeVisible({
+    timeout: 150_000,
+  });
+
+  await page.getByRole("button", { name: "Add workspace" }).click();
+  const dialog = page.getByRole("dialog", { name: "Add workspace" });
+  await dialog.getByRole("button", { name: "Enter path" }).click();
+  await dialog.getByLabel("Directory path").fill(workspacePath);
+  await dialog
+    .getByRole("button", { name: "Add workspace", exact: true })
+    .click();
+  await expect(page.getByText("Workspace attached")).toBeVisible({
+    timeout: 90_000,
+  });
+
+  await page
+    .getByRole("button", { name: "Expand This server", exact: true })
+    .click();
+  await page
+    .getByRole("button", { name: `Expand ${workspaceName}`, exact: true })
+    .click();
+  await page
+    .getByRole("button", {
+      name: `New session in ${workspaceName}`,
+      exact: true,
+    })
+    .click();
+  await page.waitForURL("**/agents/**", { timeout: 150_000 });
+  await expect(page.getByText("New Codex session")).toBeVisible({
+    timeout: 150_000,
+  });
+
+  const composer = page.getByPlaceholder(
+    "Message Codex or type / for commands",
+  );
+  const prompt =
+    "Respond with exactly OVERTCHAT_CODEX_E2E_OK and nothing else.";
+  await composer.fill(prompt);
+  await composer.press("Enter");
+  await expect(
+    page.getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
+  ).toBeVisible({ timeout: 150_000 });
+  await expect(composer).toBeEnabled({ timeout: 30_000 });
+  await expect(composer).toHaveValue("");
+  await expect(
+    page.locator("main").getByText(prompt, { exact: true }),
+  ).toBeVisible();
+
+  await page.reload();
+  await expect(
+    page.locator("main").getByText(prompt, { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(
+    page.getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await page.screenshot({
+    path: testInfo.outputPath("codex-session-desktop.png"),
+    fullPage: true,
+  });
   expect(browserErrors).toEqual([]);
 });
 

--- a/apps/web/lib/agents/catalog.ts
+++ b/apps/web/lib/agents/catalog.ts
@@ -33,6 +33,12 @@ export const AGENT_PROVIDERS: Record<
       customCompactionInstructions: true,
     },
   },
+  codex: {
+    id: "codex",
+    label: "Codex",
+    executable: "codex",
+    capabilities: { steer: true },
+  },
 };
 
 export function agentProviderMetadata(

--- a/apps/web/lib/agents/catalog.ts
+++ b/apps/web/lib/agents/catalog.ts
@@ -37,7 +37,7 @@ export const AGENT_PROVIDERS: Record<
     id: "codex",
     label: "Codex",
     executable: "codex",
-    capabilities: { steer: true },
+    capabilities: { steer: true, usage: true },
   },
 };
 

--- a/apps/web/lib/agents/codex/app-server.test.ts
+++ b/apps/web/lib/agents/codex/app-server.test.ts
@@ -1,0 +1,145 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { CodexAppServer } from "./app-server";
+import type {
+  AgentProcess,
+  AgentProcessExit,
+} from "@/lib/agents/runtime/process";
+
+class FakeAgentProcess implements AgentProcess {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly exit: Promise<AgentProcessExit>;
+  readonly frames: Array<Record<string, unknown>> = [];
+  killedWith: NodeJS.Signals | null = null;
+  private resolveExit: (exit: AgentProcessExit) => void = () => {};
+
+  constructor(
+    private readonly handle: (
+      frame: Record<string, unknown>,
+      process: FakeAgentProcess,
+    ) => void,
+  ) {
+    this.exit = new Promise((resolve) => {
+      this.resolveExit = resolve;
+    });
+    let buffer = "";
+    this.stdin.on("data", (chunk) => {
+      buffer += chunk.toString();
+      for (;;) {
+        const newline = buffer.indexOf("\n");
+        if (newline < 0) break;
+        const frame = JSON.parse(buffer.slice(0, newline)) as Record<
+          string,
+          unknown
+        >;
+        buffer = buffer.slice(newline + 1);
+        this.frames.push(frame);
+        this.handle(frame, this);
+      }
+    });
+  }
+
+  result(frame: Record<string, unknown>, result: unknown): void {
+    this.stdout.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: frame.id, result })}\n`,
+    );
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.killedWith = signal;
+    this.resolveExit({ code: null, signal });
+    return true;
+  }
+}
+
+describe("CodexAppServer", () => {
+  it("initializes, correlates requests, and forwards notifications", async () => {
+    const process = new FakeAgentProcess((frame, fake) => {
+      if (frame.method === "initialize") {
+        fake.result(frame, { userAgent: "codex", codexHome: "/tmp", platformFamily: "unix", platformOs: "linux" });
+      } else if (frame.method === "model/list") {
+        fake.result(frame, { data: [], nextCursor: null });
+      }
+    });
+    const server = new CodexAppServer(process);
+    const notifications: unknown[] = [];
+    server.onNotification((notification) => notifications.push(notification));
+
+    await server.ready();
+    await expect(server.request("model/list", {})).resolves.toEqual({
+      data: [],
+      nextCursor: null,
+    });
+    process.stdout.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        method: "turn/started",
+        params: { threadId: "thread", turn: { id: "turn" } },
+      })}\n`,
+    );
+
+    expect(process.frames).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: "initialize" }),
+        { jsonrpc: "2.0", method: "initialized" },
+        expect.objectContaining({ method: "model/list" }),
+      ]),
+    );
+    expect(notifications).toContainEqual({
+      method: "turn/started",
+      params: { threadId: "thread", turn: { id: "turn" } },
+    });
+    await server.stop();
+  });
+
+  it("allows clients to answer server-initiated requests", async () => {
+    const process = new FakeAgentProcess((frame, fake) => {
+      if (frame.method === "initialize") fake.result(frame, {});
+    });
+    const server = new CodexAppServer(process);
+    server.onRequest((request) => {
+      server.respond(request.id, { decision: "accept" });
+    });
+    await server.ready();
+
+    process.stdout.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: "approval-1",
+        method: "item/commandExecution/requestApproval",
+        params: { command: "npm test" },
+      })}\n`,
+    );
+    await vi.waitFor(() => {
+      expect(process.frames).toContainEqual({
+        jsonrpc: "2.0",
+        id: "approval-1",
+        result: { decision: "accept" },
+      });
+    });
+    await server.stop();
+  });
+
+  it("kills the process and rejects requests after malformed JSON", async () => {
+    const process = new FakeAgentProcess((frame, fake) => {
+      if (frame.method === "initialize") fake.result(frame, {});
+    });
+    const server = new CodexAppServer(process);
+    await server.ready();
+    const request = server.request("model/list", {});
+    await vi.waitFor(() => {
+      expect(process.frames).toContainEqual(
+        expect.objectContaining({ method: "model/list" }),
+      );
+    });
+    process.stdout.write("{broken\n");
+
+    await expect(request).rejects.toThrow("invalid JSON");
+    expect(process.killedWith).toBe("SIGKILL");
+  });
+});

--- a/apps/web/lib/agents/codex/app-server.test.ts
+++ b/apps/web/lib/agents/codex/app-server.test.ts
@@ -1,13 +1,24 @@
+import { createHash } from "node:crypto";
 import { PassThrough } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { CodexAppServer } from "./app-server";
+const mocks = vi.hoisted(() => ({
+  spawnOnHost: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/runtime/process", () => ({
+  spawnOnHost: mocks.spawnOnHost,
+}));
+
+import { CodexAppServer, startCodexAppServer } from "./app-server";
 import type {
   AgentProcess,
   AgentProcessExit,
 } from "@/lib/agents/runtime/process";
+
+const WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 class FakeAgentProcess implements AgentProcess {
   readonly stdin = new PassThrough();
@@ -57,7 +68,146 @@ class FakeAgentProcess implements AgentProcess {
   }
 }
 
+class FailedAgentProcess implements AgentProcess {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly exit: Promise<AgentProcessExit>;
+  killedWith: NodeJS.Signals | null = null;
+
+  constructor(message: string) {
+    this.stderr.end(message);
+    this.exit = Promise.resolve({ code: 1, signal: null });
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.killedWith = signal;
+    return true;
+  }
+}
+
+class FakeProxyProcess implements AgentProcess {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly exit: Promise<AgentProcessExit>;
+  readonly frames: Array<Record<string, unknown>> = [];
+  killedWith: NodeJS.Signals | null = null;
+  private resolveExit: (exit: AgentProcessExit) => void = () => {};
+  private input = Buffer.alloc(0);
+  private upgraded = false;
+
+  constructor() {
+    this.exit = new Promise((resolve) => {
+      this.resolveExit = resolve;
+    });
+    this.stdin.on("data", (chunk) => {
+      this.input = Buffer.concat([this.input, Buffer.from(chunk)]);
+      this.consume();
+    });
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.killedWith = signal;
+    this.resolveExit({ code: null, signal });
+    return true;
+  }
+
+  private consume(): void {
+    if (!this.upgraded) {
+      const boundary = this.input.indexOf("\r\n\r\n");
+      if (boundary < 0) return;
+      const request = this.input.subarray(0, boundary).toString();
+      this.input = this.input.subarray(boundary + 4);
+      const key = /^Sec-WebSocket-Key:\s*(.+)$/imu.exec(request)?.[1]?.trim();
+      if (!key) throw new Error("WebSocket upgrade did not include a key.");
+      const accept = createHash("sha1")
+        .update(`${key}${WEBSOCKET_GUID}`)
+        .digest("base64");
+      this.stdout.write(
+        [
+          "HTTP/1.1 101 Switching Protocols",
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          `Sec-WebSocket-Accept: ${accept}`,
+          "",
+          "",
+        ].join("\r\n"),
+      );
+      this.upgraded = true;
+    }
+
+    for (;;) {
+      const frame = this.readFrame();
+      if (!frame) return;
+      if (frame.opcode === 0x8) return;
+      if (frame.opcode !== 0x1) continue;
+      const value = JSON.parse(frame.payload.toString()) as Record<
+        string,
+        unknown
+      >;
+      this.frames.push(value);
+      if (typeof value.id === "number" && typeof value.method === "string") {
+        this.sendJson({
+          jsonrpc: "2.0",
+          id: value.id,
+          result:
+            value.method === "model/list"
+              ? { data: [], nextCursor: null }
+              : {},
+        });
+      }
+    }
+  }
+
+  private readFrame(): { opcode: number; payload: Buffer } | null {
+    if (this.input.length < 2) return null;
+    const opcode = this.input[0] & 0x0f;
+    const masked = (this.input[1] & 0x80) !== 0;
+    let length = this.input[1] & 0x7f;
+    let offset = 2;
+    if (length === 126) {
+      if (this.input.length < 4) return null;
+      length = this.input.readUInt16BE(2);
+      offset = 4;
+    } else if (length === 127) {
+      if (this.input.length < 10) return null;
+      const extended = this.input.readBigUInt64BE(2);
+      if (extended > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new Error("WebSocket test frame is too large.");
+      }
+      length = Number(extended);
+      offset = 10;
+    }
+    const maskLength = masked ? 4 : 0;
+    if (this.input.length < offset + maskLength + length) return null;
+    const mask = masked ? this.input.subarray(offset, offset + 4) : null;
+    offset += maskLength;
+    const payload = Buffer.from(this.input.subarray(offset, offset + length));
+    this.input = this.input.subarray(offset + length);
+    if (mask) {
+      for (let index = 0; index < payload.length; index += 1) {
+        payload[index] ^= mask[index % 4];
+      }
+    }
+    return { opcode, payload };
+  }
+
+  private sendJson(value: unknown): void {
+    const payload = Buffer.from(JSON.stringify(value));
+    const header =
+      payload.length < 126
+        ? Buffer.from([0x81, payload.length])
+        : Buffer.from([0x81, 126, payload.length >> 8, payload.length & 0xff]);
+    this.stdout.write(Buffer.concat([header, payload]));
+  }
+}
+
 describe("CodexAppServer", () => {
+  beforeEach(() => {
+    mocks.spawnOnHost.mockReset();
+  });
+
   it("initializes, correlates requests, and forwards notifications", async () => {
     const process = new FakeAgentProcess((frame, fake) => {
       if (frame.method === "initialize") {
@@ -141,5 +291,81 @@ describe("CodexAppServer", () => {
 
     await expect(request).rejects.toThrow("invalid JSON");
     expect(process.killedWith).toBe("SIGKILL");
+  });
+
+  it("prefers the shared Codex daemon through app-server proxy", async () => {
+    const process = new FakeProxyProcess();
+    mocks.spawnOnHost.mockReturnValueOnce(process);
+
+    const server = await startCodexAppServer(
+      { connectorId: "connector", transport: "local" },
+      "/opt/bin/codex",
+      "/workspace",
+    );
+    await expect(server.request("model/list")).resolves.toEqual({
+      data: [],
+      nextCursor: null,
+    });
+
+    expect(mocks.spawnOnHost).toHaveBeenCalledOnce();
+    expect(mocks.spawnOnHost).toHaveBeenCalledWith(
+      { connectorId: "connector", transport: "local" },
+      {
+        command: "/opt/bin/codex",
+        args: ["app-server", "proxy"],
+        cwd: "/workspace",
+      },
+    );
+    expect(process.frames).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: "initialize" }),
+        { jsonrpc: "2.0", method: "initialized" },
+        expect.objectContaining({ method: "model/list" }),
+      ]),
+    );
+    await server.stop();
+  });
+
+  it("falls back to standalone stdio when the daemon proxy is unavailable", async () => {
+    const proxy = new FailedAgentProcess("daemon unavailable");
+    const standalone = new FakeAgentProcess((frame, fake) => {
+      if (frame.method === "initialize") fake.result(frame, {});
+      if (frame.method === "model/list") {
+        fake.result(frame, { data: [], nextCursor: null });
+      }
+    });
+    mocks.spawnOnHost
+      .mockReturnValueOnce(proxy)
+      .mockReturnValueOnce(standalone);
+
+    const server = await startCodexAppServer(
+      { connectorId: "connector", transport: "ssh", alias: "devbox" },
+      "codex",
+      "/workspace",
+    );
+    await expect(server.request("model/list")).resolves.toEqual({
+      data: [],
+      nextCursor: null,
+    });
+
+    expect(mocks.spawnOnHost).toHaveBeenNthCalledWith(
+      1,
+      { connectorId: "connector", transport: "ssh", alias: "devbox" },
+      {
+        command: "codex",
+        args: ["app-server", "proxy"],
+        cwd: "/workspace",
+      },
+    );
+    expect(mocks.spawnOnHost).toHaveBeenNthCalledWith(
+      2,
+      { connectorId: "connector", transport: "ssh", alias: "devbox" },
+      {
+        command: "codex",
+        args: ["app-server", "--stdio"],
+        cwd: "/workspace",
+      },
+    );
+    await server.stop();
   });
 });

--- a/apps/web/lib/agents/codex/app-server.ts
+++ b/apps/web/lib/agents/codex/app-server.ts
@@ -1,0 +1,325 @@
+import "server-only";
+import type { AgentProcess, HostTarget } from "@/lib/agents/runtime/process";
+import { spawnOnHost } from "@/lib/agents/runtime/process";
+import {
+  JsonlDecoder,
+  serializeJsonLine,
+} from "@/lib/agents/runtime/jsonl";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const INITIALIZE_TIMEOUT_MS = 60_000;
+const MAX_STDERR_CHARS = 64 * 1024;
+
+export type JsonRpcId = string | number;
+
+export type CodexAppServerNotification = {
+  method: string;
+  params?: unknown;
+};
+
+export type CodexAppServerRequest = {
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+};
+
+type PendingRequest = {
+  method: string;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+};
+
+type JsonRpcError = {
+  code?: number;
+  message?: string;
+  data?: unknown;
+};
+
+function errorText(error: JsonRpcError | undefined, fallback: string): string {
+  if (!error) return fallback;
+  const detail =
+    typeof error.data === "string"
+      ? error.data
+      : error.data === undefined
+        ? ""
+        : JSON.stringify(error.data);
+  return [error.message || fallback, detail].filter(Boolean).join(" ");
+}
+
+export class CodexAppServer {
+  private readonly decoder = new JsonlDecoder();
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+  private readonly notificationSubscribers = new Set<
+    (notification: CodexAppServerNotification) => void
+  >();
+  private readonly requestSubscribers = new Set<
+    (request: CodexAppServerRequest) => void
+  >();
+  private nextRequestId = 0;
+  private stderr = "";
+  private closed = false;
+  private readonly initialized: Promise<void>;
+
+  constructor(private readonly process: AgentProcess) {
+    process.stdout.on("data", (chunk) => {
+      for (const line of this.decoder.push(chunk)) this.handleLine(line);
+    });
+    process.stdout.on("end", () => {
+      for (const line of this.decoder.end()) this.handleLine(line);
+    });
+    process.stderr.on("data", (chunk) => {
+      this.stderr = `${this.stderr}${chunk.toString()}`.slice(
+        -MAX_STDERR_CHARS,
+      );
+    });
+    void process.exit.then((exit) => {
+      this.closed = true;
+      const detail = exit.error?.message ?? this.stderr.trim();
+      const error = new Error(
+        detail ||
+          `Codex app-server exited (code=${exit.code ?? "unknown"}, signal=${exit.signal ?? "none"}).`,
+      );
+      this.rejectPending(error);
+      this.emitNotification({
+        method: "overtchat/processExit",
+        params: {
+          code: exit.code,
+          signal: exit.signal,
+          error: error.message,
+        },
+      });
+    });
+    this.initialized = this.initialize();
+    void this.initialized.catch(() => {});
+  }
+
+  onNotification(
+    subscriber: (notification: CodexAppServerNotification) => void,
+  ): () => void {
+    this.notificationSubscribers.add(subscriber);
+    return () => this.notificationSubscribers.delete(subscriber);
+  }
+
+  onRequest(
+    subscriber: (request: CodexAppServerRequest) => void,
+  ): () => void {
+    this.requestSubscribers.add(subscriber);
+    return () => this.requestSubscribers.delete(subscriber);
+  }
+
+  async ready(): Promise<void> {
+    await this.initialized;
+  }
+
+  async request<T = unknown>(
+    method: string,
+    params: unknown = {},
+    timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  ): Promise<T> {
+    await this.initialized;
+    return this.requestNow<T>(method, params, timeoutMs);
+  }
+
+  respond(id: JsonRpcId, result: unknown): void {
+    this.write({ jsonrpc: "2.0", id, result });
+  }
+
+  respondError(id: JsonRpcId, code: number, message: string): void {
+    this.write({
+      jsonrpc: "2.0",
+      id,
+      error: { code, message },
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.rejectPending(new Error("The Codex app-server was stopped."));
+    this.process.stdin.end();
+    this.process.kill("SIGTERM");
+    let forceKillTimer: NodeJS.Timeout | undefined;
+    await Promise.race([
+      this.process.exit,
+      new Promise<void>((resolve) => {
+        forceKillTimer = setTimeout(() => {
+          this.process.kill("SIGKILL");
+          resolve();
+        }, 1_000);
+      }),
+    ]);
+    if (forceKillTimer) clearTimeout(forceKillTimer);
+  }
+
+  getStderr(): string {
+    return this.stderr;
+  }
+
+  private async initialize(): Promise<void> {
+    await this.requestNow(
+      "initialize",
+      {
+        clientInfo: {
+          name: "overtchat",
+          title: "OvertChat",
+          version: "0.1.0",
+        },
+        capabilities: {
+          experimentalApi: true,
+          requestAttestation: false,
+        },
+      },
+      INITIALIZE_TIMEOUT_MS,
+    );
+    this.write({ jsonrpc: "2.0", method: "initialized" });
+  }
+
+  private requestNow<T>(
+    method: string,
+    params: unknown,
+    timeoutMs: number,
+  ): Promise<T> {
+    if (this.closed || !this.process.stdin.writable) {
+      throw new Error(
+        this.stderr.trim() || "The Codex app-server is not running.",
+      );
+    }
+    const id = ++this.nextRequestId;
+    return new Promise<T>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `Timed out waiting for Codex ${method}.${this.stderr.trim() ? ` ${this.stderr.trim()}` : ""}`,
+          ),
+        );
+      }, timeoutMs);
+      this.pending.set(id, {
+        method,
+        resolve: (value) => resolve(value as T),
+        reject,
+        timeout,
+      });
+      try {
+        this.write({ jsonrpc: "2.0", id, method, params });
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  private write(value: unknown): void {
+    if (this.closed || !this.process.stdin.writable) {
+      throw new Error("The Codex app-server is not running.");
+    }
+    this.process.stdin.write(serializeJsonLine(value));
+  }
+
+  private handleLine(line: string): void {
+    if (!line) return;
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch {
+      this.failProtocol(
+        `Codex app-server emitted invalid JSON: ${line.slice(0, 200)}`,
+      );
+      return;
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      this.failProtocol("Codex app-server emitted a non-object JSON value.");
+      return;
+    }
+    const record = value as Record<string, unknown>;
+    if (
+      (typeof record.id === "string" ||
+        typeof record.id === "number") &&
+      ("result" in record || "error" in record) &&
+      typeof record.method !== "string"
+    ) {
+      this.handleResponse(record);
+      return;
+    }
+    if (typeof record.method !== "string") {
+      this.failProtocol("Codex app-server frame is missing a method.");
+      return;
+    }
+    if (typeof record.id === "string" || typeof record.id === "number") {
+      const request = {
+        id: record.id,
+        method: record.method,
+        ...("params" in record ? { params: record.params } : {}),
+      };
+      if (this.requestSubscribers.size === 0) {
+        this.respondError(record.id, -32601, "Request is not supported.");
+        return;
+      }
+      for (const subscriber of this.requestSubscribers) subscriber(request);
+      return;
+    }
+    this.emitNotification({
+      method: record.method,
+      ...("params" in record ? { params: record.params } : {}),
+    });
+  }
+
+  private handleResponse(record: Record<string, unknown>): void {
+    const id = record.id as JsonRpcId;
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    this.pending.delete(id);
+    if ("error" in record) {
+      const error =
+        record.error && typeof record.error === "object"
+          ? (record.error as JsonRpcError)
+          : undefined;
+      pending.reject(
+        new Error(errorText(error, `Codex ${pending.method} failed.`)),
+      );
+      return;
+    }
+    pending.resolve(record.result);
+  }
+
+  private emitNotification(notification: CodexAppServerNotification): void {
+    for (const subscriber of this.notificationSubscribers) {
+      subscriber(notification);
+    }
+  }
+
+  private failProtocol(message: string): void {
+    const error = new Error(message);
+    this.rejectPending(error);
+    this.emitNotification({
+      method: "overtchat/protocolError",
+      params: { error: message },
+    });
+    this.process.kill("SIGKILL");
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+export function startCodexAppServer(
+  target: HostTarget,
+  executable: string,
+  cwd?: string,
+): CodexAppServer {
+  return new CodexAppServer(
+    spawnOnHost(target, {
+      command: executable,
+      args: ["app-server", "--stdio"],
+      cwd,
+    }),
+  );
+}

--- a/apps/web/lib/agents/codex/app-server.ts
+++ b/apps/web/lib/agents/codex/app-server.ts
@@ -1,4 +1,6 @@
 import "server-only";
+import { Duplex, PassThrough, Writable } from "node:stream";
+import WebSocket from "ws";
 import type { AgentProcess, HostTarget } from "@/lib/agents/runtime/process";
 import { spawnOnHost } from "@/lib/agents/runtime/process";
 import {
@@ -9,6 +11,7 @@ import {
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const INITIALIZE_TIMEOUT_MS = 60_000;
 const MAX_STDERR_CHARS = 64 * 1024;
+const PROXY_HANDSHAKE_TIMEOUT_MS = 5_000;
 
 export type JsonRpcId = string | number;
 
@@ -47,6 +50,131 @@ function errorText(error: JsonRpcError | undefined, fallback: string): string {
   return [error.message || fallback, detail].filter(Boolean).join(" ");
 }
 
+class AgentProcessDuplex extends Duplex {
+  constructor(private readonly process: AgentProcess) {
+    super();
+    process.stdout.on("data", (chunk) => this.push(chunk));
+    process.stdout.on("end", () => this.push(null));
+    process.stdout.on("error", (error) => this.destroy(error));
+    void process.exit.then((exit) => {
+      if (!this.destroyed) {
+        this.destroy(
+          exit.error ??
+            new Error(
+              `Codex app-server proxy exited (code=${exit.code ?? "unknown"}, signal=${exit.signal ?? "none"}).`,
+            ),
+        );
+      }
+    });
+  }
+
+  _read(): void {}
+
+  _write(
+    chunk: Buffer,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.process.stdin.write(chunk, encoding, callback);
+  }
+
+  _final(callback: (error?: Error | null) => void): void {
+    this.process.stdin.end(callback);
+  }
+
+  setNoDelay(): this {
+    return this;
+  }
+
+  setTimeout(): this {
+    return this;
+  }
+}
+
+function spawnCodexProxy(
+  target: HostTarget,
+  executable: string,
+  cwd?: string,
+): AgentProcess {
+  const proxy = spawnOnHost(target, {
+    command: executable,
+    args: ["app-server", "proxy"],
+    cwd,
+  });
+  const transport = new AgentProcessDuplex(proxy);
+  const stdout = new PassThrough();
+  let inputBuffer = "";
+  const websocket = new WebSocket("ws://localhost/rpc", {
+    createConnection: () => {
+      process.nextTick(() => transport.emit("connect"));
+      return transport;
+    },
+    handshakeTimeout: PROXY_HANDSHAKE_TIMEOUT_MS,
+    perMessageDeflate: false,
+  });
+  const ready = new Promise<void>((resolve, reject) => {
+    websocket.once("open", resolve);
+    websocket.once("error", reject);
+  });
+  websocket.on("message", (data, isBinary) => {
+    if (isBinary) return;
+    stdout.write(`${data.toString()}\n`);
+  });
+  websocket.on("close", () => stdout.end());
+  websocket.on("error", () => {
+    proxy.kill("SIGTERM");
+  });
+
+  const stdin = new Writable({
+    write(chunk, _encoding, callback) {
+      inputBuffer += chunk.toString();
+      const lines: string[] = [];
+      for (;;) {
+        const newline = inputBuffer.indexOf("\n");
+        if (newline < 0) break;
+        const line = inputBuffer.slice(0, newline);
+        inputBuffer = inputBuffer.slice(newline + 1);
+        if (line) lines.push(line);
+      }
+      void ready.then(
+        async () => {
+          for (const line of lines) {
+            await new Promise<void>((resolve, reject) => {
+              websocket.send(line, (error) =>
+                error ? reject(error) : resolve(),
+              );
+            });
+          }
+          callback();
+        },
+        (error) =>
+          callback(error instanceof Error ? error : new Error(String(error))),
+      );
+    },
+    final(callback) {
+      void ready.then(
+        () => {
+          websocket.close();
+          callback();
+        },
+        () => callback(),
+      );
+    },
+  });
+
+  return {
+    stdin,
+    stdout,
+    stderr: proxy.stderr,
+    exit: proxy.exit,
+    kill(signal = "SIGTERM") {
+      if (signal === "SIGKILL") websocket.terminate();
+      else websocket.close();
+      return proxy.kill(signal);
+    },
+  };
+}
+
 export class CodexAppServer {
   private readonly decoder = new JsonlDecoder();
   private readonly pending = new Map<JsonRpcId, PendingRequest>();
@@ -62,6 +190,20 @@ export class CodexAppServer {
   private readonly initialized: Promise<void>;
 
   constructor(private readonly process: AgentProcess) {
+    process.stdin.on("error", (error) => {
+      if (this.closed) return;
+      this.closed = true;
+      this.rejectPending(error);
+      this.emitNotification({
+        method: "overtchat/processExit",
+        params: {
+          code: null,
+          signal: null,
+          error: error.message,
+        },
+      });
+      process.kill("SIGKILL");
+    });
     process.stdout.on("data", (chunk) => {
       for (const line of this.decoder.push(chunk)) this.handleLine(line);
     });
@@ -310,16 +452,27 @@ export class CodexAppServer {
   }
 }
 
-export function startCodexAppServer(
+export async function startCodexAppServer(
   target: HostTarget,
   executable: string,
   cwd?: string,
-): CodexAppServer {
-  return new CodexAppServer(
+): Promise<CodexAppServer> {
+  const proxyServer = new CodexAppServer(
+    spawnCodexProxy(target, executable, cwd),
+  );
+  try {
+    await proxyServer.ready();
+    return proxyServer;
+  } catch {
+    await proxyServer.stop().catch(() => {});
+  }
+  const standaloneServer = new CodexAppServer(
     spawnOnHost(target, {
       command: executable,
       args: ["app-server", "--stdio"],
       cwd,
     }),
   );
+  await standaloneServer.ready();
+  return standaloneServer;
 }

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -1,0 +1,588 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+type Listener<T> = (value: T) => void;
+
+class FakeCodexServer {
+  readonly requests: Array<{ method: string; params: unknown }> = [];
+  readonly responses: Array<{ id: string | number; result: unknown }> = [];
+  private notification: Listener<{ method: string; params?: unknown }> =
+    () => {};
+  private serverRequest: Listener<{
+    id: string | number;
+    method: string;
+    params?: unknown;
+  }> = () => {};
+
+  ready = vi.fn(async () => {});
+  stop = vi.fn(async () => {});
+
+  onNotification(listener: typeof this.notification) {
+    this.notification = listener;
+    return () => {};
+  }
+
+  onRequest(listener: typeof this.serverRequest) {
+    this.serverRequest = listener;
+    return () => {};
+  }
+
+  async request(method: string, params: unknown) {
+    this.requests.push({ method, params });
+    if (method === "model/list") {
+      return {
+        data: [
+          {
+            id: "gpt-5.6",
+            model: "gpt-5.6",
+            displayName: "GPT-5.6",
+            inputModalities: ["text"],
+            supportedReasoningEfforts: [
+              { reasoningEffort: "low", description: "" },
+              { reasoningEffort: "high", description: "" },
+            ],
+            defaultReasoningEffort: "high",
+          },
+        ],
+        nextCursor: null,
+      };
+    }
+    if (method === "thread/start") {
+      return {
+        thread: {
+          id: "thread-1",
+          cwd: "/workspace",
+          preview: "",
+          path: "/tmp/thread-1.jsonl",
+          name: null,
+          createdAt: 1,
+          updatedAt: 1,
+          turns: [],
+        },
+        model: "gpt-5.6",
+        reasoningEffort: "high",
+      };
+    }
+    if (method === "thread/resume") {
+      return {
+        thread: {
+          id: "thread-1",
+          cwd: "/workspace",
+          preview: "Resume this thread",
+          path: "/tmp/thread-1.jsonl",
+          name: null,
+          createdAt: 1,
+          updatedAt: 2,
+          turns: [],
+        },
+        model: "gpt-5.6",
+        reasoningEffort: "high",
+      };
+    }
+    if (method === "thread/read") {
+      return {
+        thread: {
+          id: "thread-1",
+          cwd: "/workspace",
+          preview: "Resume this thread",
+          path: "/tmp/thread-1.jsonl",
+          name: null,
+          createdAt: 1,
+          updatedAt: 2,
+          turns: [
+            {
+              id: "turn-history",
+              status: "completed",
+              startedAt: 1,
+              completedAt: 2,
+              items: [
+                {
+                  id: "user-history",
+                  type: "userMessage",
+                  content: [
+                    {
+                      type: "text",
+                      text: "Resume this thread",
+                      text_elements: [],
+                    },
+                  ],
+                },
+                {
+                  id: "assistant-history",
+                  type: "agentMessage",
+                  text: "History restored.",
+                },
+              ],
+            },
+          ],
+        },
+      };
+    }
+    if (method === "turn/start") {
+      return {
+        turn: {
+          id: "turn-1",
+          status: "inProgress",
+          startedAt: 10,
+          items: [],
+        },
+      };
+    }
+    return {};
+  }
+
+  respond(id: string | number, result: unknown) {
+    this.responses.push({ id, result });
+  }
+
+  respondError = vi.fn();
+
+  emit(method: string, params?: unknown) {
+    this.notification({ method, params });
+  }
+
+  ask(id: string | number, method: string, params?: unknown) {
+    this.serverRequest({ id, method, params });
+  }
+}
+
+const server = new FakeCodexServer();
+
+vi.mock("./app-server", () => ({
+  startCodexAppServer: () => server,
+}));
+
+import { CodexRuntimeClient } from "./client";
+
+describe("CodexRuntimeClient", () => {
+  beforeEach(() => {
+    server.requests.length = 0;
+    server.responses.length = 0;
+    server.respondError.mockClear();
+  });
+
+  it("starts a native thread and maps streamed activity", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+
+    await expect(client.getState()).resolves.toMatchObject({
+      sessionId: "thread-1",
+      sessionFile: "/tmp/thread-1.jsonl",
+      isStreaming: false,
+      model: { provider: "codex", id: "gpt-5.6" },
+      thinkingLevel: "high",
+    });
+    await client.prompt("Inspect the tests");
+    server.emit("turn/started", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "inProgress",
+        startedAt: 10,
+        items: [],
+      },
+    });
+    server.emit("item/started", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      startedAtMs: 10_001,
+      item: {
+        id: "command-1",
+        type: "commandExecution",
+        command: "npm test",
+        cwd: "/workspace",
+        status: "inProgress",
+        aggregatedOutput: "",
+      },
+    });
+    server.emit("item/commandExecution/outputDelta", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "command-1",
+      delta: "passed\n",
+    });
+    server.emit("turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        startedAt: 10,
+        completedAt: 11,
+        items: [
+          {
+            id: "command-1",
+            type: "commandExecution",
+            command: "npm test",
+            cwd: "/workspace",
+            status: "completed",
+            aggregatedOutput: "passed\n",
+            exitCode: 0,
+          },
+          {
+            id: "assistant-1",
+            type: "agentMessage",
+            text: "Everything passes.",
+          },
+        ],
+      },
+    });
+
+    await expect(client.getState()).resolves.toMatchObject({
+      isStreaming: false,
+    });
+    await expect(client.getMessages()).resolves.toEqual({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: "Inspect the tests",
+        }),
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              type: "toolCall",
+              name: "bash",
+            }),
+            { type: "text", text: "Everything passes." },
+          ]),
+        }),
+        expect.objectContaining({
+          role: "toolResult",
+          toolCallId: "command-1",
+          isError: false,
+        }),
+      ]),
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "turn_start", turnId: "turn-1" }),
+        expect.objectContaining({
+          type: "message_update",
+          message: expect.objectContaining({
+            role: "user",
+            content: "Inspect the tests",
+          }),
+        }),
+        expect.objectContaining({ type: "message_update" }),
+        expect.objectContaining({ type: "turn_end", status: "completed" }),
+      ]),
+    );
+  });
+
+  it("hydrates complete native history after resuming a thread", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+
+    await expect(client.getMessages()).resolves.toEqual({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          id: "user-history",
+          role: "user",
+          content: "Resume this thread",
+        }),
+        expect.objectContaining({
+          id: "turn-history:assistant",
+          role: "assistant",
+          content: [{ type: "text", text: "History restored." }],
+        }),
+      ]),
+    });
+    expect(server.requests).toEqual(
+      expect.arrayContaining([
+        {
+          method: "thread/resume",
+          params: { threadId: "thread-1", cwd: "/workspace" },
+        },
+        {
+          method: "thread/read",
+          params: { threadId: "thread-1", includeTurns: true },
+        },
+      ]),
+    );
+  });
+
+  it("round-trips native approvals through the generic interaction contract", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getState();
+
+    server.ask("approval-1", "item/commandExecution/requestApproval", {
+      command: "npm install",
+      reason: "Requires network access",
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: "interaction_request",
+      id: "codex:approval-1",
+      method: "select",
+      options: ["Allow once", "Allow for session", "Deny"],
+    });
+
+    client.respondToInteraction("codex:approval-1", {
+      value: "Allow for session",
+    });
+    expect(server.responses.at(-1)).toEqual({
+      id: "approval-1",
+      result: { decision: "acceptForSession" },
+    });
+
+    server.ask("permission-1", "item/permissions/requestApproval", {
+      reason: "Needs network access",
+      permissions: {
+        network: { enabled: true },
+        fileSystem: null,
+      },
+    });
+    client.respondToInteraction("codex:permission-1", {
+      value: "Allow once",
+    });
+    expect(server.responses.at(-1)).toEqual({
+      id: "permission-1",
+      result: {
+        permissions: { network: { enabled: true } },
+        scope: "turn",
+      },
+    });
+  });
+
+  it("waits for the interrupted turn to become terminal", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+    await client.prompt("Keep working");
+
+    let settled = false;
+    const abort = client.abort().then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(server.requests.at(-1)).toEqual({
+      method: "turn/interrupt",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    });
+
+    server.emit("turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "interrupted",
+        startedAt: 10,
+        completedAt: 11,
+        items: [],
+      },
+    });
+    await abort;
+    expect(settled).toBe(true);
+  });
+
+  it("waits for the compaction turn to complete", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getState();
+
+    let settled = false;
+    const compact = client.compact().then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    await expect(client.getState()).resolves.toMatchObject({
+      isCompacting: true,
+    });
+
+    server.emit("turn/started", {
+      threadId: "thread-1",
+      turn: {
+        id: "compact-turn",
+        status: "inProgress",
+        startedAt: 20,
+        items: [],
+      },
+    });
+    server.emit("item/started", {
+      threadId: "thread-1",
+      turnId: "compact-turn",
+      item: { id: "compact-item", type: "contextCompaction" },
+    });
+    server.emit("turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "compact-turn",
+        status: "completed",
+        startedAt: 20,
+        completedAt: 21,
+        items: [{ id: "compact-item", type: "contextCompaction" }],
+      },
+    });
+    await compact;
+
+    expect(settled).toBe(true);
+    await expect(client.getState()).resolves.toMatchObject({
+      isCompacting: false,
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "compaction_start" }),
+        expect.objectContaining({ type: "compaction_end" }),
+      ]),
+    );
+  });
+
+  it("maps secret questions and clears requests resolved by app-server", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getState();
+
+    server.ask("question-1", "item/tool/requestUserInput", {
+      autoResolutionMs: 5_000,
+      questions: [
+        {
+          id: "token",
+          header: "Token",
+          question: "Enter the token",
+          isOther: false,
+          isSecret: true,
+          options: null,
+        },
+      ],
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: "interaction_request",
+      id: "codex:question-1",
+      method: "input",
+      secret: true,
+      timeout: 5_000,
+    });
+
+    server.emit("serverRequest/resolved", {
+      threadId: "thread-1",
+      requestId: "question-1",
+    });
+    expect(events.at(-1)).toEqual({
+      type: "interaction_resolved",
+      id: "codex:question-1",
+    });
+  });
+
+  it("uses current-turn usage for context while retaining cumulative totals", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+
+    server.emit("thread/tokenUsage/updated", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      tokenUsage: {
+        total: {
+          inputTokens: 80_000,
+          cachedInputTokens: 10_000,
+          cacheWriteInputTokens: 0,
+          outputTokens: 5_000,
+          reasoningOutputTokens: 0,
+          totalTokens: 85_000,
+        },
+        last: {
+          inputTokens: 18_000,
+          cachedInputTokens: 0,
+          cacheWriteInputTokens: 0,
+          outputTokens: 2_000,
+          reasoningOutputTokens: 0,
+          totalTokens: 20_000,
+        },
+        modelContextWindow: 100_000,
+      },
+    });
+
+    await expect(client.getSessionStats()).resolves.toMatchObject({
+      tokens: {
+        input: 80_000,
+        output: 5_000,
+        cacheRead: 10_000,
+        total: 85_000,
+      },
+      contextUsage: {
+        tokens: 20_000,
+        contextWindow: 100_000,
+        percent: 20,
+      },
+    });
+  });
+
+  it("emits each question in a multi-question request", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getState();
+
+    server.ask("question-2", "item/tool/requestUserInput", {
+      questions: [
+        {
+          id: "first",
+          header: "First",
+          question: "Choose first",
+          isOther: false,
+          isSecret: false,
+          options: [{ label: "A", description: "" }],
+        },
+        {
+          id: "second",
+          header: "Second",
+          question: "Choose second",
+          isOther: false,
+          isSecret: false,
+          options: [{ label: "B", description: "" }],
+        },
+      ],
+    });
+    client.respondToInteraction("codex:question-2", { value: "A" });
+    expect(events.at(-1)).toMatchObject({
+      type: "interaction_request",
+      id: "codex:question-2",
+      title: "Second",
+      options: ["B"],
+    });
+    client.respondToInteraction("codex:question-2", { value: "B" });
+    expect(server.responses.at(-1)).toEqual({
+      id: "question-2",
+      result: {
+        answers: {
+          first: { answers: ["A"] },
+          second: { answers: ["B"] },
+        },
+      },
+    });
+  });
+});

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -7,6 +7,7 @@ type Listener<T> = (value: T) => void;
 class FakeCodexServer {
   readonly requests: Array<{ method: string; params: unknown }> = [];
   readonly responses: Array<{ id: string | number; result: unknown }> = [];
+  resumeError: Error | null = null;
   private notification: Listener<{ method: string; params?: unknown }> =
     () => {};
   private serverRequest: Listener<{
@@ -65,6 +66,7 @@ class FakeCodexServer {
       };
     }
     if (method === "thread/resume") {
+      if (this.resumeError) throw this.resumeError;
       return {
         thread: {
           id: "thread-1",
@@ -159,6 +161,7 @@ describe("CodexRuntimeClient", () => {
   beforeEach(() => {
     server.requests.length = 0;
     server.responses.length = 0;
+    server.resumeError = null;
     server.respondError.mockClear();
   });
 
@@ -313,6 +316,54 @@ describe("CodexRuntimeClient", () => {
         },
       ]),
     );
+  });
+
+  it("opens an active-writer thread read-only and retries interactive access", async () => {
+    server.resumeError = new Error(
+      "thread thread-1 already has an active writer",
+    );
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+
+    await expect(client.getState()).resolves.toMatchObject({
+      sessionId: "thread-1",
+      isStreaming: false,
+      readOnly: {
+        reason: expect.stringContaining("open in another Codex client"),
+        retryable: true,
+      },
+    });
+    await expect(client.getMessages()).resolves.toEqual({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          id: "user-history",
+          content: "Resume this thread",
+        }),
+        expect.objectContaining({
+          id: "turn-history:assistant",
+        }),
+      ]),
+    });
+    await expect(client.prompt("Continue here")).rejects.toThrow(
+      "open in another Codex client",
+    );
+
+    server.resumeError = null;
+    await client.retryInteractive();
+    const state = await client.getState();
+    expect(state).not.toHaveProperty("readOnly");
+    expect(
+      server.requests.filter(({ method }) => method === "thread/resume"),
+    ).toHaveLength(2);
   });
 
   it("round-trips native approvals through the generic interaction contract", async () => {

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -318,6 +318,29 @@ describe("CodexRuntimeClient", () => {
     );
   });
 
+  it("unsubscribes a resumed thread before stopping its app-server", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+    await client.getState();
+
+    await client.stop();
+
+    expect(server.requests.at(-1)).toEqual({
+      method: "thread/unsubscribe",
+      params: { threadId: "thread-1" },
+    });
+    expect(server.stop).toHaveBeenCalledOnce();
+  });
+
   it("opens an active-writer thread read-only and retries interactive access", async () => {
     server.resumeError = new Error(
       "thread thread-1 already has an active writer",
@@ -338,7 +361,7 @@ describe("CodexRuntimeClient", () => {
       sessionId: "thread-1",
       isStreaming: false,
       readOnly: {
-        reason: expect.stringContaining("open in another Codex client"),
+        reason: expect.stringContaining("Codex process currently owns"),
         retryable: true,
       },
     });
@@ -354,7 +377,7 @@ describe("CodexRuntimeClient", () => {
       ]),
     });
     await expect(client.prompt("Continue here")).rejects.toThrow(
-      "open in another Codex client",
+      "Codex process currently owns",
     );
 
     server.resumeError = null;

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -2,6 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+const mocks = vi.hoisted(() => ({
+  listCodexCustomPrompts: vi.fn(),
+}));
+
+vi.mock("./commands", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./commands")>()),
+  listCodexCustomPrompts: mocks.listCodexCustomPrompts,
+}));
+
 type Listener<T> = (value: T) => void;
 
 class FakeCodexServer {
@@ -47,6 +56,23 @@ class FakeCodexServer {
           },
         ],
         nextCursor: null,
+      };
+    }
+    if (method === "skills/list") {
+      return {
+        data: [
+          {
+            cwd: "/workspace",
+            skills: [
+              {
+                name: "release-notes",
+                path: "/workspace/.codex/skills/release-notes/SKILL.md",
+                description: "Draft release notes",
+                enabled: true,
+              },
+            ],
+          },
+        ],
       };
     }
     if (method === "thread/start") {
@@ -159,10 +185,99 @@ import { CodexRuntimeClient } from "./client";
 
 describe("CodexRuntimeClient", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     server.requests.length = 0;
     server.responses.length = 0;
     server.resumeError = null;
     server.respondError.mockClear();
+    mocks.listCodexCustomPrompts.mockResolvedValue([
+      {
+        name: "prompts:review",
+        description: "Review a path",
+        argumentHint: "<path>",
+        source: "prompt",
+        template: "Review $1 carefully.",
+      },
+    ]);
+  });
+
+  it("discovers and invokes native skills and custom prompts", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+
+    await expect(client.getCommands()).resolves.toEqual([
+      {
+        name: "prompts:review",
+        description: "Review a path",
+        argumentHint: "<path>",
+        source: "prompt",
+      },
+      {
+        name: "release-notes",
+        description: "Draft release notes",
+        source: "skill",
+      },
+    ]);
+
+    await client.prompt("/release-notes v1.2.3");
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: {
+        input: [
+          {
+            type: "skill",
+            name: "release-notes",
+            path: "/workspace/.codex/skills/release-notes/SKILL.md",
+          },
+          {
+            type: "text",
+            text: "$release-notes v1.2.3",
+            text_elements: [],
+          },
+        ],
+      },
+    });
+
+    await client.prompt('/prompts:review "src/a b.ts"');
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: {
+        input: [
+          {
+            type: "text",
+            text: "Review src/a b.ts carefully.",
+            text_elements: [],
+          },
+        ],
+      },
+    });
+  });
+
+  it("refreshes native skills when Codex reports a change", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getCommands();
+
+    server.emit("skills/changed", {});
+    await vi.waitFor(() => {
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "available_commands_update",
+          commands: expect.arrayContaining([
+            expect.objectContaining({
+              name: "release-notes",
+              source: "skill",
+            }),
+          ]),
+        }),
+      );
+    });
   });
 
   it("starts a native thread and maps streamed activity", async () => {
@@ -563,6 +678,172 @@ describe("CodexRuntimeClient", () => {
     expect(events.at(-1)).toEqual({
       type: "interaction_resolved",
       id: "codex:question-1",
+    });
+  });
+
+  it("supports legacy Codex user-input requests", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getState();
+
+    server.ask("legacy-question", "tool/requestUserInput", {
+      questions: [
+        {
+          id: "choice",
+          header: "Choose",
+          question: "Which path?",
+          isOther: false,
+          isSecret: false,
+          options: [
+            { label: "A", description: "First" },
+            { label: "B", description: "Second" },
+          ],
+        },
+      ],
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: "interaction_request",
+      id: "codex:legacy-question",
+      method: "select",
+      options: ["A", "B"],
+    });
+
+    client.respondToInteraction("codex:legacy-question", { value: "B" });
+    expect(server.responses.at(-1)).toEqual({
+      id: "legacy-question",
+      result: {
+        answers: {
+          choice: { answers: ["B"] },
+        },
+      },
+    });
+  });
+
+  it("handles typed MCP elicitation forms and authorization URLs", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getState();
+
+    server.ask("mcp-form", "mcpServer/elicitation/request", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      serverName: "GitHub",
+      mode: "form",
+      message: "Configure the GitHub tool",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          token: {
+            type: "string",
+            title: "Token",
+            description: "Personal access token",
+          },
+          environment: {
+            type: "string",
+            title: "Environment",
+            enum: ["production", "staging"],
+            enumNames: ["Production", "Staging"],
+          },
+          scopes: {
+            type: "array",
+            title: "Scopes",
+            items: {
+              type: "string",
+              enum: ["repo", "issues"],
+            },
+          },
+          private: {
+            type: "boolean",
+            title: "Private repository",
+            default: false,
+          },
+        },
+        required: ["token", "environment"],
+      },
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: "interaction_request",
+      id: "codex:mcp-form",
+      method: "form",
+      title: "GitHub needs your input",
+      fields: [
+        expect.objectContaining({
+          id: "token",
+          type: "text",
+          required: true,
+        }),
+        expect.objectContaining({
+          id: "environment",
+          type: "select",
+          options: [
+            { value: "production", label: "Production" },
+            { value: "staging", label: "Staging" },
+          ],
+        }),
+        expect.objectContaining({
+          id: "scopes",
+          type: "multiselect",
+        }),
+        expect.objectContaining({
+          id: "private",
+          type: "boolean",
+          defaultValue: false,
+        }),
+      ],
+    });
+    client.respondToInteraction("codex:mcp-form", {
+      values: {
+        token: "secret",
+        environment: "staging",
+        scopes: ["repo"],
+        private: false,
+      },
+    });
+    expect(server.responses.at(-1)).toEqual({
+      id: "mcp-form",
+      result: {
+        action: "accept",
+        content: {
+          token: "secret",
+          environment: "staging",
+          scopes: ["repo"],
+          private: false,
+        },
+        _meta: null,
+      },
+    });
+
+    server.ask("mcp-url", "mcpServer/elicitation/request", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      serverName: "GitHub",
+      mode: "url",
+      message: "Authorize GitHub",
+      url: "https://github.com/login/oauth/authorize",
+      elicitationId: "oauth-1",
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: "interaction_request",
+      id: "codex:mcp-url",
+      method: "external",
+      url: "https://github.com/login/oauth/authorize",
+    });
+    client.respondToInteraction("codex:mcp-url", { confirmed: true });
+    expect(server.responses.at(-1)).toEqual({
+      id: "mcp-url",
+      result: {
+        action: "accept",
+        content: null,
+        _meta: null,
+      },
     });
   });
 

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -17,6 +17,8 @@ class FakeCodexServer {
   readonly requests: Array<{ method: string; params: unknown }> = [];
   readonly responses: Array<{ id: string | number; result: unknown }> = [];
   resumeError: Error | null = null;
+  rateLimitsError: Error | null = null;
+  usageError: Error | null = null;
   private notification: Listener<{ method: string; params?: unknown }> =
     () => {};
   private serverRequest: Listener<{
@@ -73,6 +75,45 @@ class FakeCodexServer {
             ],
           },
         ],
+      };
+    }
+    if (method === "account/rateLimits/read") {
+      if (this.rateLimitsError) throw this.rateLimitsError;
+      return {
+        rateLimits: {
+          limitId: "codex",
+          limitName: "Codex",
+          planType: "plus",
+          primary: {
+            usedPercent: 25,
+            windowDurationMins: 300,
+            resetsAt: 1_786_300_000,
+          },
+          secondary: {
+            usedPercent: 40,
+            windowDurationMins: 10_080,
+            resetsAt: 1_786_900_000,
+          },
+          credits: {
+            hasCredits: true,
+            unlimited: false,
+            balance: "12.50",
+          },
+        },
+        rateLimitsByLimitId: null,
+        rateLimitResetCredits: null,
+      };
+    }
+    if (method === "account/usage/read") {
+      if (this.usageError) throw this.usageError;
+      return {
+        summary: {
+          lifetimeTokens: 1_234_567,
+          currentStreakDays: 4,
+          longestStreakDays: 12,
+          peakDailyTokens: 345_678,
+        },
+        dailyUsageBuckets: null,
       };
     }
     if (method === "thread/start") {
@@ -890,6 +931,73 @@ describe("CodexRuntimeClient", () => {
         contextWindow: 100_000,
         percent: 20,
       },
+    });
+  });
+
+  it("reads account usage without starting a turn", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+
+    await expect(client.getUsage()).resolves.toEqual({
+      planType: "plus",
+      windows: [
+        {
+          id: "codex:primary",
+          label: "Codex",
+          usedPercent: 25,
+          resetsAt: 1_786_300_000,
+          windowDurationMins: 300,
+        },
+        {
+          id: "codex:secondary",
+          label: "Codex",
+          usedPercent: 40,
+          resetsAt: 1_786_900_000,
+          windowDurationMins: 10_080,
+        },
+      ],
+      credits: { balance: "12.50", unlimited: false },
+      activity: {
+        lifetimeTokens: 1_234_567,
+        currentStreakDays: 4,
+        longestStreakDays: 12,
+        peakDailyTokens: 345_678,
+      },
+      unavailableReason: null,
+    });
+    expect(server.requests).toContainEqual({
+      method: "account/rateLimits/read",
+      params: undefined,
+    });
+    expect(server.requests).toContainEqual({
+      method: "account/usage/read",
+      params: undefined,
+    });
+  });
+
+  it("explains when account usage is unavailable", async () => {
+    server.rateLimitsError = new Error(
+      "codex account authentication required to read rate limits",
+    );
+    server.usageError = new Error(
+      "codex account authentication required to read token usage",
+    );
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+
+    await expect(client.getUsage()).resolves.toEqual({
+      planType: null,
+      windows: [],
+      credits: null,
+      activity: null,
+      unavailableReason:
+        "Account usage is unavailable because this Codex connection does not expose authenticated account data.",
     });
   });
 

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -35,6 +35,8 @@ import {
 
 const TURN_COMPLETION_TIMEOUT_MS = 30_000;
 const COMPACTION_TIMEOUT_MS = 5 * 60_000;
+const ACTIVE_WRITER_MESSAGE =
+  "This session is currently open in another Codex client. You can view it here, but close it there before continuing in OvertChat.";
 
 type CompletionWaiter<T> = {
   promise: Promise<T>;
@@ -102,6 +104,13 @@ function toolOutput(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function isActiveWriterError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /thread .+ already has an active writer/i.test(error.message)
+  );
 }
 
 function itemTool(item: CodexItem): {
@@ -320,6 +329,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private selectedThinking: AgentThinkingLevel | null = null;
   private modelResponse: unknown = { data: [] };
   private stats = emptyCodexStats();
+  private readOnly = false;
 
   constructor(
     target: HostTarget,
@@ -348,6 +358,14 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       isStreaming: this.activeTurnId !== null,
       isCompacting: this.isCompacting,
       model: { provider: "codex", id: this.selectedModel },
+      ...(this.readOnly
+        ? {
+            readOnly: {
+              reason: ACTIVE_WRITER_MESSAGE,
+              retryable: true,
+            },
+          }
+        : {}),
       ...(this.selectedThinking
         ? { thinkingLevel: this.selectedThinking }
         : {}),
@@ -380,6 +398,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async prompt(message: string): Promise<unknown> {
     await this.readyPromise;
+    this.assertInteractive();
     const input = this.createKnownUserInput(message);
     this.pendingPromptInput = input;
     try {
@@ -403,6 +422,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async steer(message: string): Promise<unknown> {
     await this.readyPromise;
+    this.assertInteractive();
     if (!this.activeTurnId) throw new Error("Codex has no active turn to steer.");
     const turnId = this.activeTurnId;
     const response = await this.server.request("turn/steer", {
@@ -416,6 +436,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async abort(): Promise<unknown> {
     await this.readyPromise;
+    this.assertInteractive();
     if (!this.activeTurnId) return;
     const turnId = this.activeTurnId;
     const terminal = this.waitForTurnCompletion(
@@ -441,6 +462,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async setModel(_provider: string, modelId: string): Promise<unknown> {
     await this.readyPromise;
+    this.assertInteractive();
     const models = parseCodexModels(this.modelResponse);
     if (!models.some((model) => model.id === modelId)) {
       throw new Error(`Codex model ${modelId} is not available.`);
@@ -452,6 +474,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async setThinkingLevel(level: string): Promise<unknown> {
     await this.readyPromise;
+    this.assertInteractive();
     const levels = await this.getAvailableThinkingLevels();
     if (!levels.includes(level as AgentThinkingLevel)) {
       throw new Error(`Codex reasoning level ${level} is not available.`);
@@ -463,6 +486,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async compact(customInstructions?: string): Promise<unknown> {
     await this.readyPromise;
+    this.assertInteractive();
     if (customInstructions) {
       throw new Error("Codex does not support custom compaction instructions.");
     }
@@ -502,6 +526,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async setSessionName(name: string): Promise<unknown> {
     await this.readyPromise;
+    this.assertInteractive();
     const result = await this.server.request("thread/name/set", {
       threadId: this.thread!.id,
       name,
@@ -519,6 +544,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       cancelled?: boolean;
     },
   ): void {
+    this.assertInteractive();
     const pending = this.pendingInteractions.get(id);
     if (!pending) return;
     if (pending.kind === "approval") {
@@ -563,47 +589,90 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     return this.server.stop();
   }
 
+  async retryInteractive(): Promise<unknown> {
+    await this.readyPromise;
+    if (!this.readOnly) return;
+    const response = await this.server.request<UnknownRecord>("thread/resume", {
+      threadId: this.thread!.id,
+      cwd: this.launch.cwd,
+    });
+    const hydrated = await this.server.request<UnknownRecord>("thread/read", {
+      threadId: this.thread!.id,
+      includeTurns: true,
+    });
+    this.hydrateThread(hydrated);
+    this.applyThreadConfiguration(response);
+    this.readOnly = false;
+    return response;
+  }
+
   private async openThread(): Promise<void> {
     await this.server.ready();
-    const [modelResponse, threadResponse] = await Promise.all([
-      this.server.request("model/list", { limit: 200 }),
-      this.launch.resume
-        ? this.server.request<UnknownRecord>("thread/resume", {
+    const modelPromise = this.server.request("model/list", { limit: 200 });
+    let threadResponse: UnknownRecord;
+    let hydratedThread: UnknownRecord;
+    if (this.launch.resume) {
+      try {
+        threadResponse = await this.server.request<UnknownRecord>(
+          "thread/resume",
+          {
             threadId: this.launch.resume.providerSessionId,
             cwd: this.launch.cwd,
-          })
-        : this.server.request<UnknownRecord>("thread/start", {
-            cwd: this.launch.cwd,
-            ephemeral: false,
-        }),
-    ]);
-    this.modelResponse = modelResponse;
-    const hydratedThread = this.launch.resume
-      ? await this.server.request<UnknownRecord>("thread/read", {
-          threadId: this.launch.resume.providerSessionId,
-          includeTurns: true,
-        })
-      : threadResponse;
-    this.thread = parseCodexThread(hydratedThread.thread);
+          },
+        );
+      } catch (error) {
+        if (!isActiveWriterError(error)) throw error;
+        this.readOnly = true;
+        threadResponse = {};
+      }
+      hydratedThread = await this.server.request<UnknownRecord>("thread/read", {
+        threadId: this.launch.resume.providerSessionId,
+        includeTurns: true,
+      });
+    } else {
+      threadResponse = await this.server.request<UnknownRecord>(
+        "thread/start",
+        {
+          cwd: this.launch.cwd,
+          ephemeral: false,
+        },
+      );
+      hydratedThread = threadResponse;
+    }
+    this.modelResponse = await modelPromise;
+    this.hydrateThread(hydratedThread);
+    this.applyThreadConfiguration(threadResponse);
+  }
+
+  private hydrateThread(value: UnknownRecord): void {
+    this.thread = parseCodexThread(value.thread);
+    this.turns.clear();
+    for (const turn of this.thread.turns) this.turns.set(turn.id, turn);
+  }
+
+  private applyThreadConfiguration(threadResponse: UnknownRecord): void {
     this.selectedModel =
       stringOf(threadResponse, "model") ??
-      parseCodexModels(modelResponse)[0]?.id ??
+      parseCodexModels(this.modelResponse)[0]?.id ??
       "";
     const effort = stringOf(threadResponse, "reasoningEffort");
     if (
       effort &&
-      codexThinkingLevels(modelResponse, this.selectedModel).includes(
+      codexThinkingLevels(this.modelResponse, this.selectedModel).includes(
         effort as AgentThinkingLevel,
       )
     ) {
       this.selectedThinking = effort as AgentThinkingLevel;
     } else {
       this.selectedThinking = codexDefaultThinkingLevel(
-        modelResponse,
+        this.modelResponse,
         this.selectedModel,
       );
     }
-    for (const turn of this.thread.turns) this.turns.set(turn.id, turn);
+  }
+
+  private assertInteractive(): void {
+    if (this.readOnly) throw new Error(ACTIVE_WRITER_MESSAGE);
   }
 
   private messages(): unknown[] {

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type {
+  AgentInteractionValue,
   AgentModel,
   AgentSessionStats,
   AgentSlashCommand,
@@ -32,6 +33,16 @@ import {
   type CodexTurn,
   type UnknownRecord,
 } from "@/lib/agents/codex/protocol";
+import {
+  commandMap,
+  expandCodexCustomPrompt,
+  listCodexCustomPrompts,
+  parseCodexSkills,
+  parseCodexSlashInvocation,
+  publicCommands,
+  skillInput,
+  type CodexDiscoveredCommand,
+} from "@/lib/agents/codex/commands";
 
 const TURN_COMPLETION_TIMEOUT_MS = 30_000;
 const COMPACTION_TIMEOUT_MS = 5 * 60_000;
@@ -64,6 +75,11 @@ type PendingInteraction =
       answers: Record<string, { answers: string[] }>;
       awaitingOther: boolean;
       timeout?: number;
+    }
+  | {
+      kind: "mcpElicitation";
+      rpcId: JsonRpcId;
+      mode: "form" | "url";
     };
 
 type KnownUserInput = {
@@ -103,6 +119,107 @@ function toolOutput(value: unknown): string {
     return JSON.stringify(value, null, 2);
   } catch {
     return String(value);
+  }
+}
+
+function mcpElicitationOptions(
+  schema: UnknownRecord,
+): Array<{ value: string; label: string }> {
+  if (Array.isArray(schema.enum)) {
+    const labels = Array.isArray(schema.enumNames) ? schema.enumNames : [];
+    return schema.enum.flatMap((value, index) =>
+      typeof value === "string"
+        ? [
+            {
+              value,
+              label:
+                typeof labels[index] === "string" ? labels[index] : value,
+            },
+          ]
+        : [],
+    );
+  }
+  const choices = Array.isArray(schema.oneOf)
+    ? schema.oneOf
+    : Array.isArray(schema.anyOf)
+      ? schema.anyOf
+      : [];
+  return choices.flatMap((choice) => {
+    const record = recordOf(choice);
+    const value = stringOf(record, "const");
+    return value
+      ? [{ value, label: stringOf(record, "title") ?? value }]
+      : [];
+  });
+}
+
+function mcpElicitationFields(value: unknown): UnknownRecord[] {
+  const schema = recordOf(value);
+  const properties = recordOf(schema?.properties);
+  if (!properties) return [];
+  const required = new Set(
+    Array.isArray(schema?.required)
+      ? schema.required.filter(
+          (field): field is string => typeof field === "string",
+        )
+      : [],
+  );
+  return Object.entries(properties).flatMap(([id, candidate]) => {
+    const field = recordOf(candidate);
+    const nativeType = stringOf(field, "type");
+    if (!field || !nativeType) return [];
+    const itemSchema = recordOf(field.items);
+    const options =
+      nativeType === "array"
+        ? mcpElicitationOptions(itemSchema ?? {})
+        : mcpElicitationOptions(field);
+    const type =
+      nativeType === "boolean"
+        ? "boolean"
+        : nativeType === "number" || nativeType === "integer"
+          ? "number"
+          : nativeType === "array" && options.length > 0
+            ? "multiselect"
+            : options.length > 0
+              ? "select"
+              : nativeType === "string"
+                ? "text"
+                : null;
+    if (!type) return [];
+    const defaultValue =
+      field.default ??
+      (type === "multiselect" ? [] : type === "boolean" ? false : undefined);
+    return [
+      {
+        id,
+        type,
+        label: stringOf(field, "title") ?? id,
+        ...(stringOf(field, "description")
+          ? { description: stringOf(field, "description") }
+          : {}),
+        required: required.has(id),
+        options,
+        ...(defaultValue !== undefined ? { defaultValue } : {}),
+        ...(typeof field.minimum === "number"
+          ? { minimum: field.minimum }
+          : {}),
+        ...(typeof field.maximum === "number"
+          ? { maximum: field.maximum }
+          : {}),
+      },
+    ];
+  });
+}
+
+function safeMcpUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const url = new URL(value);
+    return ["http:", "https:"].includes(url.protocol)
+      ? url.toString()
+      : null;
+  } catch {
+    return null;
   }
 }
 
@@ -316,6 +433,8 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     Set<CompletionWaiter<CodexTurn>>
   >();
   private readonly knownUserInputs = new Map<string, KnownUserInput[]>();
+  private discoveredCommands = new Map<string, CodexDiscoveredCommand>();
+  private commandRefreshPromise: Promise<void> | null = null;
   private readonly readyPromise: Promise<void>;
   private thread: CodexThread | null = null;
   private activeTurnId: string | null = null;
@@ -333,16 +452,16 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private threadSubscribed = false;
 
   constructor(
-    target: HostTarget,
+    private readonly target: HostTarget,
     private readonly launch: AgentSessionLaunch,
   ) {
-    this.readyPromise = this.initialize(target);
+    this.readyPromise = this.initialize();
     void this.readyPromise.catch(() => {});
   }
 
-  private async initialize(target: HostTarget): Promise<void> {
+  private async initialize(): Promise<void> {
     this.server = await startCodexAppServer(
-      target,
+      this.target,
       this.launch.executable,
       this.launch.cwd,
     );
@@ -351,6 +470,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     );
     this.server.onRequest((request) => this.handleRequest(request));
     await this.openThread();
+    await this.reloadCommands();
   }
 
   onEvent(subscriber: (event: AgentRuntimeEvent) => void): () => void {
@@ -401,8 +521,9 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     return codexThinkingLevels(this.modelResponse, this.selectedModel);
   }
 
-  getCommands(): Promise<AgentSlashCommand[]> {
-    return Promise.resolve([]);
+  async getCommands(): Promise<AgentSlashCommand[]> {
+    await this.readyPromise;
+    return publicCommands([...this.discoveredCommands.values()]);
   }
 
   async prompt(message: string): Promise<unknown> {
@@ -413,7 +534,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     try {
       const response = await this.server.request<UnknownRecord>("turn/start", {
         threadId: this.thread!.id,
-        input: textInput(message),
+        input: this.resolvePromptInput(message),
         model: this.selectedModel || null,
         ...(this.selectedThinking
           ? { effort: this.selectedThinking }
@@ -437,7 +558,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     const response = await this.server.request("turn/steer", {
       threadId: this.thread!.id,
       expectedTurnId: turnId,
-      input: textInput(message),
+      input: this.resolvePromptInput(message),
     });
     this.rememberUserInput(turnId, this.createKnownUserInput(message));
     return response;
@@ -549,6 +670,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     id: string,
     response: {
       value?: string;
+      values?: Record<string, AgentInteractionValue>;
       confirmed?: boolean;
       cancelled?: boolean;
     },
@@ -588,6 +710,25 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
           allowed && response.value === "Allow for session"
             ? "session"
             : "turn",
+      });
+      return;
+    }
+    if (pending.kind === "mcpElicitation") {
+      this.pendingInteractions.delete(id);
+      const accepted =
+        !response.cancelled &&
+        (response.confirmed === true || response.values !== undefined);
+      this.server.respond(pending.rpcId, {
+        action: response.cancelled
+          ? "cancel"
+          : accepted
+            ? "accept"
+            : "decline",
+        content:
+          accepted && pending.mode === "form"
+            ? (response.values ?? {})
+            : null,
+        _meta: null,
       });
       return;
     }
@@ -805,6 +946,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       }
       return;
     }
+    if (method === "skills/changed") {
+      void this.reloadCommands(true);
+      return;
+    }
     if (method === "turn/completed") {
       const turn = this.withKnownUserInputs(parseCodexTurn(data?.turn));
       this.turns.set(turn.id, turn);
@@ -905,7 +1050,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       });
       return;
     }
-    if (request.method === "item/tool/requestUserInput") {
+    if (
+      request.method === "item/tool/requestUserInput" ||
+      request.method === "tool/requestUserInput"
+    ) {
       const params = recordOf(request.params);
       const questions = Array.isArray(params?.questions)
         ? params.questions
@@ -934,6 +1082,71 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       };
       this.pendingInteractions.set(id, pending);
       this.emitQuestion(id, pending);
+      return;
+    }
+    if (request.method === "mcpServer/elicitation/request") {
+      const params = recordOf(request.params);
+      const mode = stringOf(params, "mode");
+      const serverName = stringOf(params, "serverName") ?? "MCP server";
+      const message =
+        stringOf(params, "message") ??
+        `${serverName} needs additional information.`;
+      const id = `codex:${request.id}`;
+      if (mode === "url") {
+        const url = safeMcpUrl(params?.url);
+        if (!url) {
+          this.server.respond(request.id, {
+            action: "decline",
+            content: null,
+            _meta: null,
+          });
+          return;
+        }
+        this.pendingInteractions.set(id, {
+          kind: "mcpElicitation",
+          rpcId: request.id,
+          mode: "url",
+        });
+        this.emit({
+          type: "interaction_request",
+          id,
+          method: "external",
+          title: `Continue with ${serverName}?`,
+          message,
+          url,
+        });
+        return;
+      }
+      if (mode === "form" || mode === "openai/form") {
+        const fields = mcpElicitationFields(params?.requestedSchema);
+        if (fields.length === 0) {
+          this.server.respond(request.id, {
+            action: "decline",
+            content: null,
+            _meta: null,
+          });
+          return;
+        }
+        this.pendingInteractions.set(id, {
+          kind: "mcpElicitation",
+          rpcId: request.id,
+          mode: "form",
+        });
+        this.emit({
+          type: "interaction_request",
+          id,
+          method: "form",
+          title: `${serverName} needs your input`,
+          message,
+          fields,
+        });
+        return;
+      }
+      this.server.respond(request.id, {
+        action: "decline",
+        content: null,
+        _meta: null,
+      });
       return;
     }
     if (request.method === "item/permissions/requestApproval") {
@@ -1045,6 +1258,58 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       id: `overtchat:codex-user:${++this.nextUserInputId}`,
       text,
     };
+  }
+
+  private resolvePromptInput(message: string): UnknownRecord[] {
+    const invocation = parseCodexSlashInvocation(message);
+    const command = invocation
+      ? this.discoveredCommands.get(invocation.name.toLowerCase())
+      : undefined;
+    if (!invocation || !command) return textInput(message);
+    if (command.source === "skill") {
+      return skillInput(command, invocation.arguments);
+    }
+    return textInput(
+      expandCodexCustomPrompt(command.template, invocation.arguments),
+    );
+  }
+
+  private async reloadCommands(publish = false): Promise<void> {
+    if (this.commandRefreshPromise) return this.commandRefreshPromise;
+    const refresh = (async () => {
+      const [skills, prompts] = await Promise.all([
+        this.server
+          .request("skills/list", { cwds: [this.launch.cwd] })
+          .then(parseCodexSkills)
+          .catch(() => []),
+        listCodexCustomPrompts(this.target).catch((error) => {
+          console.warn(
+            "Unable to load Codex custom prompts:",
+            error instanceof Error ? error.message : String(error),
+          );
+          return [];
+        }),
+      ]);
+      this.discoveredCommands = commandMap(
+        [...skills, ...prompts].sort((left, right) =>
+          left.name.localeCompare(right.name),
+        ),
+      );
+      if (publish) {
+        this.emit({
+          type: "available_commands_update",
+          commands: publicCommands([...this.discoveredCommands.values()]),
+        });
+      }
+    })();
+    this.commandRefreshPromise = refresh;
+    try {
+      await refresh;
+    } finally {
+      if (this.commandRefreshPromise === refresh) {
+        this.commandRefreshPromise = null;
+      }
+    }
   }
 
   private rememberUserInput(turnId: string, input: KnownUserInput): void {

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -1,0 +1,1173 @@
+import "server-only";
+import type {
+  AgentModel,
+  AgentSessionStats,
+  AgentSlashCommand,
+  AgentThinkingLevel,
+} from "@/lib/agents/types";
+import type {
+  AgentRuntimeClient,
+  AgentRuntimeEvent,
+  AgentSessionLaunch,
+} from "@/lib/agents/providers/types";
+import type { HostTarget } from "@/lib/agents/runtime/process";
+import {
+  type CodexAppServer,
+  type CodexAppServerRequest,
+  type JsonRpcId,
+  startCodexAppServer,
+} from "@/lib/agents/codex/app-server";
+import {
+  codexDefaultThinkingLevel,
+  codexThinkingLevels,
+  emptyCodexStats,
+  numberOf,
+  parseCodexModels,
+  parseCodexThread,
+  parseCodexTurn,
+  recordOf,
+  stringOf,
+  type CodexItem,
+  type CodexThread,
+  type CodexTurn,
+  type UnknownRecord,
+} from "@/lib/agents/codex/protocol";
+
+const TURN_COMPLETION_TIMEOUT_MS = 30_000;
+const COMPACTION_TIMEOUT_MS = 5 * 60_000;
+
+type CompletionWaiter<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+  cancel: () => void;
+};
+
+type PendingInteraction =
+  | {
+      kind: "approval";
+      rpcId: JsonRpcId;
+      method: string;
+    }
+  | {
+      kind: "permissions";
+      rpcId: JsonRpcId;
+      requested: UnknownRecord;
+    }
+  | {
+      kind: "questions";
+      rpcId: JsonRpcId;
+      questions: UnknownRecord[];
+      index: number;
+      answers: Record<string, { answers: string[] }>;
+      awaitingOther: boolean;
+      timeout?: number;
+    };
+
+type KnownUserInput = {
+  id: string;
+  text: string;
+};
+
+function textInput(text: string) {
+  return [{ type: "text", text, text_elements: [] }];
+}
+
+function isSyntheticUserItem(item: CodexItem): boolean {
+  return (
+    item.type === "userMessage" &&
+    item.id.startsWith("overtchat:codex-user:")
+  );
+}
+
+function itemText(item: CodexItem): string {
+  const content = item.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .flatMap((part) => {
+      const record = recordOf(part);
+      return record?.type === "text" && typeof record.text === "string"
+        ? [record.text]
+        : [];
+    })
+    .join("\n");
+}
+
+function toolOutput(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function itemTool(item: CodexItem): {
+  name: string;
+  args: unknown;
+  output: string;
+  partial: boolean;
+  isError: boolean;
+} | null {
+  switch (item.type) {
+    case "commandExecution":
+      return {
+        name: "bash",
+        args: {
+          command: stringOf(item, "command") ?? "",
+          cwd: stringOf(item, "cwd") ?? "",
+        },
+        output: stringOf(item, "aggregatedOutput") ?? "",
+        partial: stringOf(item, "status") === "inProgress",
+        isError: ["failed", "declined"].includes(
+          stringOf(item, "status") ?? "",
+        ),
+      };
+    case "fileChange": {
+      const changes = Array.isArray(item.changes)
+        ? item.changes.map(recordOf).filter(Boolean)
+        : [];
+      return {
+        name: "apply_patch",
+        args: {
+          path: stringOf(changes[0] ?? null, "path") ?? "",
+          patch: changes
+            .map((change) => stringOf(change, "diff") ?? "")
+            .filter(Boolean)
+            .join("\n"),
+        },
+        output: "",
+        partial: stringOf(item, "status") === "inProgress",
+        isError: ["failed", "declined"].includes(
+          stringOf(item, "status") ?? "",
+        ),
+      };
+    }
+    case "mcpToolCall":
+      return {
+        name: `${stringOf(item, "server") ?? "mcp"}/${stringOf(item, "tool") ?? "tool"}`,
+        args: item.arguments,
+        output: toolOutput(item.result ?? item.error),
+        partial: stringOf(item, "status") === "inProgress",
+        isError: stringOf(item, "status") === "failed",
+      };
+    case "dynamicToolCall":
+      return {
+        name: stringOf(item, "tool") ?? "tool",
+        args: item.arguments,
+        output: toolOutput(item.contentItems),
+        partial: stringOf(item, "status") === "inProgress",
+        isError:
+          stringOf(item, "status") === "failed" || item.success === false,
+      };
+    case "webSearch":
+      return {
+        name: "web_search",
+        args: { query: stringOf(item, "query") ?? "" },
+        output: toolOutput(item.results),
+        partial: item.results === null,
+        isError: false,
+      };
+    case "imageView":
+      return {
+        name: "read",
+        args: { path: stringOf(item, "path") ?? "" },
+        output: "",
+        partial: false,
+        isError: false,
+      };
+    default:
+      return null;
+  }
+}
+
+function canonicalTurnMessages(turn: CodexTurn): unknown[] {
+  const startedAt = (turn.startedAt ?? Date.now() / 1_000) * 1_000;
+  const messages: unknown[] = [];
+  const assistantContent: UnknownRecord[] = [];
+  const results: unknown[] = [];
+
+  for (const item of turn.items) {
+    if (item.type === "userMessage") {
+      const text = itemText(item);
+      if (text) {
+        messages.push({
+          id: item.id,
+          role: "user",
+          content: text,
+          timestamp: startedAt,
+        });
+      }
+      continue;
+    }
+    if (item.type === "agentMessage") {
+      const text = stringOf(item, "text") ?? "";
+      if (text) assistantContent.push({ type: "text", text });
+      continue;
+    }
+    if (item.type === "reasoning" || item.type === "plan") {
+      const summary = Array.isArray(item.summary)
+        ? item.summary.filter((part): part is string => typeof part === "string")
+        : [];
+      const content = Array.isArray(item.content)
+        ? item.content.filter((part): part is string => typeof part === "string")
+        : [];
+      const thinking =
+        item.type === "plan"
+          ? stringOf(item, "text") ?? ""
+          : [...summary, ...content].join("\n\n");
+      if (thinking) assistantContent.push({ type: "thinking", thinking });
+      continue;
+    }
+    if (item.type === "contextCompaction") {
+      messages.push({
+        id: item.id,
+        role: "custom",
+        display: true,
+        content: "Conversation context compacted.",
+        timestamp: startedAt + messages.length + 1,
+      });
+      continue;
+    }
+    const tool = itemTool(item);
+    if (!tool) continue;
+    assistantContent.push({
+      type: "toolCall",
+      id: item.id,
+      name: tool.name,
+      arguments: tool.args,
+    });
+    results.push({
+      id: `${item.id}:result`,
+      role: "toolResult",
+      toolCallId: item.id,
+      toolName: tool.name,
+      content: [{ type: "text", text: tool.output }],
+      overtchatPartial: tool.partial,
+      isError: tool.isError,
+      timestamp: startedAt + results.length + 2,
+    });
+  }
+
+  if (assistantContent.length > 0) {
+    messages.push({
+      id: `${turn.id}:assistant`,
+      role: "assistant",
+      content: assistantContent,
+      timestamp: startedAt + 1,
+      ...(turn.status === "failed" && recordOf(turn.error)
+        ? { errorMessage: stringOf(recordOf(turn.error), "message") ?? undefined }
+        : {}),
+    });
+  }
+  messages.push(...results);
+  return messages;
+}
+
+function statsFromMessages(
+  messages: unknown[],
+  base: AgentSessionStats,
+): AgentSessionStats {
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolCalls = 0;
+  let toolResults = 0;
+  for (const message of messages) {
+    const record = recordOf(message);
+    if (record?.role === "user") userMessages += 1;
+    if (record?.role === "assistant") {
+      assistantMessages += 1;
+      if (Array.isArray(record.content)) {
+        toolCalls += record.content.filter(
+          (part) => recordOf(part)?.type === "toolCall",
+        ).length;
+      }
+    }
+    if (record?.role === "toolResult") toolResults += 1;
+  }
+  return {
+    ...base,
+    userMessages,
+    assistantMessages,
+    toolCalls,
+    toolResults,
+    totalMessages: messages.length,
+  };
+}
+
+export class CodexRuntimeClient implements AgentRuntimeClient {
+  private readonly server: CodexAppServer;
+  private readonly subscribers = new Set<(event: AgentRuntimeEvent) => void>();
+  private readonly turns = new Map<string, CodexTurn>();
+  private readonly pendingInteractions = new Map<string, PendingInteraction>();
+  private readonly turnCompletionWaiters = new Map<
+    string,
+    Set<CompletionWaiter<CodexTurn>>
+  >();
+  private readonly knownUserInputs = new Map<string, KnownUserInput[]>();
+  private readonly readyPromise: Promise<void>;
+  private thread: CodexThread | null = null;
+  private activeTurnId: string | null = null;
+  private pendingPromptInput: KnownUserInput | null = null;
+  private nextUserInputId = 0;
+  private compactionWaiter:
+    | (CompletionWaiter<CodexTurn> & { turnId: string | null })
+    | null = null;
+  private isCompacting = false;
+  private selectedModel = "";
+  private selectedThinking: AgentThinkingLevel | null = null;
+  private modelResponse: unknown = { data: [] };
+  private stats = emptyCodexStats();
+
+  constructor(
+    target: HostTarget,
+    private readonly launch: AgentSessionLaunch,
+  ) {
+    this.server = startCodexAppServer(target, launch.executable, launch.cwd);
+    this.server.onNotification((notification) =>
+      this.handleNotification(notification.method, notification.params),
+    );
+    this.server.onRequest((request) => this.handleRequest(request));
+    this.readyPromise = this.openThread();
+    void this.readyPromise.catch(() => {});
+  }
+
+  onEvent(subscriber: (event: AgentRuntimeEvent) => void): () => void {
+    this.subscribers.add(subscriber);
+    return () => this.subscribers.delete(subscriber);
+  }
+
+  async getState(): Promise<Record<string, unknown>> {
+    await this.readyPromise;
+    return {
+      sessionId: this.thread!.id,
+      sessionFile: this.thread!.path ?? this.thread!.id,
+      sessionName: this.thread!.name,
+      isStreaming: this.activeTurnId !== null,
+      isCompacting: this.isCompacting,
+      model: { provider: "codex", id: this.selectedModel },
+      ...(this.selectedThinking
+        ? { thinkingLevel: this.selectedThinking }
+        : {}),
+    };
+  }
+
+  async getMessages(): Promise<{ messages: unknown[] }> {
+    await this.readyPromise;
+    return { messages: this.messages() };
+  }
+
+  async getAvailableModels(): Promise<AgentModel[]> {
+    await this.readyPromise;
+    return parseCodexModels(this.modelResponse);
+  }
+
+  async getSessionStats(): Promise<AgentSessionStats> {
+    await this.readyPromise;
+    return statsFromMessages(this.messages(), this.stats);
+  }
+
+  async getAvailableThinkingLevels(): Promise<AgentThinkingLevel[]> {
+    await this.readyPromise;
+    return codexThinkingLevels(this.modelResponse, this.selectedModel);
+  }
+
+  getCommands(): Promise<AgentSlashCommand[]> {
+    return Promise.resolve([]);
+  }
+
+  async prompt(message: string): Promise<unknown> {
+    await this.readyPromise;
+    const input = this.createKnownUserInput(message);
+    this.pendingPromptInput = input;
+    try {
+      const response = await this.server.request<UnknownRecord>("turn/start", {
+        threadId: this.thread!.id,
+        input: textInput(message),
+        model: this.selectedModel || null,
+        ...(this.selectedThinking
+          ? { effort: this.selectedThinking }
+          : {}),
+      });
+      const turn = parseCodexTurn(response.turn);
+      this.rememberUserInput(turn.id, input);
+      this.turns.set(turn.id, this.withKnownUserInputs(turn));
+      this.activeTurnId = turn.id;
+      return response;
+    } finally {
+      if (this.pendingPromptInput === input) this.pendingPromptInput = null;
+    }
+  }
+
+  async steer(message: string): Promise<unknown> {
+    await this.readyPromise;
+    if (!this.activeTurnId) throw new Error("Codex has no active turn to steer.");
+    const turnId = this.activeTurnId;
+    const response = await this.server.request("turn/steer", {
+      threadId: this.thread!.id,
+      expectedTurnId: turnId,
+      input: textInput(message),
+    });
+    this.rememberUserInput(turnId, this.createKnownUserInput(message));
+    return response;
+  }
+
+  async abort(): Promise<unknown> {
+    await this.readyPromise;
+    if (!this.activeTurnId) return;
+    const turnId = this.activeTurnId;
+    const terminal = this.waitForTurnCompletion(
+      turnId,
+      TURN_COMPLETION_TIMEOUT_MS,
+    );
+    try {
+      const response = await this.server.request("turn/interrupt", {
+        threadId: this.thread!.id,
+        turnId,
+      });
+      await terminal.promise;
+      return response;
+    } catch (error) {
+      if (this.activeTurnId !== turnId) {
+        await terminal.promise;
+        return;
+      }
+      terminal.cancel();
+      throw error;
+    }
+  }
+
+  async setModel(_provider: string, modelId: string): Promise<unknown> {
+    await this.readyPromise;
+    const models = parseCodexModels(this.modelResponse);
+    if (!models.some((model) => model.id === modelId)) {
+      throw new Error(`Codex model ${modelId} is not available.`);
+    }
+    this.selectedModel = modelId;
+    this.emitConfig();
+    return { model: modelId };
+  }
+
+  async setThinkingLevel(level: string): Promise<unknown> {
+    await this.readyPromise;
+    const levels = await this.getAvailableThinkingLevels();
+    if (!levels.includes(level as AgentThinkingLevel)) {
+      throw new Error(`Codex reasoning level ${level} is not available.`);
+    }
+    this.selectedThinking = level as AgentThinkingLevel;
+    this.emitConfig();
+    return { thinkingLevel: level };
+  }
+
+  async compact(customInstructions?: string): Promise<unknown> {
+    await this.readyPromise;
+    if (customInstructions) {
+      throw new Error("Codex does not support custom compaction instructions.");
+    }
+    if (this.isCompacting) {
+      throw new Error("Codex is already compacting this thread.");
+    }
+    const completion = this.createCompletionWaiter<CodexTurn>(
+      COMPACTION_TIMEOUT_MS,
+      "Timed out waiting for Codex compaction to finish.",
+    );
+    this.compactionWaiter = { ...completion, turnId: null };
+    this.isCompacting = true;
+    this.emit({ type: "compaction_start" });
+    try {
+      const response = await this.server.request("thread/compact/start", {
+        threadId: this.thread!.id,
+      });
+      await completion.promise;
+      return response;
+    } catch (error) {
+      completion.cancel();
+      throw error;
+    } finally {
+      if (this.compactionWaiter?.promise === completion.promise) {
+        this.compactionWaiter = null;
+      }
+      this.isCompacting = false;
+      this.emit({ type: "compaction_end" });
+    }
+  }
+
+  setAutoCompaction(): Promise<unknown> {
+    return Promise.reject(
+      new Error("Codex manages context compaction automatically."),
+    );
+  }
+
+  async setSessionName(name: string): Promise<unknown> {
+    await this.readyPromise;
+    const result = await this.server.request("thread/name/set", {
+      threadId: this.thread!.id,
+      name,
+    });
+    this.thread = { ...this.thread!, name };
+    this.emit({ type: "session_info_update", title: name });
+    return result;
+  }
+
+  respondToInteraction(
+    id: string,
+    response: {
+      value?: string;
+      confirmed?: boolean;
+      cancelled?: boolean;
+    },
+  ): void {
+    const pending = this.pendingInteractions.get(id);
+    if (!pending) return;
+    if (pending.kind === "approval") {
+      this.pendingInteractions.delete(id);
+      const decision = response.cancelled
+        ? "cancel"
+        : response.value === "Allow for session"
+          ? "acceptForSession"
+          : response.value === "Allow once" || response.confirmed === true
+            ? "accept"
+            : "decline";
+      this.server.respond(pending.rpcId, { decision });
+      return;
+    }
+    if (pending.kind === "permissions") {
+      this.pendingInteractions.delete(id);
+      const allowed =
+        !response.cancelled &&
+        (response.value === "Allow once" ||
+          response.value === "Allow for session" ||
+          response.confirmed === true);
+      const network = recordOf(pending.requested.network);
+      const fileSystem = recordOf(pending.requested.fileSystem);
+      this.server.respond(pending.rpcId, {
+        permissions: allowed
+          ? {
+              ...(network ? { network } : {}),
+              ...(fileSystem ? { fileSystem } : {}),
+            }
+          : {},
+        scope:
+          allowed && response.value === "Allow for session"
+            ? "session"
+            : "turn",
+      });
+      return;
+    }
+    this.handleQuestionResponse(id, pending, response);
+  }
+
+  stop(): Promise<void> {
+    return this.server.stop();
+  }
+
+  private async openThread(): Promise<void> {
+    await this.server.ready();
+    const [modelResponse, threadResponse] = await Promise.all([
+      this.server.request("model/list", { limit: 200 }),
+      this.launch.resume
+        ? this.server.request<UnknownRecord>("thread/resume", {
+            threadId: this.launch.resume.providerSessionId,
+            cwd: this.launch.cwd,
+          })
+        : this.server.request<UnknownRecord>("thread/start", {
+            cwd: this.launch.cwd,
+            ephemeral: false,
+        }),
+    ]);
+    this.modelResponse = modelResponse;
+    const hydratedThread = this.launch.resume
+      ? await this.server.request<UnknownRecord>("thread/read", {
+          threadId: this.launch.resume.providerSessionId,
+          includeTurns: true,
+        })
+      : threadResponse;
+    this.thread = parseCodexThread(hydratedThread.thread);
+    this.selectedModel =
+      stringOf(threadResponse, "model") ??
+      parseCodexModels(modelResponse)[0]?.id ??
+      "";
+    const effort = stringOf(threadResponse, "reasoningEffort");
+    if (
+      effort &&
+      codexThinkingLevels(modelResponse, this.selectedModel).includes(
+        effort as AgentThinkingLevel,
+      )
+    ) {
+      this.selectedThinking = effort as AgentThinkingLevel;
+    } else {
+      this.selectedThinking = codexDefaultThinkingLevel(
+        modelResponse,
+        this.selectedModel,
+      );
+    }
+    for (const turn of this.thread.turns) this.turns.set(turn.id, turn);
+  }
+
+  private messages(): unknown[] {
+    return [...this.turns.values()]
+      .sort(
+        (left, right) =>
+          (left.startedAt ?? 0) - (right.startedAt ?? 0),
+      )
+      .flatMap(canonicalTurnMessages);
+  }
+
+  private handleNotification(method: string, params: unknown): void {
+    const data = recordOf(params);
+    if (method === "overtchat/processExit") {
+      const error = new Error(stringOf(data, "error") ?? "Codex exited.");
+      this.rejectCompletionWaiters(error);
+      this.emit({
+        type: "process_exit",
+        code: numberOf(data, "code"),
+        signal: stringOf(data, "signal"),
+        error: error.message,
+      });
+      return;
+    }
+    if (method === "overtchat/protocolError") {
+      this.emit({
+        type: "rpc_error",
+        command: "protocol",
+        error: stringOf(data, "error") ?? "Codex protocol error.",
+      });
+      return;
+    }
+    if (method === "turn/started") {
+      const turn = parseCodexTurn(data?.turn);
+      this.turns.set(turn.id, this.withKnownUserInputs(turn));
+      if (this.pendingPromptInput) {
+        this.rememberUserInput(turn.id, this.pendingPromptInput);
+      }
+      this.activeTurnId = turn.id;
+      this.emit({ type: "turn_start", turnId: turn.id });
+      return;
+    }
+    if (method === "item/started" || method === "item/completed") {
+      const turnId = stringOf(data, "turnId");
+      const item = recordOf(data?.item);
+      if (turnId && item) {
+        this.upsertItem(turnId, item);
+        if (
+          method === "item/started" &&
+          stringOf(item, "type") === "contextCompaction" &&
+          this.compactionWaiter
+        ) {
+          this.compactionWaiter.turnId = turnId;
+        }
+      }
+      return;
+    }
+    if (method === "item/agentMessage/delta") {
+      this.appendItemText(data, "text", stringOf(data, "delta") ?? "");
+      return;
+    }
+    if (
+      method === "item/reasoning/summaryTextDelta" ||
+      method === "item/reasoning/textDelta"
+    ) {
+      const key =
+        method === "item/reasoning/textDelta" ? "content" : "summary";
+      this.appendItemArrayText(
+        data,
+        key,
+        method === "item/reasoning/textDelta"
+          ? numberOf(data, "contentIndex") ?? 0
+          : numberOf(data, "summaryIndex") ?? 0,
+        stringOf(data, "delta") ?? "",
+      );
+      return;
+    }
+    if (method === "item/commandExecution/outputDelta") {
+      this.appendItemText(
+        data,
+        "aggregatedOutput",
+        stringOf(data, "delta") ?? "",
+      );
+      return;
+    }
+    if (method === "item/fileChange/patchUpdated") {
+      const turnId = stringOf(data, "turnId");
+      const itemId = stringOf(data, "itemId");
+      const turn = turnId ? this.turns.get(turnId) : undefined;
+      const item = turn?.items.find((candidate) => candidate.id === itemId);
+      if (turn && item && Array.isArray(data?.changes)) {
+        item.changes = data.changes;
+        this.emitTurn(turn);
+      }
+      return;
+    }
+    if (method === "thread/tokenUsage/updated") {
+      this.updateTokenUsage(data);
+      return;
+    }
+    if (method === "thread/name/updated") {
+      const name = stringOf(data, "threadName");
+      if (name && this.thread) {
+        this.thread = { ...this.thread, name };
+        this.emit({ type: "session_info_update", title: name });
+      }
+      return;
+    }
+    if (method === "turn/completed") {
+      const turn = this.withKnownUserInputs(parseCodexTurn(data?.turn));
+      this.turns.set(turn.id, turn);
+      this.emitTurn(turn);
+      if (this.activeTurnId === turn.id) this.activeTurnId = null;
+      this.resolveTurnCompletion(turn);
+      const isCompactionTurn =
+        this.compactionWaiter?.turnId === turn.id ||
+        (this.compactionWaiter?.turnId === null &&
+          turn.items.some((item) => item.type === "contextCompaction"));
+      if (isCompactionTurn && this.compactionWaiter) {
+        if (turn.status === "completed") {
+          this.compactionWaiter.resolve(turn);
+        } else {
+          this.compactionWaiter.reject(
+            new Error(
+              turn.status === "failed"
+                ? stringOf(recordOf(turn.error), "message") ??
+                    "Codex compaction failed."
+                : "Codex compaction was interrupted.",
+            ),
+          );
+        }
+      }
+      if (turn.status === "failed") {
+        const message =
+          stringOf(recordOf(turn.error), "message") ?? "Codex turn failed.";
+        this.emit({ type: "rpc_error", command: "prompt", error: message });
+      }
+      this.emit({
+        type: "turn_end",
+        turnId: turn.id,
+        status: turn.status,
+      });
+      return;
+    }
+    if (method === "serverRequest/resolved") {
+      const requestId = data?.requestId;
+      if (typeof requestId === "string" || typeof requestId === "number") {
+        const id = `codex:${requestId}`;
+        this.pendingInteractions.delete(id);
+        this.emit({ type: "interaction_resolved", id });
+      }
+      return;
+    }
+    if (method === "error") {
+      const error = recordOf(data?.error);
+      this.emit({
+        type: "rpc_error",
+        command: "prompt",
+        error: stringOf(error, "message") ?? "Codex reported an error.",
+      });
+    }
+  }
+
+  private handleRequest(request: CodexAppServerRequest): void {
+    if (
+      request.method === "item/commandExecution/requestApproval" ||
+      request.method === "item/fileChange/requestApproval"
+    ) {
+      const params = recordOf(request.params);
+      const command = stringOf(params, "command");
+      const reason = stringOf(params, "reason");
+      const network = recordOf(params?.networkApprovalContext);
+      const id = `codex:${request.id}`;
+      this.pendingInteractions.set(id, {
+        kind: "approval",
+        rpcId: request.id,
+        method: request.method,
+      });
+      this.emit({
+        type: "interaction_request",
+        id,
+        method: "select",
+        title:
+          network
+            ? "Approve network access?"
+            : request.method === "item/fileChange/requestApproval"
+            ? "Approve file changes?"
+            : "Approve command?",
+        message:
+          [
+            reason,
+            network
+              ? [
+                  stringOf(network, "host"),
+                  stringOf(network, "protocol"),
+                  numberOf(network, "port"),
+                ]
+                  .filter((value) => value !== null && value !== undefined)
+                  .join(" · ")
+              : null,
+            !network && command ? `$ ${command}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n\n") || "Codex needs approval to continue.",
+        options: ["Allow once", "Allow for session", "Deny"],
+      });
+      return;
+    }
+    if (request.method === "item/tool/requestUserInput") {
+      const params = recordOf(request.params);
+      const questions = Array.isArray(params?.questions)
+        ? params.questions
+            .map(recordOf)
+            .filter((question): question is UnknownRecord => question !== null)
+        : [];
+      if (questions.length === 0) {
+        this.server.respond(request.id, { answers: {} });
+        return;
+      }
+      const id = `codex:${request.id}`;
+      const pending: Extract<
+        PendingInteraction,
+        { kind: "questions" }
+      > = {
+        kind: "questions",
+        rpcId: request.id,
+        questions,
+        index: 0,
+        answers: {},
+        awaitingOther: false,
+        ...(typeof params?.autoResolutionMs === "number" &&
+        params.autoResolutionMs > 0
+          ? { timeout: params.autoResolutionMs }
+          : {}),
+      };
+      this.pendingInteractions.set(id, pending);
+      this.emitQuestion(id, pending);
+      return;
+    }
+    if (request.method === "item/permissions/requestApproval") {
+      const params = recordOf(request.params);
+      const requested = recordOf(params?.permissions) ?? {};
+      const id = `codex:${request.id}`;
+      this.pendingInteractions.set(id, {
+        kind: "permissions",
+        rpcId: request.id,
+        requested,
+      });
+      const details = [
+        params?.reason,
+        requested.network
+          ? `Network: ${toolOutput(requested.network)}`
+          : null,
+        requested.fileSystem
+          ? `Files: ${toolOutput(requested.fileSystem)}`
+          : null,
+      ]
+        .filter((value): value is string => typeof value === "string" && !!value)
+        .join("\n\n");
+      this.emit({
+        type: "interaction_request",
+        id,
+        method: "select",
+        title: "Approve additional permissions?",
+        message: details || "Codex needs additional permissions to continue.",
+        options: ["Allow once", "Allow for session", "Deny"],
+      });
+      return;
+    }
+    this.server.respondError(
+      request.id,
+      -32601,
+      `OvertChat does not support ${request.method}.`,
+    );
+  }
+
+  private handleQuestionResponse(
+    id: string,
+    pending: Extract<PendingInteraction, { kind: "questions" }>,
+    response: {
+      value?: string;
+      cancelled?: boolean;
+    },
+  ): void {
+    if (response.cancelled) {
+      this.pendingInteractions.delete(id);
+      this.server.respond(pending.rpcId, { answers: pending.answers });
+      return;
+    }
+    const question = pending.questions[pending.index];
+    const questionId = stringOf(question, "id");
+    if (!questionId) return;
+    if (response.value === "Other…" && !pending.awaitingOther) {
+      pending.awaitingOther = true;
+      this.emitQuestion(id, pending);
+      return;
+    }
+    pending.answers[questionId] = {
+      answers: response.value === undefined ? [] : [response.value],
+    };
+    pending.index += 1;
+    pending.awaitingOther = false;
+    if (pending.index < pending.questions.length) {
+      this.emitQuestion(id, pending);
+      return;
+    }
+    this.pendingInteractions.delete(id);
+    this.server.respond(pending.rpcId, { answers: pending.answers });
+  }
+
+  private emitQuestion(
+    id: string,
+    pending: Extract<PendingInteraction, { kind: "questions" }>,
+  ): void {
+    const question = pending.questions[pending.index];
+    const options = Array.isArray(question?.options)
+      ? question.options
+          .map(recordOf)
+          .flatMap((option) => {
+            const label = stringOf(option, "label");
+            return label ? [label] : [];
+          })
+      : [];
+    const other = question?.isOther === true;
+    this.emit({
+      type: "interaction_request",
+      id,
+      method:
+        pending.awaitingOther || (options.length === 0 && !other)
+          ? "input"
+          : "select",
+      title: stringOf(question, "header") ?? "Codex needs your input",
+      message: stringOf(question, "question") ?? "",
+      ...(question?.isSecret === true ? { secret: true } : {}),
+      ...(pending.timeout ? { timeout: pending.timeout } : {}),
+      ...(pending.awaitingOther
+        ? { placeholder: "Enter another answer" }
+        : options.length > 0 || other
+          ? { options: [...options, ...(other ? ["Other…"] : [])] }
+          : {}),
+    });
+  }
+
+  private createKnownUserInput(text: string): KnownUserInput {
+    return {
+      id: `overtchat:codex-user:${++this.nextUserInputId}`,
+      text,
+    };
+  }
+
+  private rememberUserInput(turnId: string, input: KnownUserInput): void {
+    const inputs = this.knownUserInputs.get(turnId) ?? [];
+    if (!inputs.some((candidate) => candidate.id === input.id)) {
+      inputs.push(input);
+      this.knownUserInputs.set(turnId, inputs);
+    }
+    const turn = this.turns.get(turnId);
+    if (!turn) return;
+    const next = this.withKnownUserInputs(turn);
+    this.turns.set(turnId, next);
+    this.emitTurn(next);
+  }
+
+  private withKnownUserInputs(turn: CodexTurn): CodexTurn {
+    const known = this.knownUserInputs.get(turn.id);
+    if (!known?.length) return turn;
+    const items = turn.items.filter((item) => !isSyntheticUserItem(item));
+    const nativeUserTexts = items
+      .filter((item) => item.type === "userMessage")
+      .map(itemText);
+    const synthetic: CodexItem[] = [];
+    for (const input of known) {
+      const nativeIndex = nativeUserTexts.indexOf(input.text);
+      if (nativeIndex >= 0) {
+        nativeUserTexts.splice(nativeIndex, 1);
+        continue;
+      }
+      synthetic.push({
+        id: input.id,
+        type: "userMessage",
+        content: textInput(input.text),
+      });
+    }
+    return synthetic.length === 0 && items.length === turn.items.length
+      ? turn
+      : { ...turn, items: [...synthetic, ...items] };
+  }
+
+  private upsertItem(turnId: string, value: UnknownRecord): void {
+    const id = stringOf(value, "id");
+    const type = stringOf(value, "type");
+    if (!id || !type) return;
+    const turn =
+      this.turns.get(turnId) ??
+      parseCodexTurn({
+        id: turnId,
+        status: "inProgress",
+        items: [],
+        startedAt: Date.now() / 1_000,
+      });
+    const item = { ...value, id, type };
+    const index = turn.items.findIndex((candidate) => candidate.id === id);
+    if (index >= 0) turn.items[index] = item;
+    else turn.items.push(item);
+    this.turns.set(turnId, turn);
+    this.emitTurn(turn);
+  }
+
+  private appendItemText(
+    data: UnknownRecord | null,
+    key: string,
+    delta: string,
+  ): void {
+    const turnId = stringOf(data, "turnId");
+    const itemId = stringOf(data, "itemId");
+    const turn = turnId ? this.turns.get(turnId) : undefined;
+    const item = turn?.items.find((candidate) => candidate.id === itemId);
+    if (!turn || !item || !delta) return;
+    item[key] = `${typeof item[key] === "string" ? item[key] : ""}${delta}`;
+    this.emitTurn(turn);
+  }
+
+  private appendItemArrayText(
+    data: UnknownRecord | null,
+    key: string,
+    index: number,
+    delta: string,
+  ): void {
+    const turnId = stringOf(data, "turnId");
+    const itemId = stringOf(data, "itemId");
+    const turn = turnId ? this.turns.get(turnId) : undefined;
+    const item = turn?.items.find((candidate) => candidate.id === itemId);
+    if (!turn || !item || !delta) return;
+    const parts = Array.isArray(item[key]) ? [...item[key]] : [];
+    parts[index] = `${typeof parts[index] === "string" ? parts[index] : ""}${delta}`;
+    item[key] = parts;
+    this.emitTurn(turn);
+  }
+
+  private emitTurn(turn: CodexTurn): void {
+    for (const message of canonicalTurnMessages(turn)) {
+      this.emit({ type: "message_update", message });
+    }
+  }
+
+  private updateTokenUsage(data: UnknownRecord | null): void {
+    const tokenUsage = recordOf(data?.tokenUsage);
+    const usage = recordOf(tokenUsage?.total);
+    if (!usage) return;
+    const context = recordOf(tokenUsage?.last);
+    const input = numberOf(usage, "inputTokens") ?? 0;
+    const output = numberOf(usage, "outputTokens") ?? 0;
+    const cacheRead = numberOf(usage, "cachedInputTokens") ?? 0;
+    const cacheWrite = numberOf(usage, "cacheWriteInputTokens") ?? 0;
+    const total = numberOf(usage, "totalTokens") ?? input + output;
+    const contextTokens = numberOf(context, "totalTokens") ?? total;
+    const contextWindow = numberOf(
+      tokenUsage,
+      "modelContextWindow",
+    );
+    this.stats = {
+      ...this.stats,
+      sessionFile: this.thread?.path ?? this.thread?.id ?? null,
+      sessionId: this.thread?.id ?? null,
+      tokens: { input, output, cacheRead, cacheWrite, total },
+      ...(contextWindow
+        ? {
+            contextUsage: {
+              tokens: contextTokens,
+              contextWindow,
+              percent: (contextTokens / contextWindow) * 100,
+            },
+          }
+        : {}),
+    };
+  }
+
+  private emitConfig(): void {
+    this.emit({
+      type: "config_update",
+      model: { provider: "codex", id: this.selectedModel },
+      ...(this.selectedThinking
+        ? { thinkingLevel: this.selectedThinking }
+        : {}),
+    });
+  }
+
+  private emit(event: AgentRuntimeEvent): void {
+    for (const subscriber of this.subscribers) subscriber(event);
+  }
+
+  private createCompletionWaiter<T>(
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): CompletionWaiter<T> {
+    let resolvePromise: (value: T) => void = () => {};
+    let rejectPromise: (error: Error) => void = () => {};
+    let settled = false;
+    const promise = new Promise<T>((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+    void promise.catch(() => {});
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      rejectPromise(new Error(timeoutMessage));
+    }, timeoutMs);
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    };
+    return {
+      promise,
+      resolve: (value) => settle(() => resolvePromise(value)),
+      reject: (error) => settle(() => rejectPromise(error)),
+      cancel: () =>
+        settle(() =>
+          rejectPromise(new Error("The Codex completion wait was cancelled.")),
+        ),
+    };
+  }
+
+  private waitForTurnCompletion(
+    turnId: string,
+    timeoutMs: number,
+  ): CompletionWaiter<CodexTurn> {
+    const waiter = this.createCompletionWaiter<CodexTurn>(
+      timeoutMs,
+      `Timed out waiting for Codex turn ${turnId} to finish.`,
+    );
+    const waiters = this.turnCompletionWaiters.get(turnId) ?? new Set();
+    waiters.add(waiter);
+    this.turnCompletionWaiters.set(turnId, waiters);
+    const cleanUp = () => {
+      waiters.delete(waiter);
+      if (waiters.size === 0) this.turnCompletionWaiters.delete(turnId);
+    };
+    void waiter.promise.then(cleanUp, cleanUp);
+    return waiter;
+  }
+
+  private resolveTurnCompletion(turn: CodexTurn): void {
+    for (const waiter of this.turnCompletionWaiters.get(turn.id) ?? []) {
+      waiter.resolve(turn);
+    }
+  }
+
+  private rejectCompletionWaiters(error: Error): void {
+    for (const waiters of this.turnCompletionWaiters.values()) {
+      for (const waiter of waiters) waiter.reject(error);
+    }
+    this.turnCompletionWaiters.clear();
+    this.compactionWaiter?.reject(error);
+    this.compactionWaiter = null;
+    this.isCompacting = false;
+  }
+}
+
+export function startCodexRuntime(
+  target: HostTarget,
+  launch: AgentSessionLaunch,
+): CodexRuntimeClient {
+  return new CodexRuntimeClient(target, launch);
+}

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -36,7 +36,7 @@ import {
 const TURN_COMPLETION_TIMEOUT_MS = 30_000;
 const COMPACTION_TIMEOUT_MS = 5 * 60_000;
 const ACTIVE_WRITER_MESSAGE =
-  "This session is currently open in another Codex client. You can view it here, but close it there before continuing in OvertChat.";
+  "Another Codex process currently owns this session. You can view it here and retry when it becomes available.";
 
 type CompletionWaiter<T> = {
   promise: Promise<T>;
@@ -307,7 +307,7 @@ function statsFromMessages(
 }
 
 export class CodexRuntimeClient implements AgentRuntimeClient {
-  private readonly server: CodexAppServer;
+  private server!: CodexAppServer;
   private readonly subscribers = new Set<(event: AgentRuntimeEvent) => void>();
   private readonly turns = new Map<string, CodexTurn>();
   private readonly pendingInteractions = new Map<string, PendingInteraction>();
@@ -330,18 +330,27 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private modelResponse: unknown = { data: [] };
   private stats = emptyCodexStats();
   private readOnly = false;
+  private threadSubscribed = false;
 
   constructor(
     target: HostTarget,
     private readonly launch: AgentSessionLaunch,
   ) {
-    this.server = startCodexAppServer(target, launch.executable, launch.cwd);
+    this.readyPromise = this.initialize(target);
+    void this.readyPromise.catch(() => {});
+  }
+
+  private async initialize(target: HostTarget): Promise<void> {
+    this.server = await startCodexAppServer(
+      target,
+      this.launch.executable,
+      this.launch.cwd,
+    );
     this.server.onNotification((notification) =>
       this.handleNotification(notification.method, notification.params),
     );
     this.server.onRequest((request) => this.handleRequest(request));
-    this.readyPromise = this.openThread();
-    void this.readyPromise.catch(() => {});
+    await this.openThread();
   }
 
   onEvent(subscriber: (event: AgentRuntimeEvent) => void): () => void {
@@ -585,8 +594,20 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     this.handleQuestionResponse(id, pending, response);
   }
 
-  stop(): Promise<void> {
-    return this.server.stop();
+  async stop(): Promise<void> {
+    await this.readyPromise.catch(() => {});
+    if (!this.server) return;
+    if (this.thread?.id && this.threadSubscribed) {
+      await this.server
+        .request(
+          "thread/unsubscribe",
+          { threadId: this.thread.id },
+          5_000,
+        )
+        .catch(() => {});
+      this.threadSubscribed = false;
+    }
+    await this.server.stop();
   }
 
   async retryInteractive(): Promise<unknown> {
@@ -596,6 +617,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       threadId: this.thread!.id,
       cwd: this.launch.cwd,
     });
+    this.threadSubscribed = true;
     const hydrated = await this.server.request<UnknownRecord>("thread/read", {
       threadId: this.thread!.id,
       includeTurns: true,
@@ -620,6 +642,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
             cwd: this.launch.cwd,
           },
         );
+        this.threadSubscribed = true;
       } catch (error) {
         if (!isActiveWriterError(error)) throw error;
         this.readOnly = true;
@@ -637,6 +660,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
           ephemeral: false,
         },
       );
+      this.threadSubscribed = true;
       hydratedThread = threadResponse;
     }
     this.modelResponse = await modelPromise;

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -5,6 +5,7 @@ import type {
   AgentSessionStats,
   AgentSlashCommand,
   AgentThinkingLevel,
+  AgentUsageSnapshot,
 } from "@/lib/agents/types";
 import type {
   AgentRuntimeClient,
@@ -423,6 +424,85 @@ function statsFromMessages(
   };
 }
 
+function parseUsageSnapshot(
+  rateLimitValue: unknown,
+  activityValue: unknown,
+  unavailableReason: string | null = null,
+): AgentUsageSnapshot {
+  const rateLimitResponse = recordOf(rateLimitValue);
+  const byId = recordOf(rateLimitResponse?.rateLimitsByLimitId);
+  const snapshots: Array<[string, unknown]> =
+    byId && Object.keys(byId).length > 0
+      ? Object.entries(byId)
+      : [["codex", rateLimitResponse?.rateLimits]];
+  const windows: AgentUsageSnapshot["windows"] = [];
+  let planType: string | null = null;
+  let credits: AgentUsageSnapshot["credits"] = null;
+
+  for (const [fallbackId, value] of snapshots) {
+    const snapshot = recordOf(value);
+    if (!snapshot) continue;
+    const id = stringOf(snapshot, "limitId") ?? fallbackId;
+    const label =
+      stringOf(snapshot, "limitName") ??
+      id.replace(/[_-]+/gu, " ").replace(/\b\w/gu, (char) => char.toUpperCase());
+    planType ??= stringOf(snapshot, "planType");
+    const creditData = recordOf(snapshot.credits);
+    if (!credits && creditData) {
+      credits = {
+        balance: stringOf(creditData, "balance"),
+        unlimited: creditData.unlimited === true,
+      };
+    }
+    for (const [kind, windowValue] of [
+      ["primary", snapshot.primary],
+      ["secondary", snapshot.secondary],
+    ] as const) {
+      const window = recordOf(windowValue);
+      const usedPercent = numberOf(window, "usedPercent");
+      if (usedPercent === null) continue;
+      windows.push({
+        id: `${id}:${kind}`,
+        label,
+        usedPercent: Math.max(0, Math.min(100, usedPercent)),
+        resetsAt: numberOf(window, "resetsAt"),
+        windowDurationMins: numberOf(window, "windowDurationMins"),
+      });
+    }
+  }
+
+  const summary = recordOf(recordOf(activityValue)?.summary);
+  return {
+    planType,
+    windows,
+    credits,
+    activity: summary
+      ? {
+          lifetimeTokens: numberOf(summary, "lifetimeTokens"),
+          currentStreakDays: numberOf(summary, "currentStreakDays"),
+          longestStreakDays: numberOf(summary, "longestStreakDays"),
+          peakDailyTokens: numberOf(summary, "peakDailyTokens"),
+        }
+      : null,
+    unavailableReason,
+  };
+}
+
+function usageUnavailableReason(reasons: PromiseRejectedResult[]): string {
+  const messages = reasons.map((result) =>
+    result.reason instanceof Error
+      ? result.reason.message
+      : String(result.reason),
+  );
+  if (messages.some((message) => /authentication required/iu.test(message))) {
+    return "Account usage is unavailable because this Codex connection does not expose authenticated account data.";
+  }
+  if (messages.some((message) => /method not found/iu.test(message))) {
+    return "Account usage is unavailable in this version of Codex.";
+  }
+  return "Codex could not read account usage for this connection.";
+}
+
 export class CodexRuntimeClient implements AgentRuntimeClient {
   private server!: CodexAppServer;
   private readonly subscribers = new Set<(event: AgentRuntimeEvent) => void>();
@@ -767,6 +847,25 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     this.applyThreadConfiguration(response);
     this.readOnly = false;
     return response;
+  }
+
+  async getUsage(): Promise<AgentUsageSnapshot> {
+    await this.readyPromise;
+    const [rateLimits, activity] = await Promise.allSettled([
+      this.server.request("account/rateLimits/read"),
+      this.server.request("account/usage/read"),
+    ]);
+    const rejected = [rateLimits, activity].filter(
+      (result): result is PromiseRejectedResult =>
+        result.status === "rejected",
+    );
+    return parseUsageSnapshot(
+      rateLimits.status === "fulfilled" ? rateLimits.value : null,
+      activity.status === "fulfilled" ? activity.value : null,
+      rateLimits.status === "rejected" && activity.status === "rejected"
+        ? usageUnavailableReason(rejected)
+        : null,
+    );
   }
 
   private async openThread(): Promise<void> {

--- a/apps/web/lib/agents/codex/commands.test.ts
+++ b/apps/web/lib/agents/codex/commands.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  executeOnHost: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/runtime/process", () => ({
+  executeOnHost: mocks.executeOnHost,
+}));
+
+import {
+  expandCodexCustomPrompt,
+  listCodexCustomPrompts,
+  parseCodexSkills,
+  parseCodexSlashInvocation,
+  skillInput,
+} from "./commands";
+
+describe("Codex commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps enabled app-server skills and ignores duplicates and disabled skills", () => {
+    expect(
+      parseCodexSkills({
+        data: [
+          {
+            cwd: "/workspace",
+            skills: [
+              {
+                name: "release-notes",
+                path: "/workspace/.codex/skills/release-notes/SKILL.md",
+                description: "Draft release notes",
+                enabled: true,
+              },
+              {
+                name: "disabled",
+                path: "/tmp/disabled/SKILL.md",
+                enabled: false,
+              },
+            ],
+          },
+          {
+            cwd: "/workspace/subdir",
+            skills: [
+              {
+                name: "release-notes",
+                path: "/other/SKILL.md",
+                enabled: true,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        name: "release-notes",
+        path: "/workspace/.codex/skills/release-notes/SKILL.md",
+        description: "Draft release notes",
+        source: "skill",
+      },
+    ]);
+  });
+
+  it("loads and parses custom prompts on the configured host target", async () => {
+    const record = (filePath: string, markdown: string) =>
+      [
+        "OVERTCHAT_PROMPT_PATH",
+        Buffer.from(filePath).toString("hex"),
+        "OVERTCHAT_PROMPT_BODY",
+        Buffer.from(markdown).toString("hex"),
+        "OVERTCHAT_PROMPT_END",
+      ].join("\n");
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: [
+        record(
+          "/home/yash/.codex/prompts/review.md",
+          [
+          "---",
+          "description: Review this change",
+          "argument-hint: <path>",
+          "---",
+          "Review $1 carefully.",
+          ].join("\n"),
+        ),
+        record(
+          "/home/yash/.codex/prompts/plain.md",
+          "Summarize $ARGUMENTS.",
+        ),
+      ].join("\n"),
+      stderr: "",
+    });
+    const target = {
+      connectorId: "connector",
+      transport: "ssh" as const,
+      alias: "macbook",
+    };
+
+    await expect(listCodexCustomPrompts(target)).resolves.toEqual([
+      {
+        name: "prompts:plain",
+        description: "Custom prompt",
+        source: "prompt",
+        template: "Summarize $ARGUMENTS.",
+      },
+      {
+        name: "prompts:review",
+        description: "Review this change",
+        source: "prompt",
+        argumentHint: "<path>",
+        template: "Review $1 carefully.",
+      },
+    ]);
+    expect(mocks.executeOnHost).toHaveBeenCalledWith(
+      target,
+      expect.objectContaining({
+        command: "sh",
+      }),
+      {
+        timeoutMs: 15_000,
+        stdin: expect.stringContaining("CODEX_HOME"),
+      },
+    );
+    const stdin = mocks.executeOnHost.mock.calls[0]?.[2]?.stdin;
+    expect(stdin).toContain("OVERTCHAT_PROMPT_PATH");
+    expect(stdin).toContain('od -An -tx1 -v "$file"');
+  });
+
+  it("parses invocations and expands Codex prompt arguments", () => {
+    expect(parseCodexSlashInvocation("/prompts:review \"src/a b.ts\" mode=deep"))
+      .toEqual({
+        name: "prompts:review",
+        arguments: '"src/a b.ts" mode=deep',
+      });
+    expect(
+      expandCodexCustomPrompt(
+        "File=$1 Mode=$mode All=$ARGUMENTS Dollar=$$",
+        '"src/a b.ts" mode=deep',
+      ),
+    ).toBe(
+      'File=src/a b.ts Mode=deep All="src/a b.ts" mode=deep Dollar=$',
+    );
+  });
+
+  it("builds native structured skill input", () => {
+    expect(
+      skillInput(
+        {
+          name: "release-notes",
+          description: "Draft release notes",
+          source: "skill",
+          path: "/skills/release-notes/SKILL.md",
+        },
+        "v1.2.3",
+      ),
+    ).toEqual([
+      {
+        type: "skill",
+        name: "release-notes",
+        path: "/skills/release-notes/SKILL.md",
+      },
+      {
+        type: "text",
+        text: "$release-notes v1.2.3",
+        text_elements: [],
+      },
+    ]);
+  });
+});

--- a/apps/web/lib/agents/codex/commands.ts
+++ b/apps/web/lib/agents/codex/commands.ts
@@ -1,0 +1,319 @@
+import "server-only";
+import path from "node:path";
+import type { AgentSlashCommand } from "@/lib/agents/types";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@/lib/agents/runtime/process";
+import {
+  recordOf,
+  stringOf,
+  type UnknownRecord,
+} from "@/lib/agents/codex/protocol";
+
+const MAX_CUSTOM_PROMPTS = 100;
+const PROMPT_PATH_MARKER = "OVERTCHAT_PROMPT_PATH";
+const PROMPT_BODY_MARKER = "OVERTCHAT_PROMPT_BODY";
+const PROMPT_END_MARKER = "OVERTCHAT_PROMPT_END";
+
+export type CodexSkillCommand = AgentSlashCommand & {
+  source: "skill";
+  path: string;
+};
+
+export type CodexPromptCommand = AgentSlashCommand & {
+  source: "prompt";
+  template: string;
+};
+
+export type CodexDiscoveredCommand =
+  | CodexSkillCommand
+  | CodexPromptCommand;
+
+export type CodexSlashInvocation = {
+  name: string;
+  arguments: string;
+};
+
+const CUSTOM_PROMPT_SCRIPT = [
+  'dir="${CODEX_HOME:-"$HOME/.codex"}/prompts"',
+  '[ -d "$dir" ] || exit 0',
+  `find "$dir" -maxdepth 1 -type f -name '*.md' -exec sh -c '`,
+  "  for file do",
+  `    echo "${PROMPT_PATH_MARKER}"`,
+  '    printf "%s" "$file" | od -An -tx1 -v',
+  `    echo "${PROMPT_BODY_MARKER}"`,
+  '    od -An -tx1 -v "$file"',
+  `    echo "${PROMPT_END_MARKER}"`,
+  "  done",
+  "' sh {} +",
+].join("\n");
+
+export function parseCodexSlashInvocation(
+  value: string,
+): CodexSlashInvocation | null {
+  const match = /^\/([a-z0-9:_-]+)(?:[^\S\n]+([^\n]*))?$/iu.exec(
+    value.trim(),
+  );
+  return match
+    ? {
+        name: match[1],
+        arguments: (match[2] ?? "").trim(),
+      }
+    : null;
+}
+
+export function parseCodexSkills(value: unknown): CodexSkillCommand[] {
+  const response = recordOf(value);
+  const entries = Array.isArray(response?.data) ? response.data : [];
+  const skills = new Map<string, CodexSkillCommand>();
+  for (const entry of entries) {
+    const entryRecord = recordOf(entry);
+    const list: unknown[] = Array.isArray(entryRecord?.skills)
+      ? entryRecord.skills
+      : [];
+    for (const candidate of list) {
+      const skill = recordOf(candidate);
+      const name = stringOf(skill, "name");
+      const skillPath = stringOf(skill, "path");
+      if (!name || !skillPath || skill?.enabled === false) continue;
+      const key = name.toLowerCase();
+      if (skills.has(key)) continue;
+      skills.set(key, {
+        name,
+        description:
+          stringOf(skill, "shortDescription") ??
+          stringOf(skill, "description") ??
+          "Codex skill",
+        source: "skill",
+        path: skillPath,
+      });
+    }
+  }
+  return [...skills.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+}
+
+export async function listCodexCustomPrompts(
+  target: HostTarget,
+): Promise<CodexPromptCommand[]> {
+  const result = await executeOnHost(
+    target,
+    {
+      command: "sh",
+    },
+    {
+      timeoutMs: 15_000,
+      stdin: CUSTOM_PROMPT_SCRIPT,
+    },
+  );
+  const records = parseCustomPromptOutput(result.stdout);
+  const prompts: CodexPromptCommand[] = [];
+  for (const { filePath, markdown } of records) {
+    if (prompts.length >= MAX_CUSTOM_PROMPTS) break;
+    const basename = path.posix.basename(filePath);
+    if (!basename.endsWith(".md")) continue;
+    const name = basename.slice(0, -3);
+    if (!name) continue;
+    const parsed = parseFrontMatter(markdown);
+    prompts.push({
+      name: `prompts:${name}`,
+      description: parsed.frontMatter.description ?? "Custom prompt",
+      source: "prompt",
+      ...(parsed.frontMatter["argument-hint"] ||
+      parsed.frontMatter.argument_hint
+        ? {
+            argumentHint:
+              parsed.frontMatter["argument-hint"] ??
+              parsed.frontMatter.argument_hint,
+          }
+        : {}),
+      template: parsed.body,
+    });
+  }
+  return prompts.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function parseCustomPromptOutput(
+  output: string,
+): Array<{ filePath: string; markdown: string }> {
+  const records: Array<{ filePath: string; markdown: string }> = [];
+  const lines = output.split(/\r?\n/u);
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() !== PROMPT_PATH_MARKER) continue;
+    const pathHex: string[] = [];
+    const bodyHex: string[] = [];
+    index += 1;
+    while (
+      index < lines.length &&
+      lines[index].trim() !== PROMPT_BODY_MARKER
+    ) {
+      pathHex.push(lines[index]);
+      index += 1;
+    }
+    if (index >= lines.length) break;
+    index += 1;
+    while (
+      index < lines.length &&
+      lines[index].trim() !== PROMPT_END_MARKER
+    ) {
+      bodyHex.push(lines[index]);
+      index += 1;
+    }
+    const filePath = decodeHex(pathHex.join(""));
+    const markdown = decodeHex(bodyHex.join(""));
+    if (filePath !== null && markdown !== null) {
+      records.push({ filePath, markdown });
+    }
+  }
+  return records;
+}
+
+function decodeHex(value: string): string | null {
+  const compact = value.replace(/\s/gu, "");
+  if (
+    compact.length === 0 ||
+    compact.length % 2 !== 0 ||
+    !/^[0-9a-f]+$/iu.test(compact)
+  ) {
+    return null;
+  }
+  return Buffer.from(compact, "hex").toString("utf8");
+}
+
+export function expandCodexCustomPrompt(
+  template: string,
+  argumentsText: string,
+): string {
+  const trimmed = argumentsText.trim();
+  const tokens = tokenizeArguments(trimmed);
+  const positional: string[] = [];
+  const named = new Map<string, string>();
+  for (const token of tokens) {
+    const separator = token.indexOf("=");
+    if (separator > 0) {
+      named.set(token.slice(0, separator), token.slice(separator + 1));
+    } else {
+      positional.push(token);
+    }
+  }
+
+  const dollarPlaceholder = "__OVERTCHAT_CODEX_DOLLAR__";
+  let expanded = template.replaceAll("$$", dollarPlaceholder);
+  expanded = expanded.replaceAll("$ARGUMENTS", trimmed);
+  for (let index = 1; index <= 9; index += 1) {
+    expanded = expanded.replaceAll(`$${index}`, positional[index - 1] ?? "");
+  }
+  for (const [name, value] of [...named.entries()].sort(
+    ([left], [right]) => right.length - left.length,
+  )) {
+    expanded = expanded.replace(
+      new RegExp(`\\$${escapeRegExp(name)}\\b`, "gu"),
+      value,
+    );
+  }
+  return expanded.replaceAll(dollarPlaceholder, "$");
+}
+
+function parseFrontMatter(markdown: string): {
+  frontMatter: Record<string, string>;
+  body: string;
+} {
+  const lines = markdown.split("\n");
+  if (lines[0]?.trim() !== "---") {
+    return { frontMatter: {}, body: markdown };
+  }
+  const end = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === "---",
+  );
+  if (end < 0) return { frontMatter: {}, body: markdown };
+  const frontMatter: Record<string, string> = {};
+  for (const line of lines.slice(1, end)) {
+    const separator = line.indexOf(":");
+    if (separator <= 0) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line
+      .slice(separator + 1)
+      .trim()
+      .replace(/^['"]|['"]$/gu, "");
+    if (key && value) frontMatter[key] = value;
+  }
+  return {
+    frontMatter,
+    body: lines.slice(end + 1).join("\n"),
+  };
+}
+
+function tokenizeArguments(value: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else if (character === "\\" && index + 1 < value.length) {
+        current += decodeEscapedCharacter(value[++index]);
+      } else {
+        current += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+    } else if (/\s/u.test(character)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += character;
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function decodeEscapedCharacter(value: string): string {
+  if (value === "n") return "\n";
+  if (value === "t") return "\t";
+  return value;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+export function commandMap(
+  commands: readonly CodexDiscoveredCommand[],
+): Map<string, CodexDiscoveredCommand> {
+  return new Map(
+    commands.map((command) => [command.name.toLowerCase(), command]),
+  );
+}
+
+export function publicCommands(
+  commands: readonly CodexDiscoveredCommand[],
+): AgentSlashCommand[] {
+  return commands.map(({ name, description, source, argumentHint }) => ({
+    name,
+    description,
+    source,
+    ...(argumentHint ? { argumentHint } : {}),
+  }));
+}
+
+export function skillInput(
+  command: CodexSkillCommand,
+  argumentsText: string,
+): UnknownRecord[] {
+  const text = argumentsText
+    ? `$${command.name} ${argumentsText}`
+    : `$${command.name}`;
+  return [
+    { type: "skill", name: command.name, path: command.path },
+    { type: "text", text, text_elements: [] },
+  ];
+}

--- a/apps/web/lib/agents/codex/probe.test.ts
+++ b/apps/web/lib/agents/codex/probe.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  executeOnHost: vi.fn(),
+  startCodexAppServer: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/runtime/discovery", () => ({
+  parseAgentVersion: (stdout: string) =>
+    /codex-cli\s+(\S+)/u.exec(stdout)?.[1] ?? null,
+  shellModesForTarget: () => ["interactive", "login"],
+  targetForConnectionDraft: () => ({
+    connectorId: "connector",
+    transport: "local",
+  }),
+  targetWithShellMode: (
+    target: Record<string, unknown>,
+    shellMode: string,
+  ) => ({ ...target, shellMode }),
+}));
+
+vi.mock("@/lib/agents/runtime/process", () => ({
+  executeOnHost: mocks.executeOnHost,
+}));
+
+vi.mock("./app-server", () => ({
+  startCodexAppServer: mocks.startCodexAppServer,
+}));
+
+import { probeCodexTarget } from "./probe";
+
+describe("Codex connection probing", () => {
+  const server = {
+    ready: vi.fn(async () => {}),
+    request: vi.fn(),
+    stop: vi.fn(async () => {}),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.startCodexAppServer.mockReturnValue(server);
+    server.request.mockImplementation(async (method: string) => {
+      if (method === "account/read") {
+        return { account: { type: "chatgpt" }, requiresOpenaiAuth: true };
+      }
+      if (method === "model/list") {
+        return {
+          data: [
+            {
+              model: "gpt-5.6",
+              displayName: "GPT-5.6",
+              inputModalities: ["text"],
+              supportedReasoningEfforts: [],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+  });
+
+  it("falls back to the login shell and verifies app-server readiness", async () => {
+    mocks.executeOnHost
+      .mockRejectedValueOnce(new Error("not found"))
+      .mockResolvedValueOnce({
+        stdout: "codex-cli 0.147.0\n",
+        stderr: "",
+      });
+
+    await expect(
+      probeCodexTarget(
+        { connectorId: "connector", transport: "local" },
+        "/opt/bin/codex",
+      ),
+    ).resolves.toMatchObject({
+      status: "ready",
+      version: "0.147.0",
+      shellMode: "login",
+      models: [
+        expect.objectContaining({
+          provider: "codex",
+          id: "gpt-5.6",
+        }),
+      ],
+    });
+    expect(mocks.startCodexAppServer).toHaveBeenCalledWith(
+      expect.objectContaining({ shellMode: "login" }),
+      "/opt/bin/codex",
+    );
+    expect(server.stop).toHaveBeenCalledOnce();
+  });
+
+  it("reports missing authentication and still stops app-server", async () => {
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: "codex-cli 0.147.0\n",
+      stderr: "",
+    });
+    server.request.mockImplementation(async (method: string) =>
+      method === "account/read"
+        ? { account: null, requiresOpenaiAuth: true }
+        : { data: [] },
+    );
+
+    await expect(
+      probeCodexTarget(
+        { connectorId: "connector", transport: "local" },
+        "codex",
+      ),
+    ).rejects.toThrow("Codex is installed but not signed in");
+    expect(server.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/agents/codex/probe.ts
+++ b/apps/web/lib/agents/codex/probe.ts
@@ -65,7 +65,7 @@ export async function probeCodexTarget(
     throw new Error(`Codex could not be started. ${failures.join(" ")}`);
   }
 
-  const server = startCodexAppServer(resolved.target, executable);
+  const server = await startCodexAppServer(resolved.target, executable);
   try {
     await server.ready();
     const [accountResponse, modelResponse] = await Promise.all([

--- a/apps/web/lib/agents/codex/probe.ts
+++ b/apps/web/lib/agents/codex/probe.ts
@@ -1,0 +1,100 @@
+import "server-only";
+import type { ConnectorShellMode } from "@overtchat/agent-bridge";
+import type {
+  AgentConnectionDraft,
+  AgentReadyConnectionProbe,
+} from "@/lib/agents/types";
+import {
+  parseAgentVersion,
+  shellModesForTarget,
+  targetForConnectionDraft,
+  targetWithShellMode,
+} from "@/lib/agents/runtime/discovery";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@/lib/agents/runtime/process";
+import { startCodexAppServer } from "@/lib/agents/codex/app-server";
+import { parseCodexModels, recordOf } from "@/lib/agents/codex/protocol";
+
+const MODEL_PROBE_TIMEOUT_MS = 120_000;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function probeCodexConnection(
+  draft: AgentConnectionDraft,
+): Promise<AgentReadyConnectionProbe> {
+  return probeCodexTarget(
+    targetForConnectionDraft(draft),
+    draft.executable,
+  );
+}
+
+export async function probeCodexTarget(
+  target: HostTarget,
+  executable: string,
+): Promise<AgentReadyConnectionProbe> {
+  let resolved:
+    | {
+        target: HostTarget;
+        shellMode: ConnectorShellMode;
+        version: string;
+      }
+    | undefined;
+  const failures: string[] = [];
+  for (const shellMode of shellModesForTarget(target)) {
+    try {
+      const resolvedTarget = targetWithShellMode(target, shellMode);
+      const versionResult = await executeOnHost(resolvedTarget, {
+        command: executable,
+        args: ["--version"],
+      });
+      const version = parseAgentVersion(versionResult.stdout);
+      if (!version) throw new Error("Codex returned an invalid version.");
+      resolved = { target: resolvedTarget, shellMode, version };
+      break;
+    } catch (error) {
+      failures.push(
+        `${shellMode === "interactive" ? "Interactive login" : "Login"}: ${errorMessage(error)}`,
+      );
+    }
+  }
+  if (!resolved) {
+    throw new Error(`Codex could not be started. ${failures.join(" ")}`);
+  }
+
+  const server = startCodexAppServer(resolved.target, executable);
+  try {
+    await server.ready();
+    const [accountResponse, modelResponse] = await Promise.all([
+      server.request("account/read", {}),
+      server.request(
+        "model/list",
+        { limit: 200 },
+        MODEL_PROBE_TIMEOUT_MS,
+      ),
+    ]);
+    const account = recordOf(accountResponse);
+    if (!account?.account && account?.requiresOpenaiAuth === true) {
+      throw new Error(
+        "Codex is installed but not signed in. Run `codex login` on this machine.",
+      );
+    }
+    const models = parseCodexModels(modelResponse);
+    if (models.length === 0) {
+      throw new Error(
+        "Codex is installed, but it did not report any usable models.",
+      );
+    }
+    return {
+      status: "ready",
+      version: resolved.version,
+      models,
+      shellMode: resolved.shellMode,
+    };
+  } finally {
+    await server.stop();
+  }
+}

--- a/apps/web/lib/agents/codex/protocol.test.ts
+++ b/apps/web/lib/agents/codex/protocol.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  codexDefaultThinkingLevel,
+  codexSessionMetadata,
+  codexThinkingLevels,
+  parseCodexModels,
+  parseCodexThread,
+} from "./protocol";
+
+describe("Codex protocol parsing", () => {
+  it("maps the model catalog without inventing context limits", () => {
+    const response = {
+      data: [
+        {
+          id: "gpt-5.6",
+          model: "gpt-5.6",
+          displayName: "GPT-5.6",
+          inputModalities: ["text", "image"],
+          supportedReasoningEfforts: [
+            { reasoningEffort: "low", description: "" },
+            { reasoningEffort: "high", description: "" },
+          ],
+          defaultReasoningEffort: "high",
+        },
+      ],
+    };
+
+    expect(parseCodexModels(response)).toEqual([
+      expect.objectContaining({
+        id: "gpt-5.6",
+        name: "GPT-5.6",
+        provider: "codex",
+        input: ["text", "image"],
+        contextWindow: null,
+        maxTokens: null,
+      }),
+    ]);
+    expect(codexThinkingLevels(response, "gpt-5.6")).toEqual([
+      "low",
+      "high",
+    ]);
+    expect(codexDefaultThinkingLevel(response, "gpt-5.6")).toBe("high");
+  });
+
+  it("maps native threads to existing session metadata", () => {
+    const thread = parseCodexThread({
+      id: "thread-1",
+      cwd: "/workspace",
+      preview: "Fix the test",
+      name: "Test repair",
+      path: "/home/user/.codex/sessions/thread.jsonl",
+      createdAt: 100,
+      updatedAt: 200,
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          startedAt: 100,
+          items: [{ id: "user-1", type: "userMessage" }],
+        },
+      ],
+    });
+
+    expect(codexSessionMetadata(thread)).toEqual({
+      providerSessionId: "thread-1",
+      providerSessionPath: "/home/user/.codex/sessions/thread.jsonl",
+      name: "Test repair",
+      firstMessage: "Fix the test",
+      messageCount: 1,
+      createdAt: new Date(100_000),
+      modifiedAt: new Date(200_000),
+    });
+  });
+});

--- a/apps/web/lib/agents/codex/protocol.ts
+++ b/apps/web/lib/agents/codex/protocol.ts
@@ -1,0 +1,229 @@
+import type {
+  AgentModel,
+  AgentProviderSessionMetadata,
+  AgentSessionStats,
+  AgentThinkingLevel,
+} from "@/lib/agents/types";
+
+export type UnknownRecord = Record<string, unknown>;
+
+export type CodexThread = UnknownRecord & {
+  id: string;
+  preview: string;
+  path: string | null;
+  cwd: string;
+  name: string | null;
+  createdAt: number;
+  updatedAt: number;
+  turns: CodexTurn[];
+};
+
+export type CodexTurn = UnknownRecord & {
+  id: string;
+  status: string;
+  items: CodexItem[];
+  startedAt: number | null;
+  completedAt: number | null;
+};
+
+export type CodexItem = UnknownRecord & {
+  id: string;
+  type: string;
+};
+
+export function recordOf(value: unknown): UnknownRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+export function stringOf(
+  record: UnknownRecord | null,
+  key: string,
+): string | null {
+  const value = record?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+export function numberOf(
+  record: UnknownRecord | null,
+  key: string,
+): number | null {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function parseCodexThread(value: unknown): CodexThread {
+  const thread = recordOf(value);
+  const id = stringOf(thread, "id");
+  const cwd = stringOf(thread, "cwd");
+  if (!thread || !id || !cwd) {
+    throw new Error("Codex returned an invalid thread.");
+  }
+  return {
+    ...thread,
+    id,
+    cwd,
+    preview: stringOf(thread, "preview") ?? "",
+    path: stringOf(thread, "path"),
+    name: stringOf(thread, "name"),
+    createdAt: numberOf(thread, "createdAt") ?? 0,
+    updatedAt: numberOf(thread, "updatedAt") ?? 0,
+    turns: Array.isArray(thread.turns)
+      ? thread.turns.map(parseCodexTurn)
+      : [],
+  };
+}
+
+export function parseCodexTurn(value: unknown): CodexTurn {
+  const turn = recordOf(value);
+  const id = stringOf(turn, "id");
+  if (!turn || !id) throw new Error("Codex returned an invalid turn.");
+  return {
+    ...turn,
+    id,
+    status: stringOf(turn, "status") ?? "completed",
+    items: Array.isArray(turn.items)
+      ? turn.items.flatMap((item) => {
+          const record = recordOf(item);
+          const itemId = stringOf(record, "id");
+          const type = stringOf(record, "type");
+          return record && itemId && type
+            ? [{ ...record, id: itemId, type }]
+            : [];
+        })
+      : [],
+    startedAt: numberOf(turn, "startedAt"),
+    completedAt: numberOf(turn, "completedAt"),
+  };
+}
+
+export function parseCodexModels(value: unknown): AgentModel[] {
+  const response = recordOf(value);
+  if (!Array.isArray(response?.data)) {
+    throw new Error("Codex returned an invalid model list.");
+  }
+  return response.data.flatMap((candidate) => {
+    const model = recordOf(candidate);
+    const id = stringOf(model, "model") ?? stringOf(model, "id");
+    if (!model || !id) return [];
+    const modalities = Array.isArray(model.inputModalities)
+      ? model.inputModalities
+      : [];
+    return [
+      {
+        id,
+        name: stringOf(model, "displayName") ?? id,
+        provider: "codex",
+        api: "codex-app-server",
+        baseUrl: "",
+        reasoning:
+          Array.isArray(model.supportedReasoningEfforts) &&
+          model.supportedReasoningEfforts.length > 0,
+        input: [
+          "text" as const,
+          ...(modalities.includes("image") ? (["image"] as const) : []),
+        ],
+        contextWindow: null,
+        maxTokens: null,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+      },
+    ];
+  });
+}
+
+export function codexThinkingLevels(
+  modelList: unknown,
+  modelId: string | null,
+): AgentThinkingLevel[] {
+  const response = recordOf(modelList);
+  if (!Array.isArray(response?.data)) return [];
+  const model = response.data
+    .map(recordOf)
+    .find(
+      (candidate) =>
+        (stringOf(candidate, "model") ?? stringOf(candidate, "id")) ===
+        modelId,
+    );
+  if (!Array.isArray(model?.supportedReasoningEfforts)) return [];
+  const allowed = new Set<AgentThinkingLevel>([
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+  ]);
+  return model.supportedReasoningEfforts.flatMap((candidate) => {
+    const effort = stringOf(recordOf(candidate), "reasoningEffort");
+    return effort && allowed.has(effort as AgentThinkingLevel)
+      ? [effort as AgentThinkingLevel]
+      : [];
+  });
+}
+
+export function codexDefaultThinkingLevel(
+  modelList: unknown,
+  modelId: string | null,
+): AgentThinkingLevel | null {
+  const response = recordOf(modelList);
+  if (!Array.isArray(response?.data)) return null;
+  const model = response.data
+    .map(recordOf)
+    .find(
+      (candidate) =>
+        (stringOf(candidate, "model") ?? stringOf(candidate, "id")) ===
+        modelId,
+    );
+  const effort = stringOf(model ?? null, "defaultReasoningEffort");
+  return effort &&
+    codexThinkingLevels(modelList, modelId).includes(
+      effort as AgentThinkingLevel,
+    )
+    ? (effort as AgentThinkingLevel)
+    : null;
+}
+
+export function codexSessionMetadata(
+  thread: CodexThread,
+): AgentProviderSessionMetadata {
+  return {
+    providerSessionId: thread.id,
+    providerSessionPath: thread.path ?? thread.id,
+    name: thread.name,
+    firstMessage: thread.preview.trim() || null,
+    messageCount: thread.turns.reduce(
+      (total, turn) => total + turn.items.length,
+      0,
+    ),
+    createdAt:
+      thread.createdAt > 0 ? new Date(thread.createdAt * 1_000) : null,
+    modifiedAt:
+      thread.updatedAt > 0 ? new Date(thread.updatedAt * 1_000) : null,
+  };
+}
+
+export function emptyCodexStats(): AgentSessionStats {
+  return {
+    sessionFile: null,
+    sessionId: null,
+    userMessages: 0,
+    assistantMessages: 0,
+    toolCalls: 0,
+    toolResults: 0,
+    totalMessages: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+    cost: 0,
+  };
+}

--- a/apps/web/lib/agents/codex/sessions.test.ts
+++ b/apps/web/lib/agents/codex/sessions.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  startCodexAppServer: vi.fn(),
+}));
+
+vi.mock("./app-server", () => ({
+  startCodexAppServer: mocks.startCodexAppServer,
+}));
+
+import { listCodexWorkspaceSessions } from "./sessions";
+
+function thread(id: string, cwd: string, updatedAt: number) {
+  return {
+    id,
+    cwd,
+    preview: `Prompt ${id}`,
+    path: `/sessions/${id}.jsonl`,
+    name: null,
+    createdAt: updatedAt - 10,
+    updatedAt,
+    turns: [],
+  };
+}
+
+describe("Codex workspace session discovery", () => {
+  const server = {
+    ready: vi.fn(async () => {}),
+    request: vi.fn(),
+    stop: vi.fn(async () => {}),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.startCodexAppServer.mockReturnValue(server);
+  });
+
+  it("paginates native threads and keeps the exact workspace", async () => {
+    server.request
+      .mockResolvedValueOnce({
+        data: [
+          thread("thread-1", "/workspace", 20),
+          thread("other", "/other", 30),
+        ],
+        nextCursor: "next",
+      })
+      .mockResolvedValueOnce({
+        data: [thread("thread-2", "/workspace", 10)],
+        nextCursor: null,
+      });
+
+    await expect(
+      listCodexWorkspaceSessions(
+        { connectorId: "connector", transport: "local" },
+        "/opt/bin/codex",
+        "/workspace",
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        providerSessionId: "thread-1",
+        firstMessage: "Prompt thread-1",
+      }),
+      expect.objectContaining({
+        providerSessionId: "thread-2",
+        firstMessage: "Prompt thread-2",
+      }),
+    ]);
+    expect(server.request).toHaveBeenNthCalledWith(1, "thread/list", {
+      cwd: "/workspace",
+      limit: 100,
+      sortKey: "updated_at",
+      sortDirection: "desc",
+    });
+    expect(server.request).toHaveBeenNthCalledWith(2, "thread/list", {
+      cwd: "/workspace",
+      limit: 100,
+      sortKey: "updated_at",
+      sortDirection: "desc",
+      cursor: "next",
+    });
+    expect(server.stop).toHaveBeenCalledOnce();
+  });
+
+  it("rejects repeated cursors and still stops app-server", async () => {
+    server.request.mockResolvedValue({
+      data: [],
+      nextCursor: "same",
+    });
+
+    await expect(
+      listCodexWorkspaceSessions(
+        { connectorId: "connector", transport: "local" },
+        "codex",
+        "/workspace",
+      ),
+    ).rejects.toThrow("Codex repeated a thread-list cursor");
+    expect(server.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/agents/codex/sessions.ts
+++ b/apps/web/lib/agents/codex/sessions.ts
@@ -17,7 +17,11 @@ export async function listCodexWorkspaceSessions(
   executable: string,
   workspacePath: string,
 ): Promise<AgentProviderSessionMetadata[]> {
-  const server = startCodexAppServer(target, executable, workspacePath);
+  const server = await startCodexAppServer(
+    target,
+    executable,
+    workspacePath,
+  );
   try {
     await server.ready();
     const sessions: AgentProviderSessionMetadata[] = [];

--- a/apps/web/lib/agents/codex/sessions.ts
+++ b/apps/web/lib/agents/codex/sessions.ts
@@ -1,0 +1,56 @@
+import "server-only";
+import type { AgentProviderSessionMetadata } from "@/lib/agents/types";
+import type { HostTarget } from "@/lib/agents/runtime/process";
+import { startCodexAppServer } from "@/lib/agents/codex/app-server";
+import {
+  codexSessionMetadata,
+  parseCodexThread,
+  recordOf,
+  stringOf,
+} from "@/lib/agents/codex/protocol";
+
+const MAX_SESSIONS = 200;
+const PAGE_SIZE = 100;
+
+export async function listCodexWorkspaceSessions(
+  target: HostTarget,
+  executable: string,
+  workspacePath: string,
+): Promise<AgentProviderSessionMetadata[]> {
+  const server = startCodexAppServer(target, executable, workspacePath);
+  try {
+    await server.ready();
+    const sessions: AgentProviderSessionMetadata[] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+    do {
+      const response = recordOf(
+        await server.request("thread/list", {
+          cwd: workspacePath,
+          limit: PAGE_SIZE,
+          sortKey: "updated_at",
+          sortDirection: "desc",
+          ...(cursor ? { cursor } : {}),
+        }),
+      );
+      if (!Array.isArray(response?.data)) {
+        throw new Error("Codex returned an invalid thread list.");
+      }
+      for (const value of response.data) {
+        const thread = parseCodexThread(value);
+        if (thread.cwd === workspacePath) {
+          sessions.push(codexSessionMetadata(thread));
+        }
+        if (sessions.length >= MAX_SESSIONS) return sessions;
+      }
+      cursor = stringOf(response, "nextCursor") ?? undefined;
+      if (cursor && seenCursors.has(cursor)) {
+        throw new Error("Codex repeated a thread-list cursor.");
+      }
+      if (cursor) seenCursors.add(cursor);
+    } while (cursor);
+    return sessions;
+  } finally {
+    await server.stop();
+  }
+}

--- a/apps/web/lib/agents/providers/codex.test.ts
+++ b/apps/web/lib/agents/providers/codex.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { codexProviderAdapter } from "./codex";
+
+describe("codexProviderAdapter", () => {
+  it("normalizes /usage without sending it to the model", () => {
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/usage" },
+        {},
+      ),
+    ).toEqual({ type: "show_usage" });
+  });
+
+  it("keeps /usage with arguments as model input", () => {
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/usage extra" },
+        {},
+      ),
+    ).toEqual({ type: "prompt", message: "/usage extra" });
+  });
+});

--- a/apps/web/lib/agents/providers/codex.ts
+++ b/apps/web/lib/agents/providers/codex.ts
@@ -1,0 +1,95 @@
+import type {
+  AgentProviderAdapter,
+  AgentRuntimeEvent,
+  AgentRuntimeEventClassifier,
+  AgentSessionIdentity,
+} from "@/lib/agents/providers/types";
+import type {
+  AgentSessionCommand,
+  AgentSlashCommand,
+} from "@/lib/agents/types";
+import {
+  mergeAgentSlashCommands,
+  normalizeAgentSessionCommand,
+} from "@/lib/agents/runtime/commands";
+import { startCodexRuntime } from "@/lib/agents/codex/client";
+import {
+  probeCodexConnection,
+  probeCodexTarget,
+} from "@/lib/agents/codex/probe";
+import { listCodexWorkspaceSessions } from "@/lib/agents/codex/sessions";
+
+const CODEX_COMMANDS: readonly AgentSlashCommand[] = [
+  {
+    name: "new",
+    description: "Start a new session",
+    source: "builtin",
+  },
+  {
+    name: "compact",
+    description: "Compact conversation context",
+    source: "builtin",
+  },
+  {
+    name: "name",
+    description: "Set the session name",
+    source: "builtin",
+    argumentHint: "<name>",
+  },
+];
+
+class CodexEventClassifier implements AgentRuntimeEventClassifier {
+  reset(): void {}
+
+  classify(event: AgentRuntimeEvent) {
+    return {
+      started: event.type === "turn_start",
+      terminal: event.type === "turn_end",
+    };
+  }
+}
+
+function sessionIdentity(
+  state: Record<string, unknown>,
+): AgentSessionIdentity {
+  if (typeof state.sessionId !== "string" || !state.sessionId) {
+    throw new Error("Codex did not return a thread ID.");
+  }
+  return {
+    providerSessionId: state.sessionId,
+    providerSessionPath:
+      typeof state.sessionFile === "string" && state.sessionFile
+        ? state.sessionFile
+        : state.sessionId,
+    sessionName:
+      typeof state.sessionName === "string" && state.sessionName.trim()
+        ? state.sessionName.trim()
+        : null,
+  };
+}
+
+function normalizeCommand(
+  command: AgentSessionCommand,
+  state: Record<string, unknown>,
+): AgentSessionCommand {
+  const normalized = normalizeAgentSessionCommand(command, state);
+  if (normalized.type === "set_auto_compaction") {
+    throw new Error("Codex manages context compaction automatically.");
+  }
+  return normalized;
+}
+
+export const codexProviderAdapter: AgentProviderAdapter = {
+  provider: "codex",
+  startSession: startCodexRuntime,
+  probeConnection: (draft) =>
+    probeCodexConnection({ ...draft, provider: "codex" }),
+  probeTarget: probeCodexTarget,
+  listWorkspaceSessions: listCodexWorkspaceSessions,
+  sessionIdentity,
+  createEventClassifier: () => new CodexEventClassifier(),
+  commandsFromEvent: () => null,
+  mergeCommands: (discovered) =>
+    mergeAgentSlashCommands(CODEX_COMMANDS, discovered),
+  normalizeCommand,
+};

--- a/apps/web/lib/agents/providers/codex.ts
+++ b/apps/web/lib/agents/providers/codex.ts
@@ -88,7 +88,11 @@ export const codexProviderAdapter: AgentProviderAdapter = {
   listWorkspaceSessions: listCodexWorkspaceSessions,
   sessionIdentity,
   createEventClassifier: () => new CodexEventClassifier(),
-  commandsFromEvent: () => null,
+  commandsFromEvent: (event) =>
+    event.type === "available_commands_update" &&
+    Array.isArray(event.commands)
+      ? (event.commands as AgentSlashCommand[])
+      : null,
   mergeCommands: (discovered) =>
     mergeAgentSlashCommands(CODEX_COMMANDS, discovered),
   normalizeCommand,

--- a/apps/web/lib/agents/providers/codex.ts
+++ b/apps/web/lib/agents/providers/codex.ts
@@ -36,6 +36,11 @@ const CODEX_COMMANDS: readonly AgentSlashCommand[] = [
     source: "builtin",
     argumentHint: "<name>",
   },
+  {
+    name: "usage",
+    description: "Show Codex plan usage and token activity",
+    source: "builtin",
+  },
 ];
 
 class CodexEventClassifier implements AgentRuntimeEventClassifier {
@@ -72,6 +77,12 @@ function normalizeCommand(
   command: AgentSessionCommand,
   state: Record<string, unknown>,
 ): AgentSessionCommand {
+  if (
+    command.type === "prompt" &&
+    /^\/usage(?:\s*)$/iu.test(command.message)
+  ) {
+    return { type: "show_usage" };
+  }
   const normalized = normalizeAgentSessionCommand(command, state);
   if (normalized.type === "set_auto_compaction") {
     throw new Error("Codex manages context compaction automatically.");

--- a/apps/web/lib/agents/providers/registry.ts
+++ b/apps/web/lib/agents/providers/registry.ts
@@ -1,15 +1,14 @@
 import "server-only";
 import type { AgentProviderAdapter } from "@/lib/agents/providers/types";
 import { createPiRpcProviderAdapter } from "@/lib/agents/providers/pi-rpc";
+import { codexProviderAdapter } from "@/lib/agents/providers/codex";
 import type { AgentProviderId } from "@/lib/agents/types";
-import { AGENT_PROVIDER_IDS } from "@/lib/agents/types";
 
-const adapters = Object.fromEntries(
-  AGENT_PROVIDER_IDS.map((provider) => [
-    provider,
-    createPiRpcProviderAdapter(provider),
-  ]),
-) as Record<AgentProviderId, AgentProviderAdapter>;
+const adapters = {
+  pi: createPiRpcProviderAdapter("pi"),
+  omp: createPiRpcProviderAdapter("omp"),
+  codex: codexProviderAdapter,
+} satisfies Record<AgentProviderId, AgentProviderAdapter>;
 
 export function agentProviderAdapter(
   provider: AgentProviderId,

--- a/apps/web/lib/agents/providers/types.ts
+++ b/apps/web/lib/agents/providers/types.ts
@@ -10,6 +10,7 @@ import type {
   AgentSlashCommand,
   AgentThinkingLevel,
   AgentInteractionValue,
+  AgentUsageSnapshot,
 } from "@/lib/agents/types";
 import type { HostTarget } from "@/lib/agents/runtime/process";
 
@@ -68,6 +69,7 @@ export interface AgentRuntimeClient {
     },
   ): void;
   retryInteractive?(): Promise<unknown>;
+  getUsage?(): Promise<AgentUsageSnapshot>;
   stop(): Promise<void>;
 }
 

--- a/apps/web/lib/agents/providers/types.ts
+++ b/apps/web/lib/agents/providers/types.ts
@@ -67,6 +67,7 @@ export interface AgentRuntimeClient {
       cancelled?: boolean;
     },
   ): void;
+  retryInteractive?(): Promise<unknown>;
   stop(): Promise<void>;
 }
 

--- a/apps/web/lib/agents/runtime/registry.test.ts
+++ b/apps/web/lib/agents/runtime/registry.test.ts
@@ -87,6 +87,7 @@ class FakeAgentClient {
   readonly compact = vi.fn(async () => ({}));
   readonly setAutoCompaction = vi.fn(async () => ({}));
   readonly setSessionName = vi.fn(async () => ({}));
+  readonly retryInteractive = vi.fn(async () => ({}));
   readonly respondToInteraction = vi.fn();
   readonly respondToExtensionUi = this.respondToInteraction;
   readonly getState = vi.fn(async () => ({ ...idleProviderState }));
@@ -175,6 +176,40 @@ function owned(): OwnedAgentSession {
 }
 
 describe("Agent session runtime", () => {
+  it("blocks mutations in read-only sessions and retries interactive access", async () => {
+    const client = new FakeAgentClient();
+    const readOnly = {
+      reason: "This session is open elsewhere.",
+      retryable: true,
+    };
+    client.getState.mockResolvedValueOnce({ ...idleProviderState });
+    const runtime = new AgentSessionRuntime(
+      "session",
+      "user",
+      "connection",
+      "workspace",
+      agentProviderAdapter("pi"),
+      client as unknown as AgentRuntimeClient,
+      {
+        ...initial(),
+        state: { ...initial().state, readOnly },
+        thinkingLevels: [...initial().thinkingLevels],
+      },
+      vi.fn(),
+    );
+
+    expect(runtime.snapshot().readOnly).toEqual(readOnly);
+    await expect(
+      runtime.command({ type: "prompt", message: "Continue" }),
+    ).rejects.toThrow("open elsewhere");
+    expect(client.prompt).not.toHaveBeenCalled();
+
+    await runtime.command({ type: "retry_interactive" });
+    expect(client.retryInteractive).toHaveBeenCalledTimes(1);
+    expect(runtime.snapshot().readOnly).toBeUndefined();
+    await runtime.stop();
+  });
+
   it("keeps live provider messages in authoritative snapshots", async () => {
     const client = new FakeAgentClient();
     const runtime = new AgentSessionRuntime(

--- a/apps/web/lib/agents/runtime/registry.ts
+++ b/apps/web/lib/agents/runtime/registry.ts
@@ -116,6 +116,20 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function readOnlyState(
+  state: Record<string, unknown>,
+): AgentRuntimeSnapshot["readOnly"] {
+  const value = state.readOnly;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const reason = Reflect.get(value, "reason");
+  const retryable = Reflect.get(value, "retryable");
+  return typeof reason === "string" && typeof retryable === "boolean"
+    ? { reason, retryable }
+    : undefined;
+}
+
 function wait(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
@@ -335,6 +349,7 @@ export class AgentSessionRuntime {
   }
 
   snapshot(): AgentRuntimeSnapshot {
+    const readOnly = readOnlyState(this.state);
     return {
       sessionId: this.dbSessionId,
       provider: this.provider,
@@ -351,6 +366,7 @@ export class AgentSessionRuntime {
       commands: this.commands,
       stats: this.stats,
       queuedMessages: this.queuedMessages,
+      ...(readOnly ? { readOnly } : {}),
       ...(this.pendingInteraction
         ? { pendingInteraction: this.pendingInteraction }
         : {}),
@@ -384,6 +400,10 @@ export class AgentSessionRuntime {
 
   command(input: AgentSessionCommand): Promise<unknown> {
     const command = this.normalizeCommand(input);
+    const readOnly = readOnlyState(this.state);
+    if (readOnly && command.type !== "retry_interactive") {
+      return Promise.reject(new Error(readOnly.reason));
+    }
     switch (command.type) {
       case "new_session":
         return Promise.reject(
@@ -453,6 +473,18 @@ export class AgentSessionRuntime {
         }
         return Promise.resolve();
       }
+      case "retry_interactive":
+        if (!this.client.retryInteractive) {
+          return Promise.reject(
+            new Error(
+              `${agentProviderMetadata(this.provider).label} cannot retry interactive access.`,
+            ),
+          );
+        }
+        return this.client.retryInteractive().then(async (value) => {
+          await this.refresh();
+          return value;
+        });
     }
   }
 

--- a/apps/web/lib/agents/runtime/registry.ts
+++ b/apps/web/lib/agents/runtime/registry.ts
@@ -401,7 +401,11 @@ export class AgentSessionRuntime {
   command(input: AgentSessionCommand): Promise<unknown> {
     const command = this.normalizeCommand(input);
     const readOnly = readOnlyState(this.state);
-    if (readOnly && command.type !== "retry_interactive") {
+    if (
+      readOnly &&
+      command.type !== "retry_interactive" &&
+      command.type !== "show_usage"
+    ) {
       return Promise.reject(new Error(readOnly.reason));
     }
     switch (command.type) {
@@ -485,6 +489,15 @@ export class AgentSessionRuntime {
           await this.refresh();
           return value;
         });
+      case "show_usage":
+        if (!this.client.getUsage) {
+          return Promise.reject(
+            new Error(
+              `${agentProviderMetadata(this.provider).label} does not provide account usage.`,
+            ),
+          );
+        }
+        return this.client.getUsage();
     }
   }
 

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -221,6 +221,31 @@ export type AgentInteractionValue =
 export type AgentRuntimeCapabilities = {
   steer: boolean;
   customCompactionInstructions?: boolean;
+  usage?: boolean;
+};
+
+export type AgentUsageWindow = {
+  id: string;
+  label: string;
+  usedPercent: number;
+  resetsAt: number | null;
+  windowDurationMins: number | null;
+};
+
+export type AgentUsageSnapshot = {
+  planType: string | null;
+  windows: AgentUsageWindow[];
+  credits: {
+    balance: string | null;
+    unlimited: boolean;
+  } | null;
+  activity: {
+    lifetimeTokens: number | null;
+    currentStreakDays: number | null;
+    longestStreakDays: number | null;
+    peakDailyTokens: number | null;
+  } | null;
+  unavailableReason: string | null;
 };
 
 export const agentSessionCommandSchema = z.discriminatedUnion("type", [
@@ -267,6 +292,7 @@ export const agentSessionCommandSchema = z.discriminatedUnion("type", [
     name: z.string().trim().min(1).max(120),
   }),
   z.object({ type: z.literal("new_session") }),
+  z.object({ type: z.literal("show_usage") }),
   z.object({
     type: z.literal("interaction_response"),
     id: z.string().min(1).max(500),

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -285,6 +285,7 @@ export const agentSessionCommandSchema = z.discriminatedUnion("type", [
     confirmed: z.boolean().optional(),
     cancelled: z.boolean().optional(),
   }),
+  z.object({ type: z.literal("retry_interactive") }),
 ]);
 
 export type AgentSessionCommand = z.infer<typeof agentSessionCommandSchema>;
@@ -327,6 +328,10 @@ export type AgentRuntimeSnapshot = {
   commands: AgentSlashCommand[];
   stats: AgentSessionStats;
   queuedMessages: AgentQueuedMessage[];
+  readOnly?: {
+    reason: string;
+    retryable: boolean;
+  };
   pendingInteraction?: {
     type: "interaction_request";
     id: string;

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ConnectorShellMode } from "@overtchat/agent-bridge";
 
-export const AGENT_PROVIDER_IDS = ["pi", "omp"] as const;
+export const AGENT_PROVIDER_IDS = ["pi", "omp", "codex"] as const;
 export type AgentProviderId = (typeof AGENT_PROVIDER_IDS)[number];
 export type AgentRuntimeStatus = "idle" | "running" | "exited";
 

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -7,6 +7,7 @@ import type {
   AgentRuntimeEnvelope,
   AgentRuntimeSnapshot,
   AgentSessionCommand,
+  AgentUsageSnapshot,
 } from "@/lib/agents/types";
 import { applyAgentRuntimeEnvelope } from "@/lib/agents/runtime/state";
 import {
@@ -80,6 +81,7 @@ export function useAgentSessionCommand(id: string) {
     ): Promise<{
       sessionId?: string;
       queuedMessages?: AgentQueuedMessage[];
+      usage?: AgentUsageSnapshot;
     }> => {
       const response = await fetch(`/api/agent-sessions/${id}`, {
         method: "POST",
@@ -90,6 +92,7 @@ export function useAgentSessionCommand(id: string) {
       return (await response.json()) as {
         sessionId?: string;
         queuedMessages?: AgentQueuedMessage[];
+        usage?: AgentUsageSnapshot;
       };
     },
     onSuccess: (data, command) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
     "tw-animate-css": "^1.4.0",
     "unpdf": "^1.6.2",
     "use-stick-to-bottom": "^1.1.6",
+    "ws": "^8.21.3",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.4.3"
   },
@@ -77,6 +78,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/ws": "^8.18.1",
     "@vitest/ui": "^4.1.6",
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1364,6 +1364,7 @@
         "tw-animate-css": "^1.4.0",
         "unpdf": "^1.6.2",
         "use-stick-to-bottom": "^1.1.6",
+        "ws": "^8.21.3",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "zod": "^4.4.3"
       },
@@ -1374,6 +1375,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/ws": "^8.18.1",
         "@vitest/ui": "^4.1.6",
         "dotenv": "^17.4.2",
         "drizzle-kit": "^0.31.10",
@@ -9907,6 +9909,16 @@
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -27326,9 +27338,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
- add Codex discovery, authentication checks, model/reasoning discovery, native thread listing, start, and resume
- stream reasoning, messages, commands, file changes, tools, images, token usage, and session metadata into the existing agent UI
- support native queue/steer/stop/compaction plus approvals and structured user/MCP interactions
- expose installed skills, host custom prompts, and local `/usage` account status
- expose Codex for local and SSH Agent Connections without schema changes

## Runtime
- prefer the installed Codex shared daemon through `app-server proxy`, matching Codex client ownership semantics
- fall back to standalone `app-server --stdio` when no compatible control daemon is available
- open genuinely busy standalone threads read-only with Retry instead of failing the entire session
- unsubscribe loaded threads before closing each runtime
- preserve native thread IDs and reconstruct full history with `thread/read`
- show a clear unavailable state when a standalone/headless connection cannot expose authenticated account usage

## Deferred
- Codex login/OAuth inside OvertChat
- review/plan modes, subagents, MCP configuration management, and thread rewind/fork UI

## Verification
- `npm run test -w apps/web` (455 passed, 4 skipped)
- `npm run lint -w apps/web -- --no-cache`
- `npm run typecheck -w apps/web`
- `npm run build -w apps/web`
- `CI=1 RUN_CODEX_E2E=1 E2E_PORT=4742 npm run test:e2e -w apps/web -- --grep "connect local Codex and resume a native thread"`
- resumed the exact daemon-owned thread that previously failed while Codex Desktop remained attached
- validated Codex discovery and native session resume over the existing Mac SSH alias

## Database
- no migration required; provider IDs and native session IDs are already stored as text
