### PR TITLE
feat(web): move agent controls to composer

### DIFF
--- a/apps/web/components/agents/AgentComposer.tsx
+++ b/apps/web/components/agents/AgentComposer.tsx
@@ -24,6 +24,7 @@ import { agentSlashCommandQuery } from "@/lib/agents/runtime/commands";
 import type {
   AgentPromptImage,
   AgentQueuedMessage,
+  AgentSessionStats,
   AgentSlashCommand,
 } from "@/lib/agents/types";
 import {
@@ -40,6 +41,11 @@ import {
   useChatAttachments,
 } from "@/components/chat/useChatAttachments";
 import { toast } from "@/components/ui/toast";
+import { UsageIndicator } from "@/components/chat/UsageIndicator";
+import {
+  AgentComposerControls,
+  type AgentComposerControlsProps,
+} from "./AgentComposerControls";
 
 function commandSource(source: AgentSlashCommand["source"]): string {
   const labels: Record<AgentSlashCommand["source"], string> = {
@@ -64,6 +70,8 @@ export function AgentComposer({
   pending,
   stopping,
   disabled,
+  controls,
+  contextUsage,
   onSubmit,
   onStop,
   onEditQueued,
@@ -79,6 +87,8 @@ export function AgentComposer({
   pending: boolean;
   stopping: boolean;
   disabled: boolean;
+  controls: AgentComposerControlsProps;
+  contextUsage?: AgentSessionStats["contextUsage"];
   onSubmit: (
     message: string,
     images: AgentPromptImage[],
@@ -106,6 +116,13 @@ export function AgentComposer({
   } = useChatAttachments();
   const listboxId = useId();
   const optionIdPrefix = useId();
+  const composerContextUsage =
+    contextUsage?.tokens !== null && contextUsage?.tokens !== undefined
+      ? {
+          usedTokens: contextUsage.tokens,
+          contextWindow: contextUsage.contextWindow,
+        }
+      : undefined;
 
   useEffect(() => {
     const element = textareaRef.current;
@@ -347,7 +364,7 @@ export function AgentComposer({
   }
 
   return (
-    <div className="relative">
+    <div className="relative @container" data-testid="agent-composer">
       {menuOpen && (
         <div
           className={cn(
@@ -509,58 +526,94 @@ export function AgentComposer({
           }
           aria-autocomplete="list"
         />
-        <div className="flex h-8 items-center gap-1">
-          {supportsImages && (
-            <>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept={AGENT_IMAGE_MEDIA_TYPES.join(",")}
-                multiple
-                className="hidden"
-                onChange={(event) => {
-                  addImageFiles(Array.from(event.target.files ?? []));
-                  event.target.value = "";
-                }}
-              />
+        <div className="flex min-h-10 items-center gap-1 @2xl:min-h-8">
+          <div className="flex min-w-0 flex-1 items-center gap-0.5">
+            {supportsImages && (
+              <>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={AGENT_IMAGE_MEDIA_TYPES.join(",")}
+                  multiple
+                  className="hidden"
+                  onChange={(event) => {
+                    addImageFiles(Array.from(event.target.files ?? []));
+                    event.target.value = "";
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="rounded-full"
+                  disabled={pending || submitting || uploading || disabled}
+                  onClick={() => fileInputRef.current?.click()}
+                  aria-label="Attach images"
+                  title="Attach images"
+                >
+                  <ImagePlus />
+                </Button>
+              </>
+            )}
+            <AgentComposerControls {...controls} />
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {composerContextUsage && (
+              <>
+                <UsageIndicator
+                  contextUsage={composerContextUsage}
+                  compact
+                  side="top"
+                  className="@2xl:hidden"
+                />
+                <UsageIndicator
+                  contextUsage={composerContextUsage}
+                  side="top"
+                  className="hidden @2xl:inline-flex"
+                />
+              </>
+            )}
+            {running && supportsSteer && (
               <Button
                 type="button"
-                variant="ghost"
+                variant="secondary"
                 size="icon-sm"
                 className="rounded-full"
-                disabled={pending || submitting || uploading || disabled}
-                onClick={() => fileInputRef.current?.click()}
-                aria-label="Attach images"
-                title="Attach images"
+                disabled={pending || submitting}
+                onClick={onStop}
+                aria-label={`${stopping ? "Stopping" : "Stop"} ${providerLabel}`}
+                title={`${stopping ? "Stopping" : "Stop"} ${providerLabel}`}
               >
-                <ImagePlus />
+                {stopping ? (
+                  <Loader2 className={cn("size-3.5", motionClasses.spinner)} />
+                ) : (
+                  <Square className="size-3 fill-current" />
+                )}
               </Button>
-            </>
-          )}
-          <span className="flex-1" />
-          {running && supportsSteer && (
+            )}
+            {running && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon-sm"
+                className="rounded-full"
+                disabled={
+                  (!input.trim() && readyParts.length === 0) ||
+                  uploading ||
+                  pending ||
+                  submitting ||
+                  disabled
+                }
+                onClick={() => submit("queue")}
+                aria-label={`Queue message for ${providerLabel}`}
+                title={`Queue after ${providerLabel} finishes`}
+              >
+                <ListEnd />
+              </Button>
+            )}
             <Button
               type="button"
-              variant="secondary"
-              size="icon-sm"
-              className="rounded-full"
-              disabled={pending || submitting}
-              onClick={onStop}
-              aria-label={`${stopping ? "Stopping" : "Stop"} ${providerLabel}`}
-              title={`${stopping ? "Stopping" : "Stop"} ${providerLabel}`}
-            >
-              {stopping ? (
-                <Loader2 className={cn("size-3.5", motionClasses.spinner)} />
-              ) : (
-                <Square className="size-3 fill-current" />
-              )}
-            </Button>
-          )}
-          {running && (
-            <Button
-              type="button"
-              variant="secondary"
-              size="icon-sm"
+              size={running ? "sm" : "icon-sm"}
               className="rounded-full"
               disabled={
                 (!input.trim() && readyParts.length === 0) ||
@@ -569,51 +622,34 @@ export function AgentComposer({
                 submitting ||
                 disabled
               }
-              onClick={() => submit("queue")}
-              aria-label={`Queue message for ${providerLabel}`}
-              title={`Queue after ${providerLabel} finishes`}
+              onClick={() => submit()}
+              aria-label={
+                running
+                  ? supportsSteer
+                    ? `Steer ${providerLabel}`
+                    : `Queue message for ${providerLabel}`
+                  : "Send message"
+              }
+              title={
+                running
+                  ? supportsSteer
+                    ? `Add message to the active ${providerLabel} turn`
+                    : `Queue after ${providerLabel} finishes`
+                  : "Send message"
+              }
             >
-              <ListEnd />
-            </Button>
-          )}
-          <Button
-            type="button"
-            size={running ? "sm" : "icon-sm"}
-            className="rounded-full"
-            disabled={
-              (!input.trim() && readyParts.length === 0) ||
-              uploading ||
-              pending ||
-              submitting ||
-              disabled
-            }
-            onClick={() => submit()}
-            aria-label={
-              running
-                ? supportsSteer
-                  ? `Steer ${providerLabel}`
-                  : `Queue message for ${providerLabel}`
-                : "Send message"
-            }
-            title={
-              running
-                ? supportsSteer
-                  ? `Add message to the active ${providerLabel} turn`
-                  : `Queue after ${providerLabel} finishes`
-                : "Send message"
-            }
-          >
-            {running ? (
-              supportsSteer ? (
-                <CornerUpRight />
+              {running ? (
+                supportsSteer ? (
+                  <CornerUpRight />
+                ) : (
+                  <ListEnd />
+                )
               ) : (
-                <ListEnd />
-              )
-            ) : (
-              <ArrowUp />
-            )}
-            {running && (supportsSteer ? "Steer" : "Queue")}
-          </Button>
+                <ArrowUp />
+              )}
+              {running && (supportsSteer ? "Steer" : "Queue")}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/components/agents/AgentComposerControls.tsx
+++ b/apps/web/components/agents/AgentComposerControls.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useState } from "react";
+import { Menu } from "@base-ui/react/menu";
+import {
+  ArrowLeft,
+  BrainCircuit,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ListTodo,
+  X,
+  Zap,
+} from "lucide-react";
+import { ModelBrandIcon } from "@/components/ModelBrandIcon";
+import { Button } from "@/components/ui/button";
+import type {
+  AgentCollaborationMode,
+  AgentModel,
+  AgentThinkingLevel,
+} from "@/lib/agents/types";
+import { motionClasses } from "@/lib/motion";
+import { modelIconForModel } from "@/lib/providers/catalog";
+import { cn } from "@/lib/utils";
+
+export interface AgentComposerControlsProps {
+  providerLabel: string;
+  models: AgentModel[];
+  currentModel: { provider: string; id: string } | null;
+  thinkingLevel: AgentThinkingLevel | null;
+  thinkingLevels: AgentThinkingLevel[];
+  collaborationMode: AgentCollaborationMode;
+  collaborationModes: AgentCollaborationMode[];
+  fastModeEnabled: boolean;
+  fastModeAvailable: boolean;
+  disabled: boolean;
+  onSelectModel: (model: AgentModel) => void;
+  onSelectThinking: (level: AgentThinkingLevel) => void;
+  onSelectCollaborationMode: (mode: AgentCollaborationMode) => void;
+  onToggleFastMode: (enabled: boolean) => void;
+  onMenuOpenChange?: (open: boolean) => void;
+}
+
+const controlRowClassName =
+  "flex min-h-10 w-full cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[popup-open]:bg-accent data-[popup-open]:text-accent-foreground";
+
+const choiceItemClassName =
+  "flex min-h-10 cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground";
+
+export function AgentComposerControls(props: AgentComposerControlsProps) {
+  const hasModelOrEffort =
+    props.models.length > 0 ||
+    (props.thinkingLevels.length > 1 && props.thinkingLevel !== null);
+  const hasControls =
+    hasModelOrEffort ||
+    props.collaborationMode === "plan" ||
+    props.fastModeAvailable;
+
+  if (!hasControls) return null;
+
+  return (
+    <div
+      data-testid="agent-composer-controls"
+      className="flex min-w-0 items-center gap-0.5"
+    >
+      {hasModelOrEffort && <ModelEffortControl {...props} />}
+      {props.collaborationMode === "plan" && (
+        <PlanModeControl
+          disabled={props.disabled}
+          onExit={() => props.onSelectCollaborationMode("default")}
+          onOpenChange={props.onMenuOpenChange}
+        />
+      )}
+      {props.fastModeAvailable && (
+        <Button
+          type="button"
+          variant={props.fastModeEnabled ? "secondary" : "ghost"}
+          size="sm"
+          className="h-7 px-2"
+          aria-pressed={props.fastModeEnabled}
+          aria-label="Fast"
+          title="Fast mode uses priority inference at higher usage"
+          disabled={props.disabled}
+          onClick={() => props.onToggleFastMode(!props.fastModeEnabled)}
+        >
+          <Zap className="size-3.5" />
+          <span className="hidden @xl:inline">Fast</span>
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function ModelEffortControl(props: AgentComposerControlsProps) {
+  const [panel, setPanel] = useState<"root" | "model" | "effort">("root");
+  const selectedModel = props.models.find(
+    (model) =>
+      model.provider === props.currentModel?.provider &&
+      model.id === props.currentModel.id,
+  );
+  const modelLabel =
+    selectedModel?.name ?? props.currentModel?.id ?? props.providerLabel;
+  const effortLabel = props.thinkingLevel
+    ? thinkingLabel(props.thinkingLevel)
+    : null;
+  const accessibleLabel = effortLabel
+    ? `Model and effort: ${modelLabel}, ${effortLabel}`
+    : `Model: ${modelLabel}`;
+  const showEffort =
+    props.thinkingLevels.length > 1 && props.thinkingLevel !== null;
+
+  return (
+    <Menu.Root
+      onOpenChange={(open) => {
+        if (!open) setPanel("root");
+        props.onMenuOpenChange?.(open);
+      }}
+    >
+      <Menu.Trigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="min-w-0 max-w-32 gap-1.5 px-2 @lg:max-w-48 @2xl:max-w-56"
+            disabled={props.disabled}
+            aria-label={accessibleLabel}
+            data-testid="agent-model-effort-trigger"
+          />
+        }
+      >
+        <ModelBrandIcon
+          iconId={iconForModel(selectedModel)}
+          className="size-4"
+        />
+        <span className="truncate">{modelLabel}</span>
+        <ChevronDown className="text-muted-foreground" />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner side="top" align="start" sideOffset={6}>
+          <Menu.Popup
+            aria-label="Model and effort"
+            className={cn(
+              "z-50 max-h-[min(28rem,calc(100vh-2rem))] max-w-[calc(100vw-1rem)] overflow-y-auto rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+              panel === "model"
+                ? "w-80"
+                : panel === "effort"
+                  ? "w-56"
+                  : "w-72",
+              motionClasses.popup,
+            )}
+          >
+            {panel === "root" && (
+              <>
+                {props.models.length > 0 && (
+                  <Menu.Item
+                    closeOnClick={false}
+                    onClick={() => setPanel("model")}
+                    className={controlRowClassName}
+                  >
+                    <ModelBrandIcon
+                      iconId={iconForModel(selectedModel)}
+                      className="size-4"
+                    />
+                    <span className="font-medium">Model</span>
+                    <span className="ml-auto min-w-0 truncate text-muted-foreground">
+                      {modelLabel}
+                    </span>
+                    <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+                  </Menu.Item>
+                )}
+                {showEffort && (
+                  <Menu.Item
+                    closeOnClick={false}
+                    onClick={() => setPanel("effort")}
+                    className={controlRowClassName}
+                  >
+                    <BrainCircuit className="size-4 text-muted-foreground" />
+                    <span className="font-medium">Effort</span>
+                    <span className="ml-auto text-muted-foreground">
+                      {effortLabel}
+                    </span>
+                    <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+                  </Menu.Item>
+                )}
+              </>
+            )}
+            {panel === "model" && (
+              <>
+                <BackItem label="Model" onClick={() => setPanel("root")} />
+                <Menu.Separator className="mx-1 my-1 h-px bg-border" />
+                {props.models.map((model) => {
+                  const selected =
+                    model.provider === props.currentModel?.provider &&
+                    model.id === props.currentModel.id;
+                  return (
+                    <Menu.Item
+                      key={`${model.provider}/${model.id}`}
+                      onClick={() => props.onSelectModel(model)}
+                      className={cn(
+                        choiceItemClassName,
+                        selected && "bg-accent text-accent-foreground",
+                      )}
+                    >
+                      <ModelBrandIcon
+                        iconId={iconForModel(model)}
+                        className="size-4"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate">{model.name}</span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {model.provider} / {model.id}
+                        </span>
+                      </span>
+                      <span className="flex size-4 shrink-0 items-center justify-center">
+                        {selected && <Check className="size-3.5" />}
+                      </span>
+                    </Menu.Item>
+                  );
+                })}
+              </>
+            )}
+            {panel === "effort" && (
+              <>
+                <BackItem label="Effort" onClick={() => setPanel("root")} />
+                <Menu.Separator className="mx-1 my-1 h-px bg-border" />
+                {props.thinkingLevels.map((level) => (
+                  <Menu.Item
+                    key={level}
+                    onClick={() => props.onSelectThinking(level)}
+                    className={choiceItemClassName}
+                  >
+                    <BrainCircuit className="size-4 text-muted-foreground" />
+                    <span className="flex-1">{thinkingLabel(level)}</span>
+                    <span className="flex size-4 shrink-0 items-center justify-center">
+                      {level === props.thinkingLevel && (
+                        <Check className="size-3.5" />
+                      )}
+                    </span>
+                  </Menu.Item>
+                ))}
+              </>
+            )}
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+function BackItem({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Menu.Item
+      closeOnClick={false}
+      onClick={onClick}
+      aria-label="Back to model and effort"
+      className={controlRowClassName}
+    >
+      <ArrowLeft className="size-4 text-muted-foreground" />
+      <span className="font-medium">{label}</span>
+    </Menu.Item>
+  );
+}
+
+function PlanModeControl({
+  disabled,
+  onExit,
+  onOpenChange,
+}: {
+  disabled: boolean;
+  onExit: () => void;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  return (
+    <Menu.Root onOpenChange={onOpenChange}>
+      <Menu.Trigger
+        render={
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-7 px-2"
+            aria-label="Plan mode"
+            aria-pressed="true"
+            disabled={disabled}
+          />
+        }
+      >
+        <ListTodo className="size-3.5" />
+        Plan
+        <ChevronDown className="text-muted-foreground" />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner side="top" align="start" sideOffset={6}>
+          <Menu.Popup
+            aria-label="Plan mode"
+            className={cn(
+              "z-50 w-44 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+              motionClasses.popup,
+            )}
+          >
+            <Menu.Item
+              onClick={onExit}
+              className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+            >
+              <X className="size-3.5 text-muted-foreground" />
+              Exit plan mode
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+function iconForModel(model: AgentModel | undefined) {
+  if (!model) return null;
+  return (
+    modelIconForModel(`${model.provider}/${model.id}`) ??
+    modelIconForModel(model.id) ??
+    modelIconForModel(model.provider)
+  );
+}
+
+function thinkingLabel(level: AgentThinkingLevel): string {
+  return level === "off"
+    ? "Off"
+    : level === "xhigh"
+      ? "Extra high"
+      : level[0].toUpperCase() + level.slice(1);
+}

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -75,6 +75,7 @@ export function AgentMessageList({
   canEditMessages,
   canForkMessages,
   actionsDisabled,
+  suppressScrollButton,
   onEditMessage,
   onForkMessage,
   onImplementPlan,
@@ -89,6 +90,7 @@ export function AgentMessageList({
   canEditMessages: boolean;
   canForkMessages: boolean;
   actionsDisabled: boolean;
+  suppressScrollButton: boolean;
   onEditMessage: (messageId: string) => void;
   onForkMessage: (messageId: string) => void;
   onImplementPlan: (plan: string) => void;
@@ -157,7 +159,7 @@ export function AgentMessageList({
         </div>
       </div>
 
-      {!isAtBottom && (
+      {!isAtBottom && !suppressScrollButton && (
         <div className="pointer-events-none absolute inset-x-0 bottom-3 z-10 flex justify-center">
           <Button
             type="button"

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -1,93 +1,46 @@
 "use client";
 
-import { useMemo, useState } from "react";
 import { writeText as clipboardWriteText } from "clipboard-polyfill";
 import { Menu } from "@base-ui/react/menu";
 import { Popover } from "@base-ui/react/popover";
 import {
-  Check,
-  ChevronDown,
-  Code2,
   Coins,
   Copy,
   FileDiff,
   GitBranch,
   MoreHorizontal,
-  ListTodo,
   Pencil,
-  Search,
   Sparkles,
-  Zap,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import { SidebarToggle } from "@/components/SidebarToggle";
-import { UsageIndicator } from "@/components/chat/UsageIndicator";
 import type {
-  AgentModel,
-  AgentCollaborationMode,
   AgentSessionStats,
-  AgentThinkingLevel,
   AgentWorkspaceGitStatus,
 } from "@/lib/agents/types";
-import { modelIconForModel } from "@/lib/providers/catalog";
 import { motionClasses } from "@/lib/motion";
 import { useAgentWorkspaceGitStatus } from "@/lib/queries/agentWorkspaces";
 import { cn } from "@/lib/utils";
 import { toast } from "@/components/ui/toast";
 
 export function AgentSessionHeader({
-  providerLabel,
   workspaceId,
   workspaceName,
   workspacePath,
-  models,
-  currentModel,
-  thinkingLevel,
-  thinkingLevels,
-  collaborationMode,
-  collaborationModes,
-  fastModeEnabled,
-  fastModeAvailable,
   stats,
   running,
   commandPending,
   readOnly,
-  onSelectModel,
-  onSelectThinking,
-  onSelectCollaborationMode,
-  onToggleFastMode,
   onRename,
   onCompact,
 }: {
-  providerLabel: string;
   workspaceId: string;
   workspaceName: string;
   workspacePath: string;
-  models: AgentModel[];
-  currentModel: { provider: string; id: string } | null;
-  thinkingLevel: AgentThinkingLevel | null;
-  thinkingLevels: AgentThinkingLevel[];
-  collaborationMode: AgentCollaborationMode;
-  collaborationModes: AgentCollaborationMode[];
-  fastModeEnabled: boolean;
-  fastModeAvailable: boolean;
   stats: AgentSessionStats;
   running: boolean;
   commandPending: boolean;
   readOnly: boolean;
-  onSelectModel: (model: AgentModel) => void;
-  onSelectThinking: (level: AgentThinkingLevel) => void;
-  onSelectCollaborationMode: (mode: AgentCollaborationMode) => void;
-  onToggleFastMode: (enabled: boolean) => void;
   onRename: () => void;
   onCompact: () => void;
 }) {
@@ -107,7 +60,10 @@ export function AgentSessionHeader({
   }
 
   return (
-    <header className="flex h-12 shrink-0 items-center gap-1 border-b px-3">
+    <header
+      data-testid="agent-session-header"
+      className="flex h-12 shrink-0 items-center gap-1 border-b px-3"
+    >
       <SidebarToggle />
       <span
         className="hidden max-w-40 truncate px-1 text-sm font-medium lg:block"
@@ -116,96 +72,7 @@ export function AgentSessionHeader({
         {workspaceName}
       </span>
       <WorkspaceGitSummary status={gitStatus} />
-      <AgentModelPicker
-        providerLabel={providerLabel}
-        models={models}
-        currentModel={currentModel}
-        disabled={readOnly || running || commandPending}
-        onSelect={onSelectModel}
-      />
-      {thinkingLevels.length > 0 && thinkingLevel && (
-        <Select
-          value={thinkingLevel}
-          onValueChange={(value) =>
-            onSelectThinking(value as AgentThinkingLevel)
-          }
-          disabled={readOnly || running || commandPending}
-        >
-          <SelectTrigger
-            size="sm"
-            aria-label="Thinking level"
-            title="Thinking level"
-            className="max-w-28 border-0"
-          >
-            <Sparkles className="size-3.5 text-muted-foreground" />
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {thinkingLevels.map((level) => (
-              <SelectItem key={level} value={level}>
-                {thinkingLabel(level)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
-      {collaborationModes.length > 1 && (
-        <div
-          role="group"
-          aria-label="Codex mode"
-          className="hidden h-8 shrink-0 items-center rounded-md border bg-muted/20 p-0.5 md:flex"
-        >
-          {collaborationModes.map((mode) => {
-            const selected = mode === collaborationMode;
-            return (
-              <button
-                key={mode}
-                type="button"
-                aria-pressed={selected}
-                disabled={readOnly || running || commandPending}
-                onClick={() => onSelectCollaborationMode(mode)}
-                className={cn(
-                  "flex h-6 items-center gap-1 rounded px-2 text-xs font-medium motion-colors disabled:cursor-not-allowed disabled:opacity-50",
-                  selected
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                {mode === "plan" ? (
-                  <ListTodo className="size-3.5" />
-                ) : (
-                  <Code2 className="size-3.5" />
-                )}
-                {mode === "plan" ? "Plan" : "Code"}
-              </button>
-            );
-          })}
-        </div>
-      )}
-      {fastModeAvailable && (
-        <Button
-          type="button"
-          variant={fastModeEnabled ? "secondary" : "ghost"}
-          size="sm"
-          className="hidden h-8 px-2 md:inline-flex"
-          aria-pressed={fastModeEnabled}
-          title="Fast mode uses priority inference at higher usage"
-          disabled={readOnly || running || commandPending}
-          onClick={() => onToggleFastMode(!fastModeEnabled)}
-        >
-          <Zap className="size-3.5" />
-          Fast
-        </Button>
-      )}
       <div className="ml-auto flex shrink-0 items-center gap-0.5">
-        {stats.contextUsage && stats.contextUsage.tokens !== null && (
-          <UsageIndicator
-            contextUsage={{
-              usedTokens: stats.contextUsage.tokens,
-              contextWindow: stats.contextUsage.contextWindow,
-            }}
-          />
-        )}
         <SessionStats stats={stats} />
         <Menu.Root>
           <Menu.Trigger
@@ -243,47 +110,12 @@ export function AgentSessionHeader({
                       void copyWorkspaceValue(branch, "Branch name")
                     }
                     className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[highlighted]:bg-accent"
-                  >
-                    <GitBranch className="size-3.5 text-muted-foreground" />
-                    Copy branch name
-                  </Menu.Item>
+                >
+                  <GitBranch className="size-3.5 text-muted-foreground" />
+                  Copy branch name
+                </Menu.Item>
                 )}
                 <Menu.Separator className="my-1 h-px bg-border" />
-                {collaborationModes.length > 1 &&
-                  collaborationModes.map((mode) => (
-                    <Menu.Item
-                      key={mode}
-                      disabled={readOnly || running || commandPending}
-                      onClick={() => onSelectCollaborationMode(mode)}
-                      className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent"
-                    >
-                      {mode === "plan" ? (
-                        <ListTodo className="size-3.5 text-muted-foreground" />
-                      ) : (
-                        <Code2 className="size-3.5 text-muted-foreground" />
-                      )}
-                      {mode === "plan" ? "Plan mode" : "Code mode"}
-                      {mode === collaborationMode && (
-                        <Check className="ml-auto size-3.5" />
-                      )}
-                    </Menu.Item>
-                  ))}
-                {fastModeAvailable && (
-                  <Menu.Item
-                    disabled={readOnly || running || commandPending}
-                    onClick={() => onToggleFastMode(!fastModeEnabled)}
-                    className="flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent"
-                  >
-                    <Zap className="size-3.5 text-muted-foreground" />
-                    Fast mode
-                    {fastModeEnabled && (
-                      <Check className="ml-auto size-3.5" />
-                    )}
-                  </Menu.Item>
-                )}
-                {(collaborationModes.length > 1 || fastModeAvailable) && (
-                  <Menu.Separator className="my-1 h-px bg-border" />
-                )}
                 <Menu.Item
                   disabled={readOnly}
                   onClick={onRename}
@@ -361,118 +193,6 @@ function WorkspaceGitSummary({
   );
 }
 
-function AgentModelPicker({
-  providerLabel,
-  models,
-  currentModel,
-  disabled,
-  onSelect,
-}: {
-  providerLabel: string;
-  models: AgentModel[];
-  currentModel: { provider: string; id: string } | null;
-  disabled: boolean;
-  onSelect: (model: AgentModel) => void;
-}) {
-  const [search, setSearch] = useState("");
-  const selected = models.find(
-    (model) =>
-      model.provider === currentModel?.provider && model.id === currentModel.id,
-  );
-  const filtered = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    if (!query) return models;
-    return models.filter((model) =>
-      [model.name, model.id, model.provider]
-        .join(" ")
-        .toLowerCase()
-        .includes(query),
-    );
-  }, [models, search]);
-
-  return (
-    <Menu.Root>
-      <Menu.Trigger
-        render={
-          <Button
-            variant="ghost"
-            size="sm"
-            className="min-w-0 max-w-[45vw] sm:max-w-72"
-            disabled={disabled || models.length === 0}
-          />
-        }
-      >
-        <ModelBrandIcon
-          iconId={iconForModel(selected)}
-          className="size-4"
-        />
-        <span className="truncate">
-          {selected?.name ?? currentModel?.id ?? "Select model"}
-        </span>
-        <ChevronDown className="text-muted-foreground" />
-      </Menu.Trigger>
-      <Menu.Portal>
-        <Menu.Positioner side="bottom" align="start" sideOffset={6}>
-          <Menu.Popup
-            className={cn(
-              "z-50 max-h-96 w-80 max-w-[calc(100vw-1rem)] overflow-y-auto rounded-lg border bg-popover text-sm text-popover-foreground shadow-md outline-none",
-              motionClasses.popup,
-            )}
-          >
-            <div className="sticky top-0 z-10 border-b bg-popover p-2">
-              <div className="relative">
-                <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  onKeyDown={(event) => event.stopPropagation()}
-                  placeholder={`Search ${providerLabel} models`}
-                  aria-label={`Search ${providerLabel} models`}
-                  className="h-7 pl-7 text-xs md:text-xs"
-                />
-              </div>
-            </div>
-            <div className="p-1">
-              {filtered.map((model) => {
-                const active =
-                  model.provider === currentModel?.provider &&
-                  model.id === currentModel.id;
-                return (
-                  <Menu.Item
-                    key={`${model.provider}/${model.id}`}
-                    onClick={() => {
-                      onSelect(model);
-                      setSearch("");
-                    }}
-                    className={cn(
-                      "flex min-h-10 cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 outline-none motion-colors data-[highlighted]:bg-accent",
-                      active && "bg-accent",
-                    )}
-                  >
-                    <ModelBrandIcon
-                      iconId={iconForModel(model)}
-                      className="size-4"
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate">{model.name}</span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {model.provider} / {model.id}
-                      </span>
-                    </span>
-                    <span className="flex size-4 shrink-0 items-center justify-center">
-                      {active && <Check className="size-3.5" />}
-                    </span>
-                  </Menu.Item>
-                );
-              })}
-            </div>
-          </Menu.Popup>
-        </Menu.Positioner>
-      </Menu.Portal>
-    </Menu.Root>
-  );
-}
-
 function SessionStats({ stats }: { stats: AgentSessionStats }) {
   return (
     <Popover.Root>
@@ -525,23 +245,6 @@ function StatsRow({ label, value }: { label: string; value: string }) {
       <span className="font-mono">{value}</span>
     </div>
   );
-}
-
-function iconForModel(model: AgentModel | undefined) {
-  if (!model) return null;
-  return (
-    modelIconForModel(`${model.provider}/${model.id}`) ??
-    modelIconForModel(model.id) ??
-    modelIconForModel(model.provider)
-  );
-}
-
-function thinkingLabel(level: AgentThinkingLevel): string {
-  return level === "off"
-    ? "Off"
-    : level === "xhigh"
-      ? "Extra high"
-      : level[0].toUpperCase() + level.slice(1);
 }
 
 function formatInteger(value: number): string {

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -17,7 +17,6 @@ import { SidebarToggle } from "@/components/SidebarToggle";
 import { toast } from "@/components/ui/toast";
 import { AGENT_GOAL_STATUSES } from "@/lib/agents/types";
 import type {
-  AgentModel,
   AgentCollaborationMode,
   AgentGoal,
   AgentPromptImage,
@@ -147,6 +146,7 @@ export function AgentSessionView({
   const [compactOpen, setCompactOpen] = useState(false);
   const [usage, setUsage] = useState<AgentUsageSnapshot | null>(null);
   const [dialogError, setDialogError] = useState("");
+  const [composerMenuOpen, setComposerMenuOpen] = useState(false);
   const snapshot = session.data;
 
   useEffect(() => {
@@ -316,42 +316,21 @@ export function AgentSessionView({
           command.submittedAt > 0
         ? command.submittedAt
         : null;
+  const composerDisabled =
+    exited || Boolean(readOnly) || Boolean(snapshot.pendingInteraction);
+  const controlsDisabled =
+    composerDisabled || running || command.isPending;
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <AgentSessionHeader
-        providerLabel={providerLabel}
         workspaceId={workspaceId}
         workspaceName={workspaceName}
         workspacePath={workspacePath}
-        models={snapshot.models}
-        currentModel={model}
-        thinkingLevel={thinking}
-        thinkingLevels={snapshot.thinkingLevels}
-        collaborationMode={collaborationMode}
-        collaborationModes={availableCollaborationModes}
-        fastModeEnabled={fastModeEnabled}
-        fastModeAvailable={fastModeAvailable}
         stats={snapshot.stats}
         running={running}
         commandPending={command.isPending}
         readOnly={Boolean(readOnly)}
-        onSelectModel={(selected: AgentModel) =>
-          void run({
-            type: "set_model",
-            provider: selected.provider,
-            modelId: selected.id,
-          })
-        }
-        onSelectThinking={(level) =>
-          void run({ type: "set_thinking_level", level })
-        }
-        onSelectCollaborationMode={(mode) =>
-          void run({ type: "set_collaboration_mode", mode })
-        }
-        onToggleFastMode={(enabled) =>
-          void run({ type: "set_fast_mode", enabled })
-        }
         onRename={() => {
           setDialogError("");
           setRenameOpen(true);
@@ -437,6 +416,7 @@ export function AgentSessionView({
           command.isPending ||
           Boolean(snapshot.pendingInteraction)
         }
+        suppressScrollButton={composerMenuOpen}
         onEditMessage={(messageId) =>
           void run({ type: "edit_message", messageId })
         }
@@ -460,11 +440,33 @@ export function AgentSessionView({
             running={running}
             pending={command.isPending}
             stopping={pendingCommand === "abort"}
-            disabled={
-              exited ||
-              Boolean(readOnly) ||
-              Boolean(snapshot.pendingInteraction)
-            }
+            disabled={composerDisabled}
+            controls={{
+              providerLabel,
+              models: snapshot.models,
+              currentModel: model,
+              thinkingLevel: thinking,
+              thinkingLevels: snapshot.thinkingLevels,
+              collaborationMode,
+              collaborationModes: availableCollaborationModes,
+              fastModeEnabled,
+              fastModeAvailable,
+              disabled: controlsDisabled,
+              onSelectModel: (selected) =>
+                void run({
+                  type: "set_model",
+                  provider: selected.provider,
+                  modelId: selected.id,
+                }),
+              onSelectThinking: (level) =>
+                void run({ type: "set_thinking_level", level }),
+              onSelectCollaborationMode: (mode) =>
+                void run({ type: "set_collaboration_mode", mode }),
+              onToggleFastMode: (enabled) =>
+                void run({ type: "set_fast_mode", enabled }),
+              onMenuOpenChange: setComposerMenuOpen,
+            }}
+            contextUsage={snapshot.stats.contextUsage}
             onSubmit={submit}
             onStop={() => void run({ type: "abort" })}
             onEditQueued={(id) =>

--- a/apps/web/components/chat/UsageIndicator.tsx
+++ b/apps/web/components/chat/UsageIndicator.tsx
@@ -20,6 +20,9 @@ interface ContextUsage {
 interface UsageIndicatorProps {
   contextUsage?: ContextUsage;
   sessionUsage?: UsageTotals;
+  compact?: boolean;
+  side?: "top" | "bottom";
+  className?: string;
 }
 
 function contextTone(values: ContextMeterValues): string {
@@ -70,6 +73,9 @@ function DetailRow({ label, value }: { label: string; value: string }) {
 export function UsageIndicator({
   contextUsage,
   sessionUsage,
+  compact = false,
+  side = "bottom",
+  className,
 }: UsageIndicatorProps) {
   const context = contextUsage
     ? getContextMeterValues(
@@ -114,7 +120,11 @@ export function UsageIndicator({
         type="button"
         aria-label={`Usage: ${triggerDetails.join("; ")}. Show details`}
         title="Usage"
-        className="inline-flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium tabular-nums text-muted-foreground outline-none motion-colors hover:bg-accent hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 data-[popup-open]:bg-accent data-[popup-open]:text-foreground max-md:h-9"
+        className={cn(
+          "inline-flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium tabular-nums text-muted-foreground outline-none motion-colors hover:bg-accent hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 data-[popup-open]:bg-accent data-[popup-open]:text-foreground max-md:h-9",
+          compact && "w-8 justify-center px-0 max-md:size-10",
+          className,
+        )}
       >
         {context ? (
           <span
@@ -124,22 +134,22 @@ export function UsageIndicator({
             )}
           >
             <ContextRing values={context} />
-            <span>{contextValue}</span>
+            {!compact && <span>{contextValue}</span>}
           </span>
         ) : null}
-        {context && session ? (
+        {context && session && !compact ? (
           <span aria-hidden="true" className="mx-2 h-4 w-px bg-border" />
         ) : null}
         {session ? (
           <span className="inline-flex items-center gap-1.5">
             <CircleDollarSign className="size-4" />
-            <span>{visibleCost}</span>
+            {!compact && <span>{visibleCost}</span>}
           </span>
         ) : null}
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Positioner
-          side="bottom"
+          side={side}
           align="end"
           sideOffset={6}
           collisionPadding={8}

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -33,6 +33,13 @@ const imageModel: AgentRuntimeSnapshot["models"][number] = {
   },
 };
 
+const textModel: AgentRuntimeSnapshot["models"][number] = {
+  ...imageModel,
+  id: "gpt-5.6-mini",
+  name: "GPT-5.6 Mini",
+  input: ["text"],
+};
+
 test.beforeEach(resetE2eDatabase);
 
 function seedAgentSession() {
@@ -90,6 +97,7 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
       isCompacting: false,
       sessionName: "Runtime activity",
       model: imageModel,
+      thinkingLevel: "high",
       collaborationMode: "default",
       collaborationModes: ["default", "plan"],
       fastModeEnabled: false,
@@ -228,9 +236,15 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
         timestamp: 7,
       },
     ],
-    models: [imageModel],
-    thinkingLevels: ["off"],
-    commands: [],
+    models: [imageModel, textModel],
+    thinkingLevels: ["low", "high"],
+    commands: [
+      {
+        name: "plan",
+        description: "Toggle Plan mode",
+        source: "builtin",
+      },
+    ],
     queuedMessages: [],
     stats: {
       sessionFile: "/tmp/runtime-test.jsonl",
@@ -248,6 +262,11 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
         total: 0,
       },
       cost: 0,
+      contextUsage: {
+        tokens: 42_000,
+        contextWindow: 100_000,
+        percent: 42,
+      },
     },
   };
 }
@@ -311,6 +330,23 @@ test("shows durable turn activity without changing completed tool status", async
         if (command.type === "retry_interactive") retryRequested = true;
         if (command.type === "set_collaboration_mode") {
           snapshot.state.collaborationMode = command.mode;
+        }
+        if (
+          command.type === "prompt" &&
+          command.message?.trim() === "/plan"
+        ) {
+          snapshot.state.collaborationMode =
+            snapshot.state.collaborationMode === "plan" ? "default" : "plan";
+        }
+        if (command.type === "set_model") {
+          snapshot.state.model = snapshot.models.find(
+            (model) =>
+              model.provider === command.provider &&
+              model.id === command.modelId,
+          );
+        }
+        if (command.type === "set_thinking_level") {
+          snapshot.state.thinkingLevel = command.level;
         }
         if (command.type === "set_fast_mode") {
           snapshot.state.fastModeEnabled = command.enabled;
@@ -497,6 +533,25 @@ test("shows durable turn activity without changing completed tool status", async
     name: "Runtime activity is working",
   });
   await expect(sessionActivity).toBeVisible();
+  const agentHeader = page.getByTestId("agent-session-header");
+  const agentComposer = page.getByTestId("agent-composer");
+  await expect(
+    agentHeader.getByTestId("agent-model-effort-trigger"),
+  ).toHaveCount(0);
+  await expect(
+    agentComposer.getByRole("button", {
+      name: "Model and effort: GPT-5.6, High",
+    }),
+  ).toBeDisabled();
+  await expect(agentComposer.getByRole("button", { name: "Plan mode" })).toHaveCount(0);
+  await expect(
+    agentComposer.getByRole("button", { name: "Fast", exact: true }),
+  ).toBeDisabled();
+  await expect(
+    agentComposer.getByRole("button", {
+      name: /Usage: 42% context used/u,
+    }),
+  ).toBeVisible();
   const headerGitStatus = page.getByTestId("agent-workspace-git-status");
   await expect(headerGitStatus).toContainText("feature/runtime-status");
   await expect(headerGitStatus).toContainText("2 files");
@@ -742,6 +797,9 @@ test("shows durable turn activity without changing completed tool status", async
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(genericActivity).toBeVisible();
   await expect(headerGitStatus).not.toBeVisible();
+  await expect(
+    agentComposer.getByTestId("agent-model-effort-trigger"),
+  ).toBeVisible();
   expect(
     await page.evaluate(
       () =>
@@ -767,6 +825,7 @@ test("shows durable turn activity without changing completed tool status", async
     path: testInfo.outputPath("runtime-activity-mobile.png"),
     fullPage: true,
   });
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
 
   await page.evaluate(() => {
     const controls = (
@@ -786,16 +845,128 @@ test("shows durable turn activity without changing completed tool status", async
   });
   await expect(genericActivity).not.toBeVisible();
 
-  await page.setViewportSize({ width: 1280, height: 720 });
   snapshot.status = "idle";
   snapshot.activeTurn = null;
   snapshot.state.isStreaming = false;
-  await page.getByRole("button", { name: "Plan", exact: true }).click();
+  const modelEffortControl = agentComposer.getByRole("button", {
+    name: "Model and effort: GPT-5.6, High",
+  });
+  await expect(modelEffortControl).toBeEnabled();
+  await modelEffortControl.click();
+  await expect(
+    page.getByRole("button", { name: "Scroll to bottom" }),
+  ).toHaveCount(0);
+  const modelEffortMenu = page.getByRole("menu", {
+    name: "Model and effort",
+  });
+  await expect(
+    modelEffortMenu.getByRole("menuitem", { name: /Model.*GPT-5\.6/u }),
+  ).toBeVisible();
+  await modelEffortMenu
+    .getByRole("menuitem", { name: /Effort.*High/u })
+    .click();
+  await expect(
+    modelEffortMenu.getByRole("menuitem", {
+      name: "Back to model and effort",
+    }),
+  ).toBeVisible();
+  await expect(
+    modelEffortMenu.getByRole("menuitem", { name: "Low" }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("runtime-model-effort-mobile.png"),
+    fullPage: true,
+  });
+  await modelEffortMenu.getByRole("menuitem", { name: "Low" }).click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "set_thinking_level",
+    level: "low",
+  });
+
+  await composer.fill("/plan");
+  await expect(
+    page
+      .getByRole("listbox", { name: "Codex commands" })
+      .getByRole("option", { name: /\/plan/u }),
+  ).toBeVisible();
+  await page.keyboard.press("Enter");
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "prompt",
+    message: "/plan",
+  });
+  await page.evaluate((model) => {
+    const controls = (
+      window as unknown as {
+        __agentRuntimeControls: {
+          emit: (envelope: unknown) => void;
+        };
+      }
+    ).__agentRuntimeControls;
+    controls.emit({
+      sequence: 4,
+      type: "runtime_event",
+      data: {
+        type: "config_update",
+        model,
+        thinkingLevel: "low",
+        collaborationMode: "plan",
+        collaborationModes: ["default", "plan"],
+        fastModeEnabled: false,
+        fastModeAvailable: true,
+      },
+    });
+  }, imageModel);
+  const planModeControl = agentComposer.getByRole("button", {
+    name: "Plan mode",
+  });
+  await expect(planModeControl).toBeVisible();
+  await planModeControl.click();
+  await page
+    .getByRole("menu", { name: "Plan mode" })
+    .getByRole("menuitem", { name: "Exit plan mode" })
+    .click();
   await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
     type: "set_collaboration_mode",
-    mode: "plan",
+    mode: "default",
   });
-  await page.getByRole("button", { name: "Fast" }).click();
+  await expect(planModeControl).toHaveCount(0);
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await agentComposer
+    .getByRole("button", {
+      name: "Model and effort: GPT-5.6, Low",
+    })
+    .click();
+  await page
+    .getByRole("menu", { name: "Model and effort" })
+    .getByRole("menuitem", { name: /Model.*GPT-5\.6/u })
+    .click();
+  await expect(
+    page
+      .getByRole("menu", { name: "Model and effort" })
+      .getByRole("menuitem", { name: "Back to model and effort" }),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByRole("menu", { name: "Model and effort" })
+      .getByRole("menuitem", { name: /GPT-5.6 Mini/u }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("runtime-model-effort-desktop.png"),
+    fullPage: true,
+  });
+  await page
+    .getByRole("menu", { name: "Model and effort" })
+    .getByRole("menuitem", { name: /GPT-5.6 Mini/u })
+    .click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "set_model",
+    provider: "codex",
+    modelId: "gpt-5.6-mini",
+  });
+  await agentComposer
+    .getByRole("button", { name: "Fast", exact: true })
+    .click();
   await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
     type: "set_fast_mode",
     enabled: true,

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -539,6 +539,11 @@ describe("CodexRuntimeClient", () => {
       source: "builtin",
       argumentHint: "<objective>|pause|resume|clear",
     });
+    await expect(client.getCommands()).resolves.toContainEqual({
+      name: "plan",
+      description: "Toggle Plan mode",
+      source: "builtin",
+    });
 
     await client.setCollaborationMode("plan");
     await client.setFastMode(true);

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -2337,6 +2337,15 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   private availableCommands(): AgentSlashCommand[] {
     return [
+      ...(this.availableCollaborationModes().includes("plan")
+        ? [
+            {
+              name: "plan",
+              description: "Toggle Plan mode",
+              source: "builtin" as const,
+            },
+          ]
+        : []),
       ...(this.goalsSupported
         ? [
             {

--- a/apps/web/lib/agents/providers/codex.test.ts
+++ b/apps/web/lib/agents/providers/codex.test.ts
@@ -63,4 +63,38 @@ describe("codexProviderAdapter", () => {
       ),
     ).toThrow("does not support durable goals");
   });
+
+  it("toggles supported Plan mode out of band", () => {
+    const state = {
+      collaborationMode: "default",
+      collaborationModes: ["default", "plan"],
+    };
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/plan" },
+        state,
+      ),
+    ).toEqual({
+      type: "set_collaboration_mode",
+      mode: "plan",
+    });
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/plan" },
+        { ...state, collaborationMode: "plan" },
+      ),
+    ).toEqual({
+      type: "set_collaboration_mode",
+      mode: "default",
+    });
+  });
+
+  it("rejects /plan when Plan mode is unavailable", () => {
+    expect(() =>
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/plan" },
+        { collaborationModes: ["default"] },
+      ),
+    ).toThrow("does not provide Plan mode");
+  });
 });

--- a/apps/web/lib/agents/providers/codex.ts
+++ b/apps/web/lib/agents/providers/codex.ts
@@ -80,6 +80,26 @@ function normalizeCommand(
   if (
     command.type === "prompt" &&
     !command.images?.length &&
+    /^\/plan(?:[^\S\n]+([^\n]*))?$/iu.test(command.message.trim())
+  ) {
+    const argumentsText =
+      /^\/plan(?:[^\S\n]+([^\n]*))?$/iu.exec(command.message.trim())?.[1]?.trim() ??
+      "";
+    if (argumentsText) throw new Error("Usage: /plan");
+    const modes = Array.isArray(state.collaborationModes)
+      ? state.collaborationModes
+      : [];
+    if (!modes.includes("default") || !modes.includes("plan")) {
+      throw new Error("This Codex installation does not provide Plan mode.");
+    }
+    return {
+      type: "set_collaboration_mode",
+      mode: state.collaborationMode === "plan" ? "default" : "plan",
+    };
+  }
+  if (
+    command.type === "prompt" &&
+    !command.images?.length &&
     /^\/usage(?:\s*)$/iu.test(command.message)
   ) {
     return { type: "show_usage" };

--- a/apps/web/lib/agents/runtime/registry.test.ts
+++ b/apps/web/lib/agents/runtime/registry.test.ts
@@ -420,6 +420,15 @@ describe("Agent session runtime", () => {
 
   it("runs Codex goals and plan handoff through native runtime controls", async () => {
     const client = new FakeAgentClient();
+    const codexProviderState = {
+      ...idleProviderState,
+      goalsSupported: true,
+      collaborationMode: "default",
+      collaborationModes: ["default", "plan"],
+      fastModeAvailable: true,
+      fastModeEnabled: false,
+    };
+    client.getState.mockResolvedValue(codexProviderState);
     const runtime = new AgentSessionRuntime(
       "session",
       "user",
@@ -450,8 +459,8 @@ describe("Agent session runtime", () => {
     expect(client.prompt).not.toHaveBeenCalled();
 
     await runtime.command({
-      type: "set_collaboration_mode",
-      mode: "plan",
+      type: "prompt",
+      message: "/plan",
     });
     await runtime.command({ type: "set_fast_mode", enabled: true });
     expect(client.setCollaborationMode).toHaveBeenCalledWith("plan");


### PR DESCRIPTION
## Summary

- move model, reasoning-effort, Plan mode, Fast mode, and context-usage controls from the agent header into the composer
- add responsive compact controls and keep message scrolling unobstructed while composer menus are open
- expose `/plan` as a native Codex command that toggles Plan mode without adding a prompt turn
- expand production browser coverage for mobile and desktop composer controls

## Scope

This PR contains the agent composer controls work only. The automated model-catalog refresh was handled separately in #147. It does not create a release or tag.

## Validation

- full monorepo ESLint
- strict web TypeScript
- 494 web tests, 19 connector tests, and 9 site tests
- production standalone Playwright suite: 9 passed, 4 intentionally skipped
- desktop and mobile Playwright screenshots reviewed
- complete Docker runner-image build
