### PR TITLE
chore: prepare v0.13.4 release

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.3}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.4}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- update the default OvertChat app image in `compose.yml` from `0.13.3` to `0.13.4`

## Validation

The release candidate on the parent `main` commit passed:

- Host Connector build
- full monorepo validation
- browser E2E smoke suite
- focused queue, steering, reconnect, and canonical timeline coverage from #153

The release bump also passes `docker compose config --quiet`.

## Upgrade notes

- Host Connector `0.2.0` is required; Connector `0.1.0` is intentionally incompatible.
- Reinstall the connector after upgrading the server.
- No database migration is required.
- Agent Connections remains Beta.