### PR TITLE
feat(web): complete Codex agent parity

### DIFF
--- a/apps/web/app/api/agent-sessions/[id]/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.ts
@@ -103,6 +103,7 @@ export async function POST(
     const commandResult = await runtime.command(normalized);
     if (
       normalized.type === "prompt" ||
+      normalized.type === "implement_plan" ||
       normalized.type === "steer" ||
       normalized.type === "steer_queued_message"
     ) {

--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -14,6 +14,7 @@ import {
   MessageSquareText,
   Search,
   Terminal,
+  Users,
   Wrench,
 } from "lucide-react";
 import { ThinkingContent } from "@/components/chat/ThinkingContent";
@@ -129,7 +130,11 @@ export function AgentActivityGroup({
   const live = active && presentation.status === "running";
   const elapsed = useElapsed(live ? startedAt : null);
   const [open, setOpen] = useState(hasError);
-  const hasTools = entries.some((entry) => entry.type === "tool");
+  const hasDetailedSteps = entries.some(
+    (entry) =>
+      entry.type === "tool" ||
+      entry.type === "subagent",
+  );
   const completedCount = entries.filter(
     (entry) =>
       entry.type === "tool" &&
@@ -142,9 +147,9 @@ export function AgentActivityGroup({
       ? formatElapsed(durationMs)
       : null;
   const headerLabel =
-    open && live && hasTools ? "Activity" : presentation.label;
+    open && live && hasDetailedSteps ? "Activity" : presentation.label;
   const headerSecondary =
-    open && live && hasTools ? null : presentation.secondary;
+    open && live && hasDetailedSteps ? null : presentation.secondary;
 
   return (
     <div className="text-xs" data-testid="agent-activity-group">
@@ -166,7 +171,7 @@ export function AgentActivityGroup({
             )}
           >
             {completedDuration
-              ? `Worked · ${completedDuration.replaceAll(" ", " · ")}`
+              ? `Worked for ${completedDuration}`
               : headerLabel}
           </span>
           {headerSecondary && (
@@ -202,7 +207,7 @@ export function AgentActivityGroup({
           <div
             className={cn(
               "relative mt-1 ml-2 pl-5",
-              hasTools && "border-l border-border/70",
+              hasDetailedSteps && "border-l border-border/70",
             )}
             data-testid="agent-activity-details"
           >
@@ -212,7 +217,9 @@ export function AgentActivityGroup({
                 entry={entry}
                 active={active}
                 last={index === entries.length - 1}
-                showDetailedStep={hasTools || entries.length > 1}
+                showDetailedStep={
+                  hasDetailedSteps || entries.length > 1
+                }
               />
             ))}
           </div>
@@ -272,6 +279,17 @@ function ActivityStep({
     );
   }
 
+  if (entry.type === "subagent") {
+    return (
+      <TimelineStep
+        icon={<Users className="size-3.5" />}
+        last={last}
+      >
+        <SubagentActivityStep activity={entry.activity} />
+      </TimelineStep>
+    );
+  }
+
   return (
     <TimelineStep
       icon={
@@ -284,6 +302,122 @@ function ActivityStep({
     >
       <ToolActivityStep tool={entry.tool} active={active} />
     </TimelineStep>
+  );
+}
+
+function SubagentActivityStep({
+  activity,
+}: {
+  activity: Extract<
+    AgentActivityEntry,
+    { type: "subagent" }
+  >["activity"];
+}) {
+  const [open, setOpen] = useState(false);
+  const running = ["inProgress", "pendingInit", "running"].includes(
+    activity.status,
+  );
+  const count = Math.max(1, activity.receivers.length);
+  const label =
+    activity.action === "spawnAgent"
+      ? running
+        ? "Starting subagent"
+        : "Started subagent"
+      : activity.action === "sendInput"
+        ? "Sent subagent input"
+        : activity.action === "wait"
+          ? running
+            ? "Waiting for subagents"
+            : "Waited for subagents"
+          : activity.action === "closeAgent"
+            ? "Closed subagent"
+            : `${count} ${count === 1 ? "subagent" : "subagents"}`;
+  const canOpen =
+    Boolean(activity.prompt) ||
+    activity.receivers.length > 0 ||
+    activity.events.length > 0;
+
+  return (
+    <div data-testid="agent-subagent-activity">
+      <button
+        type="button"
+        onClick={() => canOpen && setOpen((current) => !current)}
+        disabled={!canOpen}
+        aria-expanded={canOpen ? open : undefined}
+        className={cn(
+          "flex min-h-5 w-full items-start gap-2 text-left",
+          canOpen && "cursor-pointer hover:text-foreground",
+        )}
+      >
+        <span className="min-w-0 flex-1 font-medium text-foreground">
+          {label}
+        </span>
+        {running ? (
+          <Loader2
+            className={cn(
+              "mt-0.5 size-3.5 shrink-0 text-muted-foreground",
+              motionClasses.spinner,
+            )}
+          />
+        ) : (
+          <CircleCheck className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        {canOpen && (
+          <ChevronRight
+            className={cn(
+              "mt-0.5 size-3 shrink-0 text-muted-foreground/60 motion-transform",
+              open && "rotate-90",
+            )}
+          />
+        )}
+      </button>
+      {open && (
+        <div className="mt-2 space-y-2">
+          {activity.prompt && (
+            <CodeSurface label="Prompt" value={activity.prompt} />
+          )}
+          {activity.receivers.length > 0 && (
+            <div className="overflow-hidden rounded-md border bg-muted/15">
+              {activity.receivers.map((receiver) => (
+                <div
+                  key={receiver.threadId}
+                  className="flex items-start gap-2 border-b px-3 py-2 text-[11px] last:border-b-0"
+                >
+                  <span className="min-w-0 flex-1 truncate font-mono">
+                    {receiver.threadId}
+                  </span>
+                  <span className="shrink-0 text-muted-foreground">
+                    {receiver.status}
+                  </span>
+                  {receiver.message && (
+                    <span className="max-w-48 truncate text-muted-foreground">
+                      {receiver.message}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {activity.events.length > 0 && (
+            <div className="overflow-hidden rounded-md border bg-muted/15">
+              <div className="border-b px-3 py-1.5 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+                Activity
+              </div>
+              <div className="divide-y">
+                {activity.events.map((event, index) => (
+                  <div
+                    key={index}
+                    className="px-3 py-2 text-[11px] leading-5 whitespace-pre-wrap wrap-anywhere text-muted-foreground"
+                  >
+                    {event}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -398,7 +532,14 @@ function toolDetail(
         : null,
     ].filter((notice): notice is string => notice !== null);
 
-    if (!command && !tool.output && notices.length === 0) return null;
+    if (
+      !command &&
+      !tool.output &&
+      tool.terminalInputs.length === 0 &&
+      notices.length === 0
+    ) {
+      return null;
+    }
     return (
       <div className="mt-2 overflow-hidden rounded-md border bg-muted/15">
         {command && (
@@ -410,6 +551,18 @@ function toolDetail(
         {tool.output && (
           <pre className="max-h-72 overflow-auto border-t bg-background/50 px-3 py-2.5 font-mono text-[11px] leading-5 whitespace-pre-wrap wrap-anywhere text-muted-foreground">
             {tool.output.replace(/^\n+/, "")}
+          </pre>
+        )}
+        {tool.terminalInputs.length > 0 && (
+          <pre className="max-h-40 overflow-auto border-t px-3 py-2.5 font-mono text-[11px] leading-5 whitespace-pre-wrap wrap-anywhere text-muted-foreground">
+            {tool.terminalInputs.map((input, index) => (
+              <span key={index} className="block">
+                <span className="select-none text-muted-foreground">
+                  {"› "}
+                </span>
+                {input.replace(/\n$/u, "")}
+              </span>
+            ))}
           </pre>
         )}
         {notices.length > 0 && (
@@ -595,6 +748,9 @@ function ActivityIcon({
     ),
   );
   if (categories.size === 0) {
+    if (entries.some((entry) => entry.type === "subagent")) {
+      return <Users className="size-3.5 shrink-0 text-muted-foreground" />;
+    }
     if (entries.some((entry) => entry.type === "commentary")) {
       return (
         <MessageSquareText className="size-3.5 shrink-0 text-muted-foreground" />

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -7,7 +7,9 @@ import {
   AlertTriangle,
   ChevronDown,
   Info,
+  ListChecks,
   Minimize2,
+  Play,
   Terminal,
   GitBranch,
   Pencil,
@@ -75,6 +77,7 @@ export function AgentMessageList({
   actionsDisabled,
   onEditMessage,
   onForkMessage,
+  onImplementPlan,
 }: {
   providerLabel: string;
   messages: unknown[];
@@ -88,6 +91,7 @@ export function AgentMessageList({
   actionsDisabled: boolean;
   onEditMessage: (messageId: string) => void;
   onForkMessage: (messageId: string) => void;
+  onImplementPlan: (plan: string) => void;
 }) {
   const { scrollRef, contentRef, isAtBottom, scrollToBottom } =
     useStickToBottom({
@@ -135,6 +139,7 @@ export function AgentMessageList({
                   actionsDisabled={actionsDisabled}
                   onEditMessage={onEditMessage}
                   onForkMessage={onForkMessage}
+                  onImplementPlan={onImplementPlan}
                 />
               ))}
               {activity && !activityHasLiveStep && (
@@ -179,6 +184,7 @@ function AgentTranscriptRow({
   actionsDisabled,
   onEditMessage,
   onForkMessage,
+  onImplementPlan,
 }: {
   item: AgentTranscriptItem;
   active: boolean;
@@ -188,6 +194,7 @@ function AgentTranscriptRow({
   actionsDisabled: boolean;
   onEditMessage: (messageId: string) => void;
   onForkMessage: (messageId: string) => void;
+  onImplementPlan: (plan: string) => void;
 }) {
   if (item.type === "message") {
     return (
@@ -219,6 +226,15 @@ function AgentTranscriptRow({
   if (item.type === "assistant_error") {
     return <AgentErrorNotice error={item.error} />;
   }
+  if (item.type === "plan") {
+    return (
+      <AgentPlanCard
+        item={item}
+        disabled={actionsDisabled || active}
+        onImplement={() => onImplementPlan(item.text)}
+      />
+    );
+  }
   return (
     <AgentActivityGroup
       entries={item.entries}
@@ -226,6 +242,58 @@ function AgentTranscriptRow({
       startedAt={activityStartedAt}
       durationMs={item.durationMs}
     />
+  );
+}
+
+function AgentPlanCard({
+  item,
+  disabled,
+  onImplement,
+}: {
+  item: Extract<AgentTranscriptItem, { type: "plan" }>;
+  disabled: boolean;
+  onImplement: () => void;
+}) {
+  return (
+    <section
+      className="overflow-hidden rounded-lg border bg-muted/15"
+      data-testid="agent-plan-card"
+    >
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <ListChecks className="size-4 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Plan</h3>
+      </div>
+      <div className="space-y-3 px-3 py-3 text-sm">
+        {item.explanation && (
+          <p className="text-muted-foreground">{item.explanation}</p>
+        )}
+        {item.text ? (
+          <Markdown>{item.text}</Markdown>
+        ) : item.steps.length > 0 ? (
+          <ol className="space-y-2">
+            {item.steps.map((step, index) => (
+              <li key={`${step.step}:${index}`} className="flex gap-2">
+                <span className="text-muted-foreground tabular-nums">
+                  {index + 1}.
+                </span>
+                <span className="min-w-0 flex-1">{step.step}</span>
+              </li>
+            ))}
+          </ol>
+        ) : null}
+        <div className="flex justify-end border-t pt-3">
+          <Button
+            type="button"
+            size="sm"
+            disabled={disabled}
+            onClick={onImplement}
+          >
+            <Play />
+            Implement plan
+          </Button>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -7,14 +7,17 @@ import { Popover } from "@base-ui/react/popover";
 import {
   Check,
   ChevronDown,
+  Code2,
   Coins,
   Copy,
   FileDiff,
   GitBranch,
   MoreHorizontal,
+  ListTodo,
   Pencil,
   Search,
   Sparkles,
+  Zap,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,6 +33,7 @@ import { SidebarToggle } from "@/components/SidebarToggle";
 import { UsageIndicator } from "@/components/chat/UsageIndicator";
 import type {
   AgentModel,
+  AgentCollaborationMode,
   AgentSessionStats,
   AgentThinkingLevel,
   AgentWorkspaceGitStatus,
@@ -49,12 +53,18 @@ export function AgentSessionHeader({
   currentModel,
   thinkingLevel,
   thinkingLevels,
+  collaborationMode,
+  collaborationModes,
+  fastModeEnabled,
+  fastModeAvailable,
   stats,
   running,
   commandPending,
   readOnly,
   onSelectModel,
   onSelectThinking,
+  onSelectCollaborationMode,
+  onToggleFastMode,
   onRename,
   onCompact,
 }: {
@@ -66,12 +76,18 @@ export function AgentSessionHeader({
   currentModel: { provider: string; id: string } | null;
   thinkingLevel: AgentThinkingLevel | null;
   thinkingLevels: AgentThinkingLevel[];
+  collaborationMode: AgentCollaborationMode;
+  collaborationModes: AgentCollaborationMode[];
+  fastModeEnabled: boolean;
+  fastModeAvailable: boolean;
   stats: AgentSessionStats;
   running: boolean;
   commandPending: boolean;
   readOnly: boolean;
   onSelectModel: (model: AgentModel) => void;
   onSelectThinking: (level: AgentThinkingLevel) => void;
+  onSelectCollaborationMode: (mode: AgentCollaborationMode) => void;
+  onToggleFastMode: (enabled: boolean) => void;
   onRename: () => void;
   onCompact: () => void;
 }) {
@@ -133,6 +149,54 @@ export function AgentSessionHeader({
           </SelectContent>
         </Select>
       )}
+      {collaborationModes.length > 1 && (
+        <div
+          role="group"
+          aria-label="Codex mode"
+          className="hidden h-8 shrink-0 items-center rounded-md border bg-muted/20 p-0.5 md:flex"
+        >
+          {collaborationModes.map((mode) => {
+            const selected = mode === collaborationMode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                aria-pressed={selected}
+                disabled={readOnly || running || commandPending}
+                onClick={() => onSelectCollaborationMode(mode)}
+                className={cn(
+                  "flex h-6 items-center gap-1 rounded px-2 text-xs font-medium motion-colors disabled:cursor-not-allowed disabled:opacity-50",
+                  selected
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {mode === "plan" ? (
+                  <ListTodo className="size-3.5" />
+                ) : (
+                  <Code2 className="size-3.5" />
+                )}
+                {mode === "plan" ? "Plan" : "Code"}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {fastModeAvailable && (
+        <Button
+          type="button"
+          variant={fastModeEnabled ? "secondary" : "ghost"}
+          size="sm"
+          className="hidden h-8 px-2 md:inline-flex"
+          aria-pressed={fastModeEnabled}
+          title="Fast mode uses priority inference at higher usage"
+          disabled={readOnly || running || commandPending}
+          onClick={() => onToggleFastMode(!fastModeEnabled)}
+        >
+          <Zap className="size-3.5" />
+          Fast
+        </Button>
+      )}
       <div className="ml-auto flex shrink-0 items-center gap-0.5">
         {stats.contextUsage && stats.contextUsage.tokens !== null && (
           <UsageIndicator
@@ -185,6 +249,41 @@ export function AgentSessionHeader({
                   </Menu.Item>
                 )}
                 <Menu.Separator className="my-1 h-px bg-border" />
+                {collaborationModes.length > 1 &&
+                  collaborationModes.map((mode) => (
+                    <Menu.Item
+                      key={mode}
+                      disabled={readOnly || running || commandPending}
+                      onClick={() => onSelectCollaborationMode(mode)}
+                      className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent"
+                    >
+                      {mode === "plan" ? (
+                        <ListTodo className="size-3.5 text-muted-foreground" />
+                      ) : (
+                        <Code2 className="size-3.5 text-muted-foreground" />
+                      )}
+                      {mode === "plan" ? "Plan mode" : "Code mode"}
+                      {mode === collaborationMode && (
+                        <Check className="ml-auto size-3.5" />
+                      )}
+                    </Menu.Item>
+                  ))}
+                {fastModeAvailable && (
+                  <Menu.Item
+                    disabled={readOnly || running || commandPending}
+                    onClick={() => onToggleFastMode(!fastModeEnabled)}
+                    className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent"
+                  >
+                    <Zap className="size-3.5 text-muted-foreground" />
+                    Fast mode
+                    {fastModeEnabled && (
+                      <Check className="ml-auto size-3.5" />
+                    )}
+                  </Menu.Item>
+                )}
+                {(collaborationModes.length > 1 || fastModeAvailable) && (
+                  <Menu.Separator className="my-1 h-px bg-border" />
+                )}
                 <Menu.Item
                   disabled={readOnly}
                   onClick={onRename}

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -6,13 +6,20 @@ import {
   AlertTriangle,
   Loader2,
   LockKeyhole,
+  Pause,
+  Play,
   RefreshCw,
+  Target,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import { toast } from "@/components/ui/toast";
+import { AGENT_GOAL_STATUSES } from "@/lib/agents/types";
 import type {
   AgentModel,
+  AgentCollaborationMode,
+  AgentGoal,
   AgentPromptImage,
   AgentProviderId,
   AgentRuntimeSnapshot,
@@ -72,6 +79,45 @@ function currentThinking(
 function sessionName(snapshot: AgentRuntimeSnapshot): string {
   const value = snapshot.state.sessionName;
   return typeof value === "string" ? value : "";
+}
+
+function collaborationModes(
+  snapshot: AgentRuntimeSnapshot,
+): AgentCollaborationMode[] {
+  const value = snapshot.state.collaborationModes;
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (mode): mode is AgentCollaborationMode =>
+      mode === "default" || mode === "plan",
+  );
+}
+
+function currentCollaborationMode(
+  snapshot: AgentRuntimeSnapshot,
+): AgentCollaborationMode {
+  return snapshot.state.collaborationMode === "plan" ? "plan" : "default";
+}
+
+function currentGoal(snapshot: AgentRuntimeSnapshot): AgentGoal | null {
+  const goal = recordOf(snapshot.state.goal);
+  if (
+    typeof goal?.objective !== "string" ||
+    typeof goal.status !== "string" ||
+    !AGENT_GOAL_STATUSES.includes(goal.status as AgentGoal["status"])
+  ) {
+    return null;
+  }
+  return {
+    objective: goal.objective,
+    status: goal.status as AgentGoal["status"],
+    tokenBudget:
+      typeof goal.tokenBudget === "number" ? goal.tokenBudget : null,
+    tokensUsed: typeof goal.tokensUsed === "number" ? goal.tokensUsed : 0,
+    timeUsedSeconds:
+      typeof goal.timeUsedSeconds === "number" ? goal.timeUsedSeconds : 0,
+    createdAt: typeof goal.createdAt === "number" ? goal.createdAt : 0,
+    updatedAt: typeof goal.updatedAt === "number" ? goal.updatedAt : 0,
+  };
 }
 
 function forkDraftKey(sessionId: string): string {
@@ -244,6 +290,11 @@ export function AgentSessionView({
     : undefined;
   const thinking = currentThinking(snapshot);
   const currentName = sessionName(snapshot) || initialSessionName;
+  const availableCollaborationModes = collaborationModes(snapshot);
+  const collaborationMode = currentCollaborationMode(snapshot);
+  const fastModeEnabled = snapshot.state.fastModeEnabled === true;
+  const fastModeAvailable = snapshot.state.fastModeAvailable === true;
+  const goal = currentGoal(snapshot);
   const runtimeError =
     snapshot.error ??
     (session.error instanceof Error ? session.error.message : undefined);
@@ -277,6 +328,10 @@ export function AgentSessionView({
         currentModel={model}
         thinkingLevel={thinking}
         thinkingLevels={snapshot.thinkingLevels}
+        collaborationMode={collaborationMode}
+        collaborationModes={availableCollaborationModes}
+        fastModeEnabled={fastModeEnabled}
+        fastModeAvailable={fastModeAvailable}
         stats={snapshot.stats}
         running={running}
         commandPending={command.isPending}
@@ -291,6 +346,12 @@ export function AgentSessionView({
         onSelectThinking={(level) =>
           void run({ type: "set_thinking_level", level })
         }
+        onSelectCollaborationMode={(mode) =>
+          void run({ type: "set_collaboration_mode", mode })
+        }
+        onToggleFastMode={(enabled) =>
+          void run({ type: "set_fast_mode", enabled })
+        }
         onRename={() => {
           setDialogError("");
           setRenameOpen(true);
@@ -300,6 +361,31 @@ export function AgentSessionView({
           setCompactOpen(true);
         }}
       />
+
+      {goal && (
+        <AgentGoalBar
+          goal={goal}
+          disabled={Boolean(readOnly) || command.isPending}
+          onPause={() =>
+            void run(
+              { type: "update_goal", action: "pause" },
+              { toastTitle: "Goal paused" },
+            )
+          }
+          onResume={() =>
+            void run(
+              { type: "update_goal", action: "resume" },
+              { toastTitle: "Goal resumed" },
+            )
+          }
+          onClear={() =>
+            void run(
+              { type: "update_goal", action: "clear" },
+              { toastTitle: "Goal cleared" },
+            )
+          }
+        />
+      )}
 
       {readOnly && (
         <section
@@ -356,6 +442,9 @@ export function AgentSessionView({
         }
         onForkMessage={(messageId) =>
           void run({ type: "fork_message", messageId })
+        }
+        onImplementPlan={(plan) =>
+          void run({ type: "implement_plan", plan })
         }
       />
 
@@ -449,6 +538,84 @@ export function AgentSessionView({
         }}
       />
     </div>
+  );
+}
+
+function AgentGoalBar({
+  goal,
+  disabled,
+  onPause,
+  onResume,
+  onClear,
+}: {
+  goal: AgentGoal;
+  disabled: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onClear: () => void;
+}) {
+  const paused = goal.status === "paused";
+  const status = goal.status.replace(/([a-z])([A-Z])/gu, "$1 $2");
+  const budget =
+    goal.tokenBudget !== null
+      ? `${goal.tokensUsed.toLocaleString()} / ${goal.tokenBudget.toLocaleString()} tokens`
+      : goal.tokensUsed > 0
+        ? `${goal.tokensUsed.toLocaleString()} tokens`
+        : null;
+
+  return (
+    <section
+      aria-label={`Goal: ${goal.objective}`}
+      className="border-b bg-muted/20 px-4 py-2"
+      data-testid="agent-goal-bar"
+    >
+      <div className="mx-auto flex max-w-3xl items-center gap-2">
+        <Target className="size-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium">
+          {goal.objective}
+        </span>
+        <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+          {status}
+          {budget ? ` · ${budget}` : ""}
+        </span>
+        {paused ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            title="Resume goal"
+            aria-label="Resume goal"
+            disabled={disabled}
+            onClick={onResume}
+          >
+            <Play />
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            title="Pause goal"
+            aria-label="Pause goal"
+            disabled={disabled}
+            onClick={onPause}
+          >
+            <Pause />
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          title="Clear goal"
+          aria-label="Clear goal"
+          disabled={disabled}
+          onClick={onClear}
+        >
+          <X />
+        </Button>
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "@playwright/test";
-import type { AgentConnectionListItem } from "@/lib/agents/types";
+import type {
+  AgentConnectionListItem,
+  AgentRuntimeSnapshot,
+} from "@/lib/agents/types";
 import {
   openE2eDatabase,
   resetE2eDatabase,
@@ -12,11 +15,11 @@ const TEST_PNG = Buffer.from(
   "base64",
 );
 
-const imageModel = {
-  id: "pi-image-model",
-  name: "Pi Image Model",
-  provider: "test",
-  api: "test",
+const imageModel: AgentRuntimeSnapshot["models"][number] = {
+  id: "gpt-5.6",
+  name: "GPT-5.6",
+  provider: "codex",
+  api: "codex-app-server",
   baseUrl: "",
   reasoning: true,
   input: ["text", "image"],
@@ -52,7 +55,7 @@ function seedAgentSession() {
     db.prepare(`
       INSERT INTO agent_connections (
         id, host_id, provider, executable, detected_version
-      ) VALUES ('connection', 'host', 'pi', 'pi', 'test')
+      ) VALUES ('connection', 'host', 'codex', 'codex', '0.147.0')
     `).run();
     db.prepare(`
       INSERT INTO agent_workspaces (id, connection_id, path, name)
@@ -70,11 +73,16 @@ function seedAgentSession() {
   }
 }
 
-function runtimeSnapshot(startedAt: number) {
+function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
   return {
     sessionId: SESSION_ID,
-    provider: "pi",
-    capabilities: { steer: true },
+    provider: "codex",
+    capabilities: {
+      steer: true,
+      usage: true,
+      editSentMessages: true,
+      forkMessages: true,
+    },
     status: "running",
     activeTurn: { startedAt },
     state: {
@@ -82,6 +90,20 @@ function runtimeSnapshot(startedAt: number) {
       isCompacting: false,
       sessionName: "Runtime activity",
       model: imageModel,
+      collaborationMode: "default",
+      collaborationModes: ["default", "plan"],
+      fastModeEnabled: false,
+      fastModeAvailable: true,
+      goalsSupported: true,
+      goal: {
+        objective: "Finish Codex parity",
+        status: "active",
+        tokenBudget: 20_000,
+        tokensUsed: 4_200,
+        timeUsedSeconds: 180,
+        createdAt: 1,
+        updatedAt: 2,
+      },
     },
     messages: [
       {
@@ -112,10 +134,27 @@ function runtimeSnapshot(startedAt: number) {
         role: "assistant",
         content: [
           {
+            type: "plan",
+            id: "plan",
+            text: "- [x] Audit the runtime\n- [ ] Finish parity",
+            explanation: "Two focused steps.",
+            steps: [
+              { step: "Audit the runtime", status: "completed" },
+              { step: "Finish parity", status: "inProgress" },
+            ],
+          },
+        ],
+        timestamp: 2.5,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
             type: "toolCall",
             id: "command",
             name: "bash",
             arguments: { command: "printf done" },
+            terminalInputs: ["y\n"],
           },
         ],
         timestamp: 3,
@@ -127,6 +166,27 @@ function runtimeSnapshot(startedAt: number) {
         content: [{ type: "text", text: "done" }],
         isError: false,
         timestamp: 4,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "subagent",
+            id: "collab",
+            action: "spawnAgent",
+            prompt: "Inspect the runtime tests",
+            status: "completed",
+            receivers: [
+              {
+                threadId: "child-thread",
+                status: "completed",
+                message: "Tests are green",
+              },
+            ],
+            events: ["Checked the runtime suite.", "$ npm test\n476 passed"],
+          },
+        ],
+        timestamp: 6.5,
       },
       {
         role: "assistant",
@@ -249,6 +309,32 @@ test("shows durable turn activity without changing completed tool status", async
           delete snapshot.pendingInteraction;
         }
         if (command.type === "retry_interactive") retryRequested = true;
+        if (command.type === "set_collaboration_mode") {
+          snapshot.state.collaborationMode = command.mode;
+        }
+        if (command.type === "set_fast_mode") {
+          snapshot.state.fastModeEnabled = command.enabled;
+        }
+        if (command.type === "update_goal") {
+          if (command.action === "clear") {
+            snapshot.state.goal = null;
+          } else {
+            const current =
+              snapshot.state.goal &&
+              typeof snapshot.state.goal === "object"
+                ? snapshot.state.goal
+                : {};
+            snapshot.state.goal = {
+              ...current,
+              ...(command.action === "set" &&
+              typeof command.objective === "string"
+                ? { objective: command.objective }
+                : {}),
+              status:
+                command.action === "pause" ? "paused" : "active",
+            };
+          }
+        }
         if (
           command.type === "abort" ||
           command.type === "steer" ||
@@ -473,6 +559,12 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(
     page.getByText("I will inspect the runtime.", { exact: true }),
   ).toBeVisible();
+  await expect(page.getByTestId("agent-plan-card")).toContainText(
+    "Finish parity",
+  );
+  await expect(page.getByTestId("agent-goal-bar")).toContainText(
+    "Finish Codex parity",
+  );
   const liveActivity = page.getByRole("button", {
     name: /Searching.*runtimeStatus/u,
   });
@@ -494,11 +586,12 @@ test("shows durable turn activity without changing completed tool status", async
   await completedCommand.click();
   await expect(page.getByText("$ printf done", { exact: true })).toBeVisible();
   await expect(page.getByText("done", { exact: true })).toBeVisible();
+  await expect(page.getByText("› y", { exact: true })).toBeVisible();
   const completedEdit = page.getByRole("button", {
     name: "Edit: apps/web/runtime.ts, completed",
   });
   await completedEdit.click();
-  await expect(page.getByText("Changes", { exact: true })).toBeVisible();
+  await expect(page.getByText("Changes", { exact: true }).first()).toBeVisible();
   await expect(
     page.getByText("+export const state = 'ready';", { exact: true }),
   ).toBeVisible();
@@ -507,9 +600,16 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(
     page.getByText("Running command", { exact: true }),
   ).not.toBeVisible();
+  const subagentActivity = page.getByTestId("agent-subagent-activity");
+  await expect(subagentActivity).toContainText("Started subagent");
+  await subagentActivity.getByRole("button").click();
+  await expect(subagentActivity).toContainText("Checked the runtime suite.");
+  await expect(
+    page.getByText("Turn changes", { exact: true }),
+  ).toHaveCount(0);
 
   const composer = page.getByPlaceholder(
-    "Message Pi or type / for commands",
+    "Message Codex or type / for commands",
   );
   await expect(page.getByRole("button", { name: "Attach images" })).toBeVisible();
   await composer.evaluate(async (element) => {
@@ -547,7 +647,7 @@ test("shows durable turn activity without changing completed tool status", async
     fullPage: true,
   });
   await composer.fill("Run the tests");
-  await page.getByRole("button", { name: "Queue message for Pi" }).click();
+  await page.getByRole("button", { name: "Queue message for Codex" }).click();
   await expect(composer).toHaveValue("Run the tests");
   await expect(composer).toBeDisabled();
   await expect(composer).toHaveValue("");
@@ -577,13 +677,13 @@ test("shows durable turn activity without changing completed tool status", async
   await composer.fill("");
 
   await composer.fill("Focus on the failing test");
-  await page.getByRole("button", { name: "Steer Pi" }).click();
+  await page.getByRole("button", { name: "Steer Codex" }).click();
   await expect(composer).toHaveValue("Focus on the failing test");
   await expect(composer).toBeDisabled();
   await expect(composer).toHaveValue("");
 
   await composer.fill("Then summarize");
-  await page.getByRole("button", { name: "Queue message for Pi" }).click();
+  await page.getByRole("button", { name: "Queue message for Codex" }).click();
   await expect(
     page.getByText("Then summarize", { exact: true }),
   ).toBeVisible();
@@ -594,11 +694,13 @@ test("shows durable turn activity without changing completed tool status", async
     page.getByText("Then summarize", { exact: true }),
   ).toHaveCount(0);
 
-  await page.getByRole("button", { name: "Stop Pi" }).click();
+  await page.getByRole("button", { name: "Stop Codex" }).click();
   await expect(genericActivity).toContainText("Stopping");
-  await expect(page.getByRole("button", { name: "Stopping Pi" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Stopping Codex" }),
+  ).toBeVisible();
   await expect(genericActivity).toHaveCount(0, { timeout: 2_000 });
-  await expect(page.getByRole("button", { name: "Stop Pi" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop Codex" })).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("runtime-activity-desktop.png"),
     fullPage: true,
@@ -685,6 +787,34 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(genericActivity).not.toBeVisible();
 
   await page.setViewportSize({ width: 1280, height: 720 });
+  snapshot.status = "idle";
+  snapshot.activeTurn = null;
+  snapshot.state.isStreaming = false;
+  await page.getByRole("button", { name: "Plan", exact: true }).click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "set_collaboration_mode",
+    mode: "plan",
+  });
+  await page.getByRole("button", { name: "Fast" }).click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "set_fast_mode",
+    enabled: true,
+  });
+  await page.getByRole("button", { name: "Pause goal" }).click();
+  await expect(page.getByRole("button", { name: "Resume goal" })).toBeVisible();
+  await page.getByRole("button", { name: "Resume goal" }).click();
+  await expect(page.getByRole("button", { name: "Pause goal" })).toBeVisible();
+  await page.getByRole("button", { name: "Implement plan" }).click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "implement_plan",
+    plan: expect.stringContaining("Finish parity"),
+  });
+  await page.getByRole("button", { name: "Clear goal" }).click();
+  await expect(page.getByTestId("agent-goal-bar")).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath("runtime-codex-parity-desktop.png"),
+    fullPage: true,
+  });
   snapshot.pendingInteraction = {
     type: "interaction_request",
     id: "mcp-form",
@@ -805,10 +935,10 @@ test("shows durable turn activity without changing completed tool status", async
     });
   }, snapshot);
   await expect(
-    page.getByRole("region", { name: "Read-only Pi session" }),
+    page.getByRole("region", { name: "Read-only Codex session" }),
   ).toBeVisible();
   await expect(
-    page.getByPlaceholder("Message Pi or type / for commands"),
+    page.getByPlaceholder("Message Codex or type / for commands"),
   ).toBeDisabled();
   await page.getByLabel("Session actions").click();
   await expect(

--- a/apps/web/lib/agents/codex/app-server.test.ts
+++ b/apps/web/lib/agents/codex/app-server.test.ts
@@ -301,6 +301,7 @@ describe("CodexAppServer", () => {
       { connectorId: "connector", transport: "local" },
       "/opt/bin/codex",
       "/workspace",
+      { enableGoals: true },
     );
     await expect(server.request("model/list")).resolves.toEqual({
       data: [],
@@ -312,7 +313,7 @@ describe("CodexAppServer", () => {
       { connectorId: "connector", transport: "local" },
       {
         command: "/opt/bin/codex",
-        args: ["app-server", "proxy"],
+        args: ["app-server", "proxy", "--enable", "goals"],
         cwd: "/workspace",
       },
     );
@@ -342,6 +343,7 @@ describe("CodexAppServer", () => {
       { connectorId: "connector", transport: "ssh", alias: "devbox" },
       "codex",
       "/workspace",
+      { enableGoals: true },
     );
     await expect(server.request("model/list")).resolves.toEqual({
       data: [],
@@ -353,7 +355,7 @@ describe("CodexAppServer", () => {
       { connectorId: "connector", transport: "ssh", alias: "devbox" },
       {
         command: "codex",
-        args: ["app-server", "proxy"],
+        args: ["app-server", "proxy", "--enable", "goals"],
         cwd: "/workspace",
       },
     );
@@ -362,7 +364,7 @@ describe("CodexAppServer", () => {
       { connectorId: "connector", transport: "ssh", alias: "devbox" },
       {
         command: "codex",
-        args: ["app-server", "--stdio"],
+        args: ["app-server", "--enable", "goals", "--stdio"],
         cwd: "/workspace",
       },
     );

--- a/apps/web/lib/agents/codex/app-server.ts
+++ b/apps/web/lib/agents/codex/app-server.ts
@@ -13,6 +13,10 @@ const INITIALIZE_TIMEOUT_MS = 60_000;
 const MAX_STDERR_CHARS = 64 * 1024;
 const PROXY_HANDSHAKE_TIMEOUT_MS = 5_000;
 
+type CodexAppServerOptions = {
+  enableGoals?: boolean;
+};
+
 export type JsonRpcId = string | number;
 
 export type CodexAppServerNotification = {
@@ -95,10 +99,15 @@ function spawnCodexProxy(
   target: HostTarget,
   executable: string,
   cwd?: string,
+  options: CodexAppServerOptions = {},
 ): AgentProcess {
   const proxy = spawnOnHost(target, {
     command: executable,
-    args: ["app-server", "proxy"],
+    args: [
+      "app-server",
+      "proxy",
+      ...(options.enableGoals ? ["--enable", "goals"] : []),
+    ],
     cwd,
   });
   const transport = new AgentProcessDuplex(proxy);
@@ -456,9 +465,10 @@ export async function startCodexAppServer(
   target: HostTarget,
   executable: string,
   cwd?: string,
+  options: CodexAppServerOptions = {},
 ): Promise<CodexAppServer> {
   const proxyServer = new CodexAppServer(
-    spawnCodexProxy(target, executable, cwd),
+    spawnCodexProxy(target, executable, cwd, options),
   );
   try {
     await proxyServer.ready();
@@ -469,7 +479,11 @@ export async function startCodexAppServer(
   const standaloneServer = new CodexAppServer(
     spawnOnHost(target, {
       command: executable,
-      args: ["app-server", "--stdio"],
+      args: [
+        "app-server",
+        ...(options.enableGoals ? ["--enable", "goals"] : []),
+        "--stdio",
+      ],
       cwd,
     }),
   );

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -5,6 +5,7 @@ vi.mock("server-only", () => ({}));
 const mocks = vi.hoisted(() => ({
   listCodexCustomPrompts: vi.fn(),
   materializeAgentImages: vi.fn(),
+  startCodexAppServer: vi.fn(),
 }));
 
 vi.mock("./commands", async (importOriginal) => ({
@@ -24,6 +25,10 @@ class FakeCodexServer {
   forkError: Error | null = null;
   rateLimitsError: Error | null = null;
   usageError: Error | null = null;
+  collaborationModes: unknown[] = [];
+  goalSupported = false;
+  goal: Record<string, unknown> | null = null;
+  readonly threadReads = new Map<string, Record<string, unknown>>();
   private notification: Listener<{ method: string; params?: unknown }> =
     () => {};
   private serverRequest: Listener<{
@@ -64,6 +69,42 @@ class FakeCodexServer {
         ],
         nextCursor: null,
       };
+    }
+    if (method === "collaborationMode/list") {
+      return { data: this.collaborationModes };
+    }
+    if (method === "thread/goal/get") {
+      if (!this.goalSupported) throw new Error("Method not found");
+      return { goal: this.goal };
+    }
+    if (method === "thread/goal/set") {
+      if (!this.goalSupported) throw new Error("Method not found");
+      const input =
+        params && typeof params === "object"
+          ? (params as Record<string, unknown>)
+          : {};
+      this.goal = {
+        threadId: "thread-1",
+        objective:
+          typeof input.objective === "string"
+            ? input.objective
+            : typeof this.goal?.objective === "string"
+              ? this.goal.objective
+              : "Existing goal",
+        status:
+          typeof input.status === "string" ? input.status : "active",
+        tokenBudget: null,
+        tokensUsed: 12,
+        timeUsedSeconds: 3,
+        createdAt: 1,
+        updatedAt: 2,
+      };
+      return { goal: this.goal };
+    }
+    if (method === "thread/goal/clear") {
+      if (!this.goalSupported) throw new Error("Method not found");
+      this.goal = null;
+      return { cleared: true };
     }
     if (method === "skills/list") {
       return {
@@ -206,6 +247,15 @@ class FakeCodexServer {
       };
     }
     if (method === "thread/read") {
+      const threadId =
+        params &&
+        typeof params === "object" &&
+        "threadId" in params &&
+        typeof params.threadId === "string"
+          ? params.threadId
+          : "";
+      const override = this.threadReads.get(threadId);
+      if (override) return { thread: override };
       return {
         thread: {
           id: "thread-1",
@@ -282,7 +332,8 @@ class FakeCodexServer {
 const server = new FakeCodexServer();
 
 vi.mock("./app-server", () => ({
-  startCodexAppServer: () => server,
+  startCodexAppServer: (...args: unknown[]) =>
+    mocks.startCodexAppServer(...args),
 }));
 
 import { CodexRuntimeClient } from "./client";
@@ -296,7 +347,12 @@ describe("CodexRuntimeClient", () => {
     server.forkError = null;
     server.rateLimitsError = null;
     server.usageError = null;
+    server.collaborationModes = [];
+    server.goalSupported = false;
+    server.goal = null;
+    server.threadReads.clear();
     server.respondError.mockClear();
+    mocks.startCodexAppServer.mockResolvedValue(server);
     mocks.materializeAgentImages.mockResolvedValue([]);
     mocks.listCodexCustomPrompts.mockResolvedValue([
       {
@@ -438,7 +494,284 @@ describe("CodexRuntimeClient", () => {
     });
   });
 
+  it("supports native goals, Code/Plan modes, and Fast turns", async () => {
+    server.goalSupported = true;
+    server.collaborationModes = [
+      {
+        name: "Code",
+        mode: "default",
+        model: null,
+        reasoning_effort: null,
+      },
+      {
+        name: "Plan",
+        mode: "plan",
+        model: null,
+        reasoning_effort: null,
+      },
+    ];
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        detectedVersion: "0.147.0",
+      },
+    );
+
+    await expect(client.getState()).resolves.toMatchObject({
+      collaborationMode: "default",
+      collaborationModes: ["default", "plan"],
+      fastModeEnabled: false,
+      fastModeAvailable: true,
+      goalsSupported: true,
+      goal: null,
+    });
+    expect(mocks.startCodexAppServer).toHaveBeenCalledWith(
+      { connectorId: "connector", transport: "local" },
+      "codex",
+      "/workspace",
+      { enableGoals: true },
+    );
+    await expect(client.getCommands()).resolves.toContainEqual({
+      name: "goal",
+      description: "Set, pause, resume, or clear the agent goal",
+      source: "builtin",
+      argumentHint: "<objective>|pause|resume|clear",
+    });
+
+    await client.setCollaborationMode("plan");
+    await client.setFastMode(true);
+    await client.prompt("Design the change");
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: {
+        serviceTier: "fast",
+        collaborationMode: {
+          mode: "plan",
+          settings: {
+            model: "gpt-5.6",
+            reasoning_effort: "high",
+            developer_instructions: null,
+          },
+        },
+      },
+    });
+
+    await expect(
+      client.updateGoal("set", "Ship the parity work"),
+    ).resolves.toMatchObject({
+      objective: "Ship the parity work",
+      status: "active",
+    });
+    expect(server.requests).toContainEqual({
+      method: "thread/goal/set",
+      params: {
+        threadId: "thread-1",
+        objective: "Ship the parity work",
+        status: "active",
+      },
+    });
+    await client.updateGoal("pause");
+    await expect(client.getState()).resolves.toMatchObject({
+      goal: {
+        objective: "Ship the parity work",
+        status: "paused",
+      },
+    });
+    await client.updateGoal("clear");
+    await expect(client.getState()).resolves.toMatchObject({ goal: null });
+  });
+
+  it("keeps plans, terminal input, and child activity after sparse completion", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+    await client.prompt("Plan and implement");
+    server.emit("turn/started", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "inProgress",
+        startedAt: 10,
+        items: [],
+      },
+    });
+    server.emit("item/started", {
+      threadId: "child-1",
+      turnId: "child-turn",
+      item: {
+        id: "child-message",
+        type: "agentMessage",
+        phase: "commentary",
+        text: "Checking ",
+      },
+    });
+    server.emit("item/agentMessage/delta", {
+      threadId: "child-1",
+      turnId: "child-turn",
+      itemId: "child-message",
+      delta: "the suite.",
+    });
+    server.emit("item/started", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "collab-1",
+        type: "collabAgentToolCall",
+        tool: "spawnAgent",
+        status: "inProgress",
+        senderThreadId: "thread-1",
+        receiverThreadIds: ["child-1"],
+        prompt: "Inspect the tests",
+        agentsStates: {
+          "child-1": { status: "running", message: null },
+        },
+      },
+    });
+    server.emit("item/started", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "command-1",
+        type: "commandExecution",
+        command: "npm test",
+        cwd: "/workspace",
+        status: "inProgress",
+        aggregatedOutput: "",
+      },
+    });
+    server.emit("item/commandExecution/terminalInteraction", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "command-1",
+      processId: "pty-1",
+      stdin: "y\n",
+    });
+    server.emit("turn/plan/updated", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      explanation: "Two focused steps.",
+      plan: [
+        { step: "Inspect the runtime", status: "completed" },
+        { step: "Implement parity", status: "inProgress" },
+      ],
+    });
+    server.emit("turn/completed", {
+      threadId: "child-1",
+      turn: {
+        id: "child-turn",
+        status: "completed",
+        items: [],
+      },
+    });
+    server.emit("turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        startedAt: 10,
+        completedAt: 12,
+        items: [
+          {
+            id: "answer-1",
+            type: "agentMessage",
+            phase: "final_answer",
+            text: "Ready.",
+          },
+        ],
+      },
+    });
+
+    const messages = (await client.getMessages()).messages;
+    const assistant = messages.find(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        Reflect.get(message, "role") === "assistant",
+    ) as { content: Array<Record<string, unknown>> };
+    expect(assistant.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "subagent",
+          prompt: "Inspect the tests",
+          events: ["Checking the suite."],
+        }),
+        expect.objectContaining({
+          type: "toolCall",
+          id: "command-1",
+          terminalInputs: ["y\n"],
+        }),
+        expect.objectContaining({
+          type: "plan",
+          explanation: "Two focused steps.",
+        }),
+        { type: "text", text: "Ready." },
+      ]),
+    );
+    await expect(client.getState()).resolves.toMatchObject({
+      isStreaming: false,
+    });
+  });
+
+  it("ignores aggregate diff telemetry and keeps concrete file changes", async () => {
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+    server.emit("turn/started", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "inProgress",
+        startedAt: 10,
+        items: [],
+      },
+    });
+    server.emit("turn/diff/updated", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      diff: "--- a/runtime.ts\n+++ b/runtime.ts\n@@\n-old\n+new",
+    });
+    server.emit("item/completed", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "edit-1",
+        type: "fileChange",
+        status: "completed",
+        changes: [
+          {
+            path: "runtime.ts",
+            kind: "update",
+            diff: "@@\n-old\n+new",
+          },
+        ],
+      },
+    });
+
+    const messages = (await client.getMessages()).messages;
+    const assistant = messages.find(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        Reflect.get(message, "role") === "assistant",
+    ) as { content: Array<Record<string, unknown>> };
+    expect(assistant.content).toContainEqual(
+      expect.objectContaining({
+        type: "toolCall",
+        id: "edit-1",
+        name: "apply_patch",
+      }),
+    );
+    expect(assistant.content).toHaveLength(1);
+  });
+
   it("refreshes native skills when Codex reports a change", async () => {
+    server.goalSupported = true;
     const client = new CodexRuntimeClient(
       { connectorId: "connector", transport: "local" },
       { executable: "codex", cwd: "/workspace" },
@@ -456,6 +789,10 @@ describe("CodexRuntimeClient", () => {
             expect.objectContaining({
               name: "release-notes",
               source: "skill",
+            }),
+            expect.objectContaining({
+              name: "goal",
+              source: "builtin",
             }),
           ]),
         }),
@@ -744,6 +1081,111 @@ describe("CodexRuntimeClient", () => {
         },
       ]),
     );
+  });
+
+  it("rehydrates persisted subagent activity after resuming", async () => {
+    server.threadReads.set("thread-1", {
+      id: "thread-1",
+      cwd: "/workspace",
+      preview: "Delegate the audit",
+      path: "/tmp/thread-1.jsonl",
+      name: null,
+      createdAt: 1,
+      updatedAt: 2,
+      turns: [
+        {
+          id: "turn-root",
+          status: "completed",
+          startedAt: 1,
+          completedAt: 2,
+          items: [
+            {
+              id: "collab-1",
+              type: "collabAgentToolCall",
+              tool: "spawnAgent",
+              status: "completed",
+              senderThreadId: "thread-1",
+              receiverThreadIds: ["child-1"],
+              prompt: "Inspect the tests",
+              agentsStates: {
+                "child-1": { status: "completed", message: "Tests are green" },
+              },
+            },
+            {
+              id: "answer-root",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: "The audit passed.",
+            },
+          ],
+        },
+      ],
+    });
+    server.threadReads.set("child-1", {
+      id: "child-1",
+      cwd: "/workspace",
+      preview: "Inspect the tests",
+      path: "/tmp/child-1.jsonl",
+      name: null,
+      createdAt: 1,
+      updatedAt: 2,
+      turns: [
+        {
+          id: "turn-child",
+          status: "completed",
+          startedAt: 1,
+          completedAt: 2,
+          items: [
+            {
+              id: "child-commentary",
+              type: "agentMessage",
+              phase: "commentary",
+              text: "Checking the restored suite.",
+            },
+            {
+              id: "child-command",
+              type: "commandExecution",
+              command: "npm test",
+              cwd: "/workspace",
+              status: "completed",
+              aggregatedOutput: "491 passed",
+            },
+          ],
+        },
+      ],
+    });
+    const client = new CodexRuntimeClient(
+      { connectorId: "connector", transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        resume: {
+          providerSessionId: "thread-1",
+          providerSessionPath: "/tmp/thread-1.jsonl",
+        },
+      },
+    );
+
+    const messages = (await client.getMessages()).messages;
+    const assistant = messages.find(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        Reflect.get(message, "id") === "turn-root:assistant",
+    ) as { content: Array<Record<string, unknown>> };
+    expect(assistant.content).toContainEqual(
+      expect.objectContaining({
+        type: "subagent",
+        events: [
+          "Checking the restored suite.",
+          "$ npm test\n491 passed",
+        ],
+      }),
+    );
+    expect(server.requests).toContainEqual({
+      method: "thread/read",
+      params: { threadId: "child-1", includeTurns: true },
+    });
   });
 
   it("unsubscribes a resumed thread before stopping its app-server", async () => {

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -1,5 +1,8 @@
 import "server-only";
 import type {
+  AgentCollaborationMode,
+  AgentGoal,
+  AgentGoalStatus,
   AgentInteractionValue,
   AgentModel,
   AgentSessionStats,
@@ -7,6 +10,7 @@ import type {
   AgentThinkingLevel,
   AgentUsageSnapshot,
 } from "@/lib/agents/types";
+import { AGENT_GOAL_STATUSES } from "@/lib/agents/types";
 import type {
   AgentRuntimeClient,
   AgentRuntimeEvent,
@@ -53,6 +57,28 @@ const TURN_COMPLETION_TIMEOUT_MS = 30_000;
 const COMPACTION_TIMEOUT_MS = 5 * 60_000;
 const ACTIVE_WRITER_MESSAGE =
   "Another Codex process currently owns this session. You can view it here and retry when it becomes available.";
+const CODEX_FAST_MODE_MODEL_PREFIXES = [
+  "gpt-5",
+  "gpt-4.1",
+  "o3",
+  "o4-mini",
+] as const;
+const MAX_SUBAGENT_HISTORY_THREADS = 100;
+const MAX_PENDING_SUBAGENT_THREADS = 32;
+const MAX_PENDING_SUBAGENT_NOTIFICATIONS = 50;
+const CODEX_GOALS_MIN_VERSION = [0, 128, 0] as const;
+
+type CodexCollaborationPreset = {
+  name: string;
+  mode: AgentCollaborationMode | null;
+  model: string | null;
+  reasoningEffort: AgentThinkingLevel | null;
+};
+
+type CodexSubagentOwner = {
+  turnId: string;
+  itemId: string;
+};
 
 type CompletionWaiter<T> = {
   promise: Promise<T>;
@@ -248,10 +274,50 @@ function isBeforeTurnForkUnsupportedError(error: unknown): boolean {
   );
 }
 
+function codexModelSupportsFastMode(modelId: string): boolean {
+  return CODEX_FAST_MODE_MODEL_PREFIXES.some(
+    (prefix) => modelId === prefix || modelId.startsWith(prefix),
+  );
+}
+
+function codexVersionSupportsGoals(version: string | null | undefined): boolean {
+  const match = version?.match(/(\d+)\.(\d+)\.(\d+)/u);
+  if (!match) return false;
+  const parsed = [Number(match[1]), Number(match[2]), Number(match[3])];
+  for (let index = 0; index < CODEX_GOALS_MIN_VERSION.length; index += 1) {
+    if (parsed[index] > CODEX_GOALS_MIN_VERSION[index]) return true;
+    if (parsed[index] < CODEX_GOALS_MIN_VERSION[index]) return false;
+  }
+  return true;
+}
+
+function parseGoal(value: unknown): AgentGoal | null {
+  const goal = recordOf(value);
+  const objective = stringOf(goal, "objective");
+  const status = stringOf(goal, "status");
+  if (
+    !objective ||
+    !status ||
+    !(AGENT_GOAL_STATUSES as readonly string[]).includes(status)
+  ) {
+    return null;
+  }
+  return {
+    objective,
+    status: status as AgentGoalStatus,
+    tokenBudget: numberOf(goal, "tokenBudget"),
+    tokensUsed: numberOf(goal, "tokensUsed") ?? 0,
+    timeUsedSeconds: numberOf(goal, "timeUsedSeconds") ?? 0,
+    createdAt: numberOf(goal, "createdAt") ?? 0,
+    updatedAt: numberOf(goal, "updatedAt") ?? 0,
+  };
+}
+
 function itemTool(item: CodexItem): {
   name: string;
   args: unknown;
   output: string;
+  terminalInputs: string[];
   partial: boolean;
   isError: boolean;
 } | null {
@@ -264,6 +330,12 @@ function itemTool(item: CodexItem): {
           cwd: stringOf(item, "cwd") ?? "",
         },
         output: stringOf(item, "aggregatedOutput") ?? "",
+        terminalInputs: Array.isArray(item.overtchatTerminalInteractions)
+          ? item.overtchatTerminalInteractions.flatMap((value) => {
+              const input = stringOf(recordOf(value), "stdin");
+              return input ? [input] : [];
+            })
+          : [],
         partial: stringOf(item, "status") === "inProgress",
         isError: ["failed", "declined"].includes(
           stringOf(item, "status") ?? "",
@@ -283,6 +355,7 @@ function itemTool(item: CodexItem): {
             .join("\n"),
         },
         output: "",
+        terminalInputs: [],
         partial: stringOf(item, "status") === "inProgress",
         isError: ["failed", "declined"].includes(
           stringOf(item, "status") ?? "",
@@ -294,6 +367,7 @@ function itemTool(item: CodexItem): {
         name: `${stringOf(item, "server") ?? "mcp"}/${stringOf(item, "tool") ?? "tool"}`,
         args: item.arguments,
         output: toolOutput(item.result ?? item.error),
+        terminalInputs: [],
         partial: stringOf(item, "status") === "inProgress",
         isError: stringOf(item, "status") === "failed",
       };
@@ -302,6 +376,7 @@ function itemTool(item: CodexItem): {
         name: stringOf(item, "tool") ?? "tool",
         args: item.arguments,
         output: toolOutput(item.contentItems),
+        terminalInputs: [],
         partial: stringOf(item, "status") === "inProgress",
         isError:
           stringOf(item, "status") === "failed" || item.success === false,
@@ -311,6 +386,7 @@ function itemTool(item: CodexItem): {
         name: "web_search",
         args: { query: stringOf(item, "query") ?? "" },
         output: toolOutput(item.results),
+        terminalInputs: [],
         partial: item.results === null,
         isError: false,
       };
@@ -319,6 +395,7 @@ function itemTool(item: CodexItem): {
         name: "read",
         args: { path: stringOf(item, "path") ?? "" },
         output: "",
+        terminalInputs: [],
         partial: false,
         isError: false,
       };
@@ -334,6 +411,15 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
   const messages: unknown[] = [];
   const assistantContent: UnknownRecord[] = [];
   const results: unknown[] = [];
+  const planItems = turn.items.filter((item) => item.type === "plan");
+  const structuredPlan = planItems.findLast((item) =>
+    Array.isArray(item.steps),
+  );
+  const selectedPlan =
+    planItems.findLast((item) => (stringOf(item, "text") ?? "").trim()) ??
+    structuredPlan ??
+    null;
+  let planAdded = false;
 
   for (const item of turn.items) {
     if (item.type === "userMessage") {
@@ -384,18 +470,128 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
       }
       continue;
     }
-    if (item.type === "reasoning" || item.type === "plan") {
+    if (item.type === "plan") {
+      if (!planAdded && item.id === selectedPlan?.id) {
+        const structured = structuredPlan ?? selectedPlan;
+        assistantContent.push({
+          type: "plan",
+          id: selectedPlan.id,
+          text: stringOf(selectedPlan, "text") ?? "",
+          explanation: stringOf(structured, "explanation"),
+          steps: Array.isArray(structured?.steps) ? structured.steps : [],
+        });
+        planAdded = true;
+      }
+      continue;
+    }
+    if (item.type === "reasoning") {
       const summary = Array.isArray(item.summary)
         ? item.summary.filter((part): part is string => typeof part === "string")
         : [];
       const content = Array.isArray(item.content)
         ? item.content.filter((part): part is string => typeof part === "string")
         : [];
-      const thinking =
-        item.type === "plan"
-          ? stringOf(item, "text") ?? ""
-          : [...summary, ...content].join("\n\n");
+      const thinking = [...summary, ...content].join("\n\n");
       if (thinking) assistantContent.push({ type: "thinking", thinking });
+      continue;
+    }
+    if (item.type === "collabAgentToolCall") {
+      const receivers = Array.isArray(item.receiverThreadIds)
+        ? item.receiverThreadIds.filter(
+            (value): value is string => typeof value === "string",
+          )
+        : [];
+      const states = recordOf(item.agentsStates);
+      assistantContent.push({
+        type: "subagent",
+        id: item.id,
+        action: stringOf(item, "tool") ?? "agent",
+        prompt: stringOf(item, "prompt"),
+        status: stringOf(item, "status") ?? "completed",
+        receivers: receivers.map((threadId) => {
+          const state = recordOf(states?.[threadId]);
+          return {
+            threadId,
+            status: stringOf(state, "status") ?? "unknown",
+            message: stringOf(state, "message"),
+          };
+        }),
+        events: Array.isArray(item.overtchatChildItems)
+          ? item.overtchatChildItems.flatMap((value) => {
+              const child = recordOf(value);
+              const type = stringOf(child, "type");
+              if (type === "agentMessage") {
+                const text = stringOf(child, "text");
+                return text ? [text] : [];
+              }
+              if (type === "reasoning") {
+                const summary = Array.isArray(child?.summary)
+                  ? child.summary.filter(
+                      (part): part is string => typeof part === "string",
+                    )
+                  : [];
+                return summary;
+              }
+              if (type === "commandExecution") {
+                const command = stringOf(child, "command");
+                const output = stringOf(child, "aggregatedOutput");
+                const terminalInputs = Array.isArray(
+                  child?.overtchatTerminalInteractions,
+                )
+                  ? child.overtchatTerminalInteractions.flatMap((value) => {
+                      const stdin = stringOf(recordOf(value), "stdin");
+                      return stdin ? [`› ${stdin.replace(/\n$/u, "")}`] : [];
+                    })
+                  : [];
+                return [
+                  [
+                    command ? `$ ${command}` : "",
+                    output ?? "",
+                    ...terminalInputs,
+                  ]
+                    .filter(Boolean)
+                    .join("\n"),
+                ].filter(Boolean);
+              }
+              if (type === "fileChange") {
+                const paths = Array.isArray(child?.changes)
+                  ? child.changes.flatMap((change) => {
+                      const path = stringOf(recordOf(change), "path");
+                      return path ? [path] : [];
+                    })
+                  : [];
+                return paths.length > 0
+                  ? [`Changed ${paths.join(", ")}`]
+                  : [];
+              }
+              if (type === "plan") {
+                const text = stringOf(child, "text");
+                return text ? [text] : [];
+              }
+              return [];
+            })
+          : [],
+      });
+      continue;
+    }
+    if (item.type === "subAgentActivity") {
+      assistantContent.push({
+        type: "subagent",
+        id: item.id,
+        action: stringOf(item, "kind") ?? "activity",
+        prompt: null,
+        status:
+          stringOf(item, "kind") === "interrupted"
+            ? "failed"
+            : "completed",
+        receivers: [
+          {
+            threadId: stringOf(item, "agentThreadId") ?? "subagent",
+            status: stringOf(item, "kind") ?? "unknown",
+            message: stringOf(item, "agentPath"),
+          },
+        ],
+      });
       continue;
     }
     if (item.type === "contextCompaction") {
@@ -415,6 +611,7 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
       id: item.id,
       name: tool.name,
       arguments: tool.args,
+      terminalInputs: tool.terminalInputs,
     });
     results.push({
       id: `${item.id}:result`,
@@ -571,6 +768,11 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     Set<CompletionWaiter<CodexTurn>>
   >();
   private readonly knownUserInputs = new Map<string, KnownUserInput[]>();
+  private readonly subagentOwners = new Map<string, CodexSubagentOwner>();
+  private readonly pendingSubagentNotifications = new Map<
+    string,
+    Array<{ method: string; data: UnknownRecord }>
+  >();
   private discoveredCommands = new Map<string, CodexDiscoveredCommand>();
   private commandRefreshPromise: Promise<void> | null = null;
   private readonly readyPromise: Promise<void>;
@@ -584,6 +786,11 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private isCompacting = false;
   private selectedModel = "";
   private selectedThinking: AgentThinkingLevel | null = null;
+  private collaborationModes: CodexCollaborationPreset[] = [];
+  private selectedCollaborationMode: AgentCollaborationMode = "default";
+  private fastModeEnabled = false;
+  private goalsSupported = false;
+  private goal: AgentGoal | null = null;
   private modelResponse: unknown = { data: [] };
   private stats = emptyCodexStats();
   private readOnly = false;
@@ -602,6 +809,11 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       this.target,
       this.launch.executable,
       this.launch.cwd,
+      {
+        enableGoals: codexVersionSupportsGoals(
+          this.launch.detectedVersion,
+        ),
+      },
     );
     this.server.onNotification((notification) =>
       this.handleNotification(notification.method, notification.params),
@@ -625,6 +837,12 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       isStreaming: this.activeTurnId !== null,
       isCompacting: this.isCompacting,
       model: { provider: "codex", id: this.selectedModel },
+      collaborationMode: this.selectedCollaborationMode,
+      collaborationModes: this.availableCollaborationModes(),
+      fastModeEnabled: this.fastModeEnabled,
+      fastModeAvailable: codexModelSupportsFastMode(this.selectedModel),
+      goalsSupported: this.goalsSupported,
+      goal: this.goal,
       ...(this.readOnly
         ? {
             readOnly: {
@@ -661,7 +879,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async getCommands(): Promise<AgentSlashCommand[]> {
     await this.readyPromise;
-    return publicCommands([...this.discoveredCommands.values()]);
+    return this.availableCommands();
   }
 
   async prompt(
@@ -679,6 +897,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         model: this.selectedModel || null,
         ...(this.selectedThinking
           ? { effort: this.selectedThinking }
+          : {}),
+        ...(this.fastModeEnabled ? { serviceTier: "fast" } : {}),
+        ...(this.resolvedCollaborationMode()
+          ? { collaborationMode: this.resolvedCollaborationMode() }
           : {}),
       });
       const turn = parseCodexTurn(response.turn);
@@ -745,6 +967,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       throw new Error(`Codex model ${modelId} is not available.`);
     }
     this.selectedModel = modelId;
+    if (!codexModelSupportsFastMode(modelId)) this.fastModeEnabled = false;
     this.emitConfig();
     return { model: modelId };
   }
@@ -759,6 +982,69 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     this.selectedThinking = level as AgentThinkingLevel;
     this.emitConfig();
     return { thinkingLevel: level };
+  }
+
+  async setCollaborationMode(
+    mode: AgentCollaborationMode,
+  ): Promise<unknown> {
+    await this.readyPromise;
+    this.assertInteractive();
+    if (!this.availableCollaborationModes().includes(mode)) {
+      throw new Error(
+        mode === "plan"
+          ? "This Codex installation does not provide Plan mode."
+          : "This Codex installation does not provide Code mode.",
+      );
+    }
+    this.selectedCollaborationMode = mode;
+    this.emitConfig();
+    return { collaborationMode: mode };
+  }
+
+  async setFastMode(enabled: boolean): Promise<unknown> {
+    await this.readyPromise;
+    this.assertInteractive();
+    if (enabled && !codexModelSupportsFastMode(this.selectedModel)) {
+      throw new Error(
+        `Codex model ${this.selectedModel || "unknown"} does not support Fast mode.`,
+      );
+    }
+    this.fastModeEnabled = enabled;
+    this.emitConfig();
+    return { fastModeEnabled: enabled };
+  }
+
+  async updateGoal(
+    action: "set" | "pause" | "resume" | "clear",
+    objective?: string,
+  ): Promise<AgentGoal | null> {
+    await this.readyPromise;
+    this.assertInteractive();
+    if (!this.goalsSupported) {
+      throw new Error("This Codex installation does not support durable goals.");
+    }
+    if (action === "clear") {
+      await this.server.request("thread/goal/clear", {
+        threadId: this.thread!.id,
+      });
+      this.goal = null;
+      this.emitConfig();
+      return null;
+    }
+    if (action === "set" && !objective?.trim()) {
+      throw new Error("Usage: /goal <objective>|pause|resume|clear");
+    }
+    const response = await this.server.request<UnknownRecord>(
+      "thread/goal/set",
+      {
+        threadId: this.thread!.id,
+        ...(action === "set" ? { objective: objective!.trim() } : {}),
+        status: action === "pause" ? "paused" : "active",
+      },
+    );
+    this.goal = parseGoal(response.goal);
+    this.emitConfig();
+    return this.goal;
   }
 
   async compact(customInstructions?: string): Promise<unknown> {
@@ -1031,6 +1317,9 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private async openThread(): Promise<void> {
     await this.server.ready();
     const modelPromise = this.server.request("model/list", { limit: 200 });
+    const collaborationModePromise = this.server
+      .request("collaborationMode/list", {})
+      .catch(() => null);
     let threadResponse: UnknownRecord;
     let hydratedThread: UnknownRecord;
     if (this.launch.resume) {
@@ -1064,14 +1353,24 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       hydratedThread = threadResponse;
     }
     this.modelResponse = await modelPromise;
+    this.loadCollaborationModes(await collaborationModePromise);
     this.hydrateThread(hydratedThread);
     this.applyThreadConfiguration(threadResponse);
+    await this.hydrateSubagentHistories();
+    await this.loadGoal();
   }
 
   private hydrateThread(value: UnknownRecord): void {
     this.thread = parseCodexThread(value.thread);
     this.turns.clear();
-    for (const turn of this.thread.turns) this.turns.set(turn.id, turn);
+    this.subagentOwners.clear();
+    this.pendingSubagentNotifications.clear();
+    for (const turn of this.thread.turns) {
+      this.turns.set(turn.id, turn);
+      for (const item of turn.items) {
+        this.registerSubagentOwners(turn.id, item);
+      }
+    }
   }
 
   private applyThreadConfiguration(threadResponse: UnknownRecord): void {
@@ -1092,6 +1391,105 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         this.modelResponse,
         this.selectedModel,
       );
+    }
+    this.fastModeEnabled =
+      stringOf(threadResponse, "serviceTier") === "fast" &&
+      codexModelSupportsFastMode(this.selectedModel);
+  }
+
+  private loadCollaborationModes(value: unknown): void {
+    const response = recordOf(value);
+    const data = Array.isArray(response?.data) ? response.data : [];
+    this.collaborationModes = data.flatMap((candidate) => {
+      const preset = recordOf(candidate);
+      const name = stringOf(preset, "name");
+      const rawMode = stringOf(preset, "mode");
+      if (!name) return [];
+      const mode =
+        rawMode === "plan" || rawMode === "default" ? rawMode : null;
+      const effort = stringOf(preset, "reasoning_effort");
+      return [
+        {
+          name,
+          mode,
+          model: stringOf(preset, "model"),
+          reasoningEffort:
+            effort &&
+            ["minimal", "low", "medium", "high", "xhigh", "max"].includes(
+              effort,
+            )
+              ? (effort as AgentThinkingLevel)
+              : null,
+        },
+      ];
+    });
+    if (!this.availableCollaborationModes().includes("default")) {
+      this.selectedCollaborationMode =
+        this.availableCollaborationModes()[0] ?? "default";
+    }
+  }
+
+  private availableCollaborationModes(): AgentCollaborationMode[] {
+    return (["default", "plan"] as const).filter(
+      (mode) => this.findCollaborationMode(mode) !== null,
+    );
+  }
+
+  private findCollaborationMode(
+    mode: AgentCollaborationMode,
+  ): CodexCollaborationPreset | null {
+    if (mode === "plan") {
+      return (
+        this.collaborationModes.find(
+          (preset) =>
+            preset.mode === "plan" ||
+            /plan|read/iu.test(preset.name),
+        ) ?? null
+      );
+    }
+    return (
+      this.collaborationModes.find(
+        (preset) =>
+          preset.mode === "default" ||
+          /auto|code/iu.test(preset.name),
+      ) ??
+      this.collaborationModes.find(
+        (preset) => !/plan|read/iu.test(preset.name),
+      ) ??
+      null
+    );
+  }
+
+  private resolvedCollaborationMode(): UnknownRecord | null {
+    const preset = this.findCollaborationMode(
+      this.selectedCollaborationMode,
+    );
+    if (!preset) return null;
+    return {
+      mode: preset.mode ?? this.selectedCollaborationMode,
+      settings: {
+        model: this.selectedModel || preset.model || "",
+        reasoning_effort:
+          this.selectedThinking ?? preset.reasoningEffort ?? null,
+        developer_instructions: null,
+      },
+    };
+  }
+
+  private async loadGoal(): Promise<void> {
+    try {
+      const response = await this.server.request<UnknownRecord>(
+        "thread/goal/get",
+        { threadId: this.thread!.id },
+      );
+      if (!Object.hasOwn(response, "goal")) {
+        throw new Error("Codex returned an invalid goal response.");
+      }
+      this.goalsSupported = true;
+      this.goal = parseGoal(response.goal);
+    } catch {
+      this.goalsSupported = false;
+      this.goal = null;
     }
   }
 
@@ -1121,6 +1519,42 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         signal: stringOf(data, "signal"),
         error: error.message,
       });
+      return;
+    }
+    const notificationThreadId = stringOf(data, "threadId");
+    if (
+      notificationThreadId &&
+      this.thread?.id &&
+      notificationThreadId !== this.thread.id
+    ) {
+      const notification = { method, data: data ?? {} };
+      if (this.subagentOwners.has(notificationThreadId)) {
+        this.handleSubagentNotification(
+          notification.method,
+          notification.data,
+          notificationThreadId,
+        );
+      } else {
+        let pending =
+          this.pendingSubagentNotifications.get(notificationThreadId);
+        if (!pending) {
+          if (
+            this.pendingSubagentNotifications.size >=
+            MAX_PENDING_SUBAGENT_THREADS
+          ) {
+            const oldest = this.pendingSubagentNotifications.keys().next().value;
+            if (typeof oldest === "string") {
+              this.pendingSubagentNotifications.delete(oldest);
+            }
+          }
+          pending = [];
+        }
+        pending.push(notification);
+        if (pending.length > MAX_PENDING_SUBAGENT_NOTIFICATIONS) {
+          pending.shift();
+        }
+        this.pendingSubagentNotifications.set(notificationThreadId, pending);
+      }
       return;
     }
     if (method === "overtchat/protocolError") {
@@ -1184,6 +1618,27 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       );
       return;
     }
+    if (method === "item/commandExecution/terminalInteraction") {
+      const turnId = stringOf(data, "turnId");
+      const itemId = stringOf(data, "itemId");
+      const stdin = stringOf(data, "stdin");
+      const turn = turnId ? this.turns.get(turnId) : undefined;
+      const item = turn?.items.find((candidate) => candidate.id === itemId);
+      if (turn && item && stdin) {
+        const interactions = Array.isArray(
+          item.overtchatTerminalInteractions,
+        )
+          ? [...item.overtchatTerminalInteractions]
+          : [];
+        interactions.push({
+          processId: stringOf(data, "processId"),
+          stdin,
+        });
+        item.overtchatTerminalInteractions = interactions;
+        this.emitTurn(turn);
+      }
+      return;
+    }
     if (method === "item/fileChange/patchUpdated") {
       const turnId = stringOf(data, "turnId");
       const itemId = stringOf(data, "itemId");
@@ -1195,6 +1650,44 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       }
       return;
     }
+    if (method === "turn/plan/updated") {
+      const turnId = stringOf(data, "turnId");
+      if (turnId) {
+        const steps = Array.isArray(data?.plan)
+          ? data.plan.flatMap((value) => {
+              const step = recordOf(value);
+              const text = stringOf(step, "step");
+              const status = stringOf(step, "status");
+              return text
+                ? [{ step: text, status: status ?? "pending" }]
+                : [];
+            })
+          : [];
+        const text = steps
+          .map(({ step, status }) => {
+            const marker = status === "completed" ? "x" : " ";
+            return `- [${marker}] ${step}`;
+          })
+          .join("\n");
+        this.upsertItem(turnId, {
+          id: `overtchat:turn-plan:${turnId}`,
+          type: "plan",
+          text,
+          explanation: stringOf(data, "explanation"),
+          steps,
+        });
+      }
+      return;
+    }
+    if (method === "item/plan/delta") {
+      this.appendItemText(data, "text", stringOf(data, "delta") ?? "");
+      return;
+    }
+    if (method === "turn/diff/updated") {
+      // This is accumulated progress telemetry. Concrete fileChange items
+      // remain the durable review surface.
+      return;
+    }
     if (method === "thread/tokenUsage/updated") {
       this.updateTokenUsage(data);
       return;
@@ -1204,6 +1697,43 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       if (name && this.thread) {
         this.thread = { ...this.thread, name };
         this.emit({ type: "session_info_update", title: name });
+      }
+      return;
+    }
+    if (method === "thread/settings/updated") {
+      const threadId = stringOf(data, "threadId");
+      if (!threadId || threadId === this.thread?.id) {
+        const settings = recordOf(data?.threadSettings);
+        this.fastModeEnabled =
+          stringOf(settings, "serviceTier") === "fast" &&
+          codexModelSupportsFastMode(this.selectedModel);
+        const collaboration = recordOf(settings?.collaborationMode);
+        const mode = stringOf(collaboration, "mode");
+        if (
+          (mode === "default" || mode === "plan") &&
+          this.availableCollaborationModes().includes(mode)
+        ) {
+          this.selectedCollaborationMode = mode;
+        }
+        this.emitConfig();
+      }
+      return;
+    }
+    if (method === "thread/goal/updated") {
+      const threadId = stringOf(data, "threadId");
+      if (!threadId || threadId === this.thread?.id) {
+        this.goalsSupported = true;
+        this.goal = parseGoal(data?.goal);
+        this.emitConfig();
+      }
+      return;
+    }
+    if (method === "thread/goal/cleared") {
+      const threadId = stringOf(data, "threadId");
+      if (!threadId || threadId === this.thread?.id) {
+        this.goalsSupported = true;
+        this.goal = null;
+        this.emitConfig();
       }
       return;
     }
@@ -1578,7 +2108,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       if (publish) {
         this.emit({
           type: "available_commands_update",
-          commands: publicCommands([...this.discoveredCommands.values()]),
+          commands: this.availableCommands(),
         });
       }
     })();
@@ -1657,7 +2187,22 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         indexById.set(item.id, items.length);
         items.push(item);
       } else {
-        items[index] = item;
+        const streamedItem = items[index];
+        items[index] = {
+          ...streamedItem,
+          ...item,
+          ...(Array.isArray(streamedItem.overtchatTerminalInteractions) &&
+          !Array.isArray(item.overtchatTerminalInteractions)
+            ? {
+                overtchatTerminalInteractions:
+                  streamedItem.overtchatTerminalInteractions,
+              }
+            : {}),
+          ...(Array.isArray(streamedItem.overtchatChildItems) &&
+          !Array.isArray(item.overtchatChildItems)
+            ? { overtchatChildItems: streamedItem.overtchatChildItems }
+            : {}),
+        };
       }
     }
     return {
@@ -1686,7 +2231,278 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     if (index >= 0) turn.items[index] = item;
     else turn.items.push(item);
     this.turns.set(turnId, turn);
+    this.registerSubagentOwners(turnId, item);
     this.emitTurn(turn);
+  }
+
+  private registerSubagentOwners(turnId: string, item: CodexItem): void {
+    this.registerSubagentThreads({ turnId, itemId: item.id }, item);
+  }
+
+  private registerSubagentThreads(
+    owner: CodexSubagentOwner,
+    item: CodexItem,
+  ): string[] {
+    const receiverThreadIds =
+      item.type === "collabAgentToolCall" &&
+      Array.isArray(item.receiverThreadIds)
+        ? item.receiverThreadIds.filter(
+            (value): value is string => typeof value === "string",
+          )
+        : item.type === "subAgentActivity"
+          ? [stringOf(item, "agentThreadId")].filter(
+              (value): value is string => Boolean(value),
+            )
+          : [];
+    const registered: string[] = [];
+    for (const threadId of receiverThreadIds) {
+      if (threadId !== this.thread?.id) {
+        this.subagentOwners.set(threadId, owner);
+        registered.push(threadId);
+        const pending = this.pendingSubagentNotifications.get(threadId);
+        if (pending) {
+          this.pendingSubagentNotifications.delete(threadId);
+          for (const notification of pending) {
+            this.handleSubagentNotification(
+              notification.method,
+              notification.data,
+              threadId,
+            );
+          }
+        }
+      }
+    }
+    return registered;
+  }
+
+  private async hydrateSubagentHistories(): Promise<void> {
+    if (!this.thread) return;
+    const queue = [...this.subagentOwners.keys()];
+    const visited = new Set([this.thread.id]);
+    while (
+      queue.length > 0 &&
+      visited.size < MAX_SUBAGENT_HISTORY_THREADS
+    ) {
+      const childThreadId = queue.shift();
+      if (!childThreadId || visited.has(childThreadId)) continue;
+      visited.add(childThreadId);
+      const owner = this.subagentOwners.get(childThreadId);
+      if (!owner) continue;
+      try {
+        const response = await this.server.request<UnknownRecord>(
+          "thread/read",
+          { threadId: childThreadId, includeTurns: true },
+        );
+        const childThread = parseCodexThread(response.thread);
+        const turn = this.turns.get(owner.turnId);
+        const item = turn?.items.find(
+          (candidate) => candidate.id === owner.itemId,
+        );
+        if (!item) continue;
+        const childItems = Array.isArray(item.overtchatChildItems)
+          ? [...item.overtchatChildItems]
+          : [];
+        const indexes = new Map(
+          childItems.flatMap((candidate, index) => {
+            const id = stringOf(recordOf(candidate), "id");
+            return id ? [[id, index] as const] : [];
+          }),
+        );
+        for (const childTurn of childThread.turns) {
+          for (const childItem of childTurn.items) {
+            const hydrated = {
+              ...childItem,
+              overtchatThreadId: childThreadId,
+            };
+            const index = indexes.get(childItem.id);
+            if (index === undefined) {
+              indexes.set(childItem.id, childItems.length);
+              childItems.push(hydrated);
+            } else {
+              childItems[index] = {
+                ...recordOf(childItems[index]),
+                ...hydrated,
+              };
+            }
+            item.overtchatChildItems = childItems;
+            queue.push(...this.registerSubagentThreads(owner, childItem));
+          }
+        }
+        item.overtchatChildItems = childItems;
+      } catch {
+        // Child threads can be archived or deleted independently.
+      }
+    }
+  }
+
+  private availableCommands(): AgentSlashCommand[] {
+    return [
+      ...(this.goalsSupported
+        ? [
+            {
+              name: "goal",
+              description: "Set, pause, resume, or clear the agent goal",
+              source: "builtin" as const,
+              argumentHint: "<objective>|pause|resume|clear",
+            },
+          ]
+        : []),
+      ...publicCommands([...this.discoveredCommands.values()]),
+    ];
+  }
+
+  private handleSubagentNotification(
+    method: string,
+    data: UnknownRecord,
+    threadId: string,
+  ): void {
+    const owner = this.subagentOwners.get(threadId);
+    if (!owner) return;
+    const turn = this.turns.get(owner.turnId);
+    const item = turn?.items.find(
+      (candidate) => candidate.id === owner.itemId,
+    );
+    if (!turn || !item) return;
+
+    const childItems = Array.isArray(item.overtchatChildItems)
+      ? [...item.overtchatChildItems]
+      : [];
+    const upsertChild = (value: UnknownRecord) => {
+      const childId = stringOf(value, "id");
+      const type = stringOf(value, "type");
+      if (!childId || !type) return;
+      const child = { ...value, id: childId, type };
+      const index = childItems.findIndex(
+        (candidate) => stringOf(recordOf(candidate), "id") === childId,
+      );
+      if (index >= 0) childItems[index] = child;
+      else childItems.push(child);
+      item.overtchatChildItems = childItems;
+      this.registerSubagentThreads(owner, child);
+      this.emitTurn(turn);
+    };
+    const appendChildText = (
+      key: string,
+      delta: string,
+      arrayIndex?: number,
+    ) => {
+      const childId = stringOf(data, "itemId");
+      const child = childItems
+        .map(recordOf)
+        .find((candidate) => stringOf(candidate, "id") === childId);
+      if (!child || !delta) return;
+      if (arrayIndex === undefined) {
+        child[key] = `${typeof child[key] === "string" ? child[key] : ""}${delta}`;
+      } else {
+        const parts = Array.isArray(child[key]) ? [...child[key]] : [];
+        parts[arrayIndex] =
+          `${typeof parts[arrayIndex] === "string" ? parts[arrayIndex] : ""}${delta}`;
+        child[key] = parts;
+      }
+      item.overtchatChildItems = childItems;
+      this.emitTurn(turn);
+    };
+
+    if (method === "item/started" || method === "item/completed") {
+      const child = recordOf(data.item);
+      if (child) upsertChild(child);
+      return;
+    }
+    if (method === "item/agentMessage/delta") {
+      appendChildText("text", stringOf(data, "delta") ?? "");
+      return;
+    }
+    if (method === "item/reasoning/summaryTextDelta") {
+      appendChildText(
+        "summary",
+        stringOf(data, "delta") ?? "",
+        numberOf(data, "summaryIndex") ?? 0,
+      );
+      return;
+    }
+    if (method === "item/reasoning/textDelta") {
+      appendChildText(
+        "content",
+        stringOf(data, "delta") ?? "",
+        numberOf(data, "contentIndex") ?? 0,
+      );
+      return;
+    }
+    if (method === "item/commandExecution/outputDelta") {
+      appendChildText(
+        "aggregatedOutput",
+        stringOf(data, "delta") ?? "",
+      );
+      return;
+    }
+    if (method === "item/commandExecution/terminalInteraction") {
+      const childId = stringOf(data, "itemId");
+      const child = childItems
+        .map(recordOf)
+        .find((candidate) => stringOf(candidate, "id") === childId);
+      const stdin = stringOf(data, "stdin");
+      if (!child || !stdin) return;
+      const interactions = Array.isArray(
+        child.overtchatTerminalInteractions,
+      )
+        ? [...child.overtchatTerminalInteractions]
+        : [];
+      interactions.push({
+        processId: stringOf(data, "processId"),
+        stdin,
+      });
+      child.overtchatTerminalInteractions = interactions;
+      item.overtchatChildItems = childItems;
+      this.emitTurn(turn);
+      return;
+    }
+    if (method === "item/fileChange/patchUpdated") {
+      const childId = stringOf(data, "itemId");
+      const child = childItems
+        .map(recordOf)
+        .find((candidate) => stringOf(candidate, "id") === childId);
+      if (child && Array.isArray(data.changes)) {
+        child.changes = data.changes;
+        item.overtchatChildItems = childItems;
+        this.emitTurn(turn);
+      }
+      return;
+    }
+    if (method === "item/plan/delta") {
+      appendChildText("text", stringOf(data, "delta") ?? "");
+      return;
+    }
+    if (method === "turn/plan/updated") {
+      const steps = Array.isArray(data.plan)
+        ? data.plan.flatMap((value) => {
+            const step = recordOf(value);
+            const text = stringOf(step, "step");
+            return text ? [text] : [];
+          })
+        : [];
+      upsertChild({
+        id: `overtchat:child-plan:${threadId}`,
+        type: "plan",
+        text: steps.map((step) => `- ${step}`).join("\n"),
+      });
+      return;
+    }
+    if (method === "turn/completed") {
+      const states = recordOf(item.agentsStates) ?? {};
+      const completedTurn = recordOf(data.turn);
+      const status = stringOf(completedTurn, "status");
+      states[threadId] = {
+        status:
+          status === "failed"
+            ? "errored"
+            : status === "interrupted"
+              ? "interrupted"
+              : "completed",
+        message: stringOf(recordOf(completedTurn?.error), "message"),
+      };
+      item.agentsStates = states;
+      this.emitTurn(turn);
+    }
   }
 
   private appendItemText(
@@ -1764,6 +2580,12 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     this.emit({
       type: "config_update",
       model: { provider: "codex", id: this.selectedModel },
+      collaborationMode: this.selectedCollaborationMode,
+      collaborationModes: this.availableCollaborationModes(),
+      fastModeEnabled: this.fastModeEnabled,
+      fastModeAvailable: codexModelSupportsFastMode(this.selectedModel),
+      goalsSupported: this.goalsSupported,
+      goal: this.goal,
       ...(this.selectedThinking
         ? { thinkingLevel: this.selectedThinking }
         : {}),

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -279,6 +279,64 @@ describe("projectAgentTranscript", () => {
       },
     });
   });
+
+  it("projects plans and rich Codex activity without flattening them", () => {
+    const projected = projectAgentTranscript([
+      assistant(
+        [
+          {
+            type: "subagent",
+            id: "collab-1",
+            action: "spawnAgent",
+            prompt: "Inspect tests",
+            status: "completed",
+            receivers: [
+              {
+                threadId: "child-1",
+                status: "completed",
+                message: null,
+              },
+            ],
+            events: ["Tests are green."],
+          },
+          {
+            type: "plan",
+            id: "plan-1",
+            text: "- [x] Inspect\n- [ ] Implement",
+            explanation: "A focused plan.",
+            steps: [
+              { step: "Inspect", status: "completed" },
+              { step: "Implement", status: "pending" },
+            ],
+          },
+          { type: "text", text: "Plan ready." },
+        ],
+        1,
+      ),
+    ]);
+
+    expect(projected.map((item) => item.type)).toEqual([
+      "activity",
+      "plan",
+      "assistant_text",
+    ]);
+    expect(projected[0]).toMatchObject({
+      entries: [
+        {
+          type: "subagent",
+          activity: { events: ["Tests are green."] },
+        },
+      ],
+    });
+    expect(projected[1]).toMatchObject({
+      type: "plan",
+      explanation: "A focused plan.",
+      steps: [
+        { step: "Inspect", status: "completed" },
+        { step: "Implement", status: "pending" },
+      ],
+    });
+  });
 });
 
 describe("agent error presentation", () => {
@@ -322,6 +380,7 @@ describe("agent activity presentation", () => {
     cancelled: false,
     truncated: false,
     fullOutputPath: null,
+    terminalInputs: [],
   });
 
   it("uses typed labels and compact aggregate summaries", () => {

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -22,6 +22,20 @@ export type AgentToolActivity = {
   cancelled: boolean;
   truncated: boolean;
   fullOutputPath: string | null;
+  terminalInputs: string[];
+};
+
+export type AgentSubagentActivity = {
+  id: string;
+  action: string;
+  prompt: string | null;
+  status: string;
+  receivers: Array<{
+    threadId: string;
+    status: string;
+    message: string | null;
+  }>;
+  events: string[];
 };
 
 export type AgentActivityEntry =
@@ -39,6 +53,11 @@ export type AgentActivityEntry =
       type: "tool";
       id: string;
       tool: AgentToolActivity;
+    }
+  | {
+      type: "subagent";
+      id: string;
+      activity: AgentSubagentActivity;
     };
 
 export type AgentErrorPresentation = {
@@ -69,6 +88,16 @@ export type AgentTranscriptItem =
       key: string;
       entries: AgentActivityEntry[];
       durationMs: number | null;
+    }
+  | {
+      type: "plan";
+      key: string;
+      text: string;
+      explanation: string | null;
+      steps: Array<{
+        step: string;
+        status: string;
+      }>;
     };
 
 export type AgentToolStatus =
@@ -204,6 +233,11 @@ function toolFromCall(
     cancelled: false,
     truncated: false,
     fullOutputPath: null,
+    terminalInputs: Array.isArray(part.terminalInputs)
+      ? part.terminalInputs.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [],
   };
 }
 
@@ -226,6 +260,7 @@ function toolFromResult(
     cancelled: false,
     truncated: false,
     fullOutputPath: null,
+    terminalInputs: [],
   };
 }
 
@@ -254,6 +289,7 @@ function directShellTool(
       typeof message.fullOutputPath === "string"
         ? message.fullOutputPath
         : null,
+    terminalInputs: [],
   };
 }
 
@@ -297,6 +333,91 @@ export function projectAgentTranscript(
         const partRecord = recordOf(part);
         if (!partRecord) return;
         const partIdentity = `${identity}:${partIndex}`;
+
+        if (
+          partRecord.type === "plan" &&
+          typeof partRecord.text === "string"
+        ) {
+          flushActivity(activityDurationMs);
+          items.push({
+            type: "plan",
+            key: `plan:${typeof partRecord.id === "string" ? partRecord.id : partIdentity}`,
+            text: partRecord.text,
+            explanation:
+              typeof partRecord.explanation === "string"
+                ? partRecord.explanation
+                : null,
+            steps: Array.isArray(partRecord.steps)
+              ? partRecord.steps.flatMap((value) => {
+                  const step = recordOf(value);
+                  return typeof step?.step === "string"
+                    ? [
+                        {
+                          step: step.step,
+                          status:
+                            typeof step.status === "string"
+                              ? step.status
+                              : "pending",
+                        },
+                      ]
+                    : [];
+                })
+              : [],
+          });
+          return;
+        }
+
+        if (
+          partRecord.type === "subagent" &&
+          typeof partRecord.id === "string"
+        ) {
+          pendingActivity.push({
+            type: "subagent",
+            id: `subagent:${partRecord.id}`,
+            activity: {
+              id: partRecord.id,
+              action:
+                typeof partRecord.action === "string"
+                  ? partRecord.action
+                  : "agent",
+              prompt:
+                typeof partRecord.prompt === "string"
+                  ? partRecord.prompt
+                  : null,
+              status:
+                typeof partRecord.status === "string"
+                  ? partRecord.status
+                  : "completed",
+              receivers: Array.isArray(partRecord.receivers)
+                ? partRecord.receivers.flatMap((value) => {
+                    const receiver = recordOf(value);
+                    return typeof receiver?.threadId === "string"
+                      ? [
+                          {
+                            threadId: receiver.threadId,
+                            status:
+                              typeof receiver.status === "string"
+                                ? receiver.status
+                                : "unknown",
+                            message:
+                              typeof receiver.message === "string"
+                                ? receiver.message
+                                : null,
+                          },
+                        ]
+                      : [];
+                  })
+                : [],
+              events: Array.isArray(partRecord.events)
+                ? partRecord.events.filter(
+                    (value): value is string => typeof value === "string",
+                  )
+                : [],
+            },
+          });
+          pendingActivityDurationMs ??= activityDurationMs;
+          return;
+        }
 
         if (
           partRecord.type === "commentary" &&
@@ -604,6 +725,21 @@ export function describeAgentActivity(
     entry.type === "tool" ? [entry.tool] : [],
   );
   if (tools.length === 0) {
+    const subagents = entries.filter((entry) => entry.type === "subagent");
+    if (subagents.length > 0) {
+      const running = subagents.some((entry) =>
+        ["inProgress", "pendingInit", "running"].includes(
+          entry.activity.status,
+        ),
+      );
+      return {
+        label: running
+          ? `Running ${plural(subagents.length, "subagent")}`
+          : `Used ${plural(subagents.length, "subagent")}`,
+        secondary: null,
+        status: running ? "running" : "completed",
+      };
+    }
     return {
       label: active ? "Thinking" : "Thoughts",
       secondary: null,

--- a/apps/web/lib/agents/providers/codex.test.ts
+++ b/apps/web/lib/agents/providers/codex.test.ts
@@ -38,4 +38,29 @@ describe("codexProviderAdapter", () => {
 
     expect(codexProviderAdapter.normalizeCommand(command, {})).toBe(command);
   });
+
+  it("routes supported /goal invocations out of band", () => {
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/goal Ship parity" },
+        { goalsSupported: true },
+      ),
+    ).toEqual({
+      type: "update_goal",
+      action: "set",
+      objective: "Ship parity",
+    });
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/goal pause" },
+        { goalsSupported: true },
+      ),
+    ).toEqual({ type: "update_goal", action: "pause" });
+    expect(() =>
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/goal Ship parity" },
+        { goalsSupported: false },
+      ),
+    ).toThrow("does not support durable goals");
+  });
 });

--- a/apps/web/lib/agents/providers/codex.ts
+++ b/apps/web/lib/agents/providers/codex.ts
@@ -84,6 +84,36 @@ function normalizeCommand(
   ) {
     return { type: "show_usage" };
   }
+  if (
+    command.type === "prompt" &&
+    !command.images?.length &&
+    /^\/goal(?:[^\S\n]+([^\n]*))?$/iu.test(command.message)
+  ) {
+    if (state.goalsSupported !== true) {
+      throw new Error("This Codex installation does not support durable goals.");
+    }
+    const argumentsText =
+      /^\/goal(?:[^\S\n]+([^\n]*))?$/iu.exec(command.message.trim())?.[1]?.trim() ??
+      "";
+    if (!argumentsText) {
+      throw new Error("Usage: /goal <objective>|pause|resume|clear");
+    }
+    const action = argumentsText.toLowerCase();
+    if (["pause", "resume", "clear"].includes(action)) {
+      return {
+        type: "update_goal",
+        action: action as "pause" | "resume" | "clear",
+      };
+    }
+    if (argumentsText.length > 20_000) {
+      throw new Error("Goal objectives must be 20,000 characters or less.");
+    }
+    return {
+      type: "update_goal",
+      action: "set",
+      objective: argumentsText,
+    };
+  }
   const normalized = normalizeAgentSessionCommand(command, state);
   if (normalized.type === "set_auto_compaction") {
     throw new Error("Codex manages context compaction automatically.");

--- a/apps/web/lib/agents/providers/types.ts
+++ b/apps/web/lib/agents/providers/types.ts
@@ -1,5 +1,7 @@
 import type {
+  AgentCollaborationMode,
   AgentConnectionDraft,
+  AgentGoal,
   AgentModel,
   AgentPromptImage,
   AgentProviderSessionMetadata,
@@ -38,6 +40,7 @@ export type AgentSessionIdentity = {
 export type AgentSessionLaunch = {
   executable: string;
   cwd: string;
+  detectedVersion?: string | null;
   resume?: {
     providerSessionId: string;
     providerSessionPath: string;
@@ -72,6 +75,12 @@ export interface AgentRuntimeClient {
   abort(): Promise<unknown>;
   setModel(provider: string, modelId: string): Promise<unknown>;
   setThinkingLevel(level: string): Promise<unknown>;
+  setCollaborationMode?(mode: AgentCollaborationMode): Promise<unknown>;
+  setFastMode?(enabled: boolean): Promise<unknown>;
+  updateGoal?(
+    action: "set" | "pause" | "resume" | "clear",
+    objective?: string,
+  ): Promise<AgentGoal | null>;
   compact(customInstructions?: string): Promise<unknown>;
   setAutoCompaction(enabled: boolean): Promise<unknown>;
   setSessionName(name: string): Promise<unknown>;

--- a/apps/web/lib/agents/runtime/registry.test.ts
+++ b/apps/web/lib/agents/runtime/registry.test.ts
@@ -88,6 +88,9 @@ class FakeAgentClient {
   readonly abort = vi.fn(async () => ({}));
   readonly setModel = vi.fn(async () => ({}));
   readonly setThinkingLevel = vi.fn(async () => ({}));
+  readonly setCollaborationMode = vi.fn(async () => ({}));
+  readonly setFastMode = vi.fn(async () => ({}));
+  readonly updateGoal = vi.fn(async () => null);
   readonly compact = vi.fn(async () => ({}));
   readonly setAutoCompaction = vi.fn(async () => ({}));
   readonly setSessionName = vi.fn(async () => ({}));
@@ -412,6 +415,59 @@ describe("Agent session runtime", () => {
     expect(client.setAutoCompaction).toHaveBeenCalledWith(true);
     expect(client.setSessionName).toHaveBeenCalledWith("Release prep");
     expect(client.prompt).not.toHaveBeenCalled();
+    await runtime.stop();
+  });
+
+  it("runs Codex goals and plan handoff through native runtime controls", async () => {
+    const client = new FakeAgentClient();
+    const runtime = new AgentSessionRuntime(
+      "session",
+      "user",
+      "connection",
+      "workspace",
+      agentProviderAdapter("codex"),
+      client as unknown as AgentRuntimeClient,
+      {
+        ...initial(),
+        state: {
+          ...initial().state,
+          goalsSupported: true,
+          collaborationMode: "default",
+          collaborationModes: ["default", "plan"],
+          fastModeAvailable: true,
+          fastModeEnabled: false,
+        },
+        thinkingLevels: [...initial().thinkingLevels],
+      },
+      vi.fn(),
+    );
+
+    await runtime.command({
+      type: "prompt",
+      message: "/goal Ship parity",
+    });
+    expect(client.updateGoal).toHaveBeenCalledWith("set", "Ship parity");
+    expect(client.prompt).not.toHaveBeenCalled();
+
+    await runtime.command({
+      type: "set_collaboration_mode",
+      mode: "plan",
+    });
+    await runtime.command({ type: "set_fast_mode", enabled: true });
+    expect(client.setCollaborationMode).toHaveBeenCalledWith("plan");
+    expect(client.setFastMode).toHaveBeenCalledWith(true);
+
+    await runtime.command({
+      type: "implement_plan",
+      plan: "- Inspect\n- Implement",
+    });
+    expect(client.setCollaborationMode).toHaveBeenLastCalledWith("default");
+    expect(client.prompt).toHaveBeenCalledWith(
+      expect.stringContaining("The user approved the plan."),
+    );
+    expect(client.prompt).toHaveBeenCalledWith(
+      expect.stringContaining("- Inspect\n- Implement"),
+    );
     await runtime.stop();
   });
 

--- a/apps/web/lib/agents/runtime/registry.ts
+++ b/apps/web/lib/agents/runtime/registry.ts
@@ -338,6 +338,22 @@ export class AgentSessionRuntime {
           ...(typeof event.thinkingLevel === "string"
             ? { thinkingLevel: event.thinkingLevel }
             : {}),
+          ...(typeof event.collaborationMode === "string"
+            ? { collaborationMode: event.collaborationMode }
+            : {}),
+          ...(Array.isArray(event.collaborationModes)
+            ? { collaborationModes: event.collaborationModes }
+            : {}),
+          ...(typeof event.fastModeEnabled === "boolean"
+            ? { fastModeEnabled: event.fastModeEnabled }
+            : {}),
+          ...(typeof event.fastModeAvailable === "boolean"
+            ? { fastModeAvailable: event.fastModeAvailable }
+            : {}),
+          ...(typeof event.goalsSupported === "boolean"
+            ? { goalsSupported: event.goalsSupported }
+            : {}),
+          ...("goal" in event ? { goal: event.goal } : {}),
         };
         this.publishSnapshot();
       }
@@ -459,6 +475,71 @@ export class AgentSessionRuntime {
           await this.refresh();
           return value;
         });
+      case "set_collaboration_mode":
+        if (!this.client.setCollaborationMode) {
+          return Promise.reject(
+            new Error(
+              `${agentProviderMetadata(this.provider).label} does not provide collaboration modes.`,
+            ),
+          );
+        }
+        return this.client
+          .setCollaborationMode(command.mode)
+          .then(async (value) => {
+            await this.refresh();
+            return value;
+          });
+      case "set_fast_mode":
+        if (!this.client.setFastMode) {
+          return Promise.reject(
+            new Error(
+              `${agentProviderMetadata(this.provider).label} does not provide fast mode.`,
+            ),
+          );
+        }
+        return this.client.setFastMode(command.enabled).then(async (value) => {
+          await this.refresh();
+          return value;
+        });
+      case "update_goal":
+        if (!this.client.updateGoal) {
+          return Promise.reject(
+            new Error(
+              `${agentProviderMetadata(this.provider).label} does not provide durable goals.`,
+            ),
+          );
+        }
+        return this.client
+          .updateGoal(command.action, command.objective)
+          .then(async (value) => {
+            await this.refresh();
+            return value;
+          });
+      case "implement_plan":
+        if (!this.client.setCollaborationMode) {
+          return Promise.reject(
+            new Error(
+              `${agentProviderMetadata(this.provider).label} does not provide Plan mode.`,
+            ),
+          );
+        }
+        return this.client
+          .setCollaborationMode("default")
+          .then(() =>
+            this.submitPrompt(
+              [
+                "The user approved the plan. Implement it now. Do not restate or revise the plan unless blocked.",
+                ...(command.plan
+                  ? [
+                      "Approved plan:",
+                      command.plan,
+                      "Carry out the work, make the necessary code changes, and verify the result.",
+                    ]
+                  : ["Make the required code changes and verify them."]),
+              ].join("\n\n"),
+              [],
+            ),
+          );
       case "compact":
         return this.client
           .compact(command.customInstructions)
@@ -1236,6 +1317,7 @@ export class AgentRuntimeRegistry {
       {
         executable: owned.connection.executable,
         cwd: owned.workspace.path,
+        detectedVersion: owned.connection.detectedVersion,
       },
     );
     try {
@@ -1332,6 +1414,7 @@ export class AgentRuntimeRegistry {
       {
         executable: owned.connection.executable,
         cwd: owned.workspace.path,
+        detectedVersion: owned.connection.detectedVersion,
         resume: {
           providerSessionId: owned.agentSession.providerSessionId,
           providerSessionPath: owned.agentSession.providerSessionPath,

--- a/apps/web/lib/agents/runtime/state.ts
+++ b/apps/web/lib/agents/runtime/state.ts
@@ -316,6 +316,38 @@ export function applyAgentRuntimeEnvelope(
     };
   }
   if (
+    event.type === "config_update" &&
+    event.model &&
+    typeof event.model === "object"
+  ) {
+    return {
+      ...current,
+      state: {
+        ...current.state,
+        model: event.model,
+        ...(typeof event.thinkingLevel === "string"
+          ? { thinkingLevel: event.thinkingLevel }
+          : {}),
+        ...(typeof event.collaborationMode === "string"
+          ? { collaborationMode: event.collaborationMode }
+          : {}),
+        ...(Array.isArray(event.collaborationModes)
+          ? { collaborationModes: event.collaborationModes }
+          : {}),
+        ...(typeof event.fastModeEnabled === "boolean"
+          ? { fastModeEnabled: event.fastModeEnabled }
+          : {}),
+        ...(typeof event.fastModeAvailable === "boolean"
+          ? { fastModeAvailable: event.fastModeAvailable }
+          : {}),
+        ...(typeof event.goalsSupported === "boolean"
+          ? { goalsSupported: event.goalsSupported }
+          : {}),
+        ...("goal" in event ? { goal: event.goal } : {}),
+      },
+    };
+  }
+  if (
     event.type === "interaction_request" &&
     typeof event.id === "string" &&
     typeof event.method === "string" &&

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -260,6 +260,30 @@ export type AgentRuntimeCapabilities = {
   forkMessages?: boolean;
 };
 
+export const AGENT_COLLABORATION_MODES = ["default", "plan"] as const;
+export type AgentCollaborationMode =
+  (typeof AGENT_COLLABORATION_MODES)[number];
+
+export const AGENT_GOAL_STATUSES = [
+  "active",
+  "paused",
+  "blocked",
+  "usageLimited",
+  "budgetLimited",
+  "complete",
+] as const;
+export type AgentGoalStatus = (typeof AGENT_GOAL_STATUSES)[number];
+
+export type AgentGoal = {
+  objective: string;
+  status: AgentGoalStatus;
+  tokenBudget: number | null;
+  tokensUsed: number;
+  timeUsedSeconds: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
 export type AgentUsageWindow = {
   id: string;
   label: string;
@@ -317,6 +341,23 @@ export const agentSessionCommandSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("set_thinking_level"),
     level: z.enum(AGENT_THINKING_LEVELS),
+  }),
+  z.object({
+    type: z.literal("set_collaboration_mode"),
+    mode: z.enum(AGENT_COLLABORATION_MODES),
+  }),
+  z.object({
+    type: z.literal("set_fast_mode"),
+    enabled: z.boolean(),
+  }),
+  z.object({
+    type: z.literal("update_goal"),
+    action: z.enum(["set", "pause", "resume", "clear"]),
+    objective: z.string().trim().min(1).max(20_000).optional(),
+  }),
+  z.object({
+    type: z.literal("implement_plan"),
+    plan: z.string().trim().max(100_000),
   }),
   z.object({
     type: z.literal("compact"),

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -110,6 +110,10 @@ export function useAgentSessionCommand(id: string) {
       if (
         command.type === "set_model" ||
         command.type === "set_thinking_level" ||
+        command.type === "set_collaboration_mode" ||
+        command.type === "set_fast_mode" ||
+        command.type === "update_goal" ||
+        command.type === "implement_plan" ||
         command.type === "compact" ||
         command.type === "set_auto_compaction" ||
         command.type === "set_session_name" ||
@@ -121,6 +125,7 @@ export function useAgentSessionCommand(id: string) {
       }
       if (
         command.type === "prompt" ||
+        command.type === "implement_plan" ||
         command.type === "steer" ||
         command.type === "steer_queued_message" ||
         command.type === "set_session_name" ||


### PR DESCRIPTION
## Summary

- add durable Codex goals with `/goal`, pause/resume/clear controls, persistence, reconnect hydration, and supported-version launch gating
- add Code/Plan collaboration modes, Fast mode, plan review and implementation handoff
- preserve and render Codex commentary, reasoning, tools, subagents, terminal input, file changes, and compaction in one ordered activity timeline
- restore nested subagent history after runtime restarts and reconcile early child events without mutating the root turn
- retain existing image input, approvals, user questions, MCP elicitation, usage, queue/steer, interrupt, and reconnect behavior

## Scope

This PR is intentionally Codex-only. OMP parity and provider-neutral workspace features remain separate. It does not create a release or tag.

## Validation

- full web ESLint
- strict TypeScript
- 492 web tests
- production Next.js build and Playwright suite: 9 passed, 4 intentionally skipped
- installed `codex-cli 0.147.0` stdio contract check for collaboration presets and durable goal lifecycle
- full Docker runner-image build
