### PR TITLE
feat(web): show workspace git status

### DIFF
--- a/apps/web/app/(app)/agents/[id]/page.tsx
+++ b/apps/web/app/(app)/agents/[id]/page.tsx
@@ -22,7 +22,9 @@ export default async function AgentSessionPage({
     <AgentSessionView
       sessionId={id}
       provider={owned.connection.provider}
+      workspaceId={owned.workspace.id}
       workspaceName={owned.workspace.name}
+      workspacePath={owned.workspace.path}
       initialSessionName={
         owned.agentSession.name ??
         owned.agentSession.firstMessage ??

--- a/apps/web/app/api/agent-workspaces/[id]/git-status/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/git-status/route.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getOwnedAgentWorkspace: vi.fn(),
+  targetForStoredHost: vi.fn(),
+  inspectAgentWorkspaceGitStatus: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/agentConnections", () => ({
+  getOwnedAgentWorkspace: mocks.getOwnedAgentWorkspace,
+}));
+vi.mock("@/lib/agents/runtime/target", () => ({
+  targetForStoredHost: mocks.targetForStoredHost,
+}));
+vi.mock("@/lib/agents/runtime/git", () => ({
+  inspectAgentWorkspaceGitStatus: mocks.inspectAgentWorkspaceGitStatus,
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({ id: "workspace" }) };
+const request = new Request(
+  "http://server.test/api/agent-workspaces/workspace/git-status",
+);
+
+describe("agent workspace Git status route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "owner", role: "admin" },
+    });
+    mocks.getOwnedAgentWorkspace.mockResolvedValue({
+      host: { transport: "local", userId: "owner" },
+      connection: { id: "connection", shellMode: "interactive" },
+      workspace: {
+        id: "workspace",
+        path: "/srv/project",
+      },
+    });
+    mocks.targetForStoredHost.mockReturnValue({
+      connectorId: "connector",
+      transport: "local",
+    });
+    mocks.inspectAgentWorkspaceGitStatus.mockResolvedValue({
+      isGit: true,
+      repositoryRoot: "/srv/project",
+      branch: "feature/status",
+      upstream: "origin/feature/status",
+      ahead: 1,
+      behind: 0,
+      dirty: true,
+      changedFiles: 2,
+      additions: 8,
+      deletions: 3,
+      lineStatsComplete: true,
+    });
+  });
+
+  it("returns fresh Git metadata through the owner-scoped stored host", async () => {
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.targetForStoredHost).toHaveBeenCalled();
+    expect(mocks.inspectAgentWorkspaceGitStatus).toHaveBeenCalledWith(
+      { connectorId: "connector", transport: "local" },
+      "/srv/project",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      status: {
+        branch: "feature/status",
+        changedFiles: 2,
+      },
+    });
+  });
+
+  it("blocks unauthenticated, non-admin, and cross-user access", async () => {
+    mocks.getSession.mockResolvedValueOnce(null);
+    expect((await GET(request, context)).status).toBe(401);
+
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: "owner", role: "user" },
+    });
+    expect((await GET(request, context)).status).toBe(403);
+
+    mocks.getOwnedAgentWorkspace.mockResolvedValueOnce(null);
+    expect((await GET(request, context)).status).toBe(404);
+    expect(mocks.inspectAgentWorkspaceGitStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns a useful connector error without caching it", async () => {
+    mocks.inspectAgentWorkspaceGitStatus.mockRejectedValue(
+      new Error("Git is not installed on the selected machine."),
+    );
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Git is not installed on the selected machine.",
+    });
+  });
+});

--- a/apps/web/app/api/agent-workspaces/[id]/git-status/route.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/git-status/route.ts
@@ -1,0 +1,42 @@
+import { auth } from "@/lib/auth/server";
+import {
+  connectionErrorMessage,
+  storedConnectionAccessError,
+} from "@/lib/agents/access";
+import { inspectAgentWorkspaceGitStatus } from "@/lib/agents/runtime/git";
+import { targetForStoredHost } from "@/lib/agents/runtime/target";
+import { getOwnedAgentWorkspace } from "@/lib/db/agentConnections";
+
+export const maxDuration = 30;
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  const accessError = storedConnectionAccessError(session.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const owned = await getOwnedAgentWorkspace(id, session.user.id);
+  if (!owned) return new Response("Not found", { status: 404 });
+
+  try {
+    const status = await inspectAgentWorkspaceGitStatus(
+      targetForStoredHost(owned.host, owned.connection.shellMode),
+      owned.workspace.path,
+    );
+    return Response.json(
+      { status },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    return Response.json(
+      { error: connectionErrorMessage(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/components/SidebarConnections.tsx
+++ b/apps/web/components/SidebarConnections.tsx
@@ -7,7 +7,9 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronUp,
+  FileDiff,
   Folder,
+  GitBranch,
   Loader2,
   Plus,
   TerminalSquare,
@@ -15,6 +17,7 @@ import {
 import type {
   AgentConnectionListItem,
   AgentSessionListItem,
+  AgentWorkspaceGitStatus,
   AgentWorkspaceListItem,
 } from "@/lib/agents/types";
 import { agentProviderMetadata } from "@/lib/agents/catalog";
@@ -29,6 +32,7 @@ import { useSidebar } from "@/components/sidebar-context";
 import { toast } from "@/components/ui/toast";
 import { motionClasses } from "@/lib/motion";
 import { useCreateAgentSession } from "@/lib/queries/agentConnections";
+import { useAgentWorkspaceGitStatus } from "@/lib/queries/agentWorkspaces";
 import { cn } from "@/lib/utils";
 
 export function SidebarConnections({
@@ -122,6 +126,10 @@ function WorkspaceNode({
   const [open, setOpen] = useState(hasActiveSession);
   const [sessionsExpanded, setSessionsExpanded] = useState(false);
   const hasRunningSession = agentWorkspaceHasRunningSession(workspace);
+  const gitStatus = useAgentWorkspaceGitStatus(workspace.id, {
+    active: hasActiveSession,
+    running: hasRunningSession,
+  }).data;
   const activeSessionId =
     workspace.sessions.find(
       (session) => pathname === `/agents/${session.id}`,
@@ -160,7 +168,7 @@ function WorkspaceNode({
               ? `Collapse ${workspace.name}`
               : `Expand ${workspace.name}`
           }
-          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1 py-1.5 text-left text-sm motion-colors hover:bg-sidebar-accent"
+          className="flex min-h-11 min-w-0 flex-1 items-center gap-1.5 rounded-md px-1 py-1 text-left text-sm motion-colors hover:bg-sidebar-accent"
           title={workspace.path}
         >
           <ChevronRight
@@ -170,7 +178,10 @@ function WorkspaceNode({
             )}
           />
           <Folder className="size-3.5 shrink-0 text-muted-foreground" />
-          <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
+          <span className="flex min-h-8 min-w-0 flex-1 flex-col justify-center">
+            <span className="truncate">{workspace.name}</span>
+            <WorkspaceGitMeta status={gitStatus} workspaceId={workspace.id} />
+          </span>
           <RuntimeActivityIndicator
             active={!open && hasRunningSession}
             label={`${workspace.name} has running sessions`}
@@ -220,6 +231,45 @@ function WorkspaceNode({
         </ul>
       )}
     </li>
+  );
+}
+
+function WorkspaceGitMeta({
+  status,
+  workspaceId,
+}: {
+  status: AgentWorkspaceGitStatus | undefined;
+  workspaceId: string;
+}) {
+  if (!status?.isGit) return null;
+  return (
+    <span
+      data-testid={`sidebar-workspace-git-status-${workspaceId}`}
+      className="flex min-w-0 items-center gap-1.5 text-[11px] leading-4 text-muted-foreground"
+    >
+      <span className="flex min-w-0 items-center gap-1">
+        <GitBranch className="size-3 shrink-0" />
+        <span className="max-w-24 truncate">
+          {status.branch ?? "Detached HEAD"}
+        </span>
+      </span>
+      {status.dirty && (
+        <span className="flex shrink-0 items-center gap-1 tabular-nums">
+          <FileDiff className="size-3" />
+          <span>{status.changedFiles}</span>
+          {status.lineStatsComplete && (
+            <>
+              <span className="text-emerald-700 dark:text-emerald-300">
+                +{status.additions}
+              </span>
+              <span className="text-red-700 dark:text-red-300">
+                -{status.deletions}
+              </span>
+            </>
+          )}
+        </span>
+      )}
+    </span>
   );
 }
 

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { writeText as clipboardWriteText } from "clipboard-polyfill";
 import { Menu } from "@base-ui/react/menu";
 import { Popover } from "@base-ui/react/popover";
 import {
   Check,
   ChevronDown,
   Coins,
+  Copy,
+  FileDiff,
+  GitBranch,
   MoreHorizontal,
   Pencil,
   Search,
@@ -28,14 +32,19 @@ import type {
   AgentModel,
   AgentSessionStats,
   AgentThinkingLevel,
+  AgentWorkspaceGitStatus,
 } from "@/lib/agents/types";
 import { modelIconForModel } from "@/lib/providers/catalog";
 import { motionClasses } from "@/lib/motion";
+import { useAgentWorkspaceGitStatus } from "@/lib/queries/agentWorkspaces";
 import { cn } from "@/lib/utils";
+import { toast } from "@/components/ui/toast";
 
 export function AgentSessionHeader({
   providerLabel,
+  workspaceId,
   workspaceName,
+  workspacePath,
   models,
   currentModel,
   thinkingLevel,
@@ -50,7 +59,9 @@ export function AgentSessionHeader({
   onCompact,
 }: {
   providerLabel: string;
+  workspaceId: string;
   workspaceName: string;
+  workspacePath: string;
   models: AgentModel[];
   currentModel: { provider: string; id: string } | null;
   thinkingLevel: AgentThinkingLevel | null;
@@ -64,6 +75,21 @@ export function AgentSessionHeader({
   onRename: () => void;
   onCompact: () => void;
 }) {
+  const gitStatus = useAgentWorkspaceGitStatus(workspaceId, {
+    active: true,
+    running,
+  }).data;
+  const branch = gitStatus?.branch;
+
+  async function copyWorkspaceValue(value: string, label: string) {
+    try {
+      await clipboardWriteText(value);
+      toast.success({ title: `${label} copied` });
+    } catch {
+      toast.error({ title: `Could not copy ${label.toLowerCase()}` });
+    }
+  }
+
   return (
     <header className="flex h-12 shrink-0 items-center gap-1 border-b px-3">
       <SidebarToggle />
@@ -73,6 +99,7 @@ export function AgentSessionHeader({
       >
         {workspaceName}
       </span>
+      <WorkspaceGitSummary status={gitStatus} />
       <AgentModelPicker
         providerLabel={providerLabel}
         models={models}
@@ -124,7 +151,6 @@ export function AgentSessionHeader({
                 size="icon-sm"
                 aria-label="Session actions"
                 title="Session actions"
-                disabled={readOnly}
               />
             }
           >
@@ -138,6 +164,27 @@ export function AgentSessionHeader({
                   motionClasses.popup,
                 )}
               >
+                <Menu.Item
+                  onClick={() =>
+                    void copyWorkspaceValue(workspacePath, "Workspace path")
+                  }
+                  className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[highlighted]:bg-accent"
+                >
+                  <Copy className="size-3.5 text-muted-foreground" />
+                  Copy workspace path
+                </Menu.Item>
+                {branch && (
+                  <Menu.Item
+                    onClick={() =>
+                      void copyWorkspaceValue(branch, "Branch name")
+                    }
+                    className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[highlighted]:bg-accent"
+                  >
+                    <GitBranch className="size-3.5 text-muted-foreground" />
+                    Copy branch name
+                  </Menu.Item>
+                )}
+                <Menu.Separator className="my-1 h-px bg-border" />
                 <Menu.Item
                   disabled={readOnly}
                   onClick={onRename}
@@ -160,6 +207,58 @@ export function AgentSessionHeader({
         </Menu.Root>
       </div>
     </header>
+  );
+}
+
+function WorkspaceGitSummary({
+  status,
+}: {
+  status: AgentWorkspaceGitStatus | undefined;
+}) {
+  if (!status?.isGit) return null;
+  const branch = status.branch ?? "Detached HEAD";
+  const tracking = [
+    status.ahead ? `${status.ahead} ahead` : null,
+    status.behind ? `${status.behind} behind` : null,
+  ].filter(Boolean);
+  const title = [
+    branch,
+    ...tracking,
+    status.dirty
+      ? `${status.changedFiles} changed ${status.changedFiles === 1 ? "file" : "files"}`
+      : "Clean working tree",
+  ].join(" · ");
+
+  return (
+    <div
+      data-testid="agent-workspace-git-status"
+      title={title}
+      className="hidden min-w-0 items-center gap-2 px-1 text-[11px] text-muted-foreground lg:flex"
+    >
+      <span className="flex min-w-0 items-center gap-1">
+        <GitBranch className="size-3.5 shrink-0" />
+        <span className="max-w-28 truncate">{branch}</span>
+      </span>
+      {status.dirty && (
+        <span className="flex shrink-0 items-center gap-1.5 tabular-nums">
+          <FileDiff className="size-3.5" />
+          <span>
+            {status.changedFiles}{" "}
+            {status.changedFiles === 1 ? "file" : "files"}
+          </span>
+          {status.lineStatsComplete && (
+            <>
+              <span className="text-emerald-700 dark:text-emerald-300">
+                +{status.additions}
+              </span>
+              <span className="text-red-700 dark:text-red-300">
+                -{status.deletions}
+              </span>
+            </>
+          )}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -80,12 +80,16 @@ function forkDraftKey(sessionId: string): string {
 export function AgentSessionView({
   sessionId,
   provider,
+  workspaceId,
   workspaceName,
+  workspacePath,
   initialSessionName,
 }: {
   sessionId: string;
   provider: AgentProviderId;
+  workspaceId: string;
   workspaceName: string;
+  workspacePath: string;
   initialSessionName: string;
 }) {
   const providerLabel = agentProviderMetadata(provider).label;
@@ -253,7 +257,9 @@ export function AgentSessionView({
     <div className="flex flex-1 flex-col overflow-hidden">
       <AgentSessionHeader
         providerLabel={providerLabel}
+        workspaceId={workspaceId}
         workspaceName={workspaceName}
+        workspacePath={workspacePath}
         models={snapshot.models}
         currentModel={model}
         thinkingLevel={thinking}

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -246,6 +246,29 @@ test("shows durable turn activity without changing completed tool status", async
     }
     await route.fulfill({ response, json: body });
   });
+  await page.route(
+    new RegExp("/api/agent-workspaces/workspace/git-status$"),
+    async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: {
+            isGit: true,
+            repositoryRoot: "/tmp/runtime-test",
+            branch: "feature/runtime-status",
+            upstream: "origin/feature/runtime-status",
+            ahead: 2,
+            behind: 1,
+            dirty: true,
+            changedFiles: 2,
+            additions: 8,
+            deletions: 3,
+            lineStatsComplete: true,
+          },
+        }),
+      });
+    },
+  );
   await page.addInitScript(() => {
     type RuntimeEnvelope = {
       sequence: number;
@@ -330,6 +353,25 @@ test("shows durable turn activity without changing completed tool status", async
     name: "Runtime activity is working",
   });
   await expect(sessionActivity).toBeVisible();
+  const headerGitStatus = page.getByTestId("agent-workspace-git-status");
+  await expect(headerGitStatus).toContainText("feature/runtime-status");
+  await expect(headerGitStatus).toContainText("2 files");
+  await expect(headerGitStatus).toContainText("+8");
+  await expect(headerGitStatus).toContainText("-3");
+  const sidebarGitStatus = page.locator(
+    '[data-testid="sidebar-workspace-git-status-workspace"]:visible',
+  );
+  await expect(sidebarGitStatus).toContainText("feature/runtime-status");
+  await expect(sidebarGitStatus).toContainText("+8");
+  await expect(sidebarGitStatus).toContainText("-3");
+  await page.getByRole("button", { name: "Session actions" }).click();
+  await expect(
+    page.getByRole("menuitem", { name: "Copy workspace path" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: "Copy branch name" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
   await expect(
     page.getByRole("button", { name: "New session in Runtime test" }),
   ).toBeVisible();
@@ -484,6 +526,7 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(genericActivity).toContainText("Reconnecting");
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(genericActivity).toBeVisible();
+  await expect(headerGitStatus).not.toBeVisible();
   expect(
     await page.evaluate(
       () =>
@@ -497,6 +540,7 @@ test("shows durable turn activity without changing completed tool status", async
   });
   await page.getByRole("button", { name: "Open sidebar" }).click();
   await expect(sessionActivity).toBeVisible();
+  await expect(sidebarGitStatus).toBeVisible();
   expect(
     await page.evaluate(
       () =>
@@ -653,7 +697,17 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(
     page.getByPlaceholder("Message Pi or type / for commands"),
   ).toBeDisabled();
-  await expect(page.getByLabel("Session actions")).toBeDisabled();
+  await page.getByLabel("Session actions").click();
+  await expect(
+    page.getByRole("menuitem", { name: "Copy workspace path" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: "Rename session" }),
+  ).toHaveAttribute("aria-disabled", "true");
+  await expect(
+    page.getByRole("menuitem", { name: "Compact context" }),
+  ).toHaveAttribute("aria-disabled", "true");
+  await page.keyboard.press("Escape");
   await page.getByRole("button", { name: "Retry" }).click();
   await expect.poll(() => retryRequested).toBe(true);
 });

--- a/apps/web/lib/agents/runtime/git.test.ts
+++ b/apps/web/lib/agents/runtime/git.test.ts
@@ -1,0 +1,181 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  executeOnHost: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/agents/runtime/process", () => ({
+  executeOnHost: mocks.executeOnHost,
+}));
+
+import {
+  AGENT_WORKSPACE_GIT_PROBE_SCRIPT,
+  inspectAgentWorkspaceGitStatus,
+} from "./git";
+
+const connectorId = "11111111-1111-4111-8111-111111111111";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function probe(cwd: string): Record<string, unknown> {
+  return JSON.parse(
+    execFileSync(
+      process.execPath,
+      ["-e", AGENT_WORKSPACE_GIT_PROBE_SCRIPT],
+      { cwd, encoding: "utf8" },
+    ),
+  ) as Record<string, unknown>;
+}
+
+function createRepository(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), "overtchat-git-"));
+  git(directory, "init", "--quiet", "--initial-branch=main");
+  git(directory, "config", "user.email", "test@overtchat.local");
+  git(directory, "config", "user.name", "OvertChat Test");
+  writeFileSync(path.join(directory, "tracked.txt"), "one\ntwo\n");
+  git(directory, "add", ".");
+  git(directory, "commit", "--quiet", "-m", "initial");
+  return directory;
+}
+
+describe("agent workspace Git status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("summarizes branch, upstream, tracked, and untracked changes", () => {
+    const directory = createRepository();
+    git(directory, "checkout", "--quiet", "-b", "feature/status");
+    git(directory, "branch", "--set-upstream-to", "main");
+    writeFileSync(path.join(directory, "tracked.txt"), "one\nthree\nfour\n");
+    writeFileSync(path.join(directory, "new.txt"), "alpha\nbeta\n");
+
+    expect(probe(directory)).toMatchObject({
+      isGit: true,
+      repositoryRoot: directory,
+      branch: "feature/status",
+      upstream: "main",
+      ahead: 0,
+      behind: 0,
+      changedFiles: 2,
+      additions: 4,
+      deletions: 1,
+      lineStatsComplete: true,
+    });
+  });
+
+  it("handles non-repositories and incomplete binary line stats", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "overtchat-non-git-"));
+    expect(probe(directory)).toEqual({ isGit: false });
+
+    const repository = createRepository();
+    writeFileSync(
+      path.join(repository, "tracked.txt"),
+      Buffer.from([0, 1, 2, 3]),
+    );
+    expect(probe(repository)).toMatchObject({
+      isGit: true,
+      changedFiles: 1,
+      lineStatsComplete: false,
+    });
+  });
+
+  it("marks symlink additions incomplete without reading outside the repository", () => {
+    const directory = createRepository();
+    const outside = path.join(
+      directory,
+      "..",
+      `${path.basename(directory)}-outside.txt`,
+    );
+    writeFileSync(outside, "outside\n");
+    symlinkSync(outside, path.join(directory, "outside-link"));
+
+    const result = probe(directory);
+
+    expect(result).toMatchObject({
+      isGit: true,
+      changedFiles: 1,
+      lineStatsComplete: false,
+    });
+    expect(readFileSync(outside, "utf8")).toBe("outside\n");
+  });
+
+  it("normalizes and validates connector output", async () => {
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: JSON.stringify({
+        isGit: true,
+        repositoryRoot: "/srv/project",
+        branch: "feature/status",
+        upstream: "origin/feature/status",
+        ahead: 2,
+        behind: 1,
+        changedFiles: 3,
+        additions: 12,
+        deletions: 4,
+        lineStatsComplete: true,
+      }),
+      stderr: "",
+    });
+
+    await expect(
+      inspectAgentWorkspaceGitStatus(
+        { connectorId, transport: "local" },
+        "/srv/project",
+      ),
+    ).resolves.toEqual({
+      isGit: true,
+      repositoryRoot: "/srv/project",
+      branch: "feature/status",
+      upstream: "origin/feature/status",
+      ahead: 2,
+      behind: 1,
+      dirty: true,
+      changedFiles: 3,
+      additions: 12,
+      deletions: 4,
+      lineStatsComplete: true,
+    });
+    expect(mocks.executeOnHost).toHaveBeenCalledWith(
+      { connectorId, transport: "local" },
+      {
+        command: "node",
+        args: ["-e", AGENT_WORKSPACE_GIT_PROBE_SCRIPT],
+        cwd: "/srv/project",
+      },
+    );
+
+    mocks.executeOnHost.mockResolvedValueOnce({
+      stdout: JSON.stringify({ isGit: false }),
+      stderr: "",
+    });
+    await expect(
+      inspectAgentWorkspaceGitStatus(
+        { connectorId, transport: "local" },
+        "/srv/project",
+      ),
+    ).resolves.toMatchObject({ isGit: false, dirty: false });
+
+    mocks.executeOnHost.mockResolvedValueOnce({
+      stdout: JSON.stringify({ isGit: true, branch: "main" }),
+      stderr: "",
+    });
+    await expect(
+      inspectAgentWorkspaceGitStatus(
+        { connectorId, transport: "local" },
+        "/srv/project",
+      ),
+    ).rejects.toThrow("invalid Git metadata");
+  });
+});

--- a/apps/web/lib/agents/runtime/git.ts
+++ b/apps/web/lib/agents/runtime/git.ts
@@ -1,0 +1,329 @@
+import "server-only";
+import type { AgentWorkspaceGitStatus } from "@/lib/agents/types";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@/lib/agents/runtime/process";
+
+export const AGENT_WORKSPACE_GIT_PROBE_SCRIPT = `
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const MAX_GIT_OUTPUT_BYTES = 1024 * 1024;
+const MAX_SINGLE_FILE_BYTES = 1024 * 1024;
+const MAX_TOTAL_FILE_BYTES = 4 * 1024 * 1024;
+
+function runGit(args, cwd) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: MAX_GIT_OUTPUT_BYTES,
+  });
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      throw new Error("Git is not installed on the selected machine.");
+    }
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      String(result.stderr || "").trim() ||
+        "Git exited with code " + String(result.status),
+    );
+  }
+  return String(result.stdout || "");
+}
+
+function parseStatus(value) {
+  const records = value.split("\\0");
+  let branch = null;
+  let upstream = null;
+  let ahead = null;
+  let behind = null;
+  let initial = false;
+  let changedFiles = 0;
+  const untrackedPaths = [];
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+    if (record.startsWith("# branch.oid ")) {
+      initial = record.slice(13) === "(initial)";
+      continue;
+    }
+    if (record.startsWith("# branch.head ")) {
+      const head = record.slice(14);
+      branch = head === "(detached)" ? null : head;
+      continue;
+    }
+    if (record.startsWith("# branch.upstream ")) {
+      upstream = record.slice(18) || null;
+      continue;
+    }
+    if (record.startsWith("# branch.ab ")) {
+      const match = /^# branch\\.ab \\+(\\d+) -(\\d+)$/.exec(record);
+      if (match) {
+        ahead = Number.parseInt(match[1], 10);
+        behind = Number.parseInt(match[2], 10);
+      }
+      continue;
+    }
+    if (record.startsWith("2 ")) {
+      changedFiles += 1;
+      index += 1;
+      continue;
+    }
+    if (
+      record.startsWith("1 ") ||
+      record.startsWith("u ") ||
+      record.startsWith("? ")
+    ) {
+      changedFiles += 1;
+      if (record.startsWith("? ")) {
+        untrackedPaths.push(record.slice(2));
+      }
+    }
+  }
+
+  return {
+    branch,
+    upstream,
+    ahead,
+    behind,
+    initial,
+    changedFiles,
+    untrackedPaths,
+  };
+}
+
+function parseNumstat(value) {
+  let additions = 0;
+  let deletions = 0;
+  let complete = true;
+
+  for (const record of value.split("\\0")) {
+    const firstTab = record.indexOf("\\t");
+    const secondTab = firstTab < 0 ? -1 : record.indexOf("\\t", firstTab + 1);
+    if (firstTab < 0 || secondTab < 0) continue;
+    const added = record.slice(0, firstTab);
+    const deleted = record.slice(firstTab + 1, secondTab);
+    if (added === "-" || deleted === "-") {
+      complete = false;
+      continue;
+    }
+    additions += Number.parseInt(added, 10) || 0;
+    deletions += Number.parseInt(deleted, 10) || 0;
+  }
+
+  return { additions, deletions, complete };
+}
+
+function countAddedLines(repositoryRoot, relativePaths) {
+  let additions = 0;
+  let bytesRead = 0;
+  let complete = true;
+  const rootPrefix = repositoryRoot.endsWith(path.sep)
+    ? repositoryRoot
+    : repositoryRoot + path.sep;
+
+  for (const relativePath of relativePaths) {
+    const absolutePath = path.resolve(repositoryRoot, relativePath);
+    if (
+      absolutePath !== repositoryRoot &&
+      !absolutePath.startsWith(rootPrefix)
+    ) {
+      complete = false;
+      continue;
+    }
+    try {
+      const stat = fs.lstatSync(absolutePath);
+      if (!stat.isFile()) {
+        complete = false;
+        continue;
+      }
+      if (
+        stat.size > MAX_SINGLE_FILE_BYTES ||
+        bytesRead + stat.size > MAX_TOTAL_FILE_BYTES
+      ) {
+        complete = false;
+        continue;
+      }
+      const content = fs.readFileSync(absolutePath);
+      bytesRead += content.length;
+      if (content.includes(0)) {
+        complete = false;
+        continue;
+      }
+      let lines = 0;
+      for (const byte of content) {
+        if (byte === 10) lines += 1;
+      }
+      if (content.length > 0 && content[content.length - 1] !== 10) {
+        lines += 1;
+      }
+      additions += lines;
+    } catch {
+      complete = false;
+    }
+  }
+
+  return { additions, complete };
+}
+
+function write(value) {
+  process.stdout.write(JSON.stringify(value));
+}
+
+try {
+  let repositoryRoot;
+  try {
+    repositoryRoot = runGit(
+      ["rev-parse", "--show-toplevel"],
+      process.cwd(),
+    ).trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/not a git repository|must be run in a work tree/i.test(message)) {
+      write({ isGit: false });
+      process.exit(0);
+    }
+    throw error;
+  }
+
+  const rawStatus = runGit(
+    [
+      "status",
+      "--porcelain=v2",
+      "--branch",
+      "-z",
+      "--untracked-files=all",
+    ],
+    repositoryRoot,
+  );
+  const status = parseStatus(rawStatus);
+  const rawNumstat = status.initial
+    ? ""
+    : runGit(["diff", "--numstat", "-z", "HEAD", "--"], repositoryRoot);
+  const numstat = parseNumstat(rawNumstat);
+  const supplementalPaths = status.initial
+    ? runGit(
+        ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        repositoryRoot,
+      )
+        .split("\\0")
+        .filter(Boolean)
+    : status.untrackedPaths;
+  const supplemental = countAddedLines(repositoryRoot, supplementalPaths);
+
+  write({
+    isGit: true,
+    repositoryRoot,
+    branch: status.branch,
+    upstream: status.upstream,
+    ahead: status.ahead,
+    behind: status.behind,
+    changedFiles: status.changedFiles,
+    additions: numstat.additions + supplemental.additions,
+    deletions: numstat.deletions,
+    lineStatsComplete: numstat.complete && supplemental.complete,
+  });
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(message);
+  process.exit(1);
+}
+`.trim();
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isNullableCount(value: unknown): value is number | null {
+  return (
+    value === null ||
+    (typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= 0)
+  );
+}
+
+function isCount(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+function parseGitProbe(value: unknown): AgentWorkspaceGitStatus {
+  if (!value || typeof value !== "object") {
+    throw new Error("The remote machine returned invalid Git metadata.");
+  }
+  if (Reflect.get(value, "isGit") === false) {
+    return {
+      isGit: false,
+      repositoryRoot: null,
+      branch: null,
+      upstream: null,
+      ahead: null,
+      behind: null,
+      dirty: false,
+      changedFiles: 0,
+      additions: 0,
+      deletions: 0,
+      lineStatsComplete: true,
+    };
+  }
+
+  const repositoryRoot = Reflect.get(value, "repositoryRoot");
+  const branch = Reflect.get(value, "branch");
+  const upstream = Reflect.get(value, "upstream");
+  const ahead = Reflect.get(value, "ahead");
+  const behind = Reflect.get(value, "behind");
+  const changedFiles = Reflect.get(value, "changedFiles");
+  const additions = Reflect.get(value, "additions");
+  const deletions = Reflect.get(value, "deletions");
+  const lineStatsComplete = Reflect.get(value, "lineStatsComplete");
+  if (
+    Reflect.get(value, "isGit") !== true ||
+    typeof repositoryRoot !== "string" ||
+    !repositoryRoot ||
+    !isNullableString(branch) ||
+    !isNullableString(upstream) ||
+    !isNullableCount(ahead) ||
+    !isNullableCount(behind) ||
+    !isCount(changedFiles) ||
+    !isCount(additions) ||
+    !isCount(deletions) ||
+    typeof lineStatsComplete !== "boolean"
+  ) {
+    throw new Error("The remote machine returned invalid Git metadata.");
+  }
+
+  return {
+    isGit: true,
+    repositoryRoot,
+    branch,
+    upstream,
+    ahead,
+    behind,
+    dirty: changedFiles > 0,
+    changedFiles,
+    additions,
+    deletions,
+    lineStatsComplete,
+  };
+}
+
+export async function inspectAgentWorkspaceGitStatus(
+  target: HostTarget,
+  workspacePath: string,
+): Promise<AgentWorkspaceGitStatus> {
+  const result = await executeOnHost(target, {
+    command: "node",
+    args: ["-e", AGENT_WORKSPACE_GIT_PROBE_SCRIPT],
+    cwd: workspacePath,
+  });
+  return parseGitProbe(JSON.parse(result.stdout) as unknown);
+}

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -113,6 +113,20 @@ export type AgentWorkspaceListItem = {
   sessions: AgentSessionListItem[];
 };
 
+export type AgentWorkspaceGitStatus = {
+  isGit: boolean;
+  repositoryRoot: string | null;
+  branch: string | null;
+  upstream: string | null;
+  ahead: number | null;
+  behind: number | null;
+  dirty: boolean;
+  changedFiles: number;
+  additions: number;
+  deletions: number;
+  lineStatsComplete: boolean;
+};
+
 export type AgentConnectionListItem = {
   id: string;
   provider: AgentProviderId;

--- a/apps/web/lib/queries/agentWorkspaces.ts
+++ b/apps/web/lib/queries/agentWorkspaces.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { AgentWorkspaceGitStatus } from "@/lib/agents/types";
+import { agentWorkspaceKeys } from "@/lib/queries/keys";
+
+async function responseError(response: Response): Promise<Error> {
+  const data = (await response.json().catch(() => null)) as {
+    error?: string;
+  } | null;
+  return new Error(data?.error ?? `HTTP ${response.status}`);
+}
+
+async function fetchAgentWorkspaceGitStatus(
+  id: string,
+): Promise<AgentWorkspaceGitStatus> {
+  const response = await fetch(
+    `/api/agent-workspaces/${encodeURIComponent(id)}/git-status`,
+  );
+  if (!response.ok) throw await responseError(response);
+  return ((await response.json()) as { status: AgentWorkspaceGitStatus })
+    .status;
+}
+
+export function useAgentWorkspaceGitStatus(
+  id: string,
+  {
+    active = false,
+    running = false,
+  }: { active?: boolean; running?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: agentWorkspaceKeys.gitStatus(id),
+    queryFn: () => fetchAgentWorkspaceGitStatus(id),
+    enabled: Boolean(id),
+    retry: false,
+    staleTime: 4_000,
+    refetchInterval: running ? 2_000 : active ? 5_000 : false,
+  });
+}

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -39,6 +39,12 @@ export const agentSessionKeys = {
     [...agentSessionKeys.all(), "detail", id] as const,
 };
 
+export const agentWorkspaceKeys = {
+  all: () => ["agentWorkspaces"] as const,
+  gitStatus: (id: string) =>
+    [...agentWorkspaceKeys.all(), "gitStatus", id] as const,
+};
+
 export const modelConfigKeys = {
   all: () => ["modelConfigs"] as const,
   publicList: () => [...modelConfigKeys.all(), "list", "public"] as const,


### PR DESCRIPTION
## Summary
- add a bounded, owner-scoped Git status snapshot for local and SSH agent workspaces
- share one React Query cache between the session header and workspace sidebar
- show branch, changed-file, and line totals with read-only copy path/branch actions
- keep non-Git, detached-head, binary, oversized, offline, and mobile states quiet and bounded

## Scope
Read-only status only. This does not add branch switching, staging, commits, pushes, or full diff rendering.

## Validation
- `npm run lint -w apps/web --`
- `npm run typecheck -w apps/web --`
- `npm run test -w apps/web --` (469 passed, 4 skipped)
- `E2E_PORT=4734 npm exec -w apps/web playwright test e2e/agent-runtime.spec.ts`
- desktop and mobile screenshot review