### PR TITLE
fix(web): preserve agent turn activity

### DIFF
--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -11,6 +11,7 @@ import {
   FileText,
   Globe,
   Loader2,
+  MessageSquareText,
   Search,
   Terminal,
   Wrench,
@@ -116,10 +117,12 @@ export function AgentActivityGroup({
   entries,
   active,
   startedAt,
+  durationMs,
 }: {
   entries: AgentActivityEntry[];
   active: boolean;
   startedAt: number | null;
+  durationMs: number | null;
 }) {
   const presentation = describeAgentActivity(entries, active);
   const hasError = presentation.status === "failed";
@@ -134,7 +137,12 @@ export function AgentActivityGroup({
   ).length;
   const progress =
     live && completedCount > 0 ? `${completedCount} completed` : null;
-  const headerLabel = open && live && hasTools ? "Activity" : presentation.label;
+  const completedDuration =
+    presentation.status === "completed" && durationMs !== null
+      ? formatElapsed(durationMs)
+      : null;
+  const headerLabel =
+    open && live && hasTools ? "Activity" : presentation.label;
   const headerSecondary =
     open && live && hasTools ? null : presentation.secondary;
 
@@ -144,6 +152,9 @@ export function AgentActivityGroup({
         type="button"
         onClick={() => setOpen((current) => !current)}
         aria-expanded={open}
+        aria-label={
+          completedDuration ? `Worked for ${completedDuration}` : undefined
+        }
         className="group flex min-h-8 w-full items-center gap-2 rounded-md py-1 pr-1 text-left text-muted-foreground motion-colors hover:text-foreground"
       >
         <ActivityIcon entries={entries} status={presentation.status} />
@@ -152,9 +163,12 @@ export function AgentActivityGroup({
             className={cn(
               "shrink-0 font-medium text-foreground",
               live && !open && motionClasses.shimmer,
+              completedDuration && "tabular-nums [word-spacing:0.125rem]",
             )}
           >
-            {headerLabel}
+            {completedDuration
+              ? `Worked for ${completedDuration}`
+              : headerLabel}
           </span>
           {headerSecondary && (
             <span className="min-w-0 truncate font-mono text-[11px]">
@@ -199,7 +213,7 @@ export function AgentActivityGroup({
                 entry={entry}
                 active={active}
                 last={index === entries.length - 1}
-                showThinkingStep={hasTools || entries.length > 1}
+                showDetailedStep={hasTools || entries.length > 1}
               />
             ))}
           </div>
@@ -213,15 +227,33 @@ function ActivityStep({
   entry,
   active,
   last,
-  showThinkingStep,
+  showDetailedStep,
 }: {
   entry: AgentActivityEntry;
   active: boolean;
   last: boolean;
-  showThinkingStep: boolean;
+  showDetailedStep: boolean;
 }) {
+  if (entry.type === "commentary") {
+    if (!showDetailedStep) {
+      return (
+        <div className={cn("min-w-0", last ? "pb-1" : "pb-4")}>
+          <ThinkingContent content={entry.content} />
+        </div>
+      );
+    }
+    return (
+      <TimelineStep
+        icon={<MessageSquareText className="size-3.5" />}
+        last={last}
+      >
+        <ThinkingContent content={entry.content} />
+      </TimelineStep>
+    );
+  }
+
   if (entry.type === "thinking") {
-    if (!showThinkingStep) {
+    if (!showDetailedStep) {
       return (
         <div className={cn("min-w-0", last ? "pb-1" : "pb-4")}>
           <ThinkingContent content={entry.content} />
@@ -564,6 +596,11 @@ function ActivityIcon({
     ),
   );
   if (categories.size === 0) {
+    if (entries.some((entry) => entry.type === "commentary")) {
+      return (
+        <MessageSquareText className="size-3.5 shrink-0 text-muted-foreground" />
+      );
+    }
     return <Brain className="size-3.5 shrink-0 text-muted-foreground" />;
   }
   if (categories.size > 1) {

--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -163,12 +163,25 @@ export function AgentActivityGroup({
             className={cn(
               "shrink-0 font-medium text-foreground",
               live && !open && motionClasses.shimmer,
-              completedDuration && "tabular-nums [word-spacing:0.125rem]",
             )}
           >
-            {completedDuration
-              ? `Worked for ${completedDuration}`
-              : headerLabel}
+            {completedDuration ? (
+              <span aria-hidden="true">
+                <span>Worked</span>
+                <span style={{ marginInlineStart: 4 }}>for</span>
+                {completedDuration.split(" ").map((part) => (
+                  <span
+                    key={part}
+                    className="tabular-nums"
+                    style={{ marginInlineStart: 4 }}
+                  >
+                    {part}
+                  </span>
+                ))}
+              </span>
+            ) : (
+              headerLabel
+            )}
           </span>
           {headerSecondary && (
             <span className="min-w-0 truncate font-mono text-[11px]">

--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -166,18 +166,8 @@ export function AgentActivityGroup({
             )}
           >
             {completedDuration ? (
-              <span aria-hidden="true">
-                <span>Worked</span>
-                <span style={{ marginInlineStart: 4 }}>for</span>
-                {completedDuration.split(" ").map((part) => (
-                  <span
-                    key={part}
-                    className="tabular-nums"
-                    style={{ marginInlineStart: 4 }}
-                  >
-                    {part}
-                  </span>
-                ))}
+              <span aria-hidden="true" className="tabular-nums">
+                {`Worked\u00a0for\u00a0${completedDuration.replaceAll(" ", "\u00a0")}`}
               </span>
             ) : (
               headerLabel

--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -165,13 +165,9 @@ export function AgentActivityGroup({
               live && !open && motionClasses.shimmer,
             )}
           >
-            {completedDuration ? (
-              <span aria-hidden="true" className="tabular-nums">
-                {`Worked\u00a0for\u00a0${completedDuration.replaceAll(" ", "\u00a0")}`}
-              </span>
-            ) : (
-              headerLabel
-            )}
+            {completedDuration
+              ? `Worked · ${completedDuration.replaceAll(" ", " · ")}`
+              : headerLabel}
           </span>
           {headerSecondary && (
             <span className="min-w-0 truncate font-mono text-[11px]">

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -224,6 +224,7 @@ function AgentTranscriptRow({
       entries={item.entries}
       active={active}
       startedAt={activityStartedAt}
+      durationMs={item.durationMs}
     />
   );
 }

--- a/apps/web/components/chat/ThinkingContent.tsx
+++ b/apps/web/components/chat/ThinkingContent.tsx
@@ -12,7 +12,7 @@ const THINKING_REMARK_PLUGINS = [
   remarkBreaks,
 ];
 
-/** A reasoning part's markdown, rendered as muted text inside a ChainOfThought step. */
+/** Muted markdown rendered inside reasoning and agent-work details. */
 export function ThinkingContent({ content }: { content: string }) {
   const trimmed = content.trim();
   if (!trimmed) return null;

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -69,6 +69,10 @@ function runtimeSnapshot(startedAt: number) {
         role: "assistant",
         content: [
           {
+            type: "commentary",
+            text: "I'm auditing the release state before merging anything.",
+          },
+          {
             type: "thinking",
             thinking: "I should inspect the runtime before responding.",
           },
@@ -78,6 +82,7 @@ function runtimeSnapshot(startedAt: number) {
           },
         ],
         timestamp: 2,
+        overtchatActivityDurationMs: 246_000,
       },
       {
         role: "assistant",
@@ -358,15 +363,21 @@ test("shows durable turn activity without changing completed tool status", async
 
   const genericActivity = page.getByTestId("agent-run-activity");
   await expect(genericActivity).toHaveCount(0);
-  const thoughts = page.getByRole("button", { name: "Thoughts", exact: true });
-  await thoughts.click();
+  const completedWork = page.getByRole("button", {
+    name: "Worked for 4m 6s",
+    exact: true,
+  });
+  await completedWork.click();
+  await expect(
+    page.getByText("I'm auditing the release state before merging anything."),
+  ).toBeVisible();
   await expect(
     page.getByText("I should inspect the runtime before responding."),
   ).toBeVisible();
-  await expect(page.getByText("Thinking", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("Thinking", { exact: true })).toBeVisible();
   await expect(
-    page.getByRole("button", { name: "Thinking", exact: true }),
-  ).toHaveCount(0);
+    page.getByText("I will inspect the runtime.", { exact: true }),
+  ).toBeVisible();
   const liveActivity = page.getByRole("button", {
     name: /Searching.*runtimeStatus/u,
   });

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -230,8 +230,15 @@ class FakeCodexServer {
                   ],
                 },
                 {
+                  id: "commentary-history",
+                  type: "agentMessage",
+                  phase: "commentary",
+                  text: "I am restoring the native thread.",
+                },
+                {
                   id: "assistant-history",
                   type: "agentMessage",
+                  phase: "final_answer",
                   text: "History restored.",
                 },
               ],
@@ -488,6 +495,129 @@ describe("CodexRuntimeClient", () => {
     );
   });
 
+  it("preserves streamed work when the completed turn only includes the final answer", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+    await client.prompt("Check the release");
+
+    server.emit("turn/started", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "inProgress",
+        startedAt: 10,
+        items: [],
+      },
+    });
+    server.emit("item/started", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "commentary-1",
+        type: "agentMessage",
+        phase: "commentary",
+        text: "",
+      },
+    });
+    server.emit("item/agentMessage/delta", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "commentary-1",
+      delta: "I'm checking the release image.",
+    });
+    server.emit("item/completed", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "commentary-1",
+        type: "agentMessage",
+        phase: "commentary",
+        text: "I'm checking the release image.",
+      },
+    });
+    server.emit("item/completed", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "command-1",
+        type: "commandExecution",
+        command: "docker build .",
+        cwd: "/workspace",
+        status: "completed",
+        aggregatedOutput: "done\n",
+        exitCode: 0,
+      },
+    });
+    server.emit("item/started", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "final-1",
+        type: "agentMessage",
+        phase: "final_answer",
+        text: "",
+      },
+    });
+    server.emit("item/agentMessage/delta", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "final-1",
+      delta: "The image is ready.",
+    });
+    server.emit("turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        startedAt: 10,
+        completedAt: 256,
+        items: [
+          {
+            id: "final-1",
+            type: "agentMessage",
+            phase: "final_answer",
+            text: "The image is ready.",
+          },
+        ],
+      },
+    });
+
+    const { messages } = await client.getMessages();
+    const assistant = messages.find(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        Reflect.get(message, "id") === "turn-1:assistant",
+    );
+    expect(assistant).toMatchObject({
+      role: "assistant",
+      overtchatActivityDurationMs: 246_000,
+      content: [
+        {
+          type: "commentary",
+          text: "I'm checking the release image.",
+        },
+        {
+          type: "toolCall",
+          id: "command-1",
+          name: "bash",
+        },
+        { type: "text", text: "The image is ready." },
+      ],
+    });
+    expect(
+      messages.filter(
+        (message) =>
+          message &&
+          typeof message === "object" &&
+          Reflect.get(message, "toolCallId") === "command-1",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("hydrates complete native history after resuming a thread", async () => {
     const client = new CodexRuntimeClient(
       { connectorId: "connector", transport: "local" },
@@ -511,7 +641,14 @@ describe("CodexRuntimeClient", () => {
         expect.objectContaining({
           id: "turn-history:assistant",
           role: "assistant",
-          content: [{ type: "text", text: "History restored." }],
+          overtchatActivityDurationMs: 1_000,
+          content: [
+            {
+              type: "commentary",
+              text: "I am restoring the native thread.",
+            },
+            { type: "text", text: "History restored." },
+          ],
         }),
       ]),
     });

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -322,6 +322,8 @@ function itemTool(item: CodexItem): {
 
 function canonicalTurnMessages(turn: CodexTurn): unknown[] {
   const startedAt = (turn.startedAt ?? Date.now() / 1_000) * 1_000;
+  const completedAt =
+    turn.completedAt === null ? null : turn.completedAt * 1_000;
   const messages: unknown[] = [];
   const assistantContent: UnknownRecord[] = [];
   const results: unknown[] = [];
@@ -341,7 +343,14 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
     }
     if (item.type === "agentMessage") {
       const text = stringOf(item, "text") ?? "";
-      if (text) assistantContent.push({ type: "text", text });
+      const phase = stringOf(item, "phase");
+      if (text) {
+        assistantContent.push(
+          phase === "commentary"
+            ? { type: "commentary", text }
+            : { type: "text", text },
+        );
+      }
       continue;
     }
     if (item.type === "reasoning" || item.type === "plan") {
@@ -394,6 +403,14 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
       role: "assistant",
       content: assistantContent,
       timestamp: startedAt + 1,
+      ...(completedAt !== null
+        ? {
+            overtchatActivityDurationMs: Math.max(
+              0,
+              completedAt - startedAt,
+            ),
+          }
+        : {}),
       ...(turn.status === "failed" && recordOf(turn.error)
         ? { errorMessage: stringOf(recordOf(turn.error), "message") ?? undefined }
         : {}),
@@ -1155,7 +1172,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       return;
     }
     if (method === "turn/completed") {
-      const turn = this.withKnownUserInputs(parseCodexTurn(data?.turn));
+      const completedTurn = this.withKnownUserInputs(
+        parseCodexTurn(data?.turn),
+      );
+      const turn = this.reconcileCompletedTurn(completedTurn);
       this.turns.set(turn.id, turn);
       this.emitTurn(turn);
       if (this.activeTurnId === turn.id) this.activeTurnId = null;
@@ -1552,6 +1572,31 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     return synthetic.length === 0 && items.length === turn.items.length
       ? turn
       : { ...turn, items: [...synthetic, ...items] };
+  }
+
+  private reconcileCompletedTurn(completed: CodexTurn): CodexTurn {
+    const streamed = this.turns.get(completed.id);
+    if (!streamed) return completed;
+    const items = [...streamed.items];
+    const indexById = new Map(
+      items.map((item, index) => [item.id, index] as const),
+    );
+    for (const item of completed.items) {
+      const index = indexById.get(item.id);
+      if (index === undefined) {
+        indexById.set(item.id, items.length);
+        items.push(item);
+      } else {
+        items[index] = item;
+      }
+    }
+    return {
+      ...streamed,
+      ...completed,
+      items,
+      startedAt: completed.startedAt ?? streamed.startedAt,
+      completedAt: completed.completedAt ?? streamed.completedAt,
+    };
   }
 
   private upsertItem(turnId: string, value: UnknownRecord): void {

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -140,6 +140,50 @@ describe("projectAgentTranscript", () => {
     ]);
   });
 
+  it("keeps commentary in a timed work group before the final answer", () => {
+    const projected = projectAgentTranscript([
+      assistant(
+        [
+          {
+            type: "commentary",
+            text: "I'm checking the release image.",
+          },
+          call("build", "bash", { command: "docker build ." }),
+          { type: "text", text: "The image is ready." },
+        ],
+        1,
+        {
+          id: "turn-1:assistant",
+          overtchatActivityDurationMs: 246_355,
+        },
+      ),
+      result("build", "bash", "done"),
+    ]);
+
+    expect(projected).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        durationMs: 246_355,
+        entries: [
+          {
+            type: "commentary",
+            id: "commentary:turn-1:assistant:0",
+            content: "I'm checking the release image.",
+          },
+          expect.objectContaining({
+            type: "tool",
+            tool: expect.objectContaining({ id: "build", output: "done" }),
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        type: "assistant_text",
+        text: "The image is ready.",
+        actionable: true,
+      }),
+    ]);
+  });
+
   it("exposes one fork action on the final assistant text part", () => {
     const projected = projectAgentTranscript([
       assistant(

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -26,6 +26,11 @@ export type AgentToolActivity = {
 
 export type AgentActivityEntry =
   | {
+      type: "commentary";
+      id: string;
+      content: string;
+    }
+  | {
       type: "thinking";
       id: string;
       content: string;
@@ -63,6 +68,7 @@ export type AgentTranscriptItem =
       type: "activity";
       key: string;
       entries: AgentActivityEntry[];
+      durationMs: number | null;
     };
 
 export type AgentToolStatus =
@@ -139,6 +145,13 @@ function resultId(message: unknown): string | null {
   return roleOf(message) === "toolResult" &&
     typeof record?.toolCallId === "string"
     ? record.toolCallId
+    : null;
+}
+
+function activityDurationOf(message: UnknownRecord): number | null {
+  const value = message.overtchatActivityDurationMs;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
     : null;
 }
 
@@ -249,15 +262,18 @@ export function projectAgentTranscript(
 ): AgentTranscriptItem[] {
   const items: AgentTranscriptItem[] = [];
   const pendingActivity: AgentActivityEntry[] = [];
+  let pendingActivityDurationMs: number | null = null;
   const { callIds, results } = collectToolData(messages);
 
-  const flushActivity = () => {
+  const flushActivity = (durationMs: number | null = null) => {
     if (pendingActivity.length === 0) return;
     items.push({
       type: "activity",
       key: `activity:${pendingActivity[0].id}`,
       entries: pendingActivity.splice(0),
+      durationMs: durationMs ?? pendingActivityDurationMs,
     });
+    pendingActivityDurationMs = null;
   };
 
   messages.forEach((message, messageIndex) => {
@@ -268,6 +284,7 @@ export function projectAgentTranscript(
 
     if (role === "assistant") {
       const content = Array.isArray(record.content) ? record.content : [];
+      const activityDurationMs = activityDurationOf(record);
       const lastTextIndex = content.findLastIndex((part) => {
         const candidate = recordOf(part);
         return (
@@ -282,6 +299,20 @@ export function projectAgentTranscript(
         const partIdentity = `${identity}:${partIndex}`;
 
         if (
+          partRecord.type === "commentary" &&
+          typeof partRecord.text === "string" &&
+          partRecord.text.trim()
+        ) {
+          pendingActivity.push({
+            type: "commentary",
+            id: `commentary:${partIdentity}`,
+            content: partRecord.text,
+          });
+          pendingActivityDurationMs ??= activityDurationMs;
+          return;
+        }
+
+        if (
           partRecord.type === "thinking" &&
           typeof partRecord.thinking === "string" &&
           partRecord.thinking.trim()
@@ -291,6 +322,7 @@ export function projectAgentTranscript(
             id: `thinking:${partIdentity}`,
             content: partRecord.thinking,
           });
+          pendingActivityDurationMs ??= activityDurationMs;
           return;
         }
 
@@ -307,6 +339,7 @@ export function projectAgentTranscript(
             id: `tool:${id}`,
             tool: toolFromCall(partRecord, results.get(id), id),
           });
+          pendingActivityDurationMs ??= activityDurationMs;
           return;
         }
 
@@ -315,7 +348,7 @@ export function projectAgentTranscript(
           typeof partRecord.text === "string" &&
           partRecord.text.trim()
         ) {
-          flushActivity();
+          flushActivity(activityDurationMs);
           items.push({
             type: "assistant_text",
             key: `assistant:${partIdentity}`,
@@ -331,7 +364,7 @@ export function projectAgentTranscript(
         typeof record.errorMessage === "string" &&
         record.errorMessage.trim()
       ) {
-        flushActivity();
+        flushActivity(activityDurationMs);
         items.push({
           type: "assistant_error",
           key: `assistant-error:${identity}`,


### PR DESCRIPTION
## Summary
- preserve streamed commentary, reasoning, and tool items when the completed turn snapshot is sparse
- render commentary inside a timed expandable work disclosure while keeping only the final answer outside
- reconstruct the same activity timeline from resumed session history

## Implementation
- follows Paseo's item-ID reconciliation model instead of replacing the live timeline at turn completion
- uses the official app-server commentary and final_answer phases for presentation

## Validation
- full web ESLint
- strict TypeScript
- 464 web tests on the blocker branch
- standalone production Playwright activity flow
- clean three-way merge with #142 and #143
- combined-tree lint, typecheck, and 485 tests