### PR TITLE
feat(web): support agent image input

### DIFF
--- a/apps/web/app/api/agent-sessions/[id]/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.test.ts
@@ -122,6 +122,33 @@ describe("agent session route", () => {
     expect(invalid.status).toBe(400);
   });
 
+  it("forwards image-only prompts and records a useful first message", async () => {
+    const image = {
+      uploadId: "11111111-1111-4111-8111-111111111111",
+      filename: "screen.png",
+      mediaType: "image/png",
+    };
+    const response = await POST(
+      request("POST", {
+        type: "prompt",
+        message: "",
+        images: [image],
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.command).toHaveBeenCalledWith({
+      type: "prompt",
+      message: "",
+      images: [image],
+    });
+    expect(mocks.updateAgentSessionMetadata).toHaveBeenCalledWith(
+      "session",
+      expect.objectContaining({ firstMessage: "screen.png" }),
+    );
+  });
+
   it("executes built-in slash commands without recording prompt metadata", async () => {
     mocks.normalizeCommand.mockReturnValue({
       type: "set_session_name",

--- a/apps/web/app/api/agent-sessions/[id]/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.ts
@@ -110,7 +110,12 @@ export async function POST(
         ...(
           normalized.type === "prompt" &&
           !authorized.owned.agentSession.firstMessage
-          ? { firstMessage: normalized.message }
+          ? {
+              firstMessage:
+                normalized.message ||
+                normalized.images?.[0]?.filename ||
+                "Image attachment",
+            }
           : {}),
         providerModifiedAt: new Date(),
       });

--- a/apps/web/components/agents/AgentComposer.tsx
+++ b/apps/web/components/agents/AgentComposer.tsx
@@ -11,20 +11,35 @@ import {
   ArrowUp,
   Command,
   CornerUpRight,
+  ImagePlus,
   ListEnd,
   Loader2,
   Pencil,
   Square,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { agentSlashCommandQuery } from "@/lib/agents/runtime/commands";
 import type {
+  AgentPromptImage,
   AgentQueuedMessage,
   AgentSlashCommand,
 } from "@/lib/agents/types";
+import {
+  AGENT_IMAGE_MEDIA_TYPES,
+  MAX_AGENT_IMAGES,
+  MAX_AGENT_IMAGE_BYTES,
+  MAX_AGENT_IMAGE_TOTAL_BYTES,
+} from "@/lib/agents/types";
+import { getDataTransferFiles } from "@/lib/chat/attachments";
 import { motionClasses } from "@/lib/motion";
 import { cn } from "@/lib/utils";
+import {
+  type ChatAttachment,
+  useChatAttachments,
+} from "@/components/chat/useChatAttachments";
+import { toast } from "@/components/ui/toast";
 
 function commandSource(source: AgentSlashCommand["source"]): string {
   const labels: Record<AgentSlashCommand["source"], string> = {
@@ -44,6 +59,7 @@ export function AgentComposer({
   commands,
   queuedMessages,
   supportsSteer,
+  supportsImages,
   running,
   pending,
   stopping,
@@ -58,12 +74,14 @@ export function AgentComposer({
   commands: AgentSlashCommand[];
   queuedMessages: AgentQueuedMessage[];
   supportsSteer: boolean;
+  supportsImages: boolean;
   running: boolean;
   pending: boolean;
   stopping: boolean;
   disabled: boolean;
   onSubmit: (
     message: string,
+    images: AgentPromptImage[],
     delivery: "prompt" | "queue" | "steer",
   ) => Promise<boolean>;
   onStop: () => void;
@@ -76,6 +94,16 @@ export function AgentComposer({
   const [dismissedDraft, setDismissedDraft] = useState<string | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    attachments,
+    uploading,
+    readyParts,
+    addFiles,
+    addReadyParts,
+    removeAttachment,
+    clearAttachments,
+  } = useChatAttachments();
   const listboxId = useId();
   const optionIdPrefix = useId();
 
@@ -133,7 +161,7 @@ export function AgentComposer({
       !pending &&
       !disabled
     ) {
-      void submitMessage(`/${command.name}`, "prompt");
+      void submitMessage(`/${command.name}`, [], "prompt");
       return;
     }
 
@@ -149,14 +177,17 @@ export function AgentComposer({
 
   async function submitMessage(
     message: string,
+    images: AgentPromptImage[],
     delivery: "prompt" | "queue" | "steer",
   ) {
-    if (!message || pending || submitting || disabled) return;
+    if ((!message && images.length === 0) || pending || submitting || disabled)
+      return;
     setSubmitting(true);
     try {
-      const accepted = await onSubmit(message, delivery);
+      const accepted = await onSubmit(message, images, delivery);
       if (!accepted) return;
       setInput("");
+      clearAttachments();
       setDismissedDraft(null);
       setActiveIndex(0);
     } finally {
@@ -172,16 +203,97 @@ export function AgentComposer({
       : "prompt",
   ) {
     const message = input.trim();
-    void submitMessage(message, delivery);
+    const prefix = "/api/uploads/";
+    const images = readyParts.flatMap((part) =>
+      part.url.startsWith(prefix) &&
+      AGENT_IMAGE_MEDIA_TYPES.includes(
+        part.mediaType as AgentPromptImage["mediaType"],
+      )
+        ? [
+            {
+              uploadId: part.url.slice(prefix.length),
+              filename: part.filename || "image",
+              mediaType: part.mediaType as AgentPromptImage["mediaType"],
+            },
+          ]
+        : [],
+    );
+    void submitMessage(message, images, delivery);
+  }
+
+  function addImageFiles(files: readonly File[]) {
+    const images = files.filter((file) =>
+      AGENT_IMAGE_MEDIA_TYPES.includes(
+        file.type as AgentPromptImage["mediaType"],
+      ),
+    );
+    if (images.length === 0) {
+      if (files.some((file) => file.type.startsWith("image/"))) {
+        toast.error({ title: "Use PNG, JPEG, GIF, or WebP images" });
+      }
+      return;
+    }
+    if (!supportsImages) {
+      toast.error({ title: "The selected model does not support images" });
+      return;
+    }
+    const available = Math.max(0, MAX_AGENT_IMAGES - attachments.length);
+    if (available === 0) {
+      toast.error({ title: `Attach up to ${MAX_AGENT_IMAGES} images` });
+      return;
+    }
+    let totalBytes = attachments.reduce(
+      (total, attachment) => total + (attachment.meta?.size ?? 0),
+      0,
+    );
+    const accepted = images.slice(0, available).filter((file) => {
+      if (file.size > MAX_AGENT_IMAGE_BYTES) {
+        toast.error({ title: `${file.name || "Image"} exceeds 10MB` });
+        return false;
+      }
+      if (totalBytes + file.size > MAX_AGENT_IMAGE_TOTAL_BYTES) {
+        toast.error({ title: "Image attachments must total 20MB or less" });
+        return false;
+      }
+      totalBytes += file.size;
+      return true;
+    });
+    if (images.length > available) {
+      toast.error({ title: `Attach up to ${MAX_AGENT_IMAGES} images` });
+    }
+    addFiles(accepted);
+  }
+
+  function handlePaste(event: React.ClipboardEvent<HTMLTextAreaElement>) {
+    const files = getDataTransferFiles(event.clipboardData);
+    if (!files.some((file) => file.type.startsWith("image/"))) return;
+    event.preventDefault();
+    addImageFiles(files);
   }
 
   async function editQueuedMessage(message: AgentQueuedMessage) {
-    if (pending || submitting || disabled || input.trim()) return;
-    setInput(message.message);
-    requestAnimationFrame(() => textareaRef.current?.focus());
+    if (
+      pending ||
+      submitting ||
+      disabled ||
+      input.trim() ||
+      attachments.length > 0
+    )
+      return;
     setSubmitting(true);
     try {
-      await onEditQueued(message.id);
+      const accepted = await onEditQueued(message.id);
+      if (!accepted) return;
+      setInput(message.message);
+      addReadyParts(
+        (message.images ?? []).map((image) => ({
+          type: "file",
+          url: `/api/uploads/${image.uploadId}`,
+          mediaType: image.mediaType,
+          filename: image.filename,
+        })),
+      );
+      requestAnimationFrame(() => textareaRef.current?.focus());
     } finally {
       setSubmitting(false);
     }
@@ -307,7 +419,8 @@ export function AgentComposer({
                     className="min-w-0 flex-1 truncate text-foreground"
                     title={queuedMessage.message}
                   >
-                    {queuedMessage.message.replace(/\s+/g, " ")}
+                    {queuedMessage.message.replace(/\s+/g, " ") ||
+                      `${queuedMessage.images?.length ?? 0} attached ${(queuedMessage.images?.length ?? 0) === 1 ? "image" : "images"}`}
                   </span>
                   {!sending && (
                     <>
@@ -320,12 +433,13 @@ export function AgentComposer({
                           pending ||
                           submitting ||
                           disabled ||
-                          Boolean(input.trim())
+                          Boolean(input.trim()) ||
+                          attachments.length > 0
                         }
                         onClick={() => void editQueuedMessage(queuedMessage)}
                         aria-label="Edit queued message"
                         title={
-                          input.trim()
+                          input.trim() || attachments.length > 0
                             ? "Clear the current draft before editing"
                             : "Edit queued message"
                         }
@@ -362,6 +476,17 @@ export function AgentComposer({
       )}
 
       <div className="relative flex flex-col gap-2 rounded-3xl border bg-background px-3.5 pt-3.5 pb-2.5 shadow-sm motion-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring">
+        {attachments.length > 0 && (
+          <div className="flex gap-2 overflow-x-auto px-1">
+            {attachments.map((attachment) => (
+              <AgentImageChip
+                key={attachment.id}
+                attachment={attachment}
+                onRemove={() => removeAttachment(attachment.id)}
+              />
+            ))}
+          </div>
+        )}
         <Textarea
           ref={textareaRef}
           rows={1}
@@ -375,6 +500,7 @@ export function AgentComposer({
             setActiveIndex(0);
           }}
           onKeyDown={onKeyDown}
+          onPaste={handlePaste}
           role="combobox"
           aria-expanded={menuOpen}
           aria-controls={menuOpen ? listboxId : undefined}
@@ -383,7 +509,35 @@ export function AgentComposer({
           }
           aria-autocomplete="list"
         />
-        <div className="flex h-8 items-center justify-end gap-1">
+        <div className="flex h-8 items-center gap-1">
+          {supportsImages && (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={AGENT_IMAGE_MEDIA_TYPES.join(",")}
+                multiple
+                className="hidden"
+                onChange={(event) => {
+                  addImageFiles(Array.from(event.target.files ?? []));
+                  event.target.value = "";
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="rounded-full"
+                disabled={pending || submitting || uploading || disabled}
+                onClick={() => fileInputRef.current?.click()}
+                aria-label="Attach images"
+                title="Attach images"
+              >
+                <ImagePlus />
+              </Button>
+            </>
+          )}
+          <span className="flex-1" />
           {running && supportsSteer && (
             <Button
               type="button"
@@ -408,7 +562,13 @@ export function AgentComposer({
               variant="secondary"
               size="icon-sm"
               className="rounded-full"
-              disabled={!input.trim() || pending || submitting || disabled}
+              disabled={
+                (!input.trim() && readyParts.length === 0) ||
+                uploading ||
+                pending ||
+                submitting ||
+                disabled
+              }
               onClick={() => submit("queue")}
               aria-label={`Queue message for ${providerLabel}`}
               title={`Queue after ${providerLabel} finishes`}
@@ -420,7 +580,13 @@ export function AgentComposer({
             type="button"
             size={running ? "sm" : "icon-sm"}
             className="rounded-full"
-            disabled={!input.trim() || pending || submitting || disabled}
+            disabled={
+              (!input.trim() && readyParts.length === 0) ||
+              uploading ||
+              pending ||
+              submitting ||
+              disabled
+            }
             onClick={() => submit()}
             aria-label={
               running
@@ -450,6 +616,49 @@ export function AgentComposer({
           </Button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function AgentImageChip({
+  attachment,
+  onRemove,
+}: {
+  attachment: ChatAttachment;
+  onRemove: () => void;
+}) {
+  const src = attachment.previewUrl ?? attachment.part?.url;
+  return (
+    <div className="relative size-16 shrink-0 overflow-hidden rounded-lg border bg-muted">
+      {src && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={src}
+          alt={attachment.filename}
+          className="size-full object-cover"
+        />
+      )}
+      {attachment.status === "uploading" && (
+        <span className="absolute inset-0 flex items-center justify-center bg-background/60">
+          <Loader2 className={cn("size-4", motionClasses.spinner)} />
+        </span>
+      )}
+      {attachment.status === "error" && (
+        <span
+          className="absolute inset-0 flex items-center justify-center bg-destructive/10 px-1 text-center text-[10px] text-destructive"
+          title={attachment.error}
+        >
+          Upload failed
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${attachment.filename}`}
+        className="absolute top-1 right-1 rounded-full bg-foreground/70 p-0.5 text-background"
+      >
+        <X className="size-3" />
+      </button>
     </div>
   );
 }

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -321,17 +321,23 @@ function UserMessage({
   const images = Array.isArray(content)
     ? content.flatMap((part) => {
         const record = recordOf(part);
-        if (
-          record?.type !== "image" ||
-          typeof record.data !== "string" ||
-          typeof record.mimeType !== "string"
-        ) {
+        if (record?.type !== "image" || typeof record.mimeType !== "string") {
           return [];
         }
+        const src =
+          typeof record.url === "string"
+            ? record.url
+            : typeof record.data === "string"
+              ? `data:${record.mimeType};base64,${record.data}`
+              : null;
+        if (!src) return [];
         return [
           {
-            src: `data:${record.mimeType};base64,${record.data}`,
-            alt: "Attached image",
+            src,
+            alt:
+              typeof record.filename === "string"
+                ? record.filename
+                : "Attached image",
           },
         ];
       })

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -13,6 +13,7 @@ import { SidebarToggle } from "@/components/SidebarToggle";
 import { toast } from "@/components/ui/toast";
 import type {
   AgentModel,
+  AgentPromptImage,
   AgentProviderId,
   AgentRuntimeSnapshot,
   AgentSessionCommand,
@@ -161,18 +162,23 @@ export function AgentSessionView({
 
   async function submit(
     message: string,
+    images: AgentPromptImage[],
     delivery: "prompt" | "queue" | "steer",
   ): Promise<boolean> {
     let input: AgentSessionCommand;
     try {
       const normalized = normalizeAgentSessionCommand(
-        buildAgentPromptCommand(message),
+        buildAgentPromptCommand(message, images),
         snapshot?.state ?? {},
       );
       input =
         normalized.type !== "prompt" || delivery === "prompt"
           ? normalized
-          : { type: delivery, message };
+          : {
+              type: delivery,
+              message,
+              ...(images.length > 0 ? { images } : {}),
+            };
     } catch (cause) {
       toast.error({
         title: `${providerLabel} command failed`,
@@ -225,6 +231,13 @@ export function AgentSessionView({
   const exited = snapshot.status === "exited";
   const readOnly = snapshot.readOnly;
   const model = currentModel(snapshot);
+  const selectedModel = model
+    ? snapshot.models.find(
+        (candidate) =>
+          candidate.provider === model.provider &&
+          candidate.id === model.id,
+      )
+    : undefined;
   const thinking = currentThinking(snapshot);
   const currentName = sessionName(snapshot) || initialSessionName;
   const runtimeError =
@@ -348,6 +361,7 @@ export function AgentSessionView({
             commands={snapshot.commands}
             queuedMessages={snapshot.queuedMessages}
             supportsSteer={snapshot.capabilities.steer}
+            supportsImages={selectedModel?.input.includes("image") === true}
             running={running}
             pending={command.isPending}
             stopping={pendingCommand === "abort"}

--- a/apps/web/components/chat/useChatAttachments.ts
+++ b/apps/web/components/chat/useChatAttachments.ts
@@ -72,6 +72,22 @@ export function useChatAttachments() {
     });
   }
 
+  function addReadyParts(parts: readonly FileUIPart[]): void {
+    const next = parts.map((part) => ({
+      id: nextIdRef.current++,
+      status: "ready" as const,
+      filename: part.filename || "image",
+      mediaType: part.mediaType,
+      part,
+      meta: {
+        category: part.mediaType.startsWith("image/")
+          ? ("image" as const)
+          : undefined,
+      },
+    }));
+    setAttachments((prev) => [...prev, ...next]);
+  }
+
   function addRejectedFile(file: File): void {
     const id = nextIdRef.current++;
     setAttachments((prev) => [
@@ -98,6 +114,7 @@ export function useChatAttachments() {
         previewUrl,
         filename: file.name || "file",
         mediaType: file.type || "application/octet-stream",
+        meta: { size: file.size },
       },
     ]);
 
@@ -132,7 +149,9 @@ export function useChatAttachments() {
       };
       setAttachments((prev) =>
         prev.map((a) =>
-          a.id === id ? { ...a, status: "ready", part, meta } : a,
+          a.id === id
+            ? { ...a, status: "ready", part, meta: { ...a.meta, ...meta } }
+            : a,
         ),
       );
     } catch (err) {
@@ -152,6 +171,7 @@ export function useChatAttachments() {
     addFiles,
     removeAttachment,
     clearAttachments,
+    addReadyParts,
   };
 }
 

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -6,6 +6,29 @@ import {
 } from "./helpers/database";
 
 const SESSION_ID = "runtime-session";
+const IMAGE_UPLOAD_ID = "11111111-1111-4111-8111-111111111111";
+const TEST_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+const imageModel = {
+  id: "pi-image-model",
+  name: "Pi Image Model",
+  provider: "test",
+  api: "test",
+  baseUrl: "",
+  reasoning: true,
+  input: ["text", "image"],
+  contextWindow: 100_000,
+  maxTokens: 10_000,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  },
+};
 
 test.beforeEach(resetE2eDatabase);
 
@@ -58,6 +81,7 @@ function runtimeSnapshot(startedAt: number) {
       isStreaming: true,
       isCompacting: false,
       sessionName: "Runtime activity",
+      model: imageModel,
     },
     messages: [
       {
@@ -139,7 +163,7 @@ function runtimeSnapshot(startedAt: number) {
         timestamp: 7,
       },
     ],
-    models: [],
+    models: [imageModel],
     thinkingLevels: ["off"],
     commands: [],
     queuedMessages: [],
@@ -180,6 +204,31 @@ test("shows durable turn activity without changing completed tool status", async
   } = runtimeSnapshot(startedAt);
   let retryRequested = false;
   let interactionResponse: Record<string, unknown> | null = null;
+  const submittedCommands: Array<Record<string, unknown>> = [];
+  await page.route("**/api/uploads", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        url: `/api/uploads/${IMAGE_UPLOAD_ID}`,
+        mediaType: "image/png",
+        filename: "clipboard.png",
+        category: "image",
+        size: TEST_PNG.byteLength,
+        pageCount: null,
+        truncated: false,
+      }),
+    });
+  });
+  await page.route(`**/api/uploads/${IMAGE_UPLOAD_ID}`, async (route) => {
+    await route.fulfill({
+      contentType: "image/png",
+      body: TEST_PNG,
+    });
+  });
   await page.route(
     new RegExp(`/api/agent-sessions/${SESSION_ID}$`),
     async (route) => {
@@ -189,6 +238,7 @@ test("shows durable turn activity without changing completed tool status", async
           message?: string;
           [key: string]: unknown;
         };
+        submittedCommands.push(command);
         if (command.type === "interaction_response") {
           interactionResponse = command;
           delete snapshot.pendingInteraction;
@@ -213,6 +263,9 @@ test("shows durable turn activity without changing completed tool status", async
                     {
                       id: "queued-message",
                       message: command.message,
+                      ...(Array.isArray(command.images)
+                        ? { images: command.images }
+                        : {}),
                       status: "pending",
                     },
                   ],
@@ -405,20 +458,69 @@ test("shows durable turn activity without changing completed tool status", async
   const composer = page.getByPlaceholder(
     "Message Pi or type / for commands",
   );
+  await expect(page.getByRole("button", { name: "Attach images" })).toBeVisible();
+  await composer.evaluate(async (element) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 96;
+    canvas.height = 72;
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("Canvas is unavailable.");
+    context.fillStyle = "#2563eb";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "#f8fafc";
+    context.fillRect(18, 18, 60, 36);
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (value) =>
+          value ? resolve(value) : reject(new Error("PNG encoding failed.")),
+        "image/png",
+      );
+    });
+    const transfer = new DataTransfer();
+    transfer.items.add(
+      new File([blob], "clipboard.png", { type: "image/png" }),
+    );
+    element.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: transfer,
+      }),
+    );
+  });
+  await expect(page.getByAltText("clipboard.png")).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("runtime-image-paste-desktop.png"),
+    fullPage: true,
+  });
   await composer.fill("Run the tests");
   await page.getByRole("button", { name: "Queue message for Pi" }).click();
   await expect(composer).toHaveValue("Run the tests");
   await expect(composer).toBeDisabled();
   await expect(composer).toHaveValue("");
   await expect(page.getByText("Run the tests", { exact: true })).toBeVisible();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "queue",
+    message: "Run the tests",
+    images: [
+      {
+        uploadId: IMAGE_UPLOAD_ID,
+        filename: "clipboard.png",
+        mediaType: "image/png",
+      },
+    ],
+  });
 
   await page.getByRole("button", { name: "Edit queued message" }).click();
   await expect(composer).toHaveValue("Run the tests");
-  await expect(composer).toBeDisabled();
   await expect(composer).toBeEnabled();
   await expect(
     page.getByRole("button", { name: "Edit queued message" }),
   ).toHaveCount(0);
+  await expect(page.getByAltText("clipboard.png")).toBeVisible();
+  await page
+    .getByRole("button", { name: "Remove clipboard.png" })
+    .click();
   await composer.fill("");
 
   await composer.fill("Focus on the failing test");

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -4,11 +4,15 @@ vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
   listCodexCustomPrompts: vi.fn(),
+  materializeAgentImages: vi.fn(),
 }));
 
 vi.mock("./commands", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./commands")>()),
   listCodexCustomPrompts: mocks.listCodexCustomPrompts,
+}));
+vi.mock("@/lib/agents/runtime/materialize-images", () => ({
+  materializeAgentImages: mocks.materializeAgentImages,
 }));
 
 type Listener<T> = (value: T) => void;
@@ -286,6 +290,7 @@ describe("CodexRuntimeClient", () => {
     server.rateLimitsError = null;
     server.usageError = null;
     server.respondError.mockClear();
+    mocks.materializeAgentImages.mockResolvedValue([]);
     mocks.listCodexCustomPrompts.mockResolvedValue([
       {
         name: "prompts:review",
@@ -345,6 +350,81 @@ describe("CodexRuntimeClient", () => {
             type: "text",
             text: "Review src/a b.ts carefully.",
             text_elements: [],
+          },
+        ],
+      },
+    });
+  });
+
+  it("materializes images on the target host for prompts and steering", async () => {
+    const target = {
+      connectorId: "connector",
+      transport: "ssh" as const,
+      alias: "macbook",
+    };
+    const client = new CodexRuntimeClient(target, {
+      executable: "codex",
+      cwd: "/workspace",
+    });
+    const image = {
+      uploadId: "11111111-1111-4111-8111-111111111111",
+      filename: "screen.png",
+      mediaType: "image/png" as const,
+      data: "aW1hZ2U=",
+    };
+    mocks.materializeAgentImages.mockResolvedValue([
+      "/tmp/overtchat-agent-images/screen.png",
+    ]);
+
+    await client.prompt("Inspect this", [image]);
+    expect(mocks.materializeAgentImages).toHaveBeenCalledWith(target, [image]);
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: {
+        input: [
+          {
+            type: "text",
+            text: "Inspect this",
+            text_elements: [],
+          },
+          {
+            type: "localImage",
+            path: "/tmp/overtchat-agent-images/screen.png",
+          },
+        ],
+      },
+    });
+    await expect(client.getMessages()).resolves.toEqual({
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          content: [
+            { type: "text", text: "Inspect this" },
+            {
+              type: "image",
+              url: `/api/uploads/${image.uploadId}`,
+              filename: "screen.png",
+              mimeType: "image/png",
+            },
+          ],
+        }),
+      ],
+    });
+
+    await client.steer("", [image]);
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/steer",
+      params: {
+        expectedTurnId: "turn-1",
+        input: [
+          {
+            type: "text",
+            text: "",
+            text_elements: [],
+          },
+          {
+            type: "localImage",
+            path: "/tmp/overtchat-agent-images/screen.png",
           },
         ],
       },

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -10,10 +10,12 @@ import type {
 import type {
   AgentRuntimeClient,
   AgentRuntimeEvent,
+  ResolvedAgentImage,
   AgentSessionForkResult,
   AgentSessionLaunch,
 } from "@/lib/agents/providers/types";
 import type { HostTarget } from "@/lib/agents/runtime/process";
+import { materializeAgentImages } from "@/lib/agents/runtime/materialize-images";
 import {
   type CodexAppServer,
   type CodexAppServerRequest,
@@ -88,6 +90,11 @@ type PendingInteraction =
 type KnownUserInput = {
   id: string;
   text: string;
+  images: Array<{
+    uploadId: string;
+    filename: string;
+    mediaType: ResolvedAgentImage["mediaType"];
+  }>;
 };
 
 function textInput(text: string) {
@@ -329,11 +336,35 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
   for (const item of turn.items) {
     if (item.type === "userMessage") {
       const text = itemText(item);
-      if (text) {
+      const images = Array.isArray(item.overtchatImages)
+        ? item.overtchatImages.flatMap((value) => {
+            const image = recordOf(value);
+            const uploadId = stringOf(image, "uploadId");
+            const filename = stringOf(image, "filename");
+            const mediaType = stringOf(image, "mediaType");
+            return uploadId && filename && mediaType
+              ? [
+                  {
+                    type: "image",
+                    url: `/api/uploads/${uploadId}`,
+                    filename,
+                    mimeType: mediaType,
+                  },
+                ]
+              : [];
+          })
+        : [];
+      if (text || images.length > 0) {
         messages.push({
           id: item.id,
           role: "user",
-          content: text,
+          content:
+            images.length > 0
+              ? [
+                  ...(text ? [{ type: "text", text }] : []),
+                  ...images,
+                ]
+              : text,
           timestamp: startedAt,
         });
       }
@@ -616,15 +647,18 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     return publicCommands([...this.discoveredCommands.values()]);
   }
 
-  async prompt(message: string): Promise<unknown> {
+  async prompt(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+  ): Promise<unknown> {
     await this.readyPromise;
     this.assertInteractive();
-    const input = this.createKnownUserInput(message);
+    const input = this.createKnownUserInput(message, images);
     this.pendingPromptInput = input;
     try {
       const response = await this.server.request<UnknownRecord>("turn/start", {
         threadId: this.thread!.id,
-        input: this.resolvePromptInput(message),
+        input: await this.resolvePromptInput(message, images),
         model: this.selectedModel || null,
         ...(this.selectedThinking
           ? { effort: this.selectedThinking }
@@ -640,7 +674,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     }
   }
 
-  async steer(message: string): Promise<unknown> {
+  async steer(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+  ): Promise<unknown> {
     await this.readyPromise;
     this.assertInteractive();
     if (!this.activeTurnId) throw new Error("Codex has no active turn to steer.");
@@ -648,9 +685,12 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     const response = await this.server.request("turn/steer", {
       threadId: this.thread!.id,
       expectedTurnId: turnId,
-      input: this.resolvePromptInput(message),
+      input: await this.resolvePromptInput(message, images),
     });
-    this.rememberUserInput(turnId, this.createKnownUserInput(message));
+    this.rememberUserInput(
+      turnId,
+      this.createKnownUserInput(message, images),
+    );
     return response;
   }
 
@@ -1457,25 +1497,41 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     });
   }
 
-  private createKnownUserInput(text: string): KnownUserInput {
+  private createKnownUserInput(
+    text: string,
+    images: readonly ResolvedAgentImage[] = [],
+  ): KnownUserInput {
     return {
       id: `overtchat:codex-user:${++this.nextUserInputId}`,
       text,
+      images: images.map(({ uploadId, filename, mediaType }) => ({
+        uploadId,
+        filename,
+        mediaType,
+      })),
     };
   }
 
-  private resolvePromptInput(message: string): UnknownRecord[] {
+  private async resolvePromptInput(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+  ): Promise<UnknownRecord[]> {
     const invocation = parseCodexSlashInvocation(message);
     const command = invocation
       ? this.discoveredCommands.get(invocation.name.toLowerCase())
       : undefined;
-    if (!invocation || !command) return textInput(message);
-    if (command.source === "skill") {
-      return skillInput(command, invocation.arguments);
-    }
-    return textInput(
-      expandCodexCustomPrompt(command.template, invocation.arguments),
-    );
+    const text = !invocation || !command
+      ? textInput(message)
+      : command.source === "skill"
+        ? skillInput(command, invocation.arguments)
+        : textInput(
+            expandCodexCustomPrompt(command.template, invocation.arguments),
+          );
+    const paths = await materializeAgentImages(this.target, images);
+    return [
+      ...text,
+      ...paths.map((path) => ({ type: "localImage", path })),
+    ];
   }
 
   private async reloadCommands(publish = false): Promise<void> {
@@ -1533,20 +1589,34 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     const known = this.knownUserInputs.get(turn.id);
     if (!known?.length) return turn;
     const items = turn.items.filter((item) => !isSyntheticUserItem(item));
-    const nativeUserTexts = items
-      .filter((item) => item.type === "userMessage")
-      .map(itemText);
+    const nativeUsers = items.flatMap((item, index) =>
+      item.type === "userMessage" ? [{ index, text: itemText(item) }] : [],
+    );
+    const claimedNativeUsers = new Set<number>();
     const synthetic: CodexItem[] = [];
     for (const input of known) {
-      const nativeIndex = nativeUserTexts.indexOf(input.text);
-      if (nativeIndex >= 0) {
-        nativeUserTexts.splice(nativeIndex, 1);
+      const native = nativeUsers.find(
+        (candidate) =>
+          !claimedNativeUsers.has(candidate.index) &&
+          candidate.text === input.text,
+      );
+      if (native) {
+        claimedNativeUsers.add(native.index);
+        if (input.images.length > 0) {
+          items[native.index] = {
+            ...items[native.index],
+            overtchatImages: input.images,
+          };
+        }
         continue;
       }
       synthetic.push({
         id: input.id,
         type: "userMessage",
         content: textInput(input.text),
+        ...(input.images.length > 0
+          ? { overtchatImages: input.images }
+          : {}),
       });
     }
     return synthetic.length === 0 && items.length === turn.items.length

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -65,6 +65,39 @@ describe("Host Connector broker", () => {
     expect(stdout).toBe("world");
   });
 
+  it("chunks large stdin writes before sending them to the connector", async () => {
+    const broker = new HostConnectorBroker();
+    const commands: HostConnectorCommand[] = [];
+    broker.register("connector", (command) => commands.push(command));
+    const processHandle = broker.spawn(
+      "connector",
+      { transport: "local" },
+      { command: "pi", shellMode: "interactive" },
+    );
+    const payload = Buffer.alloc(64 * 1024 + 17, 7);
+
+    await new Promise<void>((resolve, reject) => {
+      processHandle.stdin.end(payload, (error?: Error | null) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+    const stdinCommands = commands.filter(
+      (
+        command,
+      ): command is Extract<HostConnectorCommand, { type: "stdin" }> =>
+        command.type === "stdin",
+    );
+    expect(stdinCommands).toHaveLength(2);
+    expect(
+      Buffer.concat(
+        stdinCommands.map((command) => Buffer.from(command.data, "base64")),
+      ),
+    ).toEqual(payload);
+    expect(commands.at(-1)).toMatchObject({ type: "stdin_end" });
+  });
+
   it("synchronizes active process IDs when a channel reconnects", () => {
     const broker = new HostConnectorBroker();
     const first: HostConnectorCommand[] = [];

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -12,6 +12,7 @@ import {
 const REQUEST_TIMEOUT_MS = 15_000;
 const CONNECTOR_DISCONNECT_GRACE_MS = 5_000;
 const PROCESS_EXIT_GRACE_MS = 5_000;
+const STDIN_CHUNK_BYTES = 64 * 1024;
 
 export type ConnectorProcessExit = {
   code: number | null;
@@ -118,11 +119,15 @@ export class HostConnectorBroker {
       write(chunk, _encoding, callback) {
         try {
           const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-          send({
-            type: "stdin",
-            processId,
-            data: bytes.toString("base64"),
-          });
+          for (let offset = 0; offset < bytes.length; offset += STDIN_CHUNK_BYTES) {
+            send({
+              type: "stdin",
+              processId,
+              data: bytes
+                .subarray(offset, offset + STDIN_CHUNK_BYTES)
+                .toString("base64"),
+            });
+          }
           callback();
         } catch (error) {
           callback(error instanceof Error ? error : new Error(String(error)));

--- a/apps/web/lib/agents/pi/client.test.ts
+++ b/apps/web/lib/agents/pi/client.test.ts
@@ -110,6 +110,46 @@ describe("PiRpcClient", () => {
     await client.stop();
   });
 
+  it("sends native image attachments with prompts and steering", async () => {
+    const process = new FakeAgentProcess((command, fake) => {
+      fake.reply(command);
+    });
+    const client = new PiRpcClient(process);
+    const image = {
+      uploadId: "11111111-1111-4111-8111-111111111111",
+      filename: "screen.png",
+      mediaType: "image/png" as const,
+      data: "aW1hZ2U=",
+    };
+
+    await client.prompt("Inspect this", [image]);
+    await client.steer("", [image]);
+
+    expect(process.commands).toEqual([
+      expect.objectContaining({
+        type: "prompt",
+        message: "Inspect this",
+        images: [
+          {
+            data: "aW1hZ2U=",
+            mimeType: "image/png",
+          },
+        ],
+      }),
+      expect.objectContaining({
+        type: "steer",
+        message: "",
+        images: [
+          {
+            data: "aW1hZ2U=",
+            mimeType: "image/png",
+          },
+        ],
+      }),
+    ]);
+    await client.stop();
+  });
+
   it("keeps historical process stderr out of later request timeouts", async () => {
     const process = new FakeAgentProcess(() => {});
     const client = new PiRpcClient(process);

--- a/apps/web/lib/agents/pi/client.ts
+++ b/apps/web/lib/agents/pi/client.ts
@@ -6,6 +6,7 @@ import type {
   AgentSessionStats,
   AgentThinkingLevel,
 } from "@/lib/agents/types";
+import type { ResolvedAgentImage } from "@/lib/agents/providers/types";
 import { AGENT_THINKING_LEVELS } from "@/lib/agents/types";
 import { agentProviderMetadata } from "@/lib/agents/catalog";
 import {
@@ -295,15 +296,40 @@ export class PiRpcClient {
     return this.request({ type: "get_messages" });
   }
 
-  prompt(message: string): Promise<unknown> {
+  prompt(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+  ): Promise<unknown> {
     return this.request({
       type: "prompt",
       message,
+      ...(images.length
+        ? {
+            images: images.map((image) => ({
+              data: image.data,
+              mimeType: image.mediaType,
+            })),
+          }
+        : {}),
     });
   }
 
-  steer(message: string): Promise<unknown> {
-    return this.request({ type: "steer", message });
+  steer(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+  ): Promise<unknown> {
+    return this.request({
+      type: "steer",
+      message,
+      ...(images.length
+        ? {
+            images: images.map((image) => ({
+              data: image.data,
+              mimeType: image.mediaType,
+            })),
+          }
+        : {}),
+    });
   }
 
   followUp(message: string): Promise<unknown> {

--- a/apps/web/lib/agents/providers/codex.test.ts
+++ b/apps/web/lib/agents/providers/codex.test.ts
@@ -22,4 +22,20 @@ describe("codexProviderAdapter", () => {
       ),
     ).toEqual({ type: "prompt", message: "/usage extra" });
   });
+
+  it("keeps /usage as model input when an image is attached", () => {
+    const command = {
+      type: "prompt" as const,
+      message: "/usage",
+      images: [
+        {
+          uploadId: "11111111-1111-4111-8111-111111111111",
+          filename: "screen.png",
+          mediaType: "image/png" as const,
+        },
+      ],
+    };
+
+    expect(codexProviderAdapter.normalizeCommand(command, {})).toBe(command);
+  });
 });

--- a/apps/web/lib/agents/providers/codex.ts
+++ b/apps/web/lib/agents/providers/codex.ts
@@ -79,6 +79,7 @@ function normalizeCommand(
 ): AgentSessionCommand {
   if (
     command.type === "prompt" &&
+    !command.images?.length &&
     /^\/usage(?:\s*)$/iu.test(command.message)
   ) {
     return { type: "show_usage" };

--- a/apps/web/lib/agents/providers/types.ts
+++ b/apps/web/lib/agents/providers/types.ts
@@ -1,6 +1,7 @@
 import type {
   AgentConnectionDraft,
   AgentModel,
+  AgentPromptImage,
   AgentProviderSessionMetadata,
   AgentProviderId,
   AgentReadyConnectionProbe,
@@ -48,6 +49,10 @@ export type AgentSessionForkResult = {
   draft?: string;
 };
 
+export type ResolvedAgentImage = AgentPromptImage & {
+  data: string;
+};
+
 export interface AgentRuntimeClient {
   onEvent(subscriber: (event: AgentRuntimeEvent) => void): () => void;
   getState(timeoutMs?: number): Promise<Record<string, unknown>>;
@@ -56,8 +61,14 @@ export interface AgentRuntimeClient {
   getSessionStats(): Promise<AgentSessionStats>;
   getAvailableThinkingLevels(): Promise<AgentThinkingLevel[]>;
   getCommands(): Promise<AgentSlashCommand[]>;
-  prompt(message: string): Promise<unknown>;
-  steer(message: string): Promise<unknown>;
+  prompt(
+    message: string,
+    images?: readonly ResolvedAgentImage[],
+  ): Promise<unknown>;
+  steer(
+    message: string,
+    images?: readonly ResolvedAgentImage[],
+  ): Promise<unknown>;
   abort(): Promise<unknown>;
   setModel(provider: string, modelId: string): Promise<unknown>;
   setThinkingLevel(level: string): Promise<unknown>;

--- a/apps/web/lib/agents/runtime/commands.test.ts
+++ b/apps/web/lib/agents/runtime/commands.test.ts
@@ -73,6 +73,22 @@ describe("agent slash commands", () => {
     });
   });
 
+  it("keeps attached images on the ordinary prompt path", () => {
+    const image = {
+      uploadId: "11111111-1111-4111-8111-111111111111",
+      filename: "screen.png",
+      mediaType: "image/png" as const,
+    };
+    const command = buildAgentPromptCommand("/new", [image]);
+
+    expect(command).toEqual({
+      type: "prompt",
+      message: "/new",
+      images: [image],
+    });
+    expect(normalizeAgentSessionCommand(command, {})).toBe(command);
+  });
+
   it("routes Overtchat built-ins to native RPC commands", () => {
     expect(
       normalizeAgentSessionCommand({ type: "prompt", message: "/new" }, {}),

--- a/apps/web/lib/agents/runtime/commands.ts
+++ b/apps/web/lib/agents/runtime/commands.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentPromptImage,
   AgentSessionCommand,
   AgentSlashCommand,
 } from "@/lib/agents/types";
@@ -27,10 +28,12 @@ export function agentSlashCommandQuery(value: string): string | null {
 
 export function buildAgentPromptCommand(
   message: string,
+  images: AgentPromptImage[] = [],
 ): Extract<AgentSessionCommand, { type: "prompt" }> {
   return {
     type: "prompt",
     message,
+    ...(images.length > 0 ? { images } : {}),
   };
 }
 
@@ -96,6 +99,7 @@ export function normalizeAgentSessionCommand(
   state: Record<string, unknown>,
 ): AgentSessionCommand {
   if (command.type !== "prompt") return command;
+  if (command.images?.length) return command;
   const invocation = parseInvocation(command.message);
   if (!invocation) return command;
 

--- a/apps/web/lib/agents/runtime/images.test.ts
+++ b/apps/web/lib/agents/runtime/images.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getUpload: vi.fn(),
+  uploadPath: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("node:fs/promises", () => ({
+  default: { readFile: mocks.readFile },
+}));
+vi.mock("@/lib/db/uploads", () => ({
+  getUpload: mocks.getUpload,
+  uploadPath: mocks.uploadPath,
+}));
+
+import {
+  MAX_AGENT_IMAGE_BYTES,
+  MAX_AGENT_IMAGE_TOTAL_BYTES,
+} from "@/lib/agents/types";
+import { resolveAgentImages } from "./images";
+
+const image = {
+  uploadId: "11111111-1111-4111-8111-111111111111",
+  filename: "client-name.png",
+  mediaType: "image/png" as const,
+};
+
+describe("agent image resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.uploadPath.mockImplementation((id: string) => `/uploads/${id}`);
+    mocks.readFile.mockResolvedValue(Buffer.from("image-bytes"));
+    mocks.getUpload.mockResolvedValue({
+      id: image.uploadId,
+      userId: "user",
+      filename: "stored-name.png",
+      mediaType: "image/png",
+      category: "image",
+      size: 11,
+    });
+  });
+
+  it("resolves owner-scoped uploads using authoritative metadata", async () => {
+    await expect(resolveAgentImages([image], "user")).resolves.toEqual([
+      {
+        uploadId: image.uploadId,
+        filename: "stored-name.png",
+        mediaType: "image/png",
+        data: Buffer.from("image-bytes").toString("base64"),
+      },
+    ]);
+    expect(mocks.getUpload).toHaveBeenCalledWith(image.uploadId, "user");
+    expect(mocks.readFile).toHaveBeenCalledWith(`/uploads/${image.uploadId}`);
+  });
+
+  it("rejects unavailable, non-image, and oversized uploads", async () => {
+    mocks.getUpload.mockResolvedValueOnce(null);
+    await expect(resolveAgentImages([image], "user")).rejects.toThrow(
+      "unavailable",
+    );
+
+    mocks.getUpload.mockResolvedValueOnce({
+      id: image.uploadId,
+      category: "text",
+      mediaType: "text/plain",
+      size: 10,
+    });
+    await expect(resolveAgentImages([image], "user")).rejects.toThrow(
+      "unavailable",
+    );
+
+    mocks.getUpload.mockResolvedValueOnce({
+      id: image.uploadId,
+      category: "image",
+      mediaType: "image/png",
+      size: MAX_AGENT_IMAGE_BYTES + 1,
+    });
+    await expect(resolveAgentImages([image], "user")).rejects.toThrow(
+      "10MB",
+    );
+  });
+
+  it("rejects image batches above the aggregate limit", async () => {
+    mocks.getUpload.mockResolvedValue({
+      id: image.uploadId,
+      filename: "large.png",
+      category: "image",
+      mediaType: "image/png",
+      size: Math.floor(MAX_AGENT_IMAGE_TOTAL_BYTES / 3) + 1,
+    });
+
+    await expect(
+      resolveAgentImages(
+        [
+          image,
+          {
+            ...image,
+            uploadId: "22222222-2222-4222-8222-222222222222",
+          },
+          {
+            ...image,
+            uploadId: "33333333-3333-4333-8333-333333333333",
+          },
+        ],
+        "user",
+      ),
+    ).rejects.toThrow("total 20MB");
+  });
+});

--- a/apps/web/lib/agents/runtime/images.ts
+++ b/apps/web/lib/agents/runtime/images.ts
@@ -1,0 +1,48 @@
+import "server-only";
+import fs from "node:fs/promises";
+import {
+  AGENT_IMAGE_MEDIA_TYPES,
+  MAX_AGENT_IMAGE_BYTES,
+  MAX_AGENT_IMAGE_TOTAL_BYTES,
+  type AgentPromptImage,
+} from "@/lib/agents/types";
+import type { ResolvedAgentImage } from "@/lib/agents/providers/types";
+import { getUpload, uploadPath } from "@/lib/db/uploads";
+
+const allowedMediaTypes = new Set<string>(AGENT_IMAGE_MEDIA_TYPES);
+
+export async function resolveAgentImages(
+  images: readonly AgentPromptImage[] | undefined,
+  userId: string,
+): Promise<ResolvedAgentImage[]> {
+  if (!images?.length) return [];
+  let totalBytes = 0;
+  const resolved: ResolvedAgentImage[] = [];
+
+  for (const image of images) {
+    const upload = await getUpload(image.uploadId, userId);
+    if (
+      !upload ||
+      upload.category !== "image" ||
+      !allowedMediaTypes.has(upload.mediaType)
+    ) {
+      throw new Error("An attached image is unavailable.");
+    }
+    if (upload.size > MAX_AGENT_IMAGE_BYTES) {
+      throw new Error("Agent images must be 10MB or smaller.");
+    }
+    totalBytes += upload.size;
+    if (totalBytes > MAX_AGENT_IMAGE_TOTAL_BYTES) {
+      throw new Error("Agent image attachments must total 20MB or less.");
+    }
+    const bytes = await fs.readFile(uploadPath(upload.id));
+    resolved.push({
+      uploadId: upload.id,
+      filename: upload.filename,
+      mediaType: upload.mediaType as AgentPromptImage["mediaType"],
+      data: bytes.toString("base64"),
+    });
+  }
+
+  return resolved;
+}

--- a/apps/web/lib/agents/runtime/materialize-images.test.ts
+++ b/apps/web/lib/agents/runtime/materialize-images.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  executeOnHost: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/agents/runtime/process", () => ({
+  executeOnHost: mocks.executeOnHost,
+}));
+
+import { materializeAgentImages } from "./materialize-images";
+
+describe("agent image materialization", () => {
+  it("writes image bytes on the selected host", async () => {
+    const target = {
+      connectorId: "connector",
+      transport: "ssh" as const,
+      alias: "macbook",
+    };
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: JSON.stringify(["/tmp/overtchat-agent-images/image.png"]),
+      stderr: "",
+      code: 0,
+      signal: null,
+    });
+
+    await expect(
+      materializeAgentImages(target, [
+        {
+          uploadId: "11111111-1111-4111-8111-111111111111",
+          filename: "image.png",
+          mediaType: "image/png",
+          data: "aW1hZ2U=",
+        },
+      ]),
+    ).resolves.toEqual(["/tmp/overtchat-agent-images/image.png"]);
+
+    expect(mocks.executeOnHost).toHaveBeenCalledWith(
+      target,
+      {
+        command: "node",
+        args: ["-e", expect.stringContaining("overtchat-agent-images")],
+      },
+      {
+        timeoutMs: 60_000,
+        stdin: JSON.stringify([
+          { data: "aW1hZ2U=", mediaType: "image/png" },
+        ]),
+      },
+    );
+  });
+
+  it("rejects invalid host output and skips empty batches", async () => {
+    mocks.executeOnHost.mockClear();
+    await expect(
+      materializeAgentImages(
+        { connectorId: "connector", transport: "local" },
+        [],
+      ),
+    ).resolves.toEqual([]);
+    expect(mocks.executeOnHost).not.toHaveBeenCalled();
+
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: "{}",
+      stderr: "",
+      code: 0,
+      signal: null,
+    });
+    await expect(
+      materializeAgentImages(
+        { connectorId: "connector", transport: "local" },
+        [
+          {
+            uploadId: "11111111-1111-4111-8111-111111111111",
+            filename: "image.png",
+            mediaType: "image/png",
+            data: "aW1hZ2U=",
+          },
+        ],
+      ),
+    ).rejects.toThrow("invalid image paths");
+  });
+});

--- a/apps/web/lib/agents/runtime/materialize-images.ts
+++ b/apps/web/lib/agents/runtime/materialize-images.ts
@@ -1,0 +1,62 @@
+import "server-only";
+import type { ResolvedAgentImage } from "@/lib/agents/providers/types";
+import type { HostTarget } from "@/lib/agents/runtime/process";
+import { executeOnHost } from "@/lib/agents/runtime/process";
+
+const SCRIPT = `
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const input = JSON.parse(fs.readFileSync(0, "utf8"));
+const dir = path.join(os.tmpdir(), "overtchat-agent-images");
+fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+for (const name of fs.readdirSync(dir)) {
+  const file = path.join(dir, name);
+  try {
+    if (Date.now() - fs.statSync(file).mtimeMs > 24 * 60 * 60 * 1000) {
+      fs.rmSync(file, { force: true });
+    }
+  } catch {}
+}
+const extensions = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+};
+const paths = input.map((image) => {
+  const file = path.join(
+    dir,
+    crypto.randomUUID() + (extensions[image.mediaType] || ".img"),
+  );
+  fs.writeFileSync(file, Buffer.from(image.data, "base64"), { mode: 0o600 });
+  return file;
+});
+process.stdout.write(JSON.stringify(paths));
+`.trim();
+
+export async function materializeAgentImages(
+  target: HostTarget,
+  images: readonly ResolvedAgentImage[],
+): Promise<string[]> {
+  if (images.length === 0) return [];
+  const result = await executeOnHost(
+    target,
+    { command: "node", args: ["-e", SCRIPT] },
+    {
+      timeoutMs: 60_000,
+      stdin: JSON.stringify(
+        images.map(({ data, mediaType }) => ({ data, mediaType })),
+      ),
+    },
+  );
+  const paths = JSON.parse(result.stdout) as unknown;
+  if (
+    !Array.isArray(paths) ||
+    !paths.every((item) => typeof item === "string" && item.length > 0)
+  ) {
+    throw new Error("The agent host returned invalid image paths.");
+  }
+  return paths;
+}

--- a/apps/web/lib/agents/runtime/registry.test.ts
+++ b/apps/web/lib/agents/runtime/registry.test.ts
@@ -7,6 +7,7 @@ import type {
 
 const mocks = vi.hoisted(() => ({
   startPiRpc: vi.fn(),
+  resolveAgentImages: vi.fn(),
   getOwnedAgentSession: vi.fn(),
   updateAgentSessionMetadata: vi.fn(),
   upsertAgentSession: vi.fn(),
@@ -15,6 +16,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock("server-only", () => ({}));
 vi.mock("@/lib/agents/pi/client", () => ({
   startPiRpc: mocks.startPiRpc,
+}));
+vi.mock("@/lib/agents/runtime/images", () => ({
+  resolveAgentImages: mocks.resolveAgentImages,
 }));
 vi.mock("@/lib/db/agentConnections", () => ({
   getOwnedAgentSession: mocks.getOwnedAgentSession,
@@ -520,6 +524,116 @@ describe("Agent session runtime", () => {
     });
     expect(runtime.snapshot().queuedMessages).toEqual([]);
     unsubscribe();
+    await runtime.stop();
+  });
+
+  it("preserves queued images and resolves them only when sent", async () => {
+    mocks.resolveAgentImages.mockClear();
+    const client = new FakeAgentClient();
+    const imageModel: AgentModel = {
+      ...model,
+      input: ["text", "image"],
+    };
+    const imageRef = {
+      uploadId: "11111111-1111-4111-8111-111111111111",
+      filename: "screen.png",
+      mediaType: "image/png" as const,
+    };
+    const resolvedImage = {
+      ...imageRef,
+      data: "aW1hZ2U=",
+    };
+    mocks.resolveAgentImages.mockResolvedValueOnce([resolvedImage]);
+    const runtime = new AgentSessionRuntime(
+      "session",
+      "user",
+      "connection",
+      "workspace",
+      agentProviderAdapter("pi"),
+      client as unknown as AgentRuntimeClient,
+      {
+        ...initial(),
+        state: {
+          ...initial().state,
+          model: imageModel,
+        },
+        models: [imageModel],
+        thinkingLevels: [...initial().thinkingLevels],
+      },
+      vi.fn(),
+    );
+
+    await runtime.command({ type: "prompt", message: "First" });
+    await runtime.command({
+      type: "queue",
+      message: "",
+      images: [imageRef],
+    });
+
+    expect(mocks.resolveAgentImages).not.toHaveBeenCalled();
+    expect(runtime.snapshot().queuedMessages).toEqual([
+      {
+        id: "session:1",
+        message: "",
+        images: [imageRef],
+        status: "pending",
+      },
+    ]);
+
+    client.emit({ type: "agent_settled" });
+    await vi.waitFor(() => {
+      expect(client.prompt).toHaveBeenNthCalledWith(2, "", [resolvedImage]);
+    });
+    expect(mocks.resolveAgentImages).toHaveBeenCalledWith([imageRef], "user");
+    expect(runtime.snapshot().queuedMessages).toEqual([]);
+    expect(runtime.snapshot().messages).toContainEqual(
+      expect.objectContaining({
+        role: "user",
+        content: [
+          {
+            type: "image",
+            url: `/api/uploads/${imageRef.uploadId}`,
+            mimeType: "image/png",
+            filename: "screen.png",
+          },
+        ],
+      }),
+    );
+    await runtime.stop();
+  });
+
+  it("rejects image input when the selected model is text-only", async () => {
+    mocks.resolveAgentImages.mockClear();
+    const client = new FakeAgentClient();
+    const runtime = new AgentSessionRuntime(
+      "session",
+      "user",
+      "connection",
+      "workspace",
+      agentProviderAdapter("pi"),
+      client as unknown as AgentRuntimeClient,
+      {
+        ...initial(),
+        thinkingLevels: [...initial().thinkingLevels],
+      },
+      vi.fn(),
+    );
+
+    await expect(
+      runtime.command({
+        type: "prompt",
+        message: "Inspect this",
+        images: [
+          {
+            uploadId: "11111111-1111-4111-8111-111111111111",
+            filename: "screen.png",
+            mediaType: "image/png",
+          },
+        ],
+      }),
+    ).rejects.toThrow("does not support image input");
+    expect(mocks.resolveAgentImages).not.toHaveBeenCalled();
+    expect(client.prompt).not.toHaveBeenCalled();
     await runtime.stop();
   });
 

--- a/apps/web/lib/agents/runtime/registry.ts
+++ b/apps/web/lib/agents/runtime/registry.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type {
   AgentModel,
+  AgentPromptImage,
   AgentProviderId,
   AgentQueuedMessage,
   AgentRuntimeEnvelope,
@@ -11,6 +12,7 @@ import type {
   AgentSessionStats,
   AgentThinkingLevel,
 } from "@/lib/agents/types";
+import { resolveAgentImages } from "@/lib/agents/runtime/images";
 import {
   applyAgentRuntimeMessageEvent,
   applyAgentRuntimeStateEvent,
@@ -108,6 +110,20 @@ function firstUserMessage(messages: unknown[]): string | null {
     ) {
       const text = messageText(message);
       if (text) return text;
+      const content = Reflect.get(message, "content");
+      if (!Array.isArray(content)) continue;
+      const image = content.find(
+        (part) =>
+          part &&
+          typeof part === "object" &&
+          Reflect.get(part, "type") === "image",
+      );
+      if (image) {
+        const filename = Reflect.get(image, "filename");
+        return typeof filename === "string" && filename.trim()
+          ? filename.trim()
+          : "Image attachment";
+      }
     }
   }
   return null;
@@ -420,13 +436,13 @@ export class AgentSessionRuntime {
           new Error("Session forks must be created by the runtime registry."),
         );
       case "prompt":
-        return this.submitPrompt(command.message);
+        return this.submitPrompt(command.message, command.images ?? []);
       case "abort":
         return this.abortActiveRun();
       case "steer":
-        return this.submitSteer(command.message);
+        return this.submitSteer(command.message, command.images ?? []);
       case "queue":
-        return this.enqueueMessage(command.message);
+        return this.enqueueMessage(command.message, command.images ?? []);
       case "remove_queued_message":
         return this.removeQueuedMessage(command.id);
       case "steer_queued_message":
@@ -627,7 +643,13 @@ export class AgentSessionRuntime {
     this.onExit();
   }
 
-  private submitPrompt(message: string): Promise<unknown> {
+  private submitPrompt(
+    message: string,
+    images: AgentPromptImage[],
+  ): Promise<unknown> {
+    if (!message && images.length === 0) {
+      return Promise.reject(new Error("Enter a message or attach an image."));
+    }
     if (this.status === "exited") {
       return Promise.reject(
         new Error(`${agentProviderMetadata(this.provider).label} exited.`),
@@ -648,15 +670,22 @@ export class AgentSessionRuntime {
         ),
       );
     }
-    return this.startPrompt(message).finally(() => {
+    const imageInputError = this.imageInputError(images);
+    if (imageInputError) return Promise.reject(imageInputError);
+    return this.startPrompt(message, images).finally(() => {
       if (this.status === "idle") void this.drainQueuedMessage();
     });
   }
 
   private async startPrompt(
     message: string,
+    imageRefs: AgentPromptImage[],
     submissionId = `prompt:${++this.nextSubmissionId}`,
   ): Promise<unknown> {
+    const images =
+      imageRefs.length > 0
+        ? await resolveAgentImages(imageRefs, this.userId)
+        : [];
     this.turnGeneration += 1;
     this.eventClassifier.reset();
     this.status = "running";
@@ -673,10 +702,13 @@ export class AgentSessionRuntime {
     this.promptSubmissionId = submission.id;
     this.publishStatus();
     try {
-      const result = await this.client.prompt(message);
+      const result =
+        images.length > 0
+          ? await this.client.prompt(message, images)
+          : await this.client.prompt(message);
       if (this.pendingSubmissions.get(submission.id) === submission) {
         submission.published = true;
-        this.publishSubmission(submission.id, submission.message);
+        this.publishSubmission(submission.id, submission.message, images);
       }
       return result;
     } catch (error) {
@@ -707,8 +739,12 @@ export class AgentSessionRuntime {
 
   private submitSteer(
     message: string,
+    imageRefs: AgentPromptImage[],
     submissionId = `steer:${++this.nextSubmissionId}`,
   ): Promise<unknown> {
+    if (!message && imageRefs.length === 0) {
+      return Promise.reject(new Error("Enter a message or attach an image."));
+    }
     const metadata = agentProviderMetadata(this.provider);
     if (!metadata.capabilities.steer) {
       return Promise.reject(
@@ -729,24 +765,38 @@ export class AgentSessionRuntime {
         new Error("Another steering message is already being submitted."),
       );
     }
+    const imageInputError = this.imageInputError(imageRefs);
+    if (imageInputError) return Promise.reject(imageInputError);
 
-    const submission: PendingSubmission = {
-      id: submissionId,
-      message,
-      published: false,
-    };
-    this.pendingSubmissions.set(submission.id, submission);
-    const operation = this.client
-      .steer(message)
-      .then((result) => {
+    const submit = (
+      images: Awaited<ReturnType<typeof resolveAgentImages>>,
+    ) => {
+      const submission: PendingSubmission = {
+        id: submissionId,
+        message,
+        published: false,
+      };
+      this.pendingSubmissions.set(submission.id, submission);
+      const request =
+        images.length > 0
+          ? this.client.steer(message, images)
+          : this.client.steer(message);
+      return request.then((result) => {
         if (this.pendingSubmissions.get(submission.id) === submission) {
           submission.published = true;
-          this.publishSubmission(submission.id, submission.message);
+          this.publishSubmission(submission.id, submission.message, images);
         }
         return result;
-      })
+      });
+    };
+    const operation = (
+      imageRefs.length > 0
+        ? resolveAgentImages(imageRefs, this.userId).then(submit)
+        : submit([])
+    )
       .catch((error) => {
-        if (this.pendingSubmissions.get(submission.id) === submission) {
+        const submission = this.pendingSubmissions.get(submissionId);
+        if (submission) {
           if (submission.published) this.rejectSubmission(submission.id);
           this.pendingSubmissions.delete(submission.id);
         }
@@ -931,19 +981,47 @@ export class AgentSessionRuntime {
     });
   }
 
-  private enqueueMessage(message: string): Promise<unknown> {
-    const queuedMessage = this.addQueuedMessage(message, "pending");
+  private imageInputError(images: AgentPromptImage[]): Error | null {
+    if (images.length === 0) return null;
+    const stateModel = this.state.model;
+    const model =
+      stateModel && typeof stateModel === "object" && !Array.isArray(stateModel)
+        ? (stateModel as Record<string, unknown>)
+        : null;
+    const selected = this.models.find(
+      (candidate) =>
+        candidate.provider === model?.provider &&
+        candidate.id === model?.id,
+    );
+    if (!selected?.input.includes("image")) {
+      return new Error("The selected model does not support image input.");
+    }
+    return null;
+  }
+
+  private enqueueMessage(
+    message: string,
+    images: AgentPromptImage[],
+  ): Promise<unknown> {
+    if (!message && images.length === 0) {
+      return Promise.reject(new Error("Enter a message or attach an image."));
+    }
+    const imageInputError = this.imageInputError(images);
+    if (imageInputError) return Promise.reject(imageInputError);
+    const queuedMessage = this.addQueuedMessage(message, images, "pending");
     if (this.status === "idle") void this.drainQueuedMessage();
     return Promise.resolve({ queued: true, id: queuedMessage.id });
   }
 
   private addQueuedMessage(
     message: string,
+    images: AgentPromptImage[],
     status: AgentQueuedMessage["status"],
   ): AgentQueuedMessage {
     const queuedMessage: AgentQueuedMessage = {
       id: `${this.dbSessionId}:${++this.nextQueuedMessageId}`,
       message,
+      ...(images.length > 0 ? { images } : {}),
       status,
     };
     this.queuedMessages = [...this.queuedMessages, queuedMessage];
@@ -970,7 +1048,11 @@ export class AgentSessionRuntime {
       );
     }
     this.updateQueuedMessageStatus(id, "sending");
-    return this.submitSteer(message.message, message.id)
+    return this.submitSteer(
+      message.message,
+      message.images ?? [],
+      message.id,
+    )
       .then((result) => {
         this.deleteQueuedMessage(message.id);
         return result;
@@ -995,7 +1077,11 @@ export class AgentSessionRuntime {
     );
     if (!message) return Promise.resolve();
     this.updateQueuedMessageStatus(message.id, "sending");
-    const operation = this.startPrompt(message.message, message.id)
+    const operation = this.startPrompt(
+      message.message,
+      message.images ?? [],
+      message.id,
+    )
       .then(() => {
         this.deleteQueuedMessage(message.id);
       })
@@ -1031,12 +1117,28 @@ export class AgentSessionRuntime {
     this.publishQueueUpdate();
   }
 
-  private publishSubmission(id: string, message: string): void {
+  private publishSubmission(
+    id: string,
+    message: string,
+    images: Awaited<ReturnType<typeof resolveAgentImages>>,
+  ): void {
+    const content =
+      images.length === 0
+        ? message
+        : [
+            ...(message ? [{ type: "text", text: message }] : []),
+            ...images.map((image) => ({
+              type: "image",
+              url: `/api/uploads/${image.uploadId}`,
+              mimeType: image.mediaType,
+              filename: image.filename,
+            })),
+          ];
     const event = {
       type: "overtchat_submission",
       message: {
         role: "user",
-        content: message,
+        content,
         timestamp: Date.now(),
         overtchatSubmissionId: id,
       },

--- a/apps/web/lib/agents/runtime/state.test.ts
+++ b/apps/web/lib/agents/runtime/state.test.ts
@@ -435,6 +435,44 @@ describe("agent runtime event reducer", () => {
     expect(rejected.messages).toEqual(snapshot().messages);
   });
 
+  it("preserves image references in queue updates", () => {
+    const updated = applyAgentRuntimeEnvelope(
+      snapshot(),
+      event({
+        type: "overtchat_queue_update",
+        queuedMessages: [
+          {
+            id: "session:1",
+            message: "",
+            images: [
+              {
+                uploadId: "11111111-1111-4111-8111-111111111111",
+                filename: "screen.png",
+                mediaType: "image/png",
+              },
+            ],
+            status: "pending",
+          },
+        ],
+      }),
+    )!;
+
+    expect(updated.queuedMessages).toEqual([
+      {
+        id: "session:1",
+        message: "",
+        images: [
+          {
+            uploadId: "11111111-1111-4111-8111-111111111111",
+            filename: "screen.png",
+            mediaType: "image/png",
+          },
+        ],
+        status: "pending",
+      },
+    ]);
+  });
+
   it("uses authoritative snapshots after live deltas", () => {
     const authoritative = snapshot();
     authoritative.messages.push({

--- a/apps/web/lib/agents/runtime/state.ts
+++ b/apps/web/lib/agents/runtime/state.ts
@@ -3,6 +3,7 @@ import type {
   AgentRuntimeEnvelope,
   AgentRuntimeSnapshot,
 } from "@/lib/agents/types";
+import { agentPromptImageSchema } from "@/lib/agents/types";
 import { agentProviderMetadata } from "@/lib/agents/catalog";
 
 type AgentRuntimeEvent = Extract<
@@ -351,9 +352,17 @@ function parseQueuedMessages(value: unknown): AgentQueuedMessage[] | null {
     ) {
       return null;
     }
+    const rawImages = Reflect.get(item, "images");
+    if (rawImages !== undefined && !Array.isArray(rawImages)) return null;
+    const images = (rawImages ?? []).flatMap((image: unknown) => {
+      const parsed = agentPromptImageSchema.safeParse(image);
+      return parsed.success ? [parsed.data] : [];
+    });
+    if (images.length !== (rawImages ?? []).length) return null;
     messages.push({
       id: Reflect.get(item, "id") as string,
       message: Reflect.get(item, "message") as string,
+      ...(images.length > 0 ? { images } : {}),
       status: Reflect.get(item, "status") as "pending" | "sending",
     });
   }

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -206,9 +206,29 @@ export type AgentSlashCommand = {
   argumentHint?: string;
 };
 
+export const AGENT_IMAGE_MEDIA_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export const MAX_AGENT_IMAGES = 4;
+export const MAX_AGENT_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_AGENT_IMAGE_TOTAL_BYTES = 20 * 1024 * 1024;
+
+export const agentPromptImageSchema = z.object({
+  uploadId: z.string().uuid(),
+  filename: z.string().trim().min(1).max(500),
+  mediaType: z.enum(AGENT_IMAGE_MEDIA_TYPES),
+});
+
+export type AgentPromptImage = z.infer<typeof agentPromptImageSchema>;
+
 export type AgentQueuedMessage = {
   id: string;
   message: string;
+  images?: AgentPromptImage[];
   status: "pending" | "sending";
 };
 
@@ -253,16 +273,19 @@ export type AgentUsageSnapshot = {
 export const agentSessionCommandSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("prompt"),
-    message: z.string().trim().min(1).max(200_000),
+    message: z.string().trim().max(200_000),
+    images: z.array(agentPromptImageSchema).max(MAX_AGENT_IMAGES).optional(),
   }),
   z.object({ type: z.literal("abort") }),
   z.object({
     type: z.literal("steer"),
-    message: z.string().trim().min(1).max(200_000),
+    message: z.string().trim().max(200_000),
+    images: z.array(agentPromptImageSchema).max(MAX_AGENT_IMAGES).optional(),
   }),
   z.object({
     type: z.literal("queue"),
-    message: z.string().trim().min(1).max(200_000),
+    message: z.string().trim().max(200_000),
+    images: z.array(agentPromptImageSchema).max(MAX_AGENT_IMAGES).optional(),
   }),
   z.object({
     type: z.literal("remove_queued_message"),


### PR DESCRIPTION
## Summary
- add pasted and selected image attachments to agent sessions with previews and bounded validation
- deliver images through native Pi RPC and host-local Codex image paths for local and SSH sessions
- preserve attachments across queue, steer, edit, and runtime refresh flows

## Validation
- `npm run lint -w apps/web --`
- `npm run typecheck -w apps/web --`
- `npm run test -w apps/web --`
- `E2E_PORT=4723 npm exec -w apps/web playwright test e2e/agent-runtime.spec.ts`