### PR TITLE
feat(web): improve agent timeline

### DIFF
--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -11,7 +11,6 @@ import {
   FileText,
   Globe,
   Loader2,
-  MessageSquareText,
   Search,
   Terminal,
   Users,
@@ -38,7 +37,7 @@ export type AgentRunActivity =
   | "compacting"
   | "reconnecting";
 
-function formatElapsed(milliseconds: number): string {
+export function formatAgentElapsed(milliseconds: number): string {
   const seconds = Math.max(0, Math.floor(milliseconds / 1000));
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
@@ -64,14 +63,7 @@ function useElapsed(startedAt: number | null): string | null {
 
   return startedAt === null
     ? null
-    : formatElapsed(Math.max(0, now - startedAt));
-}
-
-export function agentActivityOwnsLiveStatus(
-  entries: AgentActivityEntry[],
-  active: boolean,
-): boolean {
-  return active && describeAgentActivity(entries, true).status === "running";
+    : formatAgentElapsed(Math.max(0, now - startedAt));
 }
 
 export function AgentRunIndicator({
@@ -117,19 +109,30 @@ export function AgentRunIndicator({
 export function AgentActivityGroup({
   entries,
   active,
-  startedAt,
-  durationMs,
 }: {
   entries: AgentActivityEntry[];
   active: boolean;
-  startedAt: number | null;
-  durationMs: number | null;
 }) {
   const presentation = describeAgentActivity(entries, active);
   const hasError = presentation.status === "failed";
-  const live = active && presentation.status === "running";
-  const elapsed = useElapsed(live ? startedAt : null);
   const [open, setOpen] = useState(hasError);
+  const singleEntry = entries.length === 1 ? entries[0] : null;
+  if (singleEntry?.type === "tool") {
+    return (
+      <div className="text-xs" data-testid="agent-activity-group">
+        <ToolActivityStep tool={singleEntry.tool} active={active} showIcon />
+      </div>
+    );
+  }
+  if (singleEntry?.type === "subagent") {
+    return (
+      <div className="text-xs" data-testid="agent-activity-group">
+        <SubagentActivityStep activity={singleEntry.activity} showIcon />
+      </div>
+    );
+  }
+
+  const live = active && presentation.status === "running";
   const hasDetailedSteps = entries.some(
     (entry) =>
       entry.type === "tool" ||
@@ -142,10 +145,6 @@ export function AgentActivityGroup({
   ).length;
   const progress =
     live && completedCount > 0 ? `${completedCount} completed` : null;
-  const completedDuration =
-    presentation.status === "completed" && durationMs !== null
-      ? formatElapsed(durationMs)
-      : null;
   const headerLabel =
     open && live && hasDetailedSteps ? "Activity" : presentation.label;
   const headerSecondary =
@@ -157,9 +156,6 @@ export function AgentActivityGroup({
         type="button"
         onClick={() => setOpen((current) => !current)}
         aria-expanded={open}
-        aria-label={
-          completedDuration ? `Worked for ${completedDuration}` : undefined
-        }
         className="group flex min-h-8 w-full items-center gap-2 rounded-md py-1 pr-1 text-left text-muted-foreground motion-colors hover:text-foreground"
       >
         <ActivityIcon entries={entries} status={presentation.status} />
@@ -170,9 +166,7 @@ export function AgentActivityGroup({
               live && !open && motionClasses.shimmer,
             )}
           >
-            {completedDuration
-              ? `Worked for ${completedDuration}`
-              : headerLabel}
+            {headerLabel}
           </span>
           {headerSecondary && (
             <span className="min-w-0 truncate font-mono text-[11px]">
@@ -184,9 +178,6 @@ export function AgentActivityGroup({
           <span className="hidden shrink-0 tabular-nums text-[11px] sm:inline">
             {progress}
           </span>
-        )}
-        {elapsed && (
-          <span className="shrink-0 tabular-nums text-[11px]">{elapsed}</span>
         )}
         <ChevronRight
           className={cn(
@@ -240,24 +231,6 @@ function ActivityStep({
   last: boolean;
   showDetailedStep: boolean;
 }) {
-  if (entry.type === "commentary") {
-    if (!showDetailedStep) {
-      return (
-        <div className={cn("min-w-0", last ? "pb-1" : "pb-4")}>
-          <ThinkingContent content={entry.content} />
-        </div>
-      );
-    }
-    return (
-      <TimelineStep
-        icon={<MessageSquareText className="size-3.5" />}
-        last={last}
-      >
-        <ThinkingContent content={entry.content} />
-      </TimelineStep>
-    );
-  }
-
   if (entry.type === "thinking") {
     if (!showDetailedStep) {
       return (
@@ -307,11 +280,13 @@ function ActivityStep({
 
 function SubagentActivityStep({
   activity,
+  showIcon = false,
 }: {
   activity: Extract<
     AgentActivityEntry,
     { type: "subagent" }
   >["activity"];
+  showIcon?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const running = ["inProgress", "pendingInit", "running"].includes(
@@ -349,6 +324,9 @@ function SubagentActivityStep({
           canOpen && "cursor-pointer hover:text-foreground",
         )}
       >
+        {showIcon && (
+          <Users className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+        )}
         <span className="min-w-0 flex-1 font-medium text-foreground">
           {label}
         </span>
@@ -443,9 +421,11 @@ function TimelineStep({
 function ToolActivityStep({
   tool,
   active,
+  showIcon = false,
 }: {
   tool: AgentToolActivity;
   active: boolean;
+  showIcon?: boolean;
 }) {
   const presentation = describeAgentTool(tool);
   const status = agentToolStatus(tool, active);
@@ -466,6 +446,12 @@ function ToolActivityStep({
           canOpen && "cursor-pointer hover:text-foreground",
         )}
       >
+        {showIcon && (
+          <ToolCategoryIcon
+            category={presentation.category}
+            className="mt-0.5 size-3.5 shrink-0 text-muted-foreground"
+          />
+        )}
         <span className="min-w-0 flex flex-1 items-baseline gap-2">
           <span className="shrink-0 font-medium text-foreground">
             {toolStepLabel(presentation.category, status)}
@@ -750,11 +736,6 @@ function ActivityIcon({
   if (categories.size === 0) {
     if (entries.some((entry) => entry.type === "subagent")) {
       return <Users className="size-3.5 shrink-0 text-muted-foreground" />;
-    }
-    if (entries.some((entry) => entry.type === "commentary")) {
-      return (
-        <MessageSquareText className="size-3.5 shrink-0 text-muted-foreground" />
-      );
     }
     return <Brain className="size-3.5 shrink-0 text-muted-foreground" />;
   }

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { writeText as clipboardWriteText } from "clipboard-polyfill";
 import { useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
 import { useStickToBottom } from "use-stick-to-bottom";
 import {
   AlertTriangle,
+  Check,
   ChevronDown,
+  Copy,
   Info,
   ListChecks,
   Minimize2,
@@ -15,6 +18,7 @@ import {
   Pencil,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
 import {
   STREAMDOWN_DEFAULT_REMARK_PLUGINS,
   STREAMDOWN_PLUGINS,
@@ -29,7 +33,7 @@ import { cn } from "@/lib/utils";
 import {
   AgentActivityGroup,
   AgentRunIndicator,
-  agentActivityOwnsLiveStatus,
+  formatAgentElapsed,
   type AgentRunActivity,
 } from "./AgentActivity";
 
@@ -104,11 +108,6 @@ export function AgentMessageList({
     () => projectAgentTranscript(messages),
     [messages],
   );
-  const trailingItem = transcript.at(-1);
-  const activityHasLiveStep =
-    activity === "working" &&
-    trailingItem?.type === "activity" &&
-    agentActivityOwnsLiveStatus(trailingItem.entries, streaming);
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
@@ -129,22 +128,39 @@ export function AgentMessageList({
               </p>
             </div>
           ) : (
-            <div className="space-y-6">
-              {transcript.map((item, index) => (
-                <AgentTranscriptRow
-                  key={item.key}
-                  item={item}
-                  active={streaming && index === transcript.length - 1}
-                  activityStartedAt={activityStartedAt}
-                  canEditMessages={canEditMessages}
-                  canForkMessages={canForkMessages}
-                  actionsDisabled={actionsDisabled}
-                  onEditMessage={onEditMessage}
-                  onForkMessage={onForkMessage}
-                  onImplementPlan={onImplementPlan}
-                />
-              ))}
-              {activity && !activityHasLiveStep && (
+            <div className="flex flex-col">
+              {transcript.map((item, index) => {
+                const previous = transcript[index - 1];
+                const compact =
+                  previous &&
+                  (item.type === "activity" ||
+                    previous.type === "activity" ||
+                    item.type === "turn_footer");
+                return (
+                  <div
+                    key={item.key}
+                    className={cn(
+                      index > 0 && (compact ? "mt-3" : "mt-6"),
+                      item.type === "activity" &&
+                        previous?.type === "activity" &&
+                        "mt-1",
+                      item.type === "turn_footer" && "mt-2",
+                    )}
+                  >
+                    <AgentTranscriptRow
+                      item={item}
+                      active={streaming && index === transcript.length - 1}
+                      canEditMessages={canEditMessages}
+                      canForkMessages={canForkMessages}
+                      actionsDisabled={actionsDisabled}
+                      onEditMessage={onEditMessage}
+                      onForkMessage={onForkMessage}
+                      onImplementPlan={onImplementPlan}
+                    />
+                  </div>
+                );
+              })}
+              {activity && (
                 <AgentRunIndicator
                   activity={activity}
                   startedAt={activityStartedAt}
@@ -180,7 +196,6 @@ export function AgentMessageList({
 function AgentTranscriptRow({
   item,
   active,
-  activityStartedAt,
   canEditMessages,
   canForkMessages,
   actionsDisabled,
@@ -190,7 +205,6 @@ function AgentTranscriptRow({
 }: {
   item: AgentTranscriptItem;
   active: boolean;
-  activityStartedAt: number | null;
   canEditMessages: boolean;
   canForkMessages: boolean;
   actionsDisabled: boolean;
@@ -228,6 +242,16 @@ function AgentTranscriptRow({
   if (item.type === "assistant_error") {
     return <AgentErrorNotice error={item.error} />;
   }
+  if (item.type === "turn_footer") {
+    return (
+      <AgentTurnFooter
+        item={item}
+        canFork={canForkMessages}
+        actionsDisabled={actionsDisabled}
+        onForkMessage={onForkMessage}
+      />
+    );
+  }
   if (item.type === "plan") {
     return (
       <AgentPlanCard
@@ -237,13 +261,78 @@ function AgentTranscriptRow({
       />
     );
   }
+  return <AgentActivityGroup entries={item.entries} active={active} />;
+}
+
+function AgentTurnFooter({
+  item,
+  canFork,
+  actionsDisabled,
+  onForkMessage,
+}: {
+  item: Extract<AgentTranscriptItem, { type: "turn_footer" }>;
+  canFork: boolean;
+  actionsDisabled: boolean;
+  onForkMessage: (messageId: string) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const showFork = canFork && item.messageId !== null;
+
+  if (!item.text && !showFork && item.durationMs === null) return null;
+
+  function copyTurn() {
+    void clipboardWriteText(item.text)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1_200);
+      })
+      .catch(() => {
+        toast.error({
+          title: "Failed to copy",
+          description: "Clipboard access was denied by the browser.",
+        });
+      });
+  }
+
   return (
-    <AgentActivityGroup
-      entries={item.entries}
-      active={active}
-      startedAt={activityStartedAt}
-      durationMs={item.durationMs}
-    />
+    <div
+      className="flex min-h-7 items-center gap-1 text-xs text-muted-foreground"
+      data-testid="agent-turn-footer"
+    >
+      {item.text && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7"
+          aria-label={copied ? "Copied response" : "Copy response"}
+          title={copied ? "Copied" : "Copy response"}
+          disabled={actionsDisabled}
+          onClick={copyTurn}
+        >
+          {copied ? <Check /> : <Copy />}
+        </Button>
+      )}
+      {showFork && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-7"
+          aria-label="Fork from this response"
+          title="Fork from this response"
+          disabled={actionsDisabled}
+          onClick={() => onForkMessage(item.messageId!)}
+        >
+          <GitBranch />
+        </Button>
+      )}
+      {item.durationMs !== null && (
+        <span className="ml-1 tabular-nums">
+          Worked for {formatAgentElapsed(item.durationMs)}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -120,23 +120,56 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
         timestamp: 1,
       },
       {
+        id: "commentary",
         role: "assistant",
         content: [
           {
-            type: "commentary",
+            id: "commentary",
+            type: "text",
+            phase: "commentary",
             text: "I'm auditing the release state before merging anything.",
           },
+        ],
+        timestamp: 2,
+        overtchatTurnId: "turn-1",
+        overtchatTurnBoundaryId: "turn-1:assistant",
+      },
+      {
+        id: "reasoning",
+        role: "assistant",
+        content: [
           {
+            id: "reasoning",
             type: "thinking",
             thinking: "I should inspect the runtime before responding.",
           },
+        ],
+        timestamp: 2.1,
+        overtchatTurnId: "turn-1",
+        overtchatTurnBoundaryId: "turn-1:assistant",
+      },
+      {
+        id: "answer",
+        role: "assistant",
+        content: [
           {
+            id: "answer",
             type: "text",
             text: "I will inspect the runtime.",
           },
         ],
-        timestamp: 2,
-        overtchatActivityDurationMs: 246_000,
+        timestamp: 2.2,
+        overtchatTurnId: "turn-1",
+        overtchatTurnBoundaryId: "turn-1:assistant",
+      },
+      {
+        id: "turn-1:footer",
+        role: "turnFooter",
+        messageId: "turn-1:assistant",
+        content:
+          "I'm auditing the release state before merging anything.\n\nI will inspect the runtime.",
+        durationMs: 246_000,
+        timestamp: 2.3,
       },
       {
         role: "assistant",
@@ -598,19 +631,21 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(sessionActivity).toBeVisible();
 
   const genericActivity = page.getByTestId("agent-run-activity");
-  await expect(genericActivity).toHaveCount(0);
-  const completedWork = page.getByRole("button", {
-    name: "Worked for 4m 6s",
-    exact: true,
-  });
-  await completedWork.click();
+  await expect(genericActivity).toBeVisible();
+  await expect(genericActivity).toContainText(/\d+s/u);
   await expect(
     page.getByText("I'm auditing the release state before merging anything."),
   ).toBeVisible();
+  const completedTurn = page.getByTestId("agent-turn-footer");
+  await expect(completedTurn).toContainText("Worked for 4m 6s");
+  await expect(
+    completedTurn.getByRole("button", { name: "Copy response" }),
+  ).toBeVisible();
+  const thinking = page.getByRole("button", { name: "Thoughts" });
+  await thinking.click();
   await expect(
     page.getByText("I should inspect the runtime before responding."),
   ).toBeVisible();
-  await expect(page.getByText("Thinking", { exact: true })).toBeVisible();
   await expect(
     page.getByText("I will inspect the runtime.", { exact: true }),
   ).toBeVisible();
@@ -621,19 +656,13 @@ test("shows durable turn activity without changing completed tool status", async
     "Finish Codex parity",
   );
   const liveActivity = page.getByRole("button", {
-    name: /Searching.*runtimeStatus/u,
+    name: "Search: runtimeStatus, running",
   });
   await expect(liveActivity).toBeVisible();
-  await expect(liveActivity).toContainText(/\d+s/u);
-  await expect(liveActivity).toContainText("2 completed");
   await page.screenshot({
     path: testInfo.outputPath("runtime-activity-collapsed-desktop.png"),
     fullPage: true,
   });
-  await liveActivity.click();
-  await expect(
-    page.getByRole("button", { name: /Activity.*2 completed/u }),
-  ).toBeVisible();
   const completedCommand = page.getByRole("button", {
     name: "Terminal: printf done, completed",
   });
@@ -754,7 +783,7 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(
     page.getByRole("button", { name: "Stopping Codex" }),
   ).toBeVisible();
-  await expect(genericActivity).toHaveCount(0, { timeout: 2_000 });
+  await expect(genericActivity).toContainText("Working", { timeout: 2_000 });
   await expect(page.getByRole("button", { name: "Stop Codex" })).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("runtime-activity-desktop.png"),

--- a/apps/web/lib/agents/codex/client.test.ts
+++ b/apps/web/lib/agents/codex/client.test.ts
@@ -18,6 +18,25 @@ vi.mock("@/lib/agents/runtime/materialize-images", () => ({
 
 type Listener<T> = (value: T) => void;
 
+function assistantParts(messages: unknown[]): Array<Record<string, unknown>> {
+  return messages.flatMap((message) => {
+    if (
+      !message ||
+      typeof message !== "object" ||
+      Reflect.get(message, "role") !== "assistant"
+    ) {
+      return [];
+    }
+    const content = Reflect.get(message, "content");
+    return Array.isArray(content)
+      ? content.filter(
+          (part): part is Record<string, unknown> =>
+            Boolean(part) && typeof part === "object",
+        )
+      : [];
+  });
+}
+
 class FakeCodexServer {
   readonly requests: Array<{ method: string; params: unknown }> = [];
   readonly responses: Array<{ id: string | number; result: unknown }> = [];
@@ -691,13 +710,7 @@ describe("CodexRuntimeClient", () => {
     });
 
     const messages = (await client.getMessages()).messages;
-    const assistant = messages.find(
-      (message) =>
-        message &&
-        typeof message === "object" &&
-        Reflect.get(message, "role") === "assistant",
-    ) as { content: Array<Record<string, unknown>> };
-    expect(assistant.content).toEqual(
+    expect(assistantParts(messages)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: "subagent",
@@ -713,7 +726,7 @@ describe("CodexRuntimeClient", () => {
           type: "plan",
           explanation: "Two focused steps.",
         }),
-        { type: "text", text: "Ready." },
+        expect.objectContaining({ type: "text", text: "Ready." }),
       ]),
     );
     await expect(client.getState()).resolves.toMatchObject({
@@ -885,19 +898,35 @@ describe("CodexRuntimeClient", () => {
           content: "Inspect the tests",
         }),
         expect.objectContaining({
+          id: "command-1",
           role: "assistant",
-          content: expect.arrayContaining([
+          content: [
             expect.objectContaining({
               type: "toolCall",
               name: "bash",
             }),
-            { type: "text", text: "Everything passes." },
-          ]),
+          ],
+        }),
+        expect.objectContaining({
+          id: "assistant-1",
+          role: "assistant",
+          content: [
+            expect.objectContaining({
+              type: "text",
+              text: "Everything passes.",
+            }),
+          ],
         }),
         expect.objectContaining({
           role: "toolResult",
           toolCallId: "command-1",
           isError: false,
+        }),
+        expect.objectContaining({
+          id: "turn-1:footer",
+          role: "turnFooter",
+          content: "Everything passes.",
+          durationMs: 1_000,
         }),
       ]),
     });
@@ -973,6 +1002,29 @@ describe("CodexRuntimeClient", () => {
         exitCode: 0,
       },
     });
+    server.emit("item/completed", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "commentary-2",
+        type: "agentMessage",
+        phase: "commentary",
+        text: "The image built; I'm checking its contents.",
+      },
+    });
+    server.emit("item/completed", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "command-2",
+        type: "commandExecution",
+        command: "docker inspect image",
+        cwd: "/workspace",
+        status: "completed",
+        aggregatedOutput: "healthy\n",
+        exitCode: 0,
+      },
+    });
     server.emit("item/started", {
       threadId: "thread-1",
       turnId: "turn-1",
@@ -1008,34 +1060,58 @@ describe("CodexRuntimeClient", () => {
     });
 
     const { messages } = await client.getMessages();
-    const assistant = messages.find(
-      (message) =>
-        message &&
-        typeof message === "object" &&
-        Reflect.get(message, "id") === "turn-1:assistant",
+    expect(assistantParts(messages)).toEqual([
+      expect.objectContaining({
+        id: "commentary-1",
+        type: "text",
+        phase: "commentary",
+        text: "I'm checking the release image.",
+      }),
+      expect.objectContaining({
+        type: "toolCall",
+        id: "command-1",
+        name: "bash",
+      }),
+      expect.objectContaining({
+        id: "commentary-2",
+        type: "text",
+        phase: "commentary",
+        text: "The image built; I'm checking its contents.",
+      }),
+      expect.objectContaining({
+        type: "toolCall",
+        id: "command-2",
+        name: "bash",
+      }),
+      expect.objectContaining({
+        id: "final-1",
+        type: "text",
+        text: "The image is ready.",
+      }),
+    ]);
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        id: "turn-1:footer",
+        role: "turnFooter",
+        durationMs: 246_000,
+        content:
+          "I'm checking the release image.\n\nThe image built; I'm checking its contents.\n\nThe image is ready.",
+      }),
     );
-    expect(assistant).toMatchObject({
-      role: "assistant",
-      overtchatActivityDurationMs: 246_000,
-      content: [
-        {
-          type: "commentary",
-          text: "I'm checking the release image.",
-        },
-        {
-          type: "toolCall",
-          id: "command-1",
-          name: "bash",
-        },
-        { type: "text", text: "The image is ready." },
-      ],
-    });
     expect(
       messages.filter(
         (message) =>
           message &&
           typeof message === "object" &&
           Reflect.get(message, "toolCallId") === "command-1",
+      ),
+    ).toHaveLength(1);
+    expect(
+      messages.filter(
+        (message) =>
+          message &&
+          typeof message === "object" &&
+          Reflect.get(message, "toolCallId") === "command-2",
       ),
     ).toHaveLength(1);
   });
@@ -1061,16 +1137,30 @@ describe("CodexRuntimeClient", () => {
           content: "Resume this thread",
         }),
         expect.objectContaining({
-          id: "turn-history:assistant",
+          id: "commentary-history",
           role: "assistant",
-          overtchatActivityDurationMs: 1_000,
           content: [
-            {
-              type: "commentary",
+            expect.objectContaining({
+              type: "text",
+              phase: "commentary",
               text: "I am restoring the native thread.",
-            },
-            { type: "text", text: "History restored." },
+            }),
           ],
+        }),
+        expect.objectContaining({
+          id: "assistant-history",
+          role: "assistant",
+          content: [
+            expect.objectContaining({
+              type: "text",
+              text: "History restored.",
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          id: "turn-history:footer",
+          role: "turnFooter",
+          durationMs: 1_000,
         }),
       ]),
     });
@@ -1176,7 +1266,14 @@ describe("CodexRuntimeClient", () => {
       (message) =>
         message &&
         typeof message === "object" &&
-        Reflect.get(message, "id") === "turn-root:assistant",
+        Reflect.get(message, "role") === "assistant" &&
+        Array.isArray(Reflect.get(message, "content")) &&
+        Reflect.get(message, "content").some(
+          (part: unknown) =>
+            part &&
+            typeof part === "object" &&
+            Reflect.get(part, "type") === "subagent",
+        ),
     ) as { content: Array<Record<string, unknown>> };
     expect(assistant.content).toContainEqual(
       expect.objectContaining({
@@ -1247,7 +1344,12 @@ describe("CodexRuntimeClient", () => {
           content: "Resume this thread",
         }),
         expect.objectContaining({
-          id: "turn-history:assistant",
+          id: "assistant-history",
+          role: "assistant",
+        }),
+        expect.objectContaining({
+          id: "turn-history:footer",
+          role: "turnFooter",
         }),
       ]),
     });
@@ -1763,10 +1865,21 @@ describe("CodexRuntimeClient", () => {
       params: { threadId: "thread-fork" },
     });
     await expect(client.getMessages()).resolves.toMatchObject({
-      messages: [
-        { id: "user-history", role: "user" },
-        { id: "turn-history:assistant", role: "assistant" },
-      ],
+      messages: expect.arrayContaining([
+        expect.objectContaining({ id: "user-history", role: "user" }),
+        expect.objectContaining({
+          id: "commentary-history",
+          role: "assistant",
+        }),
+        expect.objectContaining({
+          id: "assistant-history",
+          role: "assistant",
+        }),
+        expect.objectContaining({
+          id: "turn-history:footer",
+          role: "turnFooter",
+        }),
+      ]),
     });
   });
 
@@ -1839,10 +1952,21 @@ describe("CodexRuntimeClient", () => {
       params: { threadId: "thread-fork" },
     });
     await expect(client.getMessages()).resolves.toMatchObject({
-      messages: [
-        { id: "user-history", role: "user" },
-        { id: "turn-history:assistant", role: "assistant" },
-      ],
+      messages: expect.arrayContaining([
+        expect.objectContaining({ id: "user-history", role: "user" }),
+        expect.objectContaining({
+          id: "commentary-history",
+          role: "assistant",
+        }),
+        expect.objectContaining({
+          id: "assistant-history",
+          role: "assistant",
+        }),
+        expect.objectContaining({
+          id: "turn-history:footer",
+          role: "turnFooter",
+        }),
+      ]),
     });
   });
 

--- a/apps/web/lib/agents/codex/client.ts
+++ b/apps/web/lib/agents/codex/client.ts
@@ -410,6 +410,7 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
     turn.completedAt === null ? null : turn.completedAt * 1_000;
   const messages: unknown[] = [];
   const assistantContent: UnknownRecord[] = [];
+  const assistantOrders: number[] = [];
   const results: unknown[] = [];
   const planItems = turn.items.filter((item) => item.type === "plan");
   const structuredPlan = planItems.findLast((item) =>
@@ -420,8 +421,12 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
     structuredPlan ??
     null;
   let planAdded = false;
+  const pushAssistantContent = (content: UnknownRecord, order: number) => {
+    assistantContent.push(content);
+    assistantOrders.push(order);
+  };
 
-  for (const item of turn.items) {
+  for (const [itemIndex, item] of turn.items.entries()) {
     if (item.type === "userMessage") {
       const text = itemText(item);
       const images = Array.isArray(item.overtchatImages)
@@ -453,7 +458,7 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
                   ...images,
                 ]
               : text,
-          timestamp: startedAt,
+          timestamp: startedAt + itemIndex,
         });
       }
       continue;
@@ -462,24 +467,25 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
       const text = stringOf(item, "text") ?? "";
       const phase = stringOf(item, "phase");
       if (text) {
-        assistantContent.push(
-          phase === "commentary"
-            ? { type: "commentary", text }
-            : { type: "text", text },
-        );
+        pushAssistantContent({
+          type: "text",
+          id: item.id,
+          text,
+          ...(phase ? { phase } : {}),
+        }, itemIndex);
       }
       continue;
     }
     if (item.type === "plan") {
       if (!planAdded && item.id === selectedPlan?.id) {
         const structured = structuredPlan ?? selectedPlan;
-        assistantContent.push({
+        pushAssistantContent({
           type: "plan",
           id: selectedPlan.id,
           text: stringOf(selectedPlan, "text") ?? "",
           explanation: stringOf(structured, "explanation"),
           steps: Array.isArray(structured?.steps) ? structured.steps : [],
-        });
+        }, itemIndex);
         planAdded = true;
       }
       continue;
@@ -492,7 +498,13 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
         ? item.content.filter((part): part is string => typeof part === "string")
         : [];
       const thinking = [...summary, ...content].join("\n\n");
-      if (thinking) assistantContent.push({ type: "thinking", thinking });
+      if (thinking) {
+        pushAssistantContent({
+          type: "thinking",
+          id: item.id,
+          thinking,
+        }, itemIndex);
+      }
       continue;
     }
     if (item.type === "collabAgentToolCall") {
@@ -502,7 +514,7 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
           )
         : [];
       const states = recordOf(item.agentsStates);
-      assistantContent.push({
+      pushAssistantContent({
         type: "subagent",
         id: item.id,
         action: stringOf(item, "tool") ?? "agent",
@@ -571,11 +583,11 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
               return [];
             })
           : [],
-      });
+      }, itemIndex);
       continue;
     }
     if (item.type === "subAgentActivity") {
-      assistantContent.push({
+      pushAssistantContent({
         type: "subagent",
         id: item.id,
         action: stringOf(item, "kind") ?? "activity",
@@ -591,7 +603,7 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
             message: stringOf(item, "agentPath"),
           },
         ],
-      });
+      }, itemIndex);
       continue;
     }
     if (item.type === "contextCompaction") {
@@ -600,19 +612,19 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
         role: "custom",
         display: true,
         content: "Conversation context compacted.",
-        timestamp: startedAt + messages.length + 1,
+        timestamp: startedAt + itemIndex,
       });
       continue;
     }
     const tool = itemTool(item);
     if (!tool) continue;
-    assistantContent.push({
+    pushAssistantContent({
       type: "toolCall",
       id: item.id,
       name: tool.name,
       arguments: tool.args,
       terminalInputs: tool.terminalInputs,
-    });
+    }, itemIndex);
     results.push({
       id: `${item.id}:result`,
       role: "toolResult",
@@ -621,30 +633,50 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
       content: [{ type: "text", text: tool.output }],
       overtchatPartial: tool.partial,
       isError: tool.isError,
-      timestamp: startedAt + results.length + 2,
+      timestamp: startedAt + itemIndex,
     });
   }
 
-  if (assistantContent.length > 0) {
-    messages.push({
-      id: `${turn.id}:assistant`,
+  messages.push(
+    ...assistantContent.map((content, index) => ({
+      id:
+        typeof content.id === "string"
+          ? content.id
+          : `${turn.id}:assistant:${index}`,
       role: "assistant",
-      content: assistantContent,
-      timestamp: startedAt + 1,
-      ...(completedAt !== null
-        ? {
-            overtchatActivityDurationMs: Math.max(
-              0,
-              completedAt - startedAt,
-            ),
-          }
-        : {}),
+      content: [content],
+      timestamp: startedAt + assistantOrders[index],
+      overtchatTurnId: turn.id,
+      overtchatTurnBoundaryId: `${turn.id}:assistant`,
+    })),
+  );
+  messages.push(...results);
+  messages.sort(
+    (left, right) =>
+      (numberOf(recordOf(left), "timestamp") ?? 0) -
+      (numberOf(recordOf(right), "timestamp") ?? 0),
+  );
+  if (turn.status !== "inProgress") {
+    messages.push({
+      id: `${turn.id}:footer`,
+      role: "turnFooter",
+      messageId:
+        assistantContent.length > 0 ? `${turn.id}:assistant` : null,
+      content: assistantContent
+        .flatMap((content) =>
+          content.type === "text" && typeof content.text === "string"
+            ? [content.text]
+            : [],
+        )
+        .join("\n\n"),
+      durationMs:
+        completedAt === null ? null : Math.max(0, completedAt - startedAt),
+      timestamp: startedAt + turn.items.length + 1,
       ...(turn.status === "failed" && recordOf(turn.error)
         ? { errorMessage: stringOf(recordOf(turn.error), "message") ?? undefined }
         : {}),
     });
   }
-  messages.push(...results);
   return messages;
 }
 
@@ -653,14 +685,19 @@ function statsFromMessages(
   base: AgentSessionStats,
 ): AgentSessionStats {
   let userMessages = 0;
-  let assistantMessages = 0;
+  const assistantTurns = new Set<string>();
   let toolCalls = 0;
   let toolResults = 0;
+  let otherMessages = 0;
   for (const message of messages) {
     const record = recordOf(message);
     if (record?.role === "user") userMessages += 1;
     if (record?.role === "assistant") {
-      assistantMessages += 1;
+      assistantTurns.add(
+        stringOf(record, "overtchatTurnId") ??
+          stringOf(record, "id") ??
+          `assistant:${assistantTurns.size}`,
+      );
       if (Array.isArray(record.content)) {
         toolCalls += record.content.filter(
           (part) => recordOf(part)?.type === "toolCall",
@@ -668,14 +705,24 @@ function statsFromMessages(
       }
     }
     if (record?.role === "toolResult") toolResults += 1;
+    if (
+      record?.role &&
+      !["user", "assistant", "toolResult", "turnFooter"].includes(
+        String(record.role),
+      )
+    ) {
+      otherMessages += 1;
+    }
   }
+  const assistantMessages = assistantTurns.size;
   return {
     ...base,
     userMessages,
     assistantMessages,
     toolCalls,
     toolResults,
-    totalMessages: messages.length,
+    totalMessages:
+      userMessages + assistantMessages + toolResults + otherMessages,
   };
 }
 

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -60,7 +60,7 @@ function projectedTools(messages: unknown[]) {
 }
 
 describe("projectAgentTranscript", () => {
-  it("pairs calls and results into one contiguous activity group", () => {
+  it("projects reasoning and tools as distinct ordered activity rows", () => {
     const projected = projectAgentTranscript([
       { role: "user", content: "Remove the old image", timestamp: 1 },
       assistant(
@@ -91,31 +91,42 @@ describe("projectAgentTranscript", () => {
     expect(projected.map((item) => item.type)).toEqual([
       "message",
       "activity",
+      "activity",
+      "activity",
       "assistant_text",
     ]);
-    const activity = projected[1];
-    expect(activity).toMatchObject({
-      type: "activity",
-      entries: [
-        { type: "thinking" },
-        {
-          type: "tool",
-          tool: {
-            id: "inspect",
-            output: "0.11.2 abc\n0.11.4 def",
-            hasResult: true,
-          },
-        },
-        {
-          type: "tool",
-          tool: {
-            id: "remove",
-            output: "Deleted: sha256:abc",
-            hasResult: true,
-          },
-        },
-      ],
-    });
+    expect(projected.slice(1, 4)).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        entries: [expect.objectContaining({ type: "thinking" })],
+      }),
+      expect.objectContaining({
+        type: "activity",
+        entries: [
+          expect.objectContaining({
+            type: "tool",
+            tool: expect.objectContaining({
+              id: "inspect",
+              output: "0.11.2 abc\n0.11.4 def",
+              hasResult: true,
+            }),
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        type: "activity",
+        entries: [
+          expect.objectContaining({
+            type: "tool",
+            tool: expect.objectContaining({
+              id: "remove",
+              output: "Deleted: sha256:abc",
+              hasResult: true,
+            }),
+          }),
+        ],
+      }),
+    ]);
     expect(JSON.stringify(projected)).not.toContain("48,088");
   });
 
@@ -140,7 +151,7 @@ describe("projectAgentTranscript", () => {
     ]);
   });
 
-  it("keeps commentary in a timed work group before the final answer", () => {
+  it("keeps commentary inline and puts timing on the turn footer", () => {
     const projected = projectAgentTranscript([
       assistant(
         [
@@ -154,22 +165,27 @@ describe("projectAgentTranscript", () => {
         1,
         {
           id: "turn-1:assistant",
-          overtchatActivityDurationMs: 246_355,
         },
       ),
       result("build", "bash", "done"),
+      {
+        id: "turn-1:footer",
+        role: "turnFooter",
+        messageId: "turn-1:assistant",
+        content: "I'm checking the release image.\n\nThe image is ready.",
+        durationMs: 246_355,
+      },
     ]);
 
     expect(projected).toEqual([
       expect.objectContaining({
+        type: "assistant_text",
+        text: "I'm checking the release image.",
+        actionable: false,
+      }),
+      expect.objectContaining({
         type: "activity",
-        durationMs: 246_355,
         entries: [
-          {
-            type: "commentary",
-            id: "commentary:turn-1:assistant:0",
-            content: "I'm checking the release image.",
-          },
           expect.objectContaining({
             type: "tool",
             tool: expect.objectContaining({ id: "build", output: "done" }),
@@ -179,8 +195,15 @@ describe("projectAgentTranscript", () => {
       expect.objectContaining({
         type: "assistant_text",
         text: "The image is ready.",
-        actionable: true,
+        actionable: false,
       }),
+      {
+        type: "turn_footer",
+        key: "turn-footer:turn-1:footer",
+        text: "I'm checking the release image.\n\nThe image is ready.",
+        durationMs: 246_355,
+        messageId: "turn-1:assistant",
+      },
     ]);
   });
 

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -40,11 +40,6 @@ export type AgentSubagentActivity = {
 
 export type AgentActivityEntry =
   | {
-      type: "commentary";
-      id: string;
-      content: string;
-    }
-  | {
       type: "thinking";
       id: string;
       content: string;
@@ -87,7 +82,13 @@ export type AgentTranscriptItem =
       type: "activity";
       key: string;
       entries: AgentActivityEntry[];
+    }
+  | {
+      type: "turn_footer";
+      key: string;
+      text: string;
       durationMs: number | null;
+      messageId: string | null;
     }
   | {
       type: "plan";
@@ -174,13 +175,6 @@ function resultId(message: unknown): string | null {
   return roleOf(message) === "toolResult" &&
     typeof record?.toolCallId === "string"
     ? record.toolCallId
-    : null;
-}
-
-function activityDurationOf(message: UnknownRecord): number | null {
-  const value = message.overtchatActivityDurationMs;
-  return typeof value === "number" && Number.isFinite(value) && value >= 0
-    ? value
     : null;
 }
 
@@ -297,19 +291,23 @@ export function projectAgentTranscript(
   messages: unknown[],
 ): AgentTranscriptItem[] {
   const items: AgentTranscriptItem[] = [];
-  const pendingActivity: AgentActivityEntry[] = [];
-  let pendingActivityDurationMs: number | null = null;
   const { callIds, results } = collectToolData(messages);
+  const footerMessageIds = new Set(
+    messages.flatMap((message) => {
+      const record = recordOf(message);
+      return record?.role === "turnFooter" &&
+        typeof record.messageId === "string"
+        ? [record.messageId]
+        : [];
+    }),
+  );
 
-  const flushActivity = (durationMs: number | null = null) => {
-    if (pendingActivity.length === 0) return;
+  const pushActivity = (entry: AgentActivityEntry) => {
     items.push({
       type: "activity",
-      key: `activity:${pendingActivity[0].id}`,
-      entries: pendingActivity.splice(0),
-      durationMs: durationMs ?? pendingActivityDurationMs,
+      key: `activity:${entry.id}`,
+      entries: [entry],
     });
-    pendingActivityDurationMs = null;
   };
 
   messages.forEach((message, messageIndex) => {
@@ -320,11 +318,18 @@ export function projectAgentTranscript(
 
     if (role === "assistant") {
       const content = Array.isArray(record.content) ? record.content : [];
-      const activityDurationMs = activityDurationOf(record);
+      const messageId =
+        typeof record.overtchatTurnBoundaryId === "string"
+          ? record.overtchatTurnBoundaryId
+          : typeof record.id === "string"
+            ? record.id
+            : null;
+      const actionsOwnedByFooter =
+        typeof record.overtchatTurnBoundaryId === "string";
       const lastTextIndex = content.findLastIndex((part) => {
         const candidate = recordOf(part);
         return (
-          candidate?.type === "text" &&
+          (candidate?.type === "text" || candidate?.type === "commentary") &&
           typeof candidate.text === "string" &&
           candidate.text.trim().length > 0
         );
@@ -332,13 +337,15 @@ export function projectAgentTranscript(
       content.forEach((part, partIndex) => {
         const partRecord = recordOf(part);
         if (!partRecord) return;
-        const partIdentity = `${identity}:${partIndex}`;
+        const partIdentity =
+          typeof partRecord.id === "string"
+            ? partRecord.id
+            : `${identity}:${partIndex}`;
 
         if (
           partRecord.type === "plan" &&
           typeof partRecord.text === "string"
         ) {
-          flushActivity(activityDurationMs);
           items.push({
             type: "plan",
             key: `plan:${typeof partRecord.id === "string" ? partRecord.id : partIdentity}`,
@@ -371,7 +378,7 @@ export function projectAgentTranscript(
           partRecord.type === "subagent" &&
           typeof partRecord.id === "string"
         ) {
-          pendingActivity.push({
+          pushActivity({
             type: "subagent",
             id: `subagent:${partRecord.id}`,
             activity: {
@@ -415,7 +422,6 @@ export function projectAgentTranscript(
                 : [],
             },
           });
-          pendingActivityDurationMs ??= activityDurationMs;
           return;
         }
 
@@ -424,12 +430,17 @@ export function projectAgentTranscript(
           typeof partRecord.text === "string" &&
           partRecord.text.trim()
         ) {
-          pendingActivity.push({
-            type: "commentary",
-            id: `commentary:${partIdentity}`,
-            content: partRecord.text,
+          items.push({
+            type: "assistant_text",
+            key: `assistant:${partIdentity}`,
+            text: partRecord.text,
+            messageId,
+            actionable:
+              partIndex === lastTextIndex &&
+              messageId !== null &&
+              !actionsOwnedByFooter &&
+              !footerMessageIds.has(messageId),
           });
-          pendingActivityDurationMs ??= activityDurationMs;
           return;
         }
 
@@ -438,12 +449,11 @@ export function projectAgentTranscript(
           typeof partRecord.thinking === "string" &&
           partRecord.thinking.trim()
         ) {
-          pendingActivity.push({
+          pushActivity({
             type: "thinking",
             id: `thinking:${partIdentity}`,
             content: partRecord.thinking,
           });
-          pendingActivityDurationMs ??= activityDurationMs;
           return;
         }
 
@@ -455,12 +465,11 @@ export function projectAgentTranscript(
             typeof partRecord.id === "string"
               ? partRecord.id
               : `tool:${partIdentity}`;
-          pendingActivity.push({
+          pushActivity({
             type: "tool",
             id: `tool:${id}`,
             tool: toolFromCall(partRecord, results.get(id), id),
           });
-          pendingActivityDurationMs ??= activityDurationMs;
           return;
         }
 
@@ -469,14 +478,16 @@ export function projectAgentTranscript(
           typeof partRecord.text === "string" &&
           partRecord.text.trim()
         ) {
-          flushActivity(activityDurationMs);
           items.push({
             type: "assistant_text",
             key: `assistant:${partIdentity}`,
             text: partRecord.text,
-            messageId:
-              typeof record.id === "string" ? record.id : null,
-            actionable: partIndex === lastTextIndex,
+            messageId,
+            actionable:
+              partIndex === lastTextIndex &&
+              messageId !== null &&
+              !actionsOwnedByFooter &&
+              !footerMessageIds.has(messageId),
           });
         }
       });
@@ -485,7 +496,6 @@ export function projectAgentTranscript(
         typeof record.errorMessage === "string" &&
         record.errorMessage.trim()
       ) {
-        flushActivity(activityDurationMs);
         items.push({
           type: "assistant_error",
           key: `assistant-error:${identity}`,
@@ -495,10 +505,38 @@ export function projectAgentTranscript(
       return;
     }
 
+    if (role === "turnFooter") {
+      if (
+        typeof record.errorMessage === "string" &&
+        record.errorMessage.trim()
+      ) {
+        items.push({
+          type: "assistant_error",
+          key: `assistant-error:${identity}`,
+          error: presentAgentError(record.errorMessage),
+        });
+      }
+      const durationMs = record.durationMs;
+      items.push({
+        type: "turn_footer",
+        key: `turn-footer:${identity}`,
+        text: typeof record.content === "string" ? record.content : "",
+        durationMs:
+          typeof durationMs === "number" &&
+          Number.isFinite(durationMs) &&
+          durationMs >= 0
+            ? durationMs
+            : null,
+        messageId:
+          typeof record.messageId === "string" ? record.messageId : null,
+      });
+      return;
+    }
+
     if (role === "toolResult") {
       const id = resultId(message);
       if (!id || callIds.has(id)) return;
-      pendingActivity.push({
+      pushActivity({
         type: "tool",
         id: `tool:${id}`,
         tool: toolFromResult(record, id),
@@ -508,7 +546,7 @@ export function projectAgentTranscript(
 
     if (role === "bashExecution") {
       const id = `bash:${identity}`;
-      pendingActivity.push({
+      pushActivity({
         type: "tool",
         id,
         tool: directShellTool(record, id),
@@ -518,15 +556,12 @@ export function projectAgentTranscript(
 
     if (role === "custom" && record.display === false) return;
 
-    flushActivity();
     items.push({
       type: "message",
       key: `${role || "message"}:${identity}:${messageIndex}`,
       message,
     });
   });
-
-  flushActivity();
   return items;
 }
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.2}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.3}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- render conversational progress updates inline in their original order instead of hiding them inside activity groups
- keep reasoning, tools, and subagent work as distinct first-class timeline rows with stable identities
- move copy, fork, elapsed time, and completion duration to the turn boundary
- remove redundant nested disclosure controls from individual tool and subagent rows
- update the default server image to `0.13.3`

## Validation

- `npm run test` — 494 web tests passed, 19 connector tests passed, 9 site tests passed; 4 integration tests intentionally skipped
- `npm run lint`
- `npm run typecheck`
- full production standalone Playwright suite — 9 passed, 4 intentionally skipped
- `docker compose config --quiet`

## Upgrade notes

- No database migration is required.
- Host Connector `0.1.0` remains compatible.
- Agent Connections remains Beta.