### PR TITLE
Add native agent message history actions

### DIFF
--- a/apps/web/app/api/agent-sessions/[id]/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.ts
@@ -89,6 +89,17 @@ export async function POST(
         sessionId: created.sessionId,
       });
     }
+    if (
+      normalized.type === "edit_message" ||
+      normalized.type === "fork_message"
+    ) {
+      const created = await agentRuntimeRegistry.fork(
+        authorized.owned,
+        runtime,
+        normalized,
+      );
+      return Response.json({ accepted: true, ...created });
+    }
     const commandResult = await runtime.command(normalized);
     if (
       normalized.type === "prompt" ||

--- a/apps/web/components/agents/AgentComposer.tsx
+++ b/apps/web/components/agents/AgentComposer.tsx
@@ -52,6 +52,7 @@ export function AgentComposer({
   onStop,
   onEditQueued,
   onSteerQueued,
+  restoreDraftKey,
 }: {
   providerLabel: string;
   commands: AgentSlashCommand[];
@@ -68,6 +69,7 @@ export function AgentComposer({
   onStop: () => void;
   onEditQueued: (id: string) => Promise<boolean>;
   onSteerQueued: (id: string) => Promise<boolean>;
+  restoreDraftKey?: string;
 }) {
   const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -83,6 +85,26 @@ export function AgentComposer({
     element.style.height = "auto";
     element.style.height = `${element.scrollHeight}px`;
   }, [input]);
+
+  useEffect(() => {
+    if (!restoreDraftKey) return;
+    const draft = window.sessionStorage.getItem(restoreDraftKey);
+    if (draft === null) return;
+    window.sessionStorage.removeItem(restoreDraftKey);
+    let focusFrame: number | undefined;
+    const restoreFrame = requestAnimationFrame(() => {
+      setInput((current) => current || draft);
+      focusFrame = requestAnimationFrame(() => {
+        const element = textareaRef.current;
+        element?.focus({ preventScroll: true });
+        element?.setSelectionRange(element.value.length, element.value.length);
+      });
+    });
+    return () => {
+      cancelAnimationFrame(restoreFrame);
+      if (focusFrame !== undefined) cancelAnimationFrame(focusFrame);
+    };
+  }, [restoreDraftKey]);
 
   const query = agentSlashCommandQuery(input);
   const filteredCommands = useMemo(() => {

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -10,6 +10,7 @@ import {
   Minimize2,
   Terminal,
   GitBranch,
+  Pencil,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -69,6 +70,11 @@ export function AgentMessageList({
   activityStartedAt,
   error,
   workspaceName,
+  canEditMessages,
+  canForkMessages,
+  actionsDisabled,
+  onEditMessage,
+  onForkMessage,
 }: {
   providerLabel: string;
   messages: unknown[];
@@ -77,6 +83,11 @@ export function AgentMessageList({
   activityStartedAt: number | null;
   error?: string;
   workspaceName: string;
+  canEditMessages: boolean;
+  canForkMessages: boolean;
+  actionsDisabled: boolean;
+  onEditMessage: (messageId: string) => void;
+  onForkMessage: (messageId: string) => void;
 }) {
   const { scrollRef, contentRef, isAtBottom, scrollToBottom } =
     useStickToBottom({
@@ -119,6 +130,11 @@ export function AgentMessageList({
                   item={item}
                   active={streaming && index === transcript.length - 1}
                   activityStartedAt={activityStartedAt}
+                  canEditMessages={canEditMessages}
+                  canForkMessages={canForkMessages}
+                  actionsDisabled={actionsDisabled}
+                  onEditMessage={onEditMessage}
+                  onForkMessage={onForkMessage}
                 />
               ))}
               {activity && !activityHasLiveStep && (
@@ -158,18 +174,45 @@ function AgentTranscriptRow({
   item,
   active,
   activityStartedAt,
+  canEditMessages,
+  canForkMessages,
+  actionsDisabled,
+  onEditMessage,
+  onForkMessage,
 }: {
   item: AgentTranscriptItem;
   active: boolean;
   activityStartedAt: number | null;
+  canEditMessages: boolean;
+  canForkMessages: boolean;
+  actionsDisabled: boolean;
+  onEditMessage: (messageId: string) => void;
+  onForkMessage: (messageId: string) => void;
 }) {
   if (item.type === "message") {
-    return <AgentMessage message={item.message} />;
+    return (
+      <AgentMessage
+        message={item.message}
+        canEdit={canEditMessages}
+        actionsDisabled={actionsDisabled}
+        onEditMessage={onEditMessage}
+      />
+    );
   }
   if (item.type === "assistant_text") {
     return (
-      <div className="text-sm leading-relaxed">
+      <div className="group/assistant relative text-sm leading-relaxed">
         <Markdown streaming={active}>{item.text}</Markdown>
+        {canForkMessages && item.actionable && item.messageId && (
+          <MessageAction
+            label="Fork from this response"
+            className="-bottom-6 left-0"
+            disabled={actionsDisabled}
+            onClick={() => onForkMessage(item.messageId!)}
+          >
+            <GitBranch />
+          </MessageAction>
+        )}
       </div>
     );
   }
@@ -218,12 +261,30 @@ function AgentErrorNotice({ error }: { error: AgentErrorPresentation }) {
   );
 }
 
-function AgentMessage({ message }: { message: unknown }) {
+function AgentMessage({
+  message,
+  canEdit,
+  actionsDisabled,
+  onEditMessage,
+}: {
+  message: unknown;
+  canEdit: boolean;
+  actionsDisabled: boolean;
+  onEditMessage: (messageId: string) => void;
+}) {
   const record = recordOf(message);
   if (!record) return null;
   const role = roleOf(message);
   if (role === "user") {
-    return <UserMessage content={contentOf(message)} />;
+    return (
+      <UserMessage
+        content={contentOf(message)}
+        messageId={typeof record.id === "string" ? record.id : null}
+        canEdit={canEdit}
+        actionsDisabled={actionsDisabled}
+        onEditMessage={onEditMessage}
+      />
+    );
   }
   if (role === "compactionSummary" || role === "branchSummary") {
     return <SummaryMessage message={record} role={role} />;
@@ -243,7 +304,19 @@ function AgentMessage({ message }: { message: unknown }) {
   return null;
 }
 
-function UserMessage({ content }: { content: unknown }) {
+function UserMessage({
+  content,
+  messageId,
+  canEdit,
+  actionsDisabled,
+  onEditMessage,
+}: {
+  content: unknown;
+  messageId: string | null;
+  canEdit: boolean;
+  actionsDisabled: boolean;
+  onEditMessage: (messageId: string) => void;
+}) {
   const text = textOfContent(content);
   const images = Array.isArray(content)
     ? content.flatMap((part) => {
@@ -264,7 +337,7 @@ function UserMessage({ content }: { content: unknown }) {
       })
     : [];
   return (
-    <div className="flex flex-col items-end gap-2">
+    <div className="group/user relative flex flex-col items-end gap-2">
       {images.map((image, index) => (
         // eslint-disable-next-line @next/next/no-img-element
         <img
@@ -275,11 +348,55 @@ function UserMessage({ content }: { content: unknown }) {
         />
       ))}
       {text && (
-        <div className="min-w-0 max-w-[80%] rounded-2xl bg-secondary px-4 py-2.5 text-sm whitespace-pre-wrap wrap-anywhere text-secondary-foreground">
-          {text}
+        <div className="relative min-w-0 max-w-[80%]">
+          <div className="rounded-2xl bg-secondary px-4 py-2.5 text-sm whitespace-pre-wrap wrap-anywhere text-secondary-foreground">
+            {text}
+          </div>
+          {canEdit && messageId && (
+            <MessageAction
+              label="Edit from this message"
+              className="right-full bottom-0 mr-1"
+              disabled={actionsDisabled}
+              onClick={() => onEditMessage(messageId)}
+            >
+              <Pencil />
+            </MessageAction>
+          )}
         </div>
       )}
     </div>
+  );
+}
+
+function MessageAction({
+  label,
+  className,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  className: string;
+  disabled: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(
+        "absolute size-6 text-muted-foreground opacity-60 motion-opacity hover:text-foreground sm:opacity-0 sm:group-hover/user:opacity-100 sm:group-hover/assistant:opacity-100 sm:focus:opacity-100",
+        className,
+      )}
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
   );
 }
 

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -73,6 +73,10 @@ function sessionName(snapshot: AgentRuntimeSnapshot): string {
   return typeof value === "string" ? value : "";
 }
 
+function forkDraftKey(sessionId: string): string {
+  return `overtchat:agent-fork-draft:${sessionId}`;
+}
+
 export function AgentSessionView({
   sessionId,
   provider,
@@ -111,6 +115,22 @@ export function AgentSessionView({
     try {
       const result = await command.mutateAsync(input);
       if (result.usage) setUsage(result.usage);
+      if (
+        input.type === "edit_message" ||
+        input.type === "fork_message"
+      ) {
+        if (!result.sessionId) {
+          throw new Error(`${providerLabel} did not return the forked session.`);
+        }
+        if (result.draft !== undefined) {
+          window.sessionStorage.setItem(
+            forkDraftKey(result.sessionId),
+            result.draft,
+          );
+        }
+        router.push(`/agents/${result.sessionId}`);
+        return true;
+      }
       if (input.type === "new_session") {
         if (!result.sessionId) {
           throw new Error(`${providerLabel} did not return the new session.`);
@@ -302,11 +322,28 @@ export function AgentSessionView({
         activityStartedAt={activityStartedAt}
         error={runtimeError}
         workspaceName={workspaceName}
+        canEditMessages={
+          snapshot.capabilities.editSentMessages === true
+        }
+        canForkMessages={snapshot.capabilities.forkMessages === true}
+        actionsDisabled={
+          running ||
+          exited ||
+          command.isPending ||
+          Boolean(snapshot.pendingInteraction)
+        }
+        onEditMessage={(messageId) =>
+          void run({ type: "edit_message", messageId })
+        }
+        onForkMessage={(messageId) =>
+          void run({ type: "fork_message", messageId })
+        }
       />
 
       <div className="px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
         <div className="mx-auto max-w-3xl">
           <AgentComposer
+            key={sessionId}
             providerLabel={providerLabel}
             commands={snapshot.commands}
             queuedMessages={snapshot.queuedMessages}
@@ -327,6 +364,7 @@ export function AgentSessionView({
             onSteerQueued={(id) =>
               run({ type: "steer_queued_message", id })
             }
+            restoreDraftKey={forkDraftKey(sessionId)}
           />
         </div>
       </div>

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -822,8 +822,73 @@ test("connect local Codex and resume a native thread", async ({
   await expect(
     page.getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
   ).toBeVisible({ timeout: 60_000 });
+
+  const sourceUrl = page.url();
+  await page
+    .getByRole("button", { name: "Edit from this message" })
+    .click();
+  await page.waitForURL(
+    (url) =>
+      url.pathname.startsWith("/agents/") && url.href !== sourceUrl,
+    { timeout: 30_000 },
+  );
+  await expect(composer).toHaveValue(prompt, { timeout: 30_000 });
+  await expect(composer).toBeFocused();
+  await expect
+    .poll(() =>
+      composer.evaluate((element) => {
+        const textarea = element as HTMLTextAreaElement;
+        return [textarea.selectionStart, textarea.selectionEnd];
+      }),
+    )
+    .toEqual([prompt.length, prompt.length]);
+
+  await page.goto(sourceUrl);
+  await expect(
+    page.locator("main").getByText(prompt, { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(
+    page.getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  await page
+    .getByRole("button", { name: "Fork from this response" })
+    .click();
+  await page.waitForURL(
+    (url) =>
+      url.pathname.startsWith("/agents/") && url.href !== sourceUrl,
+    { timeout: 30_000 },
+  );
+  await expect(
+    page.locator("main").getByText(prompt, { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(
+    page.getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
   await page.screenshot({
-    path: testInfo.outputPath("codex-session-desktop.png"),
+    path: testInfo.outputPath("codex-forked-session-desktop.png"),
+    fullPage: true,
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(
+    page.getByRole("button", { name: "Edit from this message" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Fork from this response" }),
+  ).toBeVisible();
+  const editBounds = await page
+    .getByRole("button", { name: "Edit from this message" })
+    .boundingBox();
+  expect(editBounds).not.toBeNull();
+  expect(editBounds!.x).toBeGreaterThanOrEqual(0);
+  expect(editBounds!.x + editBounds!.width).toBeLessThanOrEqual(390);
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
+  await page.screenshot({
+    path: testInfo.outputPath("codex-forked-session-mobile.png"),
     fullPage: true,
   });
   expect(browserErrors).toEqual([]);

--- a/apps/web/lib/agents/catalog.ts
+++ b/apps/web/lib/agents/catalog.ts
@@ -37,7 +37,12 @@ export const AGENT_PROVIDERS: Record<
     id: "codex",
     label: "Codex",
     executable: "codex",
-    capabilities: { steer: true, usage: true },
+    capabilities: {
+      steer: true,
+      usage: true,
+      editSentMessages: true,
+      forkMessages: true,
+    },
   },
 };
 

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -17,6 +17,7 @@ class FakeCodexServer {
   readonly requests: Array<{ method: string; params: unknown }> = [];
   readonly responses: Array<{ id: string | number; result: unknown }> = [];
   resumeError: Error | null = null;
+  forkError: Error | null = null;
   rateLimitsError: Error | null = null;
   usageError: Error | null = null;
   private notification: Listener<{ method: string; params?: unknown }> =
@@ -132,6 +133,57 @@ class FakeCodexServer {
         reasoningEffort: "high",
       };
     }
+    if (method === "thread/fork") {
+      if (this.forkError) throw this.forkError;
+      const beforeTurnId =
+        params &&
+        typeof params === "object" &&
+        "beforeTurnId" in params &&
+        typeof params.beforeTurnId === "string"
+          ? params.beforeTurnId
+          : null;
+      return {
+        thread: {
+          id: "thread-fork",
+          cwd: "/workspace",
+          preview: beforeTurnId ? "" : "Resume this thread",
+          path: "/tmp/thread-fork.jsonl",
+          name: null,
+          createdAt: 3,
+          updatedAt: 4,
+          turns: beforeTurnId
+            ? []
+            : [
+                {
+                  id: "turn-history",
+                  status: "completed",
+                  startedAt: 1,
+                  completedAt: 2,
+                  items: [
+                    {
+                      id: "user-history",
+                      type: "userMessage",
+                      content: [
+                        {
+                          type: "text",
+                          text: "Resume this thread",
+                          text_elements: [],
+                        },
+                      ],
+                    },
+                    {
+                      id: "assistant-history",
+                      type: "agentMessage",
+                      text: "History restored.",
+                    },
+                  ],
+                },
+              ],
+        },
+        model: "gpt-5.6",
+        reasoningEffort: "high",
+      };
+    }
     if (method === "thread/resume") {
       if (this.resumeError) throw this.resumeError;
       return {
@@ -230,6 +282,9 @@ describe("CodexRuntimeClient", () => {
     server.requests.length = 0;
     server.responses.length = 0;
     server.resumeError = null;
+    server.forkError = null;
+    server.rateLimitsError = null;
+    server.usageError = null;
     server.respondError.mockClear();
     mocks.listCodexCustomPrompts.mockResolvedValue([
       {
@@ -999,6 +1054,152 @@ describe("CodexRuntimeClient", () => {
       unavailableReason:
         "Account usage is unavailable because this Codex connection does not expose authenticated account data.",
     });
+  });
+
+  it("edits the first user message by forking before its native turn", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+    await client.getState();
+
+    await expect(
+      client.forkSession("user-history", "edit"),
+    ).resolves.toEqual({
+      session: {
+        providerSessionId: "thread-fork",
+        providerSessionPath: "/tmp/thread-fork.jsonl",
+        name: null,
+        firstMessage: null,
+        messageCount: 0,
+        createdAt: new Date(3_000),
+        modifiedAt: new Date(4_000),
+      },
+      draft: "Resume this thread",
+    });
+    expect(server.requests).toContainEqual({
+      method: "thread/fork",
+      params: {
+        threadId: "thread-1",
+        beforeTurnId: "turn-history",
+        cwd: "/workspace",
+        model: "gpt-5.6",
+        ephemeral: false,
+      },
+    });
+    expect(server.requests).toContainEqual({
+      method: "thread/unsubscribe",
+      params: { threadId: "thread-fork" },
+    });
+    await expect(client.getMessages()).resolves.toMatchObject({
+      messages: [
+        { id: "user-history", role: "user" },
+        { id: "turn-history:assistant", role: "assistant" },
+      ],
+    });
+  });
+
+  it("deletes a discarded native fork", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+    await client.getState();
+
+    await client.discardForkedSession({
+      providerSessionId: "thread-fork",
+      providerSessionPath: "/tmp/thread-fork.jsonl",
+      name: null,
+      firstMessage: null,
+      messageCount: 0,
+      createdAt: new Date(3_000),
+      modifiedAt: new Date(4_000),
+    });
+
+    expect(server.requests).toContainEqual({
+      method: "thread/delete",
+      params: { threadId: "thread-fork" },
+    });
+  });
+
+  it("forks through an assistant turn without mutating the source", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+    await client.getState();
+
+    await expect(
+      client.forkSession("turn-history:assistant", "fork"),
+    ).resolves.toMatchObject({
+      session: {
+        providerSessionId: "thread-fork",
+        providerSessionPath: "/tmp/thread-fork.jsonl",
+        firstMessage: "Resume this thread",
+        messageCount: 2,
+      },
+    });
+    expect(server.requests).toContainEqual({
+      method: "thread/fork",
+      params: {
+        threadId: "thread-1",
+        lastTurnId: "turn-history",
+        cwd: "/workspace",
+        model: "gpt-5.6",
+        ephemeral: false,
+      },
+    });
+    expect(server.requests).toContainEqual({
+      method: "thread/unsubscribe",
+      params: { threadId: "thread-fork" },
+    });
+    await expect(client.getMessages()).resolves.toMatchObject({
+      messages: [
+        { id: "user-history", role: "user" },
+        { id: "turn-history:assistant", role: "assistant" },
+      ],
+    });
+  });
+
+  it("explains when first-message editing needs newer Codex support", async () => {
+    server.forkError = new Error("unknown field `beforeTurnId`");
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+    await client.getState();
+
+    await expect(client.forkSession("user-history", "edit")).rejects.toThrow(
+      "Editing the first message requires a newer Codex installation.",
+    );
   });
 
   it("emits each question in a multi-question request", async () => {

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -10,6 +10,7 @@ import type {
 import type {
   AgentRuntimeClient,
   AgentRuntimeEvent,
+  AgentSessionForkResult,
   AgentSessionLaunch,
 } from "@/lib/agents/providers/types";
 import type { HostTarget } from "@/lib/agents/runtime/process";
@@ -21,6 +22,7 @@ import {
 } from "@/lib/agents/codex/app-server";
 import {
   codexDefaultThinkingLevel,
+  codexSessionMetadata,
   codexThinkingLevels,
   emptyCodexStats,
   numberOf,
@@ -228,6 +230,14 @@ function isActiveWriterError(error: unknown): boolean {
   return (
     error instanceof Error &&
     /thread .+ already has an active writer/i.test(error.message)
+  );
+}
+
+function isBeforeTurnForkUnsupportedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (/beforeTurnId/iu.test(error.message) ||
+      /experimentalApi capability/iu.test(error.message))
   );
 }
 
@@ -868,6 +878,99 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     );
   }
 
+  async forkSession(
+    messageId: string,
+    mode: "edit" | "fork",
+  ): Promise<AgentSessionForkResult> {
+    await this.readyPromise;
+    if (this.activeTurnId) {
+      throw new Error("Wait for the current Codex turn to finish first.");
+    }
+
+    const turns = this.orderedTurns();
+    let response: UnknownRecord;
+    let draft: string | undefined;
+
+    if (mode === "edit") {
+      const target = turns
+        .map((turn, turnIndex) => ({
+          turn,
+          turnIndex,
+          item: turn.items.find(
+            (item) => item.id === messageId && item.type === "userMessage",
+          ),
+        }))
+        .find((candidate) => candidate.item);
+      if (!target?.item) {
+        throw new Error("Codex could not find that user message.");
+      }
+      draft = itemText(target.item);
+      if (!draft) {
+        throw new Error("Codex could not restore that user message.");
+      }
+      const previousTurn = turns[target.turnIndex - 1];
+      try {
+        response = await this.server.request<UnknownRecord>("thread/fork", {
+          threadId: this.thread!.id,
+          ...(previousTurn
+            ? { lastTurnId: previousTurn.id }
+            : { beforeTurnId: target.turn.id }),
+          cwd: this.launch.cwd,
+          model: this.selectedModel || null,
+          ephemeral: false,
+        });
+      } catch (error) {
+        if (!previousTurn && isBeforeTurnForkUnsupportedError(error)) {
+          throw new Error(
+            "Editing the first message requires a newer Codex installation.",
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+    } else {
+      const turnId = messageId.endsWith(":assistant")
+        ? messageId.slice(0, -":assistant".length)
+        : messageId;
+      const target = turns.find((turn) => turn.id === turnId);
+      if (!target) {
+        throw new Error("Codex could not find that assistant response.");
+      }
+      response = await this.server.request<UnknownRecord>("thread/fork", {
+        threadId: this.thread!.id,
+        lastTurnId: target.id,
+        cwd: this.launch.cwd,
+        model: this.selectedModel || null,
+        ephemeral: false,
+      });
+    }
+
+    const thread = parseCodexThread(response.thread);
+    if (thread.id === this.thread!.id) {
+      throw new Error("Codex did not create a new thread.");
+    }
+    await this.server.request(
+      "thread/unsubscribe",
+      { threadId: thread.id },
+      5_000,
+    );
+    return {
+      session: codexSessionMetadata(thread),
+      ...(draft !== undefined ? { draft } : {}),
+    };
+  }
+
+  async discardForkedSession(
+    session: AgentSessionForkResult["session"],
+  ): Promise<void> {
+    await this.readyPromise;
+    await this.server.request(
+      "thread/delete",
+      { threadId: session.providerSessionId },
+      5_000,
+    );
+  }
+
   private async openThread(): Promise<void> {
     await this.server.ready();
     const modelPromise = this.server.request("model/list", { limit: 200 });
@@ -940,12 +1043,14 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   }
 
   private messages(): unknown[] {
-    return [...this.turns.values()]
-      .sort(
-        (left, right) =>
-          (left.startedAt ?? 0) - (right.startedAt ?? 0),
-      )
-      .flatMap(canonicalTurnMessages);
+    return this.orderedTurns().flatMap(canonicalTurnMessages);
+  }
+
+  private orderedTurns(): CodexTurn[] {
+    return [...this.turns.values()].sort(
+      (left, right) =>
+        (left.startedAt ?? 0) - (right.startedAt ?? 0),
+    );
   }
 
   private handleNotification(method: string, params: unknown): void {
@@ -1507,6 +1612,8 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   }
 
   private updateTokenUsage(data: UnknownRecord | null): void {
+    const threadId = stringOf(data, "threadId");
+    if (threadId && threadId !== this.thread?.id) return;
     const tokenUsage = recordOf(data?.tokenUsage);
     const usage = recordOf(tokenUsage?.total);
     if (!usage) return;

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -140,6 +140,36 @@ describe("projectAgentTranscript", () => {
     ]);
   });
 
+  it("exposes one fork action on the final assistant text part", () => {
+    const projected = projectAgentTranscript([
+      assistant(
+        [
+          { type: "text", text: "First update." },
+          call("inspect", "read", { path: "a.ts" }),
+          { type: "text", text: "Final answer." },
+        ],
+        1,
+        { id: "turn-1:assistant" },
+      ),
+    ]);
+    const textItems = projected.filter(
+      (item) => item.type === "assistant_text",
+    );
+
+    expect(textItems).toEqual([
+      expect.objectContaining({
+        text: "First update.",
+        messageId: "turn-1:assistant",
+        actionable: false,
+      }),
+      expect.objectContaining({
+        text: "Final answer.",
+        messageId: "turn-1:assistant",
+        actionable: true,
+      }),
+    ]);
+  });
+
   it("keeps partial, failed, and orphaned results inspectable", () => {
     const partial = projectedTools([
       assistant([call("partial", "bash", { command: "npm test" })], 1),

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -51,6 +51,8 @@ export type AgentTranscriptItem =
       type: "assistant_text";
       key: string;
       text: string;
+      messageId: string | null;
+      actionable: boolean;
     }
   | {
       type: "assistant_error";
@@ -266,6 +268,14 @@ export function projectAgentTranscript(
 
     if (role === "assistant") {
       const content = Array.isArray(record.content) ? record.content : [];
+      const lastTextIndex = content.findLastIndex((part) => {
+        const candidate = recordOf(part);
+        return (
+          candidate?.type === "text" &&
+          typeof candidate.text === "string" &&
+          candidate.text.trim().length > 0
+        );
+      });
       content.forEach((part, partIndex) => {
         const partRecord = recordOf(part);
         if (!partRecord) return;
@@ -310,6 +320,9 @@ export function projectAgentTranscript(
             type: "assistant_text",
             key: `assistant:${partIdentity}`,
             text: partRecord.text,
+            messageId:
+              typeof record.id === "string" ? record.id : null,
+            actionable: partIndex === lastTextIndex,
           });
         }
       });

--- a/apps/web/lib/agents/providers/types.ts
+++ b/apps/web/lib/agents/providers/types.ts
@@ -43,6 +43,11 @@ export type AgentSessionLaunch = {
   };
 };
 
+export type AgentSessionForkResult = {
+  session: AgentProviderSessionMetadata;
+  draft?: string;
+};
+
 export interface AgentRuntimeClient {
   onEvent(subscriber: (event: AgentRuntimeEvent) => void): () => void;
   getState(timeoutMs?: number): Promise<Record<string, unknown>>;
@@ -70,6 +75,11 @@ export interface AgentRuntimeClient {
   ): void;
   retryInteractive?(): Promise<unknown>;
   getUsage?(): Promise<AgentUsageSnapshot>;
+  forkSession?(
+    messageId: string,
+    mode: "edit" | "fork",
+  ): Promise<AgentSessionForkResult>;
+  discardForkedSession?(session: AgentProviderSessionMetadata): Promise<void>;
   stop(): Promise<void>;
 }
 

--- a/apps/web/lib/agents/runtime/registry.test.ts
+++ b/apps/web/lib/agents/runtime/registry.test.ts
@@ -88,6 +88,19 @@ class FakeAgentClient {
   readonly setAutoCompaction = vi.fn(async () => ({}));
   readonly setSessionName = vi.fn(async () => ({}));
   readonly retryInteractive = vi.fn(async () => ({}));
+  readonly forkSession = vi.fn(async () => ({
+    session: {
+      providerSessionId: "native-fork",
+      providerSessionPath: "/sessions/native-fork.jsonl",
+      name: null,
+      firstMessage: "Earlier prompt",
+      messageCount: 2,
+      createdAt: new Date(1_000),
+      modifiedAt: new Date(2_000),
+    },
+    draft: "Edit this prompt",
+  }));
+  readonly discardForkedSession = vi.fn(async () => {});
   readonly respondToInteraction = vi.fn();
   readonly respondToExtensionUi = this.respondToInteraction;
   readonly getState = vi.fn(async () => ({ ...idleProviderState }));
@@ -1185,6 +1198,88 @@ describe("Agent session runtime", () => {
     expect(runtime.snapshot().pendingInteraction).toBeUndefined();
     unsubscribeFirst();
     unsubscribeReplay();
+    await runtime.stop();
+  });
+
+  it("persists provider-native history forks as new sessions", async () => {
+    vi.clearAllMocks();
+    const client = new FakeAgentClient();
+    const runtime = new AgentSessionRuntime(
+      "session",
+      "user",
+      "connection",
+      "workspace",
+      agentProviderAdapter("pi"),
+      client as unknown as AgentRuntimeClient,
+      {
+        ...initial(),
+        thinkingLevels: [...initial().thinkingLevels],
+      },
+      vi.fn(),
+    );
+    mocks.upsertAgentSession.mockResolvedValue({
+      ...owned().agentSession,
+      id: "forked-session",
+      providerSessionId: "native-fork",
+      providerSessionPath: "/sessions/native-fork.jsonl",
+    });
+    const registry = new AgentRuntimeRegistry();
+
+    await expect(
+      registry.fork(owned(), runtime, {
+        type: "edit_message",
+        messageId: "user-message",
+      }),
+    ).resolves.toEqual({
+      sessionId: "forked-session",
+      draft: "Edit this prompt",
+    });
+    expect(client.forkSession).toHaveBeenCalledWith(
+      "user-message",
+      "edit",
+    );
+    expect(mocks.upsertAgentSession).toHaveBeenCalledWith("workspace", {
+      providerSessionId: "native-fork",
+      providerSessionPath: "/sessions/native-fork.jsonl",
+      name: null,
+      firstMessage: "Earlier prompt",
+      messageCount: 2,
+      createdAt: new Date(1_000),
+      modifiedAt: new Date(2_000),
+    });
+    await runtime.stop();
+  });
+
+  it("discards a native fork when local session persistence fails", async () => {
+    vi.clearAllMocks();
+    const client = new FakeAgentClient();
+    const runtime = new AgentSessionRuntime(
+      "session",
+      "user",
+      "connection",
+      "workspace",
+      agentProviderAdapter("pi"),
+      client as unknown as AgentRuntimeClient,
+      {
+        ...initial(),
+        thinkingLevels: [...initial().thinkingLevels],
+      },
+      vi.fn(),
+    );
+    mocks.upsertAgentSession.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+    const registry = new AgentRuntimeRegistry();
+
+    await expect(
+      registry.fork(owned(), runtime, {
+        type: "fork_message",
+        messageId: "assistant-message",
+      }),
+    ).rejects.toThrow("database unavailable");
+    expect(client.discardForkedSession).toHaveBeenCalledWith(
+      expect.objectContaining({ providerSessionId: "native-fork" }),
+    );
     await runtime.stop();
   });
 

--- a/apps/web/lib/agents/runtime/registry.ts
+++ b/apps/web/lib/agents/runtime/registry.ts
@@ -26,6 +26,7 @@ import type {
   AgentRuntimeEvent,
   AgentRuntimeEventClassifier,
   AgentRuntimeInitialState,
+  AgentSessionForkResult,
 } from "@/lib/agents/providers/types";
 import { targetForStoredHost } from "@/lib/agents/runtime/target";
 import {
@@ -413,6 +414,11 @@ export class AgentSessionRuntime {
         return Promise.reject(
           new Error("New sessions must be created by the runtime registry."),
         );
+      case "edit_message":
+      case "fork_message":
+        return Promise.reject(
+          new Error("Session forks must be created by the runtime registry."),
+        );
       case "prompt":
         return this.submitPrompt(command.message);
       case "abort":
@@ -499,6 +505,30 @@ export class AgentSessionRuntime {
         }
         return this.client.getUsage();
     }
+  }
+
+  async forkSession(
+    messageId: string,
+    mode: "edit" | "fork",
+  ): Promise<AgentSessionForkResult> {
+    if (this.status !== "idle") {
+      throw new Error("Wait for the current agent turn to finish first.");
+    }
+    if (this.pendingInteraction) {
+      throw new Error("Respond to the pending agent request first.");
+    }
+    if (!this.client.forkSession) {
+      throw new Error(
+        `${agentProviderMetadata(this.provider).label} does not support conversation forks.`,
+      );
+    }
+    return this.client.forkSession(messageId, mode);
+  }
+
+  async discardForkedSession(
+    session: AgentSessionForkResult["session"],
+  ): Promise<void> {
+    await this.client.discardForkedSession?.(session);
   }
 
   async refresh(): Promise<void> {
@@ -1130,6 +1160,31 @@ export class AgentRuntimeRegistry {
       await client.stop();
       throw error;
     }
+  }
+
+  async fork(
+    owned: OwnedAgentSession,
+    runtime: AgentSessionRuntime,
+    input: Extract<
+      AgentSessionCommand,
+      { type: "edit_message" | "fork_message" }
+    >,
+  ): Promise<{ sessionId: string; draft?: string }> {
+    const fork = await runtime.forkSession(
+      input.messageId,
+      input.type === "edit_message" ? "edit" : "fork",
+    );
+    let row;
+    try {
+      row = await upsertAgentSession(owned.workspace.id, fork.session);
+    } catch (error) {
+      await runtime.discardForkedSession(fork.session).catch(() => {});
+      throw error;
+    }
+    return {
+      sessionId: row.id,
+      ...(fork.draft !== undefined ? { draft: fork.draft } : {}),
+    };
   }
 
   async getForUser(

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -222,6 +222,8 @@ export type AgentRuntimeCapabilities = {
   steer: boolean;
   customCompactionInstructions?: boolean;
   usage?: boolean;
+  editSentMessages?: boolean;
+  forkMessages?: boolean;
 };
 
 export type AgentUsageWindow = {
@@ -293,6 +295,14 @@ export const agentSessionCommandSchema = z.discriminatedUnion("type", [
   }),
   z.object({ type: z.literal("new_session") }),
   z.object({ type: z.literal("show_usage") }),
+  z.object({
+    type: z.literal("edit_message"),
+    messageId: z.string().min(1).max(500),
+  }),
+  z.object({
+    type: z.literal("fork_message"),
+    messageId: z.string().min(1).max(500),
+  }),
   z.object({
     type: z.literal("interaction_response"),
     id: z.string().min(1).max(500),

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -80,6 +80,7 @@ export function useAgentSessionCommand(id: string) {
       command: AgentSessionCommand,
     ): Promise<{
       sessionId?: string;
+      draft?: string;
       queuedMessages?: AgentQueuedMessage[];
       usage?: AgentUsageSnapshot;
     }> => {
@@ -91,6 +92,7 @@ export function useAgentSessionCommand(id: string) {
       if (!response.ok) throw await responseError(response);
       return (await response.json()) as {
         sessionId?: string;
+        draft?: string;
         queuedMessages?: AgentQueuedMessage[];
         usage?: AgentUsageSnapshot;
       };
@@ -122,7 +124,9 @@ export function useAgentSessionCommand(id: string) {
         command.type === "steer" ||
         command.type === "steer_queued_message" ||
         command.type === "set_session_name" ||
-        command.type === "new_session"
+        command.type === "new_session" ||
+        command.type === "edit_message" ||
+        command.type === "fork_message"
       ) {
         void queryClient.invalidateQueries({
           queryKey: agentConnectionKeys.list(),


### PR DESCRIPTION
## Summary

- edit a sent Codex prompt by forking before its native turn and restoring the prompt in the new composer
- fork from an assistant response through its native turn while preserving the source thread
- capability-gate shared message actions and persist forked sessions transactionally
- clean up native forks if local persistence fails

This uses Codex `thread/fork` boundaries and does not mutate transcript text or use deprecated rollback APIs.

## Testing

- 462 web tests passed, 4 skipped
- lint, typecheck, and production build passed
- real Codex production E2E passed: `/usage`, native turn, cold resume, first-message Edit, source preservation, assistant Fork
- desktop and 390px mobile layouts verified with actions inside the viewport

## Stack

Draft stacked on #137. No migration.