### PR TITLE
ci: update Docker actions for Node 24

### DIFF
--- a/.github/workflows/app-image.yml
+++ b/.github/workflows/app-image.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/overtchat-app
           tags: |
@@ -53,7 +53,7 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/stt-images.yml
+++ b/.github/workflows/stt-images.yml
@@ -21,24 +21,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/overtchat-stt-cpu
           tags: |
             type=match,pattern=stt-v(.*),group=1
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./stt
           file: ./stt/Dockerfile.cpu
@@ -57,23 +57,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/overtchat-stt-gpu
           tags: |
             type=match,pattern=stt-v(.*),group=1
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./stt
           file: ./stt/Dockerfile.gpu


### PR DESCRIPTION
## Summary

- update Docker setup, login, metadata, and build actions to their Node 24 major versions
- apply the upgrades consistently to the app image and both STT image jobs
- remove the Node 20 deprecation annotations from future image builds

## Validation

- parsed both workflow files as YAML
- confirmed all five referenced major tags declare `using: 'node24'`
- confirmed the existing workflow inputs remain supported by the new action majors
- `git diff --check`

The jobs run on GitHub-hosted `ubuntu-latest`, which satisfies the new actions' runner requirement.
