### PR TITLE
chore: prepare v0.13.0 release

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.12.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- update the default Docker image tag in `compose.yml` from `0.12.0` to `0.13.0`

## Verification

- `docker compose config`
- `git diff --check`