### PR TITLE
chore: prepare v0.13.1 release

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.1}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- update the default OvertChat app image in `compose.yml` from `0.13.0` to `0.13.1`

## Validation

The release candidate on the parent `main` commit passed:

- full web ESLint and strict TypeScript
- 492 web tests
- production standalone Playwright suite
- complete Docker runner-image build
- GitHub Validate and Web E2E Smoke workflows
