### PR TITLE
chore: prepare v0.13.2 release

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.1}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.2}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- update the default OvertChat app image in `compose.yml` from `0.13.1` to `0.13.2`

## Validation

The release candidate on the parent `main` commit passed:

- full monorepo ESLint and strict web TypeScript
- 494 web tests, 19 connector tests, and 9 site tests
- production standalone Playwright suite: 9 passed, 4 intentionally skipped
- desktop and mobile composer-control screenshots reviewed
- complete Docker runner-image build
- GitHub Validate and Web E2E Smoke workflows on the feature PR

The release bump also passes `docker compose config --quiet`.
