### PR TITLE
Stabilize Agent Connections and prepare v0.13.5

### DIFF
--- a/.github/workflows/app-image.yml
+++ b/.github/workflows/app-image.yml
@@ -5,12 +5,10 @@ name: Build and publish app image
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Version tag to publish without the leading v
-        required: false
-        type: string
+
+concurrency:
+  group: app-image-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -24,6 +22,24 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Validate release tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "release tag must be a semantic version such as v0.13.5" >&2
+            exit 1
+          fi
+
+          version="${BASH_REMATCH[1]}"
+          compose_version="$(sed -n 's/.*${APP_VERSION:-\([^}]*\)}.*/\1/p' compose.yml)"
+          if [[ "$compose_version" != "$version" ]]; then
+            echo "compose.yml defaults to $compose_version, but the release tag is $RELEASE_TAG" >&2
+            exit 1
+          fi
 
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
@@ -34,23 +50,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Validate manual version
-        if: github.event_name == 'workflow_dispatch' && inputs.version != ''
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "version must be a semantic version such as 0.13.0" >&2
-            exit 1
-          fi
-
       - id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/overtchat-app
           tags: |
             type=match,pattern=v(.*),group=1
-            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=raw,value=latest
 
       - uses: docker/build-push-action@v7

--- a/.github/workflows/connector-release.yml
+++ b/.github/workflows/connector-release.yml
@@ -21,6 +21,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: connector-release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   build:
     outputs:
@@ -94,7 +98,7 @@ jobs:
           name: host-connector-release
           path: release
 
-      - name: Publish release assets
+      - name: Validate release tag
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -102,8 +106,75 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           test "$TAG" = "connector-v$VERSION"
-          gh release view "$TAG" >/dev/null 2>&1 ||
+
+      - name: Create or resume draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if gh release view "$TAG" --json isDraft --jq '.isDraft' > release-draft; then
+            test "$(cat release-draft)" = "true" || {
+              echo "Release $TAG is already published and immutable." >&2
+              exit 1
+            }
+          else
             gh release create "$TAG" \
+              --draft \
               --title "OvertChat Host Connector v$VERSION" \
-              --generate-notes
+              --generate-notes \
+              --latest=false \
+              --verify-tag
+          fi
+
+      - name: Upload assets to draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          test "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true"
           gh release upload "$TAG" release/* --clobber
+
+      - name: Verify draft release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          test "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true"
+
+          expected_assets=$(printf '%s\n' \
+            connector-checksums.txt \
+            install-connector.sh \
+            overtchat-connector-linux-amd64 \
+            overtchat-connector-linux-arm64)
+          actual_assets=$(gh release view "$TAG" --json assets --jq '.assets[].name' | LC_ALL=C sort)
+          test "$actual_assets" = "$expected_assets"
+
+          verification_directory=$(mktemp -d)
+          trap 'rm -rf "$verification_directory"' EXIT HUP INT TERM
+          gh release download "$TAG" --dir "$verification_directory" \
+            --pattern connector-checksums.txt \
+            --pattern install-connector.sh \
+            --pattern overtchat-connector-linux-amd64 \
+            --pattern overtchat-connector-linux-arm64
+
+          for asset in \
+            connector-checksums.txt \
+            install-connector.sh \
+            overtchat-connector-linux-amd64 \
+            overtchat-connector-linux-arm64; do
+            cmp "release/$asset" "$verification_directory/$asset"
+          done
+          (cd "$verification_directory" && sha256sum --check connector-checksums.txt)
+
+      - name: Publish verified release without changing Latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          test "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true"
+          gh release edit "$TAG" --draft=false --latest=false

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -63,6 +63,26 @@ jobs:
           NEXT_TELEMETRY_DISABLED: "1"
         run: npm run build -w apps/site --
 
+      - name: Verify public connector installer
+        if: github.event_name != 'pull_request'
+        run: |
+          connector_version=$(node -p "require('./apps/connector/package.json').version")
+          installer_url="https://github.com/yoloyash/overtchat/releases/download/connector-v$connector_version/install-connector.sh"
+          expected_redirect="/install/connector/$connector_version $installer_url 302"
+
+          grep -Fx "$expected_redirect" apps/site/public/_redirects
+          grep -Fx "/install-connector.sh /install/connector/$connector_version 302" \
+            apps/site/public/_redirects
+
+          verification_directory=$(mktemp -d)
+          trap 'rm -rf "$verification_directory"' EXIT HUP INT TERM
+          curl --proto '=https' --tlsv1.2 \
+            --fail --silent --show-error --location \
+            --retry 10 --retry-delay 3 --retry-all-errors --retry-max-time 120 \
+            --output "$verification_directory/install-connector.sh" \
+            "$installer_url"
+          cmp scripts/install-connector.sh "$verification_directory/install-connector.sh"
+
       - name: Deploy site to Cloudflare
         if: github.event_name != 'pull_request'
         env:

--- a/README.md
+++ b/README.md
@@ -53,12 +53,11 @@ Already run SearXNG or Kokoro elsewhere? You can point overtchat at them; see [d
 
 ## Agent Connections (Beta)
 
-Use OvertChat as a browser interface for Codex, Pi, and Oh My Pi installed on
-the Docker host or on machines already reachable through its SSH config. In **Settings →
-Connections**, choose **Set up** and run the generated command.
-It installs the OvertChat Host Connector as your Linux user; OvertChat never
-receives SSH keys or config. Remote aliases must already work non-interactively,
-for example `ssh devbox`.
+Run Codex, Pi, and Oh My Pi from the browser on local or SSH-connected machines.
+Setup is one generated command under **Settings → Connections** and does not
+upload SSH keys or config. Server updates leave the connector alone; if the
+connector itself needs an update, the same page shows a one-line command that
+keeps its pairing.
 
 ## Mobile
 

--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/cli.ts
+++ b/apps/connector/src/cli.ts
@@ -66,11 +66,28 @@ async function pair(values: Map<string, string>): Promise<void> {
 async function run(): Promise<void> {
   const config = await readConnectorConfig();
   const client = await ConnectorClient.create(config);
-  const stop = () => void client.stop();
+  const stop = () => {
+    void client.stop().catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+  };
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
   console.log(`Connecting to ${config.serverUrl}`);
-  return client.run();
+  try {
+    await client.run();
+  } finally {
+    await client.stop();
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
+  }
+}
+
+async function preflight(): Promise<void> {
+  const config = await readConnectorConfig();
+  const client = await ConnectorClient.create(config);
+  await client.stop();
 }
 
 async function main(): Promise<void> {
@@ -88,6 +105,12 @@ async function main(): Promise<void> {
     }
     case "run":
       await run();
+      return;
+    case "preflight":
+      if (parsed.values.size > 0) {
+        throw new Error("The preflight command does not accept arguments.");
+      }
+      await preflight();
       return;
     default:
       throw new Error(

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -1,0 +1,260 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HOST_CONNECTOR_CAPABILITIES,
+  HOST_CONNECTOR_PROTOCOL_VERSION,
+  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  type HostConnectorEventBatch,
+  type HostConnectorEventPayload,
+} from "@overtchat/agent-bridge";
+import { ConnectorClient } from "./client.js";
+
+const directories: string[] = [];
+
+async function config() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "overtchat-client-"));
+  directories.push(directory);
+  process.env.OVERTCHAT_CONNECTOR_STATE = path.join(directory, "state.json");
+  process.env.OVERTCHAT_CONNECTOR_TIMELINES = path.join(directory, "timelines");
+  process.env.OVERTCHAT_CONNECTOR_LOCK = path.join(directory, "connector.lock");
+  return {
+    serverUrl: "http://127.0.0.1:4717",
+    connectorId: "connector",
+    token: "secret",
+  };
+}
+
+function emptyChannel(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+  );
+}
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  delete process.env.OVERTCHAT_CONNECTOR_STATE;
+  delete process.env.OVERTCHAT_CONNECTOR_TIMELINES;
+  delete process.env.OVERTCHAT_CONNECTOR_LOCK;
+  await Promise.all(
+    directories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe.sequential("connector client compatibility", () => {
+  it("persists a drained request response when shutdown has already started", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyChannel()));
+    const client = await ConnectorClient.create(await config());
+    const daemon = Reflect.get(client, "daemon") as {
+      stop(): Promise<void>;
+    };
+    const journal = Reflect.get(client, "journal") as {
+      close(): Promise<void>;
+    };
+    const originalDaemonStop = daemon.stop.bind(daemon);
+    const originalJournalClose = journal.close.bind(journal);
+    let signalDrainStarted!: () => void;
+    let finishDrain!: () => void;
+    const drainStarted = new Promise<void>((resolve) => {
+      signalDrainStarted = resolve;
+    });
+    const drainFinished = new Promise<void>((resolve) => {
+      finishDrain = resolve;
+    });
+    vi.spyOn(daemon, "stop").mockImplementation(async () => {
+      signalDrainStarted();
+      await drainFinished;
+      await originalDaemonStop();
+    });
+    let responseWasDurableBeforeClose = false;
+    vi.spyOn(journal, "close").mockImplementation(async () => {
+      const persisted = JSON.parse(
+        await readFile(process.env.OVERTCHAT_CONNECTOR_STATE!, "utf8"),
+      ) as {
+        events: Array<{ payload: HostConnectorEventPayload }>;
+      };
+      responseWasDurableBeforeClose = persisted.events.some(
+        (event) =>
+          event.payload.type === "response" &&
+          event.payload.requestId === "drained-request",
+      );
+      await originalJournalClose();
+    });
+
+    const stopping = client.stop();
+    await drainStarted;
+    const enqueue = Reflect.get(client, "enqueue") as (
+      value: HostConnectorEventPayload,
+    ) => void;
+    enqueue.call(client, {
+      type: "response",
+      requestId: "drained-request",
+      success: true,
+      data: { accepted: true },
+    });
+    enqueue.call(client, {
+      type: "session_event",
+      subscriptionId: "disposable-live-hint",
+      sessionId: "session",
+      envelope: {
+        epoch: "timeline",
+        sequence: 1,
+        type: "runtime_event",
+        data: { type: "turn_start" },
+      },
+    });
+    finishDrain();
+    await stopping;
+
+    expect(responseWasDurableBeforeClose).toBe(true);
+    expect(
+      Reflect.get(client, "liveEvents") as HostConnectorEventPayload[],
+    ).toHaveLength(0);
+  });
+
+  it("uses the stable v1 compatibility token and advertises its build", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input), init });
+        return emptyChannel();
+      }),
+    );
+    const client = await ConnectorClient.create(await config());
+    const running = client.run();
+    await vi.waitFor(() => expect(requests.length).toBeGreaterThan(0));
+
+    const headers = new Headers(requests[0]!.init?.headers);
+    expect(headers.get("x-overtchat-connector-version")).toBe(
+      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+    );
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.0");
+    expect(headers.get("x-overtchat-connector-protocol")).toBe(
+      String(HOST_CONNECTOR_PROTOCOL_VERSION),
+    );
+    expect(headers.get("x-overtchat-connector-capabilities")).toBe(
+      HOST_CONNECTOR_CAPABILITIES.join(","),
+    );
+    await client.stop();
+    await running;
+  });
+
+  it("rotates recoverable live hints when a legacy server forgets its cursor", async () => {
+    const batches: HostConnectorEventBatch[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/channel")) return emptyChannel();
+        const batch = JSON.parse(String(init?.body)) as HostConnectorEventBatch;
+        batches.push(batch);
+        const acknowledgedSequence =
+          batches.length === 1 ? 0 : batch.events.at(-1)!.sequence;
+        return Response.json({
+          connectorEpoch: batch.connectorEpoch,
+          acknowledgedSequence,
+        });
+      }),
+    );
+    const client = await ConnectorClient.create(await config());
+    const running = client.run();
+    const payload: HostConnectorEventPayload = {
+      type: "session_event",
+      subscriptionId: "subscription",
+      sessionId: "session",
+      envelope: {
+        epoch: "timeline",
+        sequence: 1,
+        type: "runtime_event",
+        data: { type: "turn_start" },
+      },
+    };
+    const enqueue = Reflect.get(client, "enqueue") as (
+      value: HostConnectorEventPayload,
+    ) => void;
+    enqueue.call(client, payload);
+
+    await vi.waitFor(() => expect(batches).toHaveLength(2));
+    expect(batches[0]!.events.map((event) => event.sequence)).toEqual([1]);
+    expect(batches[1]!.events.map((event) => event.sequence)).toEqual([1]);
+    expect(batches[1]!.connectorEpoch).not.toBe(batches[0]!.connectorEpoch);
+    await client.stop();
+    await running;
+  });
+
+  it("terminates the connector loop after an unrecoverable timeline failure", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => emptyChannel()));
+    const client = await ConnectorClient.create(await config());
+    const running = client.run();
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+    const failure = new Error("Host Connector timeline persistence failed");
+
+    const fail = Reflect.get(client, "fail") as (error: Error) => void;
+    fail.call(client, failure);
+
+    await expect(running).rejects.toBe(failure);
+    await client.stop();
+  });
+
+  it("retains a reconciliation hint for a quiet session when live events overflow", async () => {
+    const batches: HostConnectorEventBatch[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        const batch = JSON.parse(String(init?.body)) as HostConnectorEventBatch;
+        batches.push(batch);
+        return Response.json({
+          connectorEpoch: batch.connectorEpoch,
+          acknowledgedSequence: batch.events.at(-1)!.sequence,
+        });
+      }),
+    );
+    const client = await ConnectorClient.create(await config());
+    const enqueue = Reflect.get(client, "enqueue") as (
+      value: HostConnectorEventPayload,
+    ) => void;
+    const sessionEvent = (
+      subscriptionId: string,
+      sessionId: string,
+      sequence: number,
+    ): HostConnectorEventPayload => ({
+      type: "session_event",
+      subscriptionId,
+      sessionId,
+      envelope: {
+        epoch: `timeline-${sessionId}`,
+        sequence,
+        type: "runtime_event",
+        data: { type: "turn_start" },
+      },
+    });
+    enqueue.call(client, sessionEvent("quiet-subscription", "quiet", 1));
+    for (let sequence = 1; sequence <= 2_049; sequence += 1) {
+      enqueue.call(
+        client,
+        sessionEvent("busy-subscription", "busy", sequence),
+      );
+    }
+
+    const flush = Reflect.get(client, "flush") as () => Promise<void>;
+    await flush.call(client);
+    await vi.waitFor(() => expect(batches.length).toBeGreaterThan(0));
+
+    expect(
+      batches.flatMap((batch) => batch.events).some(
+        (event) =>
+          event.payload.type === "session_event" &&
+          event.payload.subscriptionId === "quiet-subscription",
+      ),
+    ).toBe(true);
+    await client.stop();
+  });
+});

--- a/apps/connector/src/client.ts
+++ b/apps/connector/src/client.ts
@@ -1,5 +1,8 @@
 import {
+  HOST_CONNECTOR_CAPABILITIES,
+  HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
+  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
   isHostConnectorCommand,
   MAX_AGENT_IMAGE_BYTES,
   type AgentPromptImage,
@@ -8,14 +11,33 @@ import {
   type HostConnectorEventPayload,
 } from "@overtchat/agent-bridge";
 import type { ResolvedAgentImage } from "@overtchat/agent-runtime";
-import { connectorStatePath, type ConnectorConfig } from "./config.js";
+import {
+  connectorLockPath,
+  connectorStatePath,
+  connectorTimelinePath,
+  type ConnectorConfig,
+} from "./config.js";
 import { ConnectorDaemon } from "./daemon.js";
+import { ConnectorInstanceLock } from "./lock.js";
 import { ConnectorStateJournal } from "./state.js";
+import { ConnectorTimelineStore } from "./timeline.js";
 import { CONNECTOR_VERSION } from "./version.js";
 
 const RECONNECT_BASE_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;
 const EVENT_BATCH_DELAY_MS = 25;
+const MAX_BUFFERED_LIVE_EVENTS = 2_048;
+
+type LiveEventPayload = Extract<
+  HostConnectorEventPayload,
+  { type: "session_event" }
+>;
+
+type LiveEventBatch = {
+  payloads: LiveEventPayload[];
+  hints: Array<[string, LiveEventPayload]>;
+  queued: LiveEventPayload[];
+};
 
 function endpoint(serverUrl: string, path: string): string {
   return `${serverUrl}${path}`;
@@ -52,32 +74,66 @@ export class ConnectorClient {
   private eventRetryAttempt = 0;
   private flushing = false;
   private stopped = false;
+  private acceptingDurableEvents = true;
+  private stopPromise: Promise<void> | undefined;
+  private terminalError: Error | undefined;
+  private liveEventEpoch = crypto.randomUUID();
+  private liveEventSequence = 0;
+  private readonly liveEvents: LiveEventPayload[] = [];
+  /**
+   * The high-volume event queue is deliberately bounded, but dropping its
+   * oldest entry outright could leave a quiet session stale forever. Keep the
+   * newest displaced envelope for every subscription as a reconciliation
+   * marker. Once delivered it either fills the next sequence or makes the
+   * browser detect a gap and request the authoritative connector timeline.
+   */
+  private readonly liveOverflowHints = new Map<string, LiveEventPayload>();
 
   private constructor(
     private readonly config: ConnectorConfig,
     private readonly journal: ConnectorStateJournal,
+    private readonly timelines: ConnectorTimelineStore,
+    private readonly lock: ConnectorInstanceLock,
   ) {
     this.daemon = new ConnectorDaemon(
       (event) => this.enqueue(event),
       (images) => this.resolveImages(images),
       journal,
+      timelines,
+      (error) => this.fail(error),
     );
   }
 
   static async create(config: ConnectorConfig): Promise<ConnectorClient> {
-    const journal = await ConnectorStateJournal.open(
-      connectorStatePath(config.connectorId),
+    const lock = await ConnectorInstanceLock.acquire(
+      connectorLockPath(config.connectorId),
     );
-    return new ConnectorClient(config, journal);
+    let journal: ConnectorStateJournal | undefined;
+    let timelines: ConnectorTimelineStore | undefined;
+    try {
+      journal = await ConnectorStateJournal.open(
+        connectorStatePath(config.connectorId),
+      );
+      timelines = await ConnectorTimelineStore.open(
+        connectorTimelinePath(config.connectorId),
+      );
+      return new ConnectorClient(config, journal, timelines, lock);
+    } catch (error) {
+      await timelines?.close().catch(() => {});
+      await journal?.close().catch(() => {});
+      await lock.release();
+      throw error;
+    }
   }
 
   async run(): Promise<void> {
     void this.flush();
-    while (!this.stopped) {
+    while (!this.stopped && !this.terminalError) {
       try {
         await this.openCommandStream();
       } catch (error) {
         if (this.stopped) break;
+        if (this.terminalError) throw this.terminalError;
         console.error(
           `Connector stream disconnected: ${
             error instanceof Error ? error.message : String(error)
@@ -89,18 +145,50 @@ export class ConnectorClient {
         this.stopAbort.signal,
       );
     }
+    if (this.terminalError) throw this.terminalError;
   }
 
-  async stop(): Promise<void> {
-    if (this.stopped) return;
-    this.stopped = true;
-    if (this.flushTimer) clearTimeout(this.flushTimer);
-    this.flushTimer = undefined;
+  private fail(error: Error): void {
+    if (this.terminalError || this.stopped) return;
+    this.terminalError = error;
     this.stopAbort.abort();
     this.commandStreamAbort?.abort();
     this.eventRequestAbort?.abort();
-    await this.daemon.stop();
-    await this.journal.close();
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
+    this.stopped = true;
+    this.stopPromise = (async () => {
+      if (this.flushTimer) clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+      this.stopAbort.abort();
+      this.commandStreamAbort?.abort();
+      this.eventRequestAbort?.abort();
+      let failure: unknown;
+      for (const close of [
+        () => this.daemon.stop(),
+        // Requests already accepted by the daemon may finish while stop is
+        // draining them. Their responses are durable protocol events, so
+        // force those journal writes to disk before closing either store.
+        () => this.journal.flush(),
+        () => {
+          this.acceptingDurableEvents = false;
+          return Promise.resolve();
+        },
+        () => this.timelines.close(),
+        () => this.journal.close(),
+        () => this.lock.release(),
+      ]) {
+        try {
+          await close();
+        } catch (error) {
+          failure ??= error;
+        }
+      }
+      if (failure) throw failure;
+    })();
+    return this.stopPromise;
   }
 
   private async openCommandStream(): Promise<void> {
@@ -112,7 +200,11 @@ export class ConnectorClient {
         signal: abort.signal,
         headers: {
           Authorization: `Bearer ${this.config.token}`,
-          "X-OvertChat-Connector-Version": CONNECTOR_VERSION,
+          "X-OvertChat-Connector-Version":
+            HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+          "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
+          "X-OvertChat-Connector-Capabilities":
+            HOST_CONNECTOR_CAPABILITIES.join(","),
           "X-OvertChat-Connector-Protocol": String(
             HOST_CONNECTOR_PROTOCOL_VERSION,
           ),
@@ -158,8 +250,29 @@ export class ConnectorClient {
   }
 
   private enqueue(payload: HostConnectorEventPayload): void {
+    if (payload.type === "session_event") {
+      if (this.stopped) return;
+      // The per-session timeline is already synced to disk before the daemon
+      // emits this live hint. Keeping a second durable copy here caused stale
+      // connectors to accumulate hundreds of megabytes. A lost/bounded hint is
+      // recovered through the authoritative session sync.
+      this.liveEvents.push(payload);
+      if (this.liveEvents.length > MAX_BUFFERED_LIVE_EVENTS) {
+        const displaced = this.liveEvents.splice(
+          0,
+          this.liveEvents.length - MAX_BUFFERED_LIVE_EVENTS,
+        );
+        for (const hint of displaced) {
+          this.liveOverflowHints.set(hint.subscriptionId, hint);
+        }
+      }
+    } else {
+      if (!this.acceptingDurableEvents) return;
+      this.journal.enqueue(payload);
+    }
+    // Stopping disables transport delivery, but the stop sequence above will
+    // persist any durable response emitted while the daemon drains requests.
     if (this.stopped) return;
-    this.journal.enqueue(payload);
     if (this.flushTimer || this.flushing) return;
     this.flushTimer = setTimeout(() => {
       this.flushTimer = undefined;
@@ -169,17 +282,32 @@ export class ConnectorClient {
 
   private async flush(): Promise<void> {
     if (this.stopped || this.flushing) return;
-    const events = this.journal.eventBatch();
-    if (events.length === 0) return;
+    const durableEvents = this.journal.eventBatch();
+    const liveBatch =
+      durableEvents.length === 0
+        ? this.takeLiveEventBatch()
+        : undefined;
+    const livePayloads = liveBatch?.payloads ?? [];
+    if (durableEvents.length === 0 && livePayloads.length === 0) return;
     this.flushing = true;
+    const liveEvents = livePayloads.map((payload, index) => ({
+      sequence: this.liveEventSequence + index + 1,
+      payload,
+    }));
+    const events = durableEvents.length > 0 ? durableEvents : liveEvents;
+    const connectorEpoch =
+      durableEvents.length > 0
+        ? this.journal.connectorEpoch
+        : this.liveEventEpoch;
     const body: HostConnectorEventBatch = {
       protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
-      connectorEpoch: this.journal.connectorEpoch,
+      connectorEpoch,
       events,
     };
     const abort = new AbortController();
     this.eventRequestAbort = abort;
     try {
+      if (durableEvents.length > 0) await this.journal.flush();
       const response = await fetch(
         endpoint(this.config.serverUrl, "/api/host-connectors/events"),
         {
@@ -188,7 +316,11 @@ export class ConnectorClient {
           headers: {
             Authorization: `Bearer ${this.config.token}`,
             "Content-Type": "application/json",
-            "X-OvertChat-Connector-Version": CONNECTOR_VERSION,
+            "X-OvertChat-Connector-Version":
+              HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+            "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
+            "X-OvertChat-Connector-Capabilities":
+              HOST_CONNECTOR_CAPABILITIES.join(","),
             "X-OvertChat-Connector-Protocol": String(
               HOST_CONNECTOR_PROTOCOL_VERSION,
             ),
@@ -201,14 +333,40 @@ export class ConnectorClient {
       }
       const ack = (await response.json()) as HostConnectorEventAck;
       if (
-        ack.connectorEpoch !== this.journal.connectorEpoch ||
+        ack.connectorEpoch !== connectorEpoch ||
         !Number.isSafeInteger(ack.acknowledgedSequence)
       ) {
         throw new Error("OvertChat returned an invalid connector acknowledgement.");
       }
-      await this.journal.acknowledge(ack);
+      if (durableEvents.length > 0) {
+        await this.journal.acknowledge(ack);
+      } else {
+        const expected = liveEvents.at(-1)!.sequence;
+        if (ack.acknowledgedSequence !== expected) {
+          if (
+            Number.isSafeInteger(ack.acknowledgedSequence) &&
+            ack.acknowledgedSequence >= 0 &&
+            ack.acknowledgedSequence < liveEvents[0]!.sequence
+          ) {
+            // A pre-session-sync server forgot its process-local cursor. Live
+            // hints are recoverable from the timeline, so rotate their
+            // transport identity and retry them from sequence one.
+            this.liveEventEpoch = crypto.randomUUID();
+            this.liveEventSequence = 0;
+            if (liveBatch) this.restoreLiveEventBatch(liveBatch);
+            livePayloads.length = 0;
+            this.eventRetryAttempt = 0;
+            return;
+          }
+          throw new Error("OvertChat returned an invalid live-event acknowledgement.");
+        }
+        this.liveEventSequence = expected;
+      }
       this.eventRetryAttempt = 0;
     } catch (error) {
+      if (livePayloads.length > 0 && liveBatch) {
+        this.restoreLiveEventBatch(liveBatch);
+      }
       if (this.stopped) return;
       console.error(
         `Unable to deliver connector events: ${
@@ -224,10 +382,44 @@ export class ConnectorClient {
         this.eventRequestAbort = undefined;
       }
       this.flushing = false;
-      if (!this.stopped && this.journal.eventBatch().length > 0) {
+      if (
+        !this.stopped &&
+        (this.journal.eventBatch().length > 0 ||
+          this.liveOverflowHints.size > 0 ||
+          this.liveEvents.length > 0)
+      ) {
         void this.flush();
       }
     }
+  }
+
+  private takeLiveEventBatch(): LiveEventBatch {
+    const hints: Array<[string, LiveEventPayload]> = [];
+    for (const entry of this.liveOverflowHints) {
+      if (hints.length >= HOST_CONNECTOR_EVENT_BATCH_LIMIT) break;
+      hints.push(entry);
+      this.liveOverflowHints.delete(entry[0]);
+    }
+    const queued = this.liveEvents.splice(
+      0,
+      HOST_CONNECTOR_EVENT_BATCH_LIMIT - hints.length,
+    );
+    return {
+      payloads: [...hints.map(([, payload]) => payload), ...queued],
+      hints,
+      queued,
+    };
+  }
+
+  private restoreLiveEventBatch(batch: LiveEventBatch): void {
+    // A newer displaced event may have replaced a hint while the request was
+    // in flight. Never roll that per-subscription marker backward.
+    for (const [subscriptionId, payload] of batch.hints) {
+      if (!this.liveOverflowHints.has(subscriptionId)) {
+        this.liveOverflowHints.set(subscriptionId, payload);
+      }
+    }
+    this.liveEvents.unshift(...batch.queued);
   }
 
   private async resolveImages(

--- a/apps/connector/src/config.test.ts
+++ b/apps/connector/src/config.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  connectorLockPath,
   connectorStatePath,
+  connectorTimelinePath,
   normalizeServerUrl,
 } from "./config.js";
 
@@ -32,6 +34,12 @@ describe("connector server URLs", () => {
   it("keeps each paired connector's state separate", () => {
     expect(connectorStatePath("connector-1")).toMatch(
       /connector-connector-1\.state\.json$/u,
+    );
+    expect(connectorTimelinePath("connector-1")).toMatch(
+      /connector-connector-1\.timelines$/u,
+    );
+    expect(connectorLockPath("connector-1")).toMatch(
+      /connector-connector-1\.lock$/u,
     );
   });
 });

--- a/apps/connector/src/config.ts
+++ b/apps/connector/src/config.ts
@@ -26,6 +26,26 @@ export function connectorStatePath(connectorId: string): string {
   );
 }
 
+export function connectorTimelinePath(connectorId: string): string {
+  return (
+    process.env.OVERTCHAT_CONNECTOR_TIMELINES ??
+    path.join(
+      path.dirname(connectorConfigPath()),
+      `connector-${connectorId}.timelines`,
+    )
+  );
+}
+
+export function connectorLockPath(connectorId: string): string {
+  return (
+    process.env.OVERTCHAT_CONNECTOR_LOCK ??
+    path.join(
+      path.dirname(connectorConfigPath()),
+      `connector-${connectorId}.lock`,
+    )
+  );
+}
+
 export async function readConnectorConfig(): Promise<ConnectorConfig> {
   const file = connectorConfigPath();
   let parsed: unknown;

--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -1,21 +1,35 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentDaemonSessionDescriptor,
+  AgentQueuedMessage,
+  AgentRuntimeEnvelope,
   HostConnectorCommand,
   HostConnectorEventPayload,
 } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
   configureProcessSpawner: vi.fn(),
+  create: vi.fn(),
   getOrStart: vi.fn(),
   stopAll: vi.fn(),
   stopSession: vi.fn(),
+  stopWorkspace: vi.fn(),
+  stopConnection: vi.fn(),
   command: vi.fn(),
   normalizeCommand: vi.fn(),
   snapshot: vi.fn(),
+  observe: vi.fn(),
+  acquireLease: vi.fn(),
+  registryOptions: null as {
+    runtimeExited?: (sessionId: string, runtime: unknown) => void | Promise<void>;
+    saveQueuedMessages?: (
+      sessionId: string,
+      messages: readonly AgentQueuedMessage[],
+    ) => void | Promise<void>;
+  } | null,
 }));
 
 vi.mock("@overtchat/agent-runtime", async (importOriginal) => {
@@ -26,15 +40,22 @@ vi.mock("@overtchat/agent-runtime", async (importOriginal) => {
     ...original,
     configureProcessSpawner: mocks.configureProcessSpawner,
     AgentRuntimeRegistry: class {
+      constructor(options: NonNullable<typeof mocks.registryOptions>) {
+        mocks.registryOptions = options;
+      }
+      create = mocks.create;
       getOrStart = mocks.getOrStart;
       stopAll = mocks.stopAll;
       stopSession = mocks.stopSession;
+      stopWorkspace = mocks.stopWorkspace;
+      stopConnection = mocks.stopConnection;
     },
   };
 });
 
 import { ConnectorDaemon } from "./daemon.js";
 import { ConnectorStateJournal } from "./state.js";
+import { ConnectorTimelineStore } from "./timeline.js";
 
 const directories: string[] = [];
 
@@ -49,6 +70,26 @@ const session: AgentDaemonSessionDescriptor = {
   providerSessionId: "provider-session",
   providerSessionPath: "/sessions/provider-session.jsonl",
 };
+
+const workspace = {
+  connectionId: session.connectionId,
+  workspaceId: session.workspaceId,
+  provider: session.provider,
+  target: session.target,
+  executable: session.executable,
+  cwd: session.cwd,
+};
+
+function runtime() {
+  return {
+    dbSessionId: "session",
+    normalizeCommand: mocks.normalizeCommand,
+    command: mocks.command,
+    snapshot: mocks.snapshot,
+    observe: mocks.observe,
+    acquireLease: mocks.acquireLease,
+  };
+}
 
 function command(requestId: string): HostConnectorCommand {
   return {
@@ -68,14 +109,33 @@ function command(requestId: string): HostConnectorCommand {
   };
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((finish) => {
+    resolve = finish;
+  });
+  return { promise, resolve };
+}
+
 async function openJournal(): Promise<{
   file: string;
   journal: ConnectorStateJournal;
+  timelineDirectory: string;
+  timelines: ConnectorTimelineStore;
 }> {
   const directory = await mkdtemp(path.join(os.tmpdir(), "overtchat-daemon-"));
   directories.push(directory);
   const file = path.join(directory, "connector.state.json");
-  return { file, journal: await ConnectorStateJournal.open(file) };
+  const timelineDirectory = path.join(directory, "timelines");
+  return {
+    file,
+    journal: await ConnectorStateJournal.open(file),
+    timelineDirectory,
+    timelines: await ConnectorTimelineStore.open(timelineDirectory),
+  };
 }
 
 beforeEach(() => {
@@ -84,18 +144,56 @@ beforeEach(() => {
   mocks.command.mockResolvedValue({ queued: true, id: "message-1" });
   mocks.snapshot.mockReturnValue({
     sessionId: "session",
+    provider: "codex",
+    capabilities: { steer: true },
     status: "running",
+    activeTurn: { startedAt: 42 },
+    state: { isStreaming: true },
+    messages: [],
+    models: [],
+    thinkingLevels: [],
+    commands: [],
+    stats: {
+      sessionFile: null,
+      sessionId: null,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      toolResults: 0,
+      totalMessages: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+      cost: 0,
+    },
     queuedMessages: [
       { id: "message-1", message: "Run the tests", status: "pending" },
     ],
   });
-  mocks.getOrStart.mockResolvedValue({
-    normalizeCommand: mocks.normalizeCommand,
-    command: mocks.command,
-    snapshot: mocks.snapshot,
+  mocks.observe.mockReturnValue(() => {});
+  mocks.acquireLease.mockReturnValue(() => {});
+  mocks.create.mockResolvedValue({
+    runtime: runtime(),
+    session: {
+      providerSessionId: session.providerSessionId,
+      providerSessionPath: session.providerSessionPath,
+      name: null,
+      firstMessage: null,
+      messageCount: 0,
+      createdAt: new Date(0),
+      modifiedAt: new Date(0),
+    },
   });
+  mocks.getOrStart.mockResolvedValue(runtime());
   mocks.stopAll.mockResolvedValue(undefined);
   mocks.stopSession.mockResolvedValue(undefined);
+  mocks.stopWorkspace.mockResolvedValue(undefined);
+  mocks.stopConnection.mockResolvedValue(undefined);
+  mocks.registryOptions = null;
 });
 
 afterEach(async () => {
@@ -108,12 +206,13 @@ afterEach(async () => {
 
 describe("connector daemon command identity", () => {
   it("executes simultaneous deliveries of one command only once", async () => {
-    const { journal } = await openJournal();
+    const { journal, timelines } = await openJournal();
     const events: HostConnectorEventPayload[] = [];
     const daemon = new ConnectorDaemon(
       (event) => events.push(event),
       async () => [],
       journal,
+      timelines,
     );
 
     await Promise.all([
@@ -134,28 +233,35 @@ describe("connector daemon command identity", () => {
         success: true,
       }),
     ]);
+    await timelines.close();
     await journal.close();
   });
 
   it("reuses an accepted result after a daemon restart", async () => {
-    const { file, journal } = await openJournal();
+    const { file, journal, timelineDirectory, timelines } = await openJournal();
     const firstEvents: HostConnectorEventPayload[] = [];
     const first = new ConnectorDaemon(
       (event) => firstEvents.push(event),
       async () => [],
       journal,
+      timelines,
     );
     await first.handle(command("request-1"));
+    await timelines.close();
     await journal.close();
 
     mocks.getOrStart.mockClear();
     mocks.command.mockClear();
     const restored = await ConnectorStateJournal.open(file);
+    const restoredTimelines = await ConnectorTimelineStore.open(
+      timelineDirectory,
+    );
     const secondEvents: HostConnectorEventPayload[] = [];
     const second = new ConnectorDaemon(
       (event) => secondEvents.push(event),
       async () => [],
       restored,
+      restoredTimelines,
     );
     await second.handle(command("request-2"));
 
@@ -166,25 +272,21 @@ describe("connector daemon command identity", () => {
         type: "response",
         requestId: "request-2",
         success: true,
-        data: expect.objectContaining({
-          snapshot: expect.objectContaining({
-            queuedMessages: [
-              expect.objectContaining({ id: "message-1" }),
-            ],
-          }),
-        }),
+        data: {},
       }),
     ]);
+    await restoredTimelines.close();
     await restored.close();
   });
 
   it("stops journaled sessions that the server no longer authorizes", async () => {
-    const { journal } = await openJournal();
+    const { journal, timelines } = await openJournal();
     await journal.recordSession(session);
     const daemon = new ConnectorDaemon(
       vi.fn(),
       async () => [],
       journal,
+      timelines,
     );
 
     await daemon.handle({
@@ -195,6 +297,575 @@ describe("connector daemon command identity", () => {
 
     expect(mocks.stopSession).toHaveBeenCalledWith("session");
     expect(journal.sessionIds()).toEqual([]);
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("persists runtime events before forwarding them to a subscriber", async () => {
+    const { journal, timelines } = await openJournal();
+    const emitted: HostConnectorEventPayload[] = [];
+    let observer: ((event: AgentRuntimeEnvelope) => void) | undefined;
+    mocks.observe.mockImplementation((value) => {
+      observer = value;
+      return () => {};
+    });
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+    await daemon.handle({
+      type: "sync",
+      connectionEpoch: "connection-1",
+      activeSessionIds: ["session"],
+      serverInfo: {
+        protocolVersion: 1,
+        capabilities: ["session-sync-v1"],
+      },
+    });
+    await daemon.handle({
+      type: "request",
+      requestId: "subscribe",
+      request: {
+        type: "subscribe_session",
+        subscriptionId: "subscription",
+        session,
+      },
+    });
+    emitted.length = 0;
+    observer?.({
+      epoch: "runtime-ephemeral",
+      sequence: 99,
+      type: "runtime_event",
+      data: { type: "turn_start" },
+    });
+
+    expect(emitted).toEqual([]);
+    await timelines.flush("session");
+    await vi.waitFor(() => {
+      expect(emitted).toEqual([
+        expect.objectContaining({
+          type: "session_event",
+          envelope: expect.objectContaining({
+            epoch: expect.any(String),
+            sequence: 1,
+            data: expect.objectContaining({
+              type: "turn_start",
+              overtchatRecordedAt: expect.any(Number),
+            }),
+          }),
+        }),
+      ]);
+    });
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("coalesces consecutive growing turn projections into one durable update", async () => {
+    const { journal, timelines } = await openJournal();
+    const emitted: HostConnectorEventPayload[] = [];
+    let observer: ((event: AgentRuntimeEnvelope) => void) | undefined;
+    mocks.observe.mockImplementation((value) => {
+      observer = value;
+      return () => {};
+    });
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+    await daemon.handle({
+      type: "sync",
+      connectionEpoch: "connection-1",
+      activeSessionIds: ["session"],
+      serverInfo: { protocolVersion: 1, capabilities: ["session-sync-v1"] },
+    });
+    await daemon.handle({
+      type: "request",
+      requestId: "subscribe",
+      request: { type: "subscribe_session", subscriptionId: "subscription", session },
+    });
+    emitted.length = 0;
+
+    for (const content of ["a", "ab", "abc"]) {
+      observer?.({
+        epoch: "runtime-ephemeral",
+        sequence: content.length,
+        type: "runtime_event",
+        data: {
+          type: "overtchat_turn_update",
+          turnId: "turn-1",
+          messages: [{ role: "assistant", content }],
+        },
+      });
+    }
+    await timelines.flush("session");
+
+    await vi.waitFor(() => {
+      expect(emitted).toEqual([
+        expect.objectContaining({
+          type: "session_event",
+          envelope: expect.objectContaining({
+            sequence: 1,
+            data: expect.objectContaining({
+              type: "overtchat_turn_update",
+              messages: [{ role: "assistant", content: "abc" }],
+            }),
+          }),
+        }),
+      ]);
+    });
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("freezes capture before service shutdown can publish a synthetic exit", async () => {
+    const { journal, timelines } = await openJournal();
+    const order: string[] = [];
+    let observer: ((event: AgentRuntimeEnvelope) => void) | undefined;
+    let observing = true;
+    mocks.observe.mockImplementation((value) => {
+      observer = value;
+      observing = true;
+      return () => {
+        observing = false;
+        order.push("capture-frozen");
+      };
+    });
+    mocks.stopAll.mockImplementation(async () => {
+      order.push("providers-stopped");
+      if (observing) {
+        observer?.({
+          epoch: "runtime-ephemeral",
+          sequence: 1,
+          type: "snapshot",
+          data: { ...mocks.snapshot(), status: "exited" },
+        });
+      }
+    });
+    const daemon = new ConnectorDaemon(vi.fn(), async () => [], journal, timelines);
+    await daemon.handle({
+      type: "request",
+      requestId: "open",
+      request: { type: "open_session", session },
+    });
+
+    await daemon.stop();
+
+    expect(order).toEqual(["capture-frozen", "providers-stopped"]);
+    await expect(timelines.sync("session")).resolves.toMatchObject({
+      reset: true,
+      snapshot: { status: "running" },
+    });
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("drains an accepted command before shutting down its stores and runtimes", async () => {
+    const { journal, timelines } = await openJournal();
+    let finishCommand: (() => void) | undefined;
+    mocks.command.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishCommand = () => resolve({ queued: true, id: "message-1" });
+        }),
+    );
+    const emitted: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+    const handling = daemon.handle(command("request-1"));
+    await vi.waitFor(() => expect(mocks.command).toHaveBeenCalledOnce());
+
+    let stopped = false;
+    const stopping = daemon.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    expect(mocks.stopAll).not.toHaveBeenCalled();
+
+    finishCommand?.();
+    await handling;
+    await stopping;
+
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "request-1",
+        success: true,
+      }),
+    );
+    expect(journal.commandEntry("message-1")).toMatchObject({
+      status: "completed",
+      result: { success: true },
+    });
+    expect(mocks.stopAll).toHaveBeenCalledOnce();
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("bounds shutdown when an accepted provider command never settles", async () => {
+    const { journal, timelines } = await openJournal();
+    mocks.command.mockReturnValueOnce(new Promise(() => {}));
+    const emitted: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+      undefined,
+      5,
+    );
+    const handling = daemon.handle(command("request-1"));
+    await vi.waitFor(() => expect(mocks.command).toHaveBeenCalledOnce());
+
+    const stopped = daemon.stop().then(() => true);
+    await expect(
+      Promise.race([
+        stopped,
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+      ]),
+    ).resolves.toBe(true);
+    await handling;
+
+    expect(journal.commandEntry("message-1")).toMatchObject({
+      status: "pending",
+    });
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "request-1",
+        success: false,
+        error: expect.stringContaining("will not replay it automatically"),
+      }),
+    );
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("rejects a late runtime queue write after journal shutdown", async () => {
+    const { file, journal, timelines } = await openJournal();
+    await journal.recordSession(session);
+    const daemon = new ConnectorDaemon(vi.fn(), async () => [], journal, timelines);
+    const saveQueuedMessages = mocks.registryOptions?.saveQueuedMessages;
+    expect(saveQueuedMessages).toBeTypeOf("function");
+
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+    const persistedBeforeLateWrite = await readFile(file, "utf8");
+
+    await expect(
+      saveQueuedMessages?.("session", [
+        { id: "late-message", message: "Run later", status: "pending" },
+      ]),
+    ).rejects.toThrow();
+
+    expect(journal.sessionQueue("session")).toEqual([]);
+    await expect(readFile(file, "utf8")).resolves.toBe(
+      persistedBeforeLateWrite,
+    );
+  });
+
+  it("does not let a late open continuation write after shutdown", async () => {
+    const { journal, timelines } = await openJournal();
+    const started = deferred<ReturnType<typeof runtime>>();
+    mocks.getOrStart.mockReturnValueOnce(started.promise);
+    mocks.stopAll.mockReturnValueOnce(new Promise(() => {}));
+    const emitted: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+      undefined,
+      1,
+    );
+    const handling = daemon.handle({
+      type: "request",
+      requestId: "open",
+      request: { type: "open_session", session },
+    });
+    await vi.waitFor(() => expect(mocks.getOrStart).toHaveBeenCalledOnce());
+
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+    started.resolve(runtime());
+    await handling;
+
+    expect(journal.sessionIds()).toEqual([]);
+    expect(mocks.stopSession).toHaveBeenCalledWith("session");
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "open",
+        success: false,
+        error: "The Host Connector is shutting down.",
+      }),
+    );
+  });
+
+  it("does not let a late create continuation write after shutdown", async () => {
+    const { journal, timelines } = await openJournal();
+    const created = deferred<Awaited<ReturnType<typeof mocks.create>>>();
+    mocks.create.mockReturnValueOnce(created.promise);
+    const emitted: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+      undefined,
+      1,
+    );
+    const handling = daemon.handle({
+      type: "request",
+      requestId: "create",
+      request: { type: "create_session", sessionId: "session", workspace },
+    });
+    await vi.waitFor(() => expect(mocks.create).toHaveBeenCalledOnce());
+
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+    created.resolve({
+      runtime: runtime(),
+      session: {
+        providerSessionId: session.providerSessionId,
+        providerSessionPath: session.providerSessionPath,
+        name: null,
+        firstMessage: null,
+        messageCount: 0,
+        createdAt: new Date(0),
+        modifiedAt: new Date(0),
+      },
+    });
+    await handling;
+
+    expect(journal.sessionIds()).toEqual([]);
+    expect(mocks.stopSession).toHaveBeenCalledWith("session");
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "create",
+        success: false,
+        error: "The Host Connector is shutting down.",
+      }),
+    );
+  });
+
+  it("discards a subscription that resolves after bounded shutdown", async () => {
+    const { journal, timelines } = await openJournal();
+    const subscribed = deferred<
+      Awaited<ReturnType<ConnectorTimelineStore["subscribe"]>>
+    >();
+    vi.spyOn(timelines, "subscribe").mockReturnValueOnce(subscribed.promise);
+    const unsubscribe = vi.fn();
+    const emitted: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+      undefined,
+      1,
+    );
+    const handling = daemon.handle({
+      type: "request",
+      requestId: "subscribe",
+      request: {
+        type: "subscribe_session",
+        subscriptionId: "subscription",
+        session,
+      },
+    });
+    await vi.waitFor(() => expect(timelines.subscribe).toHaveBeenCalledOnce());
+
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+    subscribed.resolve({
+      sync: {
+        reset: true,
+        cursor: { epoch: "timeline", sequence: 0 },
+        snapshot: mocks.snapshot(),
+      },
+      unsubscribe,
+    });
+    await handling;
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(mocks.acquireLease).not.toHaveBeenCalled();
+    expect(
+      (Reflect.get(daemon, "subscriptions") as Map<string, unknown>).size,
+    ).toBe(0);
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "subscribe",
+        success: false,
+        error: "The Host Connector is shutting down.",
+      }),
+    );
+  });
+
+  it("releases live subscribers when timeline persistence becomes fatal", async () => {
+    const { journal, timelines } = await openJournal();
+    let observer: ((event: AgentRuntimeEnvelope) => void) | undefined;
+    const releaseRuntime = vi.fn();
+    mocks.observe.mockImplementation((value) => {
+      observer = value;
+      return () => {};
+    });
+    mocks.acquireLease.mockReturnValue(releaseRuntime);
+    const fail = vi.fn();
+    const daemon = new ConnectorDaemon(
+      vi.fn(),
+      async () => [],
+      journal,
+      timelines,
+      fail,
+    );
+    await daemon.handle({
+      type: "sync",
+      connectionEpoch: "connection-1",
+      activeSessionIds: ["session"],
+      serverInfo: { protocolVersion: 1, capabilities: ["session-sync-v1"] },
+    });
+    await daemon.handle({
+      type: "request",
+      requestId: "subscribe",
+      request: { type: "subscribe_session", subscriptionId: "subscription", session },
+    });
+    vi.spyOn(timelines, "commit").mockRejectedValueOnce(
+      new Error("timeline fsync failed"),
+    );
+
+    observer?.({
+      epoch: "runtime-ephemeral",
+      sequence: 1,
+      type: "runtime_event",
+      data: { type: "turn_start" },
+    });
+
+    await vi.waitFor(() => expect(releaseRuntime).toHaveBeenCalledOnce());
+    expect(fail).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "timeline fsync failed" }),
+    );
+    await daemon.handle({
+      type: "request",
+      requestId: "unsubscribe",
+      request: { type: "unsubscribe_session", subscriptionId: "subscription" },
+    });
+    expect(releaseRuntime).toHaveBeenCalledOnce();
+    await daemon.stop().catch(() => {});
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("does not retain a replaced subscription when resubscribe fails", async () => {
+    const { journal, timelines } = await openJournal();
+    const releaseRuntime = vi.fn();
+    mocks.acquireLease.mockReturnValue(releaseRuntime);
+    const daemon = new ConnectorDaemon(vi.fn(), async () => [], journal, timelines);
+    await daemon.handle({
+      type: "request",
+      requestId: "subscribe-1",
+      request: { type: "subscribe_session", subscriptionId: "subscription", session },
+    });
+    mocks.getOrStart.mockRejectedValueOnce(new Error("provider unavailable"));
+
+    await daemon.handle({
+      type: "request",
+      requestId: "subscribe-2",
+      request: { type: "subscribe_session", subscriptionId: "subscription", session },
+    });
+    await daemon.handle({
+      type: "request",
+      requestId: "unsubscribe",
+      request: { type: "unsubscribe_session", subscriptionId: "subscription" },
+    });
+
+    expect(releaseRuntime).toHaveBeenCalledOnce();
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("evicts an exited runtime timeline after its last subscriber leaves", async () => {
+    const { journal, timelines } = await openJournal();
+    const daemon = new ConnectorDaemon(vi.fn(), async () => [], journal, timelines);
+    await daemon.handle({
+      type: "request",
+      requestId: "subscribe",
+      request: { type: "subscribe_session", subscriptionId: "subscription", session },
+    });
+    const runtime = await mocks.getOrStart.mock.results[0]!.value;
+
+    await mocks.registryOptions?.runtimeExited?.("session", runtime);
+    await vi.waitFor(() => {
+      const captures = Reflect.get(daemon, "captures") as Map<string, unknown>;
+      expect(captures.has("session")).toBe(false);
+    });
+    expect(
+      (Reflect.get(timelines, "states") as Map<string, unknown>).has("session"),
+    ).toBe(true);
+
+    await daemon.handle({
+      type: "request",
+      requestId: "unsubscribe",
+      request: { type: "unsubscribe_session", subscriptionId: "subscription" },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        (Reflect.get(timelines, "states") as Map<string, unknown>).has("session"),
+      ).toBe(false);
+    });
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("keeps journal discovery intact if bulk timeline deletion fails", async () => {
+    const { journal, timelines } = await openJournal();
+    await journal.recordSession(session);
+    vi.spyOn(timelines, "deleteSession").mockRejectedValueOnce(
+      new Error("timeline disk failed"),
+    );
+    const emitted: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+
+    await daemon.handle({
+      type: "request",
+      requestId: "stop-workspace",
+      request: { type: "stop_workspace", workspaceId: "workspace" },
+    });
+
+    expect(journal.sessionIds()).toEqual(["session"]);
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "stop-workspace",
+        success: false,
+        error: "timeline disk failed",
+      }),
+    );
+    await timelines.close();
     await journal.close();
   });
 });

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -1,12 +1,15 @@
+import { createHash } from "node:crypto";
 import type {
   AgentDaemonRequest,
   AgentDaemonSessionDescriptor,
   AgentDaemonTarget,
   AgentDaemonWorkspaceDescriptor,
   AgentPromptImage,
+  AgentRuntimeEnvelope,
   HostConnectorCommand,
   HostConnectorEventPayload,
 } from "@overtchat/agent-bridge";
+import { parseHostConnectorCapabilities } from "@overtchat/agent-bridge";
 import {
   AgentRuntimeRegistry,
   agentProviderAdapter,
@@ -23,11 +26,65 @@ import {
 import { listSshHosts } from "./ssh.js";
 import { ConnectorProcessHost } from "./runtime.js";
 import { ConnectorStateJournal } from "./state.js";
+import { ConnectorTimelineStore } from "./timeline.js";
 
 type Emit = (event: HostConnectorEventPayload) => void;
 type ResolveImages = (
   images: readonly AgentPromptImage[],
 ) => Promise<ResolvedAgentImage[]>;
+
+type TimelineCapture = {
+  runtime: AgentSessionRuntime;
+  ready: Promise<void>;
+  initialized: boolean;
+  buffered: AgentRuntimeEnvelope[];
+  pending: Set<Promise<AgentRuntimeEnvelope | null>>;
+  unsubscribe: () => void;
+  failure?: Error;
+};
+
+type SessionSubscription = {
+  sessionId: string;
+  unsubscribeTimeline: () => void;
+  releaseRuntime: () => void;
+};
+
+const SHUTDOWN_GRACE_MS = 5_000;
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function commandFingerprint(
+  request: Extract<AgentDaemonRequest, { type: "session_command" }>,
+): string {
+  return createHash("sha256")
+    .update(
+      canonicalJson({
+        sessionId: request.session.sessionId,
+        clientMessageId: request.clientMessageId,
+        command: request.command,
+      }),
+    )
+    .digest("hex");
+}
+
+function unknownCommandOutcome(error?: unknown): Error {
+  const detail = error ? ` ${errorMessage(error)}` : "";
+  return new Error(
+    `The command may already have been accepted, so OvertChat will not replay it automatically. Inspect the session before trying different work.${detail}`,
+  );
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -62,14 +119,23 @@ function sessionDescriptor(descriptor: AgentDaemonSessionDescriptor) {
 export class ConnectorDaemon {
   private readonly processHost = new ConnectorProcessHost();
   private readonly registry: AgentRuntimeRegistry;
-  private readonly subscriptions = new Map<string, () => void>();
+  private readonly subscriptions = new Map<string, SessionSubscription>();
+  private readonly captures = new Map<string, TimelineCapture>();
   private readonly sessionTails = new Map<string, Promise<void>>();
+  private readonly activeRequests = new Set<Promise<void>>();
+  private readonly shutdownAbort = new AbortController();
+  private readonly serverCapabilities = new Set<string>();
   private connectionEpoch: string | null = null;
+  private accepting = true;
+  private storesClosing = false;
 
   constructor(
     private readonly emit: Emit,
     resolveImages: ResolveImages,
     private readonly journal: ConnectorStateJournal,
+    private readonly timelines: ConnectorTimelineStore,
+    private readonly fail: (error: Error) => void = () => {},
+    private readonly shutdownGraceMs = SHUTDOWN_GRACE_MS,
   ) {
     configureProcessSpawner(this.processHost.spawn);
     this.registry = new AgentRuntimeRegistry({
@@ -90,14 +156,31 @@ export class ConnectorDaemon {
       loadQueuedMessages: (sessionId) => this.journal.sessionQueue(sessionId),
       saveQueuedMessages: (sessionId, messages) =>
         this.journal.saveSessionQueue(sessionId, messages),
+      runtimeExited: (sessionId, runtime) => {
+        void this.retireRuntime(sessionId, runtime).catch((error) => {
+          console.error(
+            `Unable to retire the ${sessionId} session runtime: ${errorMessage(error)}`,
+          );
+        });
+      },
     });
   }
 
-  async handle(command: HostConnectorCommand): Promise<void> {
+  handle(command: HostConnectorCommand): Promise<void> {
+    if (!this.accepting) return Promise.resolve();
+    const operation = this.dispatch(command);
+    this.activeRequests.add(operation);
+    const remove = () => this.activeRequests.delete(operation);
+    void operation.then(remove, remove);
+    return operation;
+  }
+
+  private async dispatch(command: HostConnectorCommand): Promise<void> {
     if (command.type === "sync") {
       await this.beginConnection(
         command.connectionEpoch,
         command.activeSessionIds,
+        command.serverInfo?.capabilities ?? [],
       );
       return;
     }
@@ -120,28 +203,112 @@ export class ConnectorDaemon {
   }
 
   async stop(): Promise<void> {
-    for (const unsubscribe of this.subscriptions.values()) unsubscribe();
+    this.accepting = false;
+    if (!(await this.waitForActiveRequests(this.shutdownGraceMs))) {
+      // The write-ahead command entry is already durable. Unblock the daemon's
+      // request wrapper without pretending a provider outcome is known, then
+      // stop the provider below. Late provider settlement has no daemon
+      // continuation and therefore cannot touch closing stores.
+      this.shutdownAbort.abort();
+      await this.waitForActiveRequests(this.shutdownGraceMs);
+    }
+    // From this point on, an accepted request that outlived both grace periods
+    // may finish its provider operation, but it must not start another journal
+    // or timeline operation. The stores are closed by the client immediately
+    // after this method returns.
+    this.storesClosing = true;
+    for (const subscription of this.subscriptions.values()) {
+      this.closeSubscription(subscription);
+    }
     this.subscriptions.clear();
-    await this.registry.stopAll();
+    // Calling finishCapture freezes every observer synchronously before the
+    // registry is told to stop, so provider shutdown cannot publish a fake
+    // `exited` state into the durable timeline. The asynchronous drains and
+    // provider stops then share one final bounded grace period.
+    const captureCleanup = Promise.all(
+      [...this.captures.keys()].map((sessionId) =>
+        this.finishCapture(sessionId, false),
+      ),
+    ).then(() => undefined);
+    const runtimeCleanup = this.registry.stopAll();
+    const [captureOutcome, runtimeOutcome] = await Promise.all([
+      this.settleWithin(captureCleanup, this.shutdownGraceMs),
+      this.settleWithin(runtimeCleanup, this.shutdownGraceMs),
+    ]);
     this.processHost.stop();
+    const failure = [captureOutcome, runtimeOutcome].find(
+      (outcome): outcome is PromiseRejectedResult =>
+        outcome?.status === "rejected",
+    )?.reason;
+    if (failure) throw failure;
+  }
+
+  private async waitForActiveRequests(milliseconds: number): Promise<boolean> {
+    if (this.activeRequests.size === 0) return true;
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), milliseconds);
+      timer.unref();
+    });
+    const settled = Promise.allSettled([...this.activeRequests]).then(
+      () => true as const,
+    );
+    const result = await Promise.race([settled, timeout]);
+    if (timer) clearTimeout(timer);
+    return result;
+  }
+
+  private async settleWithin(
+    operation: Promise<void>,
+    milliseconds: number,
+  ): Promise<PromiseSettledResult<void> | null> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), milliseconds);
+      timer.unref();
+    });
+    const settled = operation.then<
+      PromiseFulfilledResult<void>,
+      PromiseRejectedResult
+    >(
+      (value) => ({ status: "fulfilled", value }),
+      (reason) => ({ status: "rejected", reason }),
+    );
+    const result = await Promise.race([settled, timeout]);
+    if (timer) clearTimeout(timer);
+    return result;
   }
 
   private async beginConnection(
     connectionEpoch: string,
     activeSessionIds: string[],
+    serverCapabilities: string[],
   ): Promise<void> {
+    this.serverCapabilities.clear();
+    for (const capability of parseHostConnectorCapabilities(
+      serverCapabilities.join(","),
+    )) {
+      this.serverCapabilities.add(capability);
+    }
     if (this.connectionEpoch !== connectionEpoch) {
       this.connectionEpoch = connectionEpoch;
-      for (const unsubscribe of this.subscriptions.values()) unsubscribe();
+      for (const subscription of this.subscriptions.values()) {
+        this.closeSubscription(subscription);
+      }
       this.subscriptions.clear();
     }
     const active = new Set(activeSessionIds);
+    const removed = this.journal
+      .sessionIds()
+      .filter((sessionId) => !active.has(sessionId));
     await Promise.all(
-      this.journal
-        .sessionIds()
-        .filter((sessionId) => !active.has(sessionId))
-        .map((sessionId) => this.registry.stopSession(sessionId)),
+      removed.map((sessionId) => this.registry.stopSession(sessionId)),
     );
+    this.assertAccepting();
+    await Promise.all(
+      removed.map((sessionId) => this.finishCapture(sessionId, true)),
+    );
+    this.assertAccepting();
     await this.journal.retainSessions(active);
   }
 
@@ -173,124 +340,469 @@ export class ConnectorDaemon {
           request.path,
         );
       case "create_session": {
-        const created = await this.serializeSession(request.sessionId, () =>
-          this.registry.create(
+        const created = await this.serializeSession(request.sessionId, async () => {
+          const result = await this.registry.create(
             request.sessionId,
             workspaceDescriptor(request.workspace),
-          ),
-        );
-        await this.journal.recordSession({
-          ...request.workspace,
-          sessionId: request.sessionId,
-          providerSessionId: created.session.providerSessionId,
-          providerSessionPath: created.session.providerSessionPath,
+          );
+          await this.assertRuntimeAccepted(request.sessionId);
+          await this.journal.recordSession({
+            ...request.workspace,
+            sessionId: request.sessionId,
+            providerSessionId: result.session.providerSessionId,
+            providerSessionPath: result.session.providerSessionPath,
+          });
+          await this.assertRuntimeAccepted(request.sessionId);
+          await this.attachTimeline(
+            result.runtime,
+            result.session.providerSessionId,
+          );
+          await this.assertRuntimeAccepted(request.sessionId);
+          return result;
         });
+        this.assertAccepting();
+        const sync = await this.timelines.sync(request.sessionId);
         return {
           session: created.session,
-          snapshot: created.runtime.snapshot(),
+          snapshot: sync.reset ? sync.snapshot : created.runtime.snapshot(),
+          ...(this.serverCapabilities.has("session-sync-v1") ? { sync } : {}),
         };
       }
       case "open_session": {
         const runtime = await this.open(request.session);
-        return { snapshot: runtime.snapshot() };
+        this.assertAccepting();
+        const sync = await this.timelines.sync(
+          request.session.sessionId,
+          request.after,
+        );
+        return {
+          snapshot: sync.reset ? sync.snapshot : runtime.snapshot(),
+          ...(this.serverCapabilities.has("session-sync-v1") ? { sync } : {}),
+        };
       }
       case "session_command":
         return this.runCommand(request);
       case "subscribe_session": {
-        this.subscriptions.get(request.subscriptionId)?.();
+        const previous = this.subscriptions.get(request.subscriptionId);
+        if (previous) {
+          this.closeSubscription(previous);
+          this.subscriptions.delete(request.subscriptionId);
+        }
         const runtime = await this.open(request.session);
-        const unsubscribe = runtime.subscribe((envelope) => {
+        this.assertAccepting();
+        const subscriber = (envelope: AgentRuntimeEnvelope) => {
           this.emit({
             type: "session_event",
             subscriptionId: request.subscriptionId,
             sessionId: request.session.sessionId,
             envelope,
           });
-        }, request.after);
-        this.subscriptions.set(request.subscriptionId, unsubscribe);
+        };
+        const { sync, unsubscribe } = await this.timelines.subscribe(
+          request.session.sessionId,
+          request.after,
+          subscriber,
+        );
+        if (!this.accepting) {
+          unsubscribe();
+          throw new Error("The Host Connector is shutting down.");
+        }
+        const releaseRuntime = runtime.acquireLease();
+        this.subscriptions.set(request.subscriptionId, {
+          sessionId: request.session.sessionId,
+          unsubscribeTimeline: unsubscribe,
+          releaseRuntime,
+        });
+        if (this.serverCapabilities.has("session-sync-v1")) {
+          return { subscribed: true, sync };
+        }
+        this.emitLegacySync(request.subscriptionId, request.session.sessionId, sync);
         return { subscribed: true };
       }
       case "unsubscribe_session":
-        this.subscriptions.get(request.subscriptionId)?.();
+        {
+          const subscription = this.subscriptions.get(request.subscriptionId);
+          if (subscription) this.closeSubscription(subscription);
+        }
         this.subscriptions.delete(request.subscriptionId);
         return { subscribed: false };
       case "stop_session":
         await this.registry.stopSession(request.sessionId);
+        this.assertAccepting();
+        await this.finishCapture(request.sessionId, true);
+        this.assertAccepting();
         await this.journal.deleteSession(request.sessionId);
         return { stopped: true };
-      case "stop_workspace":
+      case "stop_workspace": {
+        const removed = this.journal.sessionIdsForWorkspace(request.workspaceId);
         await this.registry.stopWorkspace(request.workspaceId);
+        this.assertAccepting();
+        await Promise.all(
+          removed.map((sessionId) => this.finishCapture(sessionId, true)),
+        );
+        this.assertAccepting();
         await this.journal.deleteWorkspace(request.workspaceId);
         return { stopped: true };
-      case "stop_connection":
+      }
+      case "stop_connection": {
+        const removed = this.journal.sessionIdsForConnection(request.connectionId);
         await this.registry.stopConnection(request.connectionId);
+        this.assertAccepting();
+        await Promise.all(
+          removed.map((sessionId) => this.finishCapture(sessionId, true)),
+        );
+        this.assertAccepting();
         await this.journal.deleteConnection(request.connectionId);
         return { stopped: true };
-      case "stop_all":
+      }
+      case "stop_all": {
+        const removed = this.journal.sessionIds();
         await this.registry.stopAll();
+        this.assertAccepting();
+        await Promise.all(
+          removed.map((sessionId) => this.finishCapture(sessionId, true)),
+        );
+        this.assertAccepting();
         await this.journal.deleteAllSessions();
         return { stopped: true };
+      }
     }
   }
 
   private async open(
     descriptor: AgentDaemonSessionDescriptor,
   ): Promise<AgentSessionRuntime> {
-    return this.serializeSession(descriptor.sessionId, async () => {
-      const runtime = await this.registry.getOrStart(
-        sessionDescriptor(descriptor),
-      );
-      await this.journal.recordSession(descriptor);
-      return runtime;
-    });
+    return this.serializeSession(descriptor.sessionId, () =>
+      this.openRuntime(descriptor),
+    );
+  }
+
+  private async openRuntime(
+    descriptor: AgentDaemonSessionDescriptor,
+  ): Promise<AgentSessionRuntime> {
+    const runtime = await this.registry.getOrStart(
+      sessionDescriptor(descriptor),
+    );
+    await this.assertRuntimeAccepted(descriptor.sessionId);
+    await this.journal.recordSession(descriptor);
+    await this.assertRuntimeAccepted(descriptor.sessionId);
+    await this.attachTimeline(runtime, descriptor.providerSessionId);
+    await this.assertRuntimeAccepted(descriptor.sessionId);
+    return runtime;
   }
 
   private async runCommand(
     request: Extract<AgentDaemonRequest, { type: "session_command" }>,
   ): Promise<unknown> {
-    const cached = this.journal.commandResult(request.commandId);
-    if (cached) {
-      if (cached.success) return cached.data;
-      throw new Error(cached.error);
-    }
     return this.serializeSession(request.session.sessionId, async () => {
-      const insideCached = this.journal.commandResult(request.commandId);
-      if (insideCached) {
-        if (insideCached.success) return insideCached.data;
-        throw new Error(insideCached.error);
+      const fingerprint = commandFingerprint(request);
+      const begun = await this.journal.beginCommand(
+        request.commandId,
+        request.session.sessionId,
+        fingerprint,
+      );
+      if (begun.status === "completed") {
+        if (begun.result.success) return begun.result.data;
+        throw new Error(begun.result.error);
       }
+      if (begun.status === "pending") {
+        throw unknownCommandOutcome();
+      }
+      let attemptedProviderAction = false;
       try {
-        await this.journal.recordSession(request.session);
-        const runtime = await this.registry.getOrStart(
-          sessionDescriptor(request.session),
-        );
+        const runtime = await this.openRuntime(request.session);
         const normalized = runtime.normalizeCommand(request.command);
+        attemptedProviderAction = true;
         const data =
           normalized.type === "edit_message" ||
           normalized.type === "fork_message"
             ? {
-                fork: await this.registry.fork(runtime, normalized),
-              }
-            : {
-                commandResult: await runtime.command(
-                  normalized,
-                  request.clientMessageId,
+                fork: await this.awaitProviderAction(
+                  this.registry.fork(runtime, normalized),
                 ),
+              }
+            : await this.awaitProviderAction(
+                runtime.command(normalized, request.clientMessageId),
+              ).then((commandResult) => ({
+                ...(normalized.type === "show_usage" ? { commandResult } : {}),
                 snapshot: {
                   queuedMessages: runtime.snapshot().queuedMessages,
                 },
-              };
-        await this.journal.recordCommandResult(request.commandId, {
-          success: true,
-          data: data ?? null,
-        });
+              }));
+        this.assertStoresAvailable();
+        await this.flushCapture(request.session.sessionId);
+        this.assertStoresAvailable();
+        await this.journal.flush();
+        this.assertStoresAvailable();
+        await this.journal.completeCommand(
+          request.commandId,
+          request.session.sessionId,
+          fingerprint,
+          { success: true, data: data ?? null },
+        );
         return data;
       } catch (error) {
-        const result = { success: false, error: errorMessage(error) } as const;
-        await this.journal.recordCommandResult(request.commandId, result);
-        throw error;
+        if (this.storesClosing) {
+          if (!attemptedProviderAction) throw error;
+          throw unknownCommandOutcome(error);
+        }
+        await this.flushCapture(request.session.sessionId).catch(() => {});
+        if (this.storesClosing) {
+          if (!attemptedProviderAction) throw error;
+          throw unknownCommandOutcome(error);
+        }
+        await this.journal.flush().catch(() => {});
+        if (this.storesClosing) {
+          if (!attemptedProviderAction) throw error;
+          throw unknownCommandOutcome(error);
+        }
+        if (!attemptedProviderAction) {
+          const result = { success: false, error: errorMessage(error) } as const;
+          await this.journal.completeCommand(
+            request.commandId,
+            request.session.sessionId,
+            fingerprint,
+            result,
+          );
+          throw error;
+        }
+        throw unknownCommandOutcome(error);
       }
     });
+  }
+
+  private awaitProviderAction<T>(operation: Promise<T>): Promise<T> {
+    const signal = this.shutdownAbort.signal;
+    if (signal.aborted) return Promise.reject(new Error("Connector shutdown."));
+    return new Promise<T>((resolve, reject) => {
+      const aborted = () => {
+        cleanup();
+        reject(new Error("Connector shutdown interrupted the command."));
+      };
+      const cleanup = () => signal.removeEventListener("abort", aborted);
+      signal.addEventListener("abort", aborted, { once: true });
+      void operation.then(
+        (value) => {
+          cleanup();
+          resolve(value);
+        },
+        (error) => {
+          cleanup();
+          reject(error);
+        },
+      );
+    });
+  }
+
+  private assertAccepting(): void {
+    if (!this.accepting) {
+      throw new Error("The Host Connector is shutting down.");
+    }
+  }
+
+  private assertStoresAvailable(): void {
+    if (this.storesClosing) {
+      throw new Error("The Host Connector stores are shutting down.");
+    }
+  }
+
+  private async assertRuntimeAccepted(sessionId: string): Promise<void> {
+    if (this.accepting) return;
+    await this.registry.stopSession(sessionId);
+    throw new Error("The Host Connector is shutting down.");
+  }
+
+  private async attachTimeline(
+    runtime: AgentSessionRuntime,
+    providerSessionId: string,
+  ): Promise<void> {
+    const sessionId = runtime.dbSessionId;
+    const existing = this.captures.get(sessionId);
+    if (existing?.runtime === runtime) {
+      await this.flushCapture(sessionId);
+      return;
+    }
+    if (existing) await this.finishCapture(sessionId, false);
+
+    const capture: TimelineCapture = {
+      runtime,
+      ready: Promise.resolve(),
+      initialized: false,
+      buffered: [],
+      pending: new Set(),
+      unsubscribe: () => {},
+    };
+    capture.unsubscribe = runtime.observe((envelope) => {
+      if (!capture.initialized) {
+        capture.buffered.push(envelope);
+        return;
+      }
+      this.commitCapturedEnvelope(sessionId, capture, envelope);
+    });
+    this.captures.set(sessionId, capture);
+    capture.ready = this.timelines
+      .openSession(sessionId, providerSessionId, runtime.snapshot())
+      .then(() => undefined);
+    try {
+      await capture.ready;
+      this.assertAccepting();
+      capture.initialized = true;
+      for (const envelope of capture.buffered.splice(0)) {
+        this.commitCapturedEnvelope(sessionId, capture, envelope);
+      }
+      await this.flushCapture(sessionId);
+      this.assertAccepting();
+      for (const subscription of this.subscriptions.values()) {
+        if (subscription.sessionId !== sessionId) continue;
+        subscription.releaseRuntime();
+        subscription.releaseRuntime = runtime.acquireLease();
+      }
+    } catch (error) {
+      capture.unsubscribe();
+      if (this.captures.get(sessionId) === capture) {
+        this.captures.delete(sessionId);
+      }
+      throw error;
+    }
+  }
+
+  private async flushCapture(sessionId: string): Promise<void> {
+    const capture = this.captures.get(sessionId);
+    if (!capture) return;
+    await capture.ready;
+    await this.timelines.flush(sessionId);
+    await Promise.all(capture.pending);
+    if (capture.failure) throw capture.failure;
+  }
+
+  private commitCapturedEnvelope(
+    sessionId: string,
+    capture: TimelineCapture,
+    envelope: AgentRuntimeEnvelope,
+  ): void {
+    let operation: Promise<AgentRuntimeEnvelope | null>;
+    try {
+      operation = this.timelines.commit(sessionId, envelope);
+    } catch (error) {
+      this.recordCaptureFailure(sessionId, capture, error);
+      return;
+    }
+    capture.pending.add(operation);
+    void operation
+      .catch((error) => {
+        this.recordCaptureFailure(sessionId, capture, error);
+        return null;
+      })
+      .finally(() => capture.pending.delete(operation));
+  }
+
+  private recordCaptureFailure(
+    sessionId: string,
+    capture: TimelineCapture,
+    error: unknown,
+  ): void {
+    const failure = error instanceof Error ? error : new Error(String(error));
+    if (capture.failure) return;
+    capture.failure = failure;
+    // A failed fsync means the canonical timeline can no longer advance. Close
+    // every affected browser lease immediately instead of leaving a healthy-
+    // looking SSE stream parked forever on stale state.
+    for (const [subscriptionId, subscription] of this.subscriptions) {
+      if (subscription.sessionId !== sessionId) continue;
+      this.closeSubscription(subscription);
+      this.subscriptions.delete(subscriptionId);
+    }
+    this.fail(failure);
+    console.error(
+      `Unable to persist the ${sessionId} session timeline: ${failure.message}`,
+    );
+  }
+
+  private async finishCapture(
+    sessionId: string,
+    deleteTimeline: boolean,
+  ): Promise<void> {
+    const capture = this.captures.get(sessionId);
+    let failure: unknown;
+    if (capture) {
+      // Stop accepting new envelopes before taking the set of pending commits.
+      // Otherwise an event can land between flushCapture and unsubscribe.
+      capture.unsubscribe();
+      try {
+        await this.flushCapture(sessionId);
+      } catch (error) {
+        failure = error;
+      }
+      if (this.captures.get(sessionId) === capture) {
+        this.captures.delete(sessionId);
+      }
+    }
+    if (deleteTimeline) {
+      for (const [subscriptionId, subscription] of this.subscriptions) {
+        if (subscription.sessionId !== sessionId) continue;
+        this.closeSubscription(subscription);
+        this.subscriptions.delete(subscriptionId);
+      }
+    }
+    if (deleteTimeline) await this.timelines.deleteSession(sessionId);
+    if (failure) throw failure;
+  }
+
+  private async retireRuntime(
+    sessionId: string,
+    runtime: AgentSessionRuntime,
+  ): Promise<void> {
+    const capture = this.captures.get(sessionId);
+    if (!capture || capture.runtime !== runtime) return;
+    capture.unsubscribe();
+    await this.flushCapture(sessionId);
+    if (this.captures.get(sessionId) === capture) {
+      this.captures.delete(sessionId);
+    }
+    await this.timelines.releaseSession(sessionId);
+  }
+
+  private closeSubscription(subscription: SessionSubscription): void {
+    subscription.unsubscribeTimeline();
+    subscription.releaseRuntime();
+    if (!this.captures.has(subscription.sessionId)) {
+      void this.timelines.releaseSession(subscription.sessionId).catch((error) => {
+        const failure = error instanceof Error ? error : new Error(String(error));
+        this.fail(failure);
+        console.error(
+          `Unable to release the ${subscription.sessionId} session timeline: ${failure.message}`,
+        );
+      });
+    }
+  }
+
+  private emitLegacySync(
+    subscriptionId: string,
+    sessionId: string,
+    sync: Awaited<ReturnType<ConnectorTimelineStore["sync"]>>,
+  ): void {
+    if (sync.reset) {
+      if (sync.cursor.sequence === 0) return;
+      this.emit({
+        type: "session_event",
+        subscriptionId,
+        sessionId,
+        envelope: {
+          ...sync.cursor,
+          type: "snapshot",
+          data: sync.snapshot,
+        },
+      });
+      return;
+    }
+    for (const envelope of sync.events) {
+      this.emit({
+        type: "session_event",
+        subscriptionId,
+        sessionId,
+        envelope,
+      });
+    }
   }
 
   private serializeSession<T>(

--- a/apps/connector/src/lock.test.ts
+++ b/apps/connector/src/lock.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ConnectorInstanceLock } from "./lock.js";
+
+const directories: string[] = [];
+
+async function lockPath(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "overtchat-lock-"));
+  directories.push(directory);
+  return path.join(directory, "connector.lock");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("connector instance lock", () => {
+  it("prevents two connector processes from owning one pairing", async () => {
+    const file = await lockPath();
+    const first = await ConnectorInstanceLock.acquire(file);
+    await expect(ConnectorInstanceLock.acquire(file)).rejects.toThrow(
+      "already running",
+    );
+    await first.release();
+    const second = await ConnectorInstanceLock.acquire(file);
+    await second.release();
+  });
+
+  it("reclaims a stale process lock", async () => {
+    const file = await lockPath();
+    await writeFile(file, '{"pid":999999999,"startedAt":"old"}\n');
+    const lock = await ConnectorInstanceLock.acquire(file);
+    await lock.release();
+  });
+
+  it("recovers a reclaim guard abandoned by a dead owner", async () => {
+    const file = await lockPath();
+    await writeFile(file, '{"pid":999999999,"startedAt":"old"}\n');
+    await writeFile(
+      `${file}.reclaim`,
+      '{"pid":999999998,"startedAt":"old","ownerId":"abandoned"}\n',
+    );
+
+    const lock = await ConnectorInstanceLock.acquire(file);
+    await lock.release();
+  });
+
+  it("never steals a live process lock while cleaning a stale guard", async () => {
+    const file = await lockPath();
+    const first = await ConnectorInstanceLock.acquire(file);
+    const firstRecord = await readFile(file, "utf8");
+    await writeFile(
+      `${file}.reclaim`,
+      '{"pid":999999998,"startedAt":"old","ownerId":"abandoned"}\n',
+    );
+
+    await expect(ConnectorInstanceLock.acquire(file)).rejects.toThrow(
+      "already running",
+    );
+    await expect(readFile(file, "utf8")).resolves.toBe(firstRecord);
+    await first.release();
+  });
+
+  it("recovers an old malformed reclaim guard but preserves a live one", async () => {
+    const file = await lockPath();
+    const reclaimFile = `${file}.reclaim`;
+    await writeFile(file, '{"pid":999999999,"startedAt":"old"}\n');
+    await writeFile(reclaimFile, "");
+    const old = new Date(Date.now() - 60_000);
+    await utimes(reclaimFile, old, old);
+
+    const lock = await ConnectorInstanceLock.acquire(file);
+    await lock.release();
+
+    await writeFile(file, '{"pid":999999999,"startedAt":"old"}\n');
+    await writeFile(
+      reclaimFile,
+      `${JSON.stringify({
+        pid: process.pid,
+        startedAt: new Date(0).toISOString(),
+        ownerId: "live-owner",
+      })}\n`,
+    );
+    await expect(ConnectorInstanceLock.acquire(file)).rejects.toThrow(
+      "already running",
+    );
+    await expect(readFile(file, "utf8")).resolves.toContain("999999999");
+  });
+
+  it("does not remove a replacement lock it no longer owns", async () => {
+    const file = await lockPath();
+    const lock = await ConnectorInstanceLock.acquire(file);
+    await rm(file);
+    await writeFile(
+      file,
+      `${JSON.stringify({
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        ownerId: "replacement-owner",
+      })}\n`,
+    );
+
+    await lock.release();
+    await expect(readFile(file, "utf8")).resolves.toContain(
+      "replacement-owner",
+    );
+  });
+
+  it("does not steal a freshly-created lock before its owner writes it", async () => {
+    const file = await lockPath();
+    await writeFile(file, "");
+    await expect(ConnectorInstanceLock.acquire(file)).rejects.toThrow(
+      "already running",
+    );
+  });
+
+  it("lets only one contender reclaim an abandoned lock", async () => {
+    const file = await lockPath();
+    await writeFile(file, '{"pid":999999999,"startedAt":"old"}\n');
+    const contenders = await Promise.allSettled([
+      ConnectorInstanceLock.acquire(file),
+      ConnectorInstanceLock.acquire(file),
+    ]);
+    const acquired = contenders.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value] : [],
+    );
+    expect(acquired).toHaveLength(1);
+    await acquired[0]!.release();
+  });
+});

--- a/apps/connector/src/lock.ts
+++ b/apps/connector/src/lock.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from "node:crypto";
+import {
+  mkdir,
+  open,
+  rm,
+  type FileHandle,
+} from "node:fs/promises";
+import path from "node:path";
+
+type LockRecord = {
+  pid: number;
+  startedAt: string;
+  ownerId?: string;
+};
+
+type OwnedLockRecord = LockRecord & { ownerId: string };
+
+type LockObservation = {
+  raw: string;
+  device: number;
+  inode: number;
+  modifiedAt: number;
+  record: LockRecord | null;
+};
+
+const MALFORMED_LOCK_GRACE_MS = 30_000;
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function parseLockRecord(raw: string): LockRecord | null {
+  try {
+    const value = JSON.parse(raw) as Partial<LockRecord>;
+    if (
+      typeof value.pid !== "number" ||
+      typeof value.startedAt !== "string"
+    ) {
+      return null;
+    }
+    return value as LockRecord;
+  } catch {
+    return null;
+  }
+}
+
+async function observeLock(file: string): Promise<LockObservation | null> {
+  let handle: FileHandle;
+  try {
+    handle = await open(file, "r");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    const [raw, metadata] = await Promise.all([
+      handle.readFile("utf8"),
+      handle.stat(),
+    ]);
+    return {
+      raw,
+      device: metadata.dev,
+      inode: metadata.ino,
+      modifiedAt: metadata.mtimeMs,
+      record: parseLockRecord(raw),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function sameLock(
+  left: LockObservation,
+  right: LockObservation,
+): boolean {
+  return (
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.raw === right.raw
+  );
+}
+
+function staleLock(observation: LockObservation): boolean {
+  if (observation.record) {
+    return !isProcessAlive(observation.record.pid);
+  }
+  // Do not steal the file during the tiny create-before-write window of a
+  // process that just acquired it. A malformed file is reclaimable only
+  // after it has clearly been abandoned.
+  return Date.now() - observation.modifiedAt > MALFORMED_LOCK_GRACE_MS;
+}
+
+async function removeObservedLock(
+  file: string,
+  observation: LockObservation,
+): Promise<boolean> {
+  const current = await observeLock(file);
+  if (!current) return true;
+  if (!sameLock(observation, current)) return false;
+  try {
+    await rm(file);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return true;
+}
+
+async function removeOwnedLock(
+  file: string,
+  ownerId: string,
+): Promise<void> {
+  const observation = await observeLock(file);
+  if (observation?.record?.ownerId !== ownerId) return;
+  await removeObservedLock(file, observation);
+}
+
+async function createOwnedLock(
+  file: string,
+): Promise<{ handle: FileHandle; ownerId: string }> {
+  const ownerId = randomUUID();
+  const handle = await open(file, "wx", 0o600);
+  try {
+    await handle.writeFile(
+      `${JSON.stringify({
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        ownerId,
+      } satisfies OwnedLockRecord)}\n`,
+      "utf8",
+    );
+    await handle.sync();
+    return { handle, ownerId };
+  } catch (error) {
+    await handle.close().catch(() => {});
+    await rm(file, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+async function acquireReclaimGuard(
+  file: string,
+): Promise<{ handle: FileHandle; ownerId: string } | null> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await createOwnedLock(file);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const observation = await observeLock(file);
+      if (!observation) continue;
+      if (!staleLock(observation)) return null;
+      if (!(await removeObservedLock(file, observation))) continue;
+    }
+  }
+  return null;
+}
+
+async function reclaimStaleLock(file: string): Promise<boolean> {
+  const reclaimFile = `${file}.reclaim`;
+  const reclaim = await acquireReclaimGuard(reclaimFile);
+  if (!reclaim) return false;
+  try {
+    const observation = await observeLock(file);
+    if (!observation || !staleLock(observation)) return false;
+    return removeObservedLock(file, observation);
+  } finally {
+    await reclaim.handle.close().catch(() => {});
+    await removeOwnedLock(reclaimFile, reclaim.ownerId).catch(() => {});
+  }
+}
+
+export class ConnectorInstanceLock {
+  private released = false;
+
+  private constructor(
+    private readonly file: string,
+    private readonly handle: FileHandle,
+    private readonly ownerId: string,
+  ) {}
+
+  static async acquire(file: string): Promise<ConnectorInstanceLock> {
+    await mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const lock = await createOwnedLock(file);
+        return new ConnectorInstanceLock(file, lock.handle, lock.ownerId);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+          throw error;
+        }
+        if (attempt > 0 || !(await reclaimStaleLock(file))) {
+          if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+            throw new Error(
+              "Another OvertChat Connector is already running for this pairing. Stop the installed service before running a development connector.",
+            );
+          }
+        }
+      }
+    }
+    throw new Error("Unable to acquire the OvertChat Connector instance lock.");
+  }
+
+  async release(): Promise<void> {
+    if (this.released) return;
+    this.released = true;
+    await this.handle.close();
+    await removeOwnedLock(this.file, this.ownerId);
+  }
+}

--- a/apps/connector/src/state.test.ts
+++ b/apps/connector/src/state.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -80,28 +80,279 @@ describe("connector state journal", () => {
       {
         id: "message-1",
         message: "Run the tests",
-        status: "sending",
+        status: "uncertain",
       },
     ]);
-    await value.recordCommandResult("message-1", {
+    await expect(
+      value.beginCommand("message-1", "session", "a".repeat(64)),
+    ).resolves.toEqual({ status: "execute" });
+    await value.completeCommand("message-1", "session", "a".repeat(64), {
       success: true,
-      data: { queued: true, id: "message-1" },
+      data: {
+        queued: true,
+        id: "message-1",
+        snapshot: { queuedMessages: [{ id: "stale-message" }] },
+      },
     });
     await value.close();
 
     const restored = await ConnectorStateJournal.open(file);
-    expect(restored.commandResult("message-1")).toEqual({
-      success: true,
-      data: { queued: true, id: "message-1" },
+    expect(restored.commandEntry("message-1")).toEqual({
+      commandId: "message-1",
+      sessionId: "session",
+      fingerprint: "a".repeat(64),
+      status: "completed",
+      result: {
+        success: true,
+        data: { queued: true, id: "message-1" },
+      },
     });
     expect(restored.sessionQueue("session")).toEqual([
       {
         id: "message-1",
         message: "Run the tests",
-        status: "sending",
+        status: "uncertain",
       },
     ]);
     await restored.close();
+  });
+
+  it("rejects late journal mutations as soon as close begins", async () => {
+    const { file, value } = await journal();
+    await value.recordSession(session);
+    await value.saveSessionQueue("session", [
+      {
+        id: "original-message",
+        message: "Keep this state",
+        status: "uncertain",
+      },
+    ]);
+
+    const closing = value.close();
+
+    expect(() =>
+      value.enqueue({
+        type: "response",
+        requestId: "late-response",
+        success: true,
+        data: null,
+      }),
+    ).toThrow("state journal is closed");
+    await expect(
+      value.saveSessionQueue("session", [
+        {
+          id: "late-message",
+          message: "Must not overwrite the journal",
+          status: "pending",
+        },
+      ]),
+    ).rejects.toThrow("state journal is closed");
+    await expect(
+      value.recordSession({ ...session, sessionId: "late-session" }),
+    ).rejects.toThrow("state journal is closed");
+    await expect(
+      value.beginCommand("late-command", "session", "f".repeat(64)),
+    ).rejects.toThrow("state journal is closed");
+    await expect(value.flush()).rejects.toThrow("state journal is closed");
+    await closing;
+
+    const persisted = JSON.parse(await readFile(file, "utf8"));
+    expect(persisted.nextEventSequence).toBe(0);
+    expect(persisted.commands).toEqual([]);
+    expect(persisted.sessions).not.toHaveProperty("late-session");
+    expect(persisted.sessions.session.queuedMessages).toEqual([
+      {
+        id: "original-message",
+        message: "Keep this state",
+        status: "uncertain",
+      },
+    ]);
+    await expect(value.deleteSession("session")).rejects.toThrow(
+      "state journal is closed",
+    );
+  });
+
+  it("never re-executes a command left pending across a restart", async () => {
+    const { file, value } = await journal();
+    await value.beginCommand("message-1", "session", "b".repeat(64));
+    expect(JSON.parse(await readFile(file, "utf8")).commands).toEqual([
+      {
+        commandId: "message-1",
+        sessionId: "session",
+        fingerprint: "b".repeat(64),
+        status: "pending",
+      },
+    ]);
+    await value.close();
+
+    const restored = await ConnectorStateJournal.open(file);
+    await expect(
+      restored.beginCommand("message-1", "session", "b".repeat(64)),
+    ).resolves.toEqual({ status: "pending" });
+    await expect(
+      restored.beginCommand("message-1", "other-session", "b".repeat(64)),
+    ).rejects.toThrow("reused for different work");
+    await expect(
+      restored.beginCommand("message-1", "session", "c".repeat(64)),
+    ).rejects.toThrow("reused for different work");
+    await restored.close();
+  });
+
+  it("does not allow a completed command result to be rewritten", async () => {
+    const { value } = await journal();
+    const fingerprint = "d".repeat(64);
+    await value.beginCommand("message-1", "session", fingerprint);
+    await value.completeCommand("message-1", "session", fingerprint, {
+      success: true,
+      data: { accepted: true },
+    });
+
+    await expect(
+      value.completeCommand("message-1", "session", fingerprint, {
+        success: false,
+        error: "replacement",
+      }),
+    ).rejects.toThrow("already completed");
+    expect(value.commandEntry("message-1")).toMatchObject({
+      result: { success: true, data: { accepted: true } },
+    });
+    await value.close();
+  });
+
+  it.each([
+    { encoding: "compact", space: undefined },
+    { encoding: "pretty-printed", space: 2 },
+  ])("migrates a $encoding v0.2 transport backlog", async ({ space }) => {
+    const { file, value } = await journal();
+    await value.close();
+    const legacySessionEvent = {
+      sequence: 1,
+      payload: {
+        type: "session_event",
+        subscriptionId: "subscription",
+        sessionId: "session",
+        envelope: {
+          epoch: "runtime",
+          sequence: 1,
+          type: "runtime_event",
+          data: { type: "turn_start", text: "x".repeat(10_000) },
+        },
+      },
+    };
+    await writeFile(
+      file,
+      `${JSON.stringify(
+        {
+          format: 1,
+          connectorEpoch: "legacy-epoch",
+          nextEventSequence: 3,
+          acknowledgedSequence: 0,
+          events: [
+            legacySessionEvent,
+            { ...legacySessionEvent, sequence: 2 },
+            {
+              sequence: 3,
+              payload: {
+                type: "response",
+                requestId: "request-1",
+                success: true,
+                data: null,
+              },
+            },
+          ],
+          commandResults: [
+            [
+              "message-1",
+              {
+                success: true,
+                data: {
+                  commandResult: { accepted: true },
+                  snapshot: {
+                    queuedMessages: [{ message: "x".repeat(10_000) }],
+                  },
+                },
+              },
+            ],
+          ],
+          sessions: {
+            session: { descriptor: session, queuedMessages: [] },
+          },
+        },
+        null,
+        space,
+      )}\n`,
+    );
+
+    const migrated = await ConnectorStateJournal.open(file);
+    expect(migrated.connectorEpoch).not.toBe("legacy-epoch");
+    expect(migrated.eventBatch()).toEqual([
+      {
+        sequence: 1,
+        payload: {
+          type: "response",
+          requestId: "request-1",
+          success: true,
+          data: null,
+        },
+      },
+    ]);
+    expect(migrated.commandEntry("message-1")).toMatchObject({
+      sessionId: null,
+      fingerprint: null,
+      result: { success: true, data: { commandResult: { accepted: true } } },
+    });
+    await migrated.close();
+    const persisted = await readFile(file, "utf8");
+    expect(JSON.parse(persisted)).toMatchObject({ format: 2 });
+    expect(persisted).not.toContain("x".repeat(10_000));
+  });
+
+  it("rejects ambiguous format-2 ledgers with duplicate command identities", async () => {
+    const { file, value } = await journal();
+    await value.close();
+    const state = JSON.parse(await readFile(file, "utf8"));
+    state.commands = [
+      {
+        commandId: "duplicate",
+        sessionId: "session",
+        fingerprint: "e".repeat(64),
+        status: "pending",
+      },
+      {
+        commandId: "duplicate",
+        sessionId: "session",
+        fingerprint: "e".repeat(64),
+        status: "pending",
+      },
+    ];
+    await writeFile(file, JSON.stringify(state, null, 2));
+
+    await expect(ConnectorStateJournal.open(file)).rejects.toThrow(
+      "Invalid Host Connector command journal",
+    );
+  });
+
+  it("rejects a format-2 transport journal with a missing event", async () => {
+    const { file, value } = await journal();
+    await value.close();
+    const state = JSON.parse(await readFile(file, "utf8"));
+    state.nextEventSequence = 2;
+    state.events = [
+      {
+        sequence: 2,
+        payload: {
+          type: "response",
+          requestId: "request-2",
+          success: true,
+          data: null,
+        },
+      },
+    ];
+    await writeFile(file, JSON.stringify(state));
+
+    await expect(ConnectorStateJournal.open(file)).rejects.toThrow(
+      "Invalid Host Connector event journal",
+    );
   });
 
   it("rejects acknowledgements for a different transport epoch", async () => {
@@ -122,13 +373,87 @@ describe("connector state journal", () => {
     await value.close();
   });
 
-  it("removes sessions that are no longer authorized by the server", async () => {
+  it("rebases pending events when a legacy server loses its receive cursor", async () => {
+    const { file, value } = await journal();
+    const originalEpoch = value.connectorEpoch;
+    value.enqueue({
+      type: "response",
+      requestId: "acknowledged-request",
+      success: true,
+      data: null,
+    });
+    await value.acknowledge({
+      connectorEpoch: originalEpoch,
+      acknowledgedSequence: 1,
+    });
+    value.enqueue({
+      type: "response",
+      requestId: "pending-request-1",
+      success: true,
+      data: 1,
+    });
+    value.enqueue({
+      type: "response",
+      requestId: "pending-request-2",
+      success: true,
+      data: 2,
+    });
+
+    await expect(
+      value.acknowledge({
+        connectorEpoch: originalEpoch,
+        acknowledgedSequence: 0,
+      }),
+    ).resolves.toBe("rebased");
+    expect(value.connectorEpoch).not.toBe(originalEpoch);
+    expect(value.eventBatch()).toEqual([
+      {
+        sequence: 1,
+        payload: {
+          type: "response",
+          requestId: "pending-request-1",
+          success: true,
+          data: 1,
+        },
+      },
+      {
+        sequence: 2,
+        payload: {
+          type: "response",
+          requestId: "pending-request-2",
+          success: true,
+          data: 2,
+        },
+      },
+    ]);
+    await value.close();
+
+    const restored = await ConnectorStateJournal.open(file);
+    expect(restored.connectorEpoch).not.toBe(originalEpoch);
+    expect(restored.eventBatch().map((event) => event.sequence)).toEqual([1, 2]);
+    await restored.close();
+  });
+
+  it("removes sessions and scoped command entries no longer authorized by the server", async () => {
     const { value } = await journal();
     await value.recordSession(session);
+    await value.beginCommand("session-command", "session", "f".repeat(64));
+    await value.beginCommand("orphan-command", "orphan", "0".repeat(64));
 
     await value.retainSessions(new Set());
 
     expect(value.sessionIds()).toEqual([]);
+    expect(value.commandEntry("session-command")).toBeUndefined();
+    expect(value.commandEntry("orphan-command")).toBeUndefined();
+    await value.close();
+  });
+
+  it("cleans up an orphan command even when its session was never recorded", async () => {
+    const { value } = await journal();
+    await value.beginCommand("orphan-command", "orphan", "1".repeat(64));
+
+    await expect(value.deleteSession("orphan")).resolves.toEqual([]);
+    expect(value.commandEntry("orphan-command")).toBeUndefined();
     await value.close();
   });
 });

--- a/apps/connector/src/state.ts
+++ b/apps/connector/src/state.ts
@@ -1,4 +1,10 @@
-import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+} from "node:fs/promises";
 import path from "node:path";
 import {
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
@@ -16,22 +22,40 @@ export type CachedCommandResult =
   | { success: true; data: unknown }
   | { success: false; error: string };
 
+export type CommandJournalEntry =
+  | {
+      commandId: string;
+      sessionId: string;
+      fingerprint: string;
+      status: "pending";
+    }
+  | {
+      commandId: string;
+      sessionId: string | null;
+      fingerprint: string | null;
+      status: "completed";
+      result: CachedCommandResult;
+    };
+
+export type BeginCommandResult =
+  | { status: "execute" }
+  | { status: "pending" }
+  | { status: "completed"; result: CachedCommandResult };
+
 type SessionState = {
   descriptor: AgentDaemonSessionDescriptor;
   queuedMessages: AgentQueuedMessage[];
 };
 
 type ConnectorState = {
-  format: 1;
+  format: 2;
   connectorEpoch: string;
   nextEventSequence: number;
   acknowledgedSequence: number;
   events: HostConnectorEvent[];
-  commandResults: Array<[string, CachedCommandResult]>;
+  commands: CommandJournalEntry[];
   sessions: Record<string, SessionState>;
 };
-
-const COMMAND_RESULT_LIMIT = 2_048;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -43,7 +67,9 @@ function isQueuedMessage(value: unknown): value is AgentQueuedMessage {
     typeof value.id === "string" &&
     value.id.length > 0 &&
     typeof value.message === "string" &&
-    (value.status === "pending" || value.status === "sending") &&
+    (value.status === "pending" ||
+      value.status === "sending" ||
+      value.status === "uncertain") &&
     (value.images === undefined ||
       (Array.isArray(value.images) &&
         value.images.every((image) => agentPromptImageSchema.safeParse(image).success)))
@@ -58,10 +84,165 @@ function isCommandResult(value: unknown): value is CachedCommandResult {
   );
 }
 
+function stableCommandResult(result: CachedCommandResult): CachedCommandResult {
+  if (!result.success) return { success: false, error: result.error };
+  if (!isRecord(result.data)) return { success: true, data: result.data };
+  // Queue state is a mutable projection and is already persisted in the
+  // session journal/timeline. Replaying old snapshots from the command ledger
+  // can resurrect drained messages and made v0.2 journals grow quadratically.
+  const stable = { ...result.data };
+  delete stable.snapshot;
+  return { success: true, data: stable };
+}
+
+function isCommandIdentity(
+  commandId: string,
+  sessionId: string,
+  fingerprint: string,
+): boolean {
+  return (
+    commandId.length > 0 &&
+    sessionId.length > 0 &&
+    /^[a-f0-9]{64}$/u.test(fingerprint)
+  );
+}
+
+function isCommandEntry(value: unknown): value is CommandJournalEntry {
+  if (
+    !isRecord(value) ||
+    typeof value.commandId !== "string" ||
+    !value.commandId
+  ) {
+    return false;
+  }
+  if (value.status === "pending") {
+    return (
+      typeof value.sessionId === "string" &&
+      value.sessionId.length > 0 &&
+      typeof value.fingerprint === "string" &&
+      /^[a-f0-9]{64}$/u.test(value.fingerprint)
+    );
+  }
+  return (
+    value.status === "completed" &&
+    (value.sessionId === null ||
+      (typeof value.sessionId === "string" && value.sessionId.length > 0)) &&
+    (value.fingerprint === null ||
+      (typeof value.fingerprint === "string" &&
+        /^[a-f0-9]{64}$/u.test(value.fingerprint))) &&
+    ((value.sessionId === null && value.fingerprint === null) ||
+      (typeof value.sessionId === "string" &&
+        typeof value.fingerprint === "string")) &&
+    isCommandResult(value.result)
+  );
+}
+
+type JsonArrayRange = { start: number; end: number };
+
+function scanJsonArray(
+  raw: string,
+  key: string,
+  after: number,
+  visit: (element: string) => void,
+): JsonArrayRange {
+  const marker = new RegExp(`"${key}"\\s*:\\s*\\[`, "gu");
+  marker.lastIndex = after;
+  const match = marker.exec(raw);
+  if (!match) throw new Error(`Invalid Host Connector ${key} journal.`);
+  const start = match.index + match[0].lastIndexOf("[");
+  let elementStart = start + 1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start + 1; index < raw.length; index += 1) {
+    const character = raw[index]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{" || character === "[") {
+      depth += 1;
+      continue;
+    }
+    if (character === "}" || character === "]") {
+      if (character === "]" && depth === 0) {
+        const element = raw.slice(elementStart, index).trim();
+        if (element) {
+          visit(element);
+        } else if (elementStart !== start + 1) {
+          throw new Error(`Invalid Host Connector ${key} journal.`);
+        }
+        return { start, end: index };
+      }
+      depth -= 1;
+      if (depth < 0) break;
+      continue;
+    }
+    if (character === "," && depth === 0) {
+      const element = raw.slice(elementStart, index).trim();
+      if (!element) throw new Error(`Invalid Host Connector ${key} journal.`);
+      visit(element);
+      elementStart = index + 1;
+    }
+  }
+  throw new Error(`Invalid Host Connector ${key} journal.`);
+}
+
+/**
+ * v0.2 persisted every token-shaped session event in the general transport
+ * outbox. Real installations reached hundreds of megabytes, so parsing the
+ * whole JSON into objects during upgrade can exhaust memory. Scan the two
+ * legacy arrays element-by-element, discard session events, and strip mutable
+ * snapshots before parsing the much smaller reconstructed document.
+ */
+function compactLegacyState(raw: string): string {
+  const events: HostConnectorEvent[] = [];
+  const eventsRange = scanJsonArray(raw, "events", 0, (element) => {
+    const event: unknown = JSON.parse(element);
+    if (!isHostConnectorEvent(event)) {
+      throw new Error("Invalid Host Connector event journal.");
+    }
+    if (event.payload.type === "session_event") return;
+    events.push({ sequence: events.length + 1, payload: event.payload });
+  });
+  const commandResults: Array<[string, CachedCommandResult]> = [];
+  const commandResultsRange = scanJsonArray(
+    raw,
+    "commandResults",
+    eventsRange.end,
+    (element) => {
+      const entry: unknown = JSON.parse(element);
+      if (
+        !Array.isArray(entry) ||
+        entry.length !== 2 ||
+        typeof entry[0] !== "string" ||
+        !entry[0] ||
+        !isCommandResult(entry[1])
+      ) {
+        throw new Error("Invalid Host Connector command journal.");
+      }
+      commandResults.push([entry[0], stableCommandResult(entry[1])]);
+    },
+  );
+  return [
+    raw.slice(0, eventsRange.start),
+    JSON.stringify(events),
+    raw.slice(eventsRange.end + 1, commandResultsRange.start),
+    JSON.stringify(commandResults),
+    raw.slice(commandResultsRange.end + 1),
+  ].join("");
+}
+
 function parseState(value: unknown): ConnectorState {
   if (
     !isRecord(value) ||
-    value.format !== 1 ||
+    value.format !== 2 ||
     typeof value.connectorEpoch !== "string" ||
     !value.connectorEpoch ||
     !Number.isSafeInteger(value.nextEventSequence) ||
@@ -70,23 +251,11 @@ function parseState(value: unknown): ConnectorState {
     Number(value.acknowledgedSequence) < 0 ||
     !Array.isArray(value.events) ||
     !value.events.every(isHostConnectorEvent) ||
-    !Array.isArray(value.commandResults) ||
+    !Array.isArray(value.commands) ||
+    !value.commands.every(isCommandEntry) ||
     !isRecord(value.sessions)
   ) {
     throw new Error("Invalid Host Connector state journal.");
-  }
-  const commandResults: Array<[string, CachedCommandResult]> = [];
-  for (const entry of value.commandResults) {
-    if (
-      !Array.isArray(entry) ||
-      entry.length !== 2 ||
-      typeof entry[0] !== "string" ||
-      !entry[0] ||
-      !isCommandResult(entry[1])
-    ) {
-      throw new Error("Invalid Host Connector command journal.");
-    }
-    commandResults.push([entry[0], entry[1]]);
   }
   const sessions: Record<string, SessionState> = {};
   for (const [sessionId, session] of Object.entries(value.sessions)) {
@@ -105,10 +274,13 @@ function parseState(value: unknown): ConnectorState {
     };
   }
   const events = value.events as HostConnectorEvent[];
+  const commands = value.commands as CommandJournalEntry[];
   const nextEventSequence = Number(value.nextEventSequence);
   const acknowledgedSequence = Number(value.acknowledgedSequence);
   if (
     acknowledgedSequence > nextEventSequence ||
+    (events[0]?.sequence ?? acknowledgedSequence + 1) !==
+      acknowledgedSequence + 1 ||
     events.some(
       (event, index) =>
         event.sequence <= acknowledgedSequence ||
@@ -118,25 +290,74 @@ function parseState(value: unknown): ConnectorState {
   ) {
     throw new Error("Invalid Host Connector event journal.");
   }
+  if (new Set(commands.map((entry) => entry.commandId)).size !== commands.length) {
+    throw new Error("Invalid Host Connector command journal.");
+  }
   return {
-    format: 1,
+    format: 2,
     connectorEpoch: value.connectorEpoch,
     nextEventSequence,
     acknowledgedSequence,
     events,
-    commandResults: commandResults.slice(-COMMAND_RESULT_LIMIT),
+    commands,
     sessions,
   };
 }
 
+function migrateLegacyState(value: unknown): ConnectorState {
+  if (
+    !isRecord(value) ||
+    value.format !== 1 ||
+    typeof value.connectorEpoch !== "string" ||
+    !value.connectorEpoch ||
+    !Array.isArray(value.events) ||
+    !value.events.every(isHostConnectorEvent) ||
+    !Array.isArray(value.commandResults) ||
+    !isRecord(value.sessions)
+  ) {
+    throw new Error("Invalid Host Connector legacy state journal.");
+  }
+  const events = (value.events as HostConnectorEvent[]).flatMap((event) =>
+    event.payload.type === "session_event" ? [] : [event.payload],
+  );
+  const commands: CommandJournalEntry[] = value.commandResults.map((entry) => {
+    if (
+      !Array.isArray(entry) ||
+      entry.length !== 2 ||
+      typeof entry[0] !== "string" ||
+      !entry[0] ||
+      !isCommandResult(entry[1])
+    ) {
+      throw new Error("Invalid Host Connector command journal.");
+    }
+    return {
+      commandId: entry[0],
+      sessionId: null,
+      fingerprint: null,
+      status: "completed",
+      result: stableCommandResult(entry[1]),
+    };
+  });
+  return parseState({
+    ...value,
+    format: 2,
+    connectorEpoch: crypto.randomUUID(),
+    acknowledgedSequence: 0,
+    nextEventSequence: events.length,
+    events: events.map((payload, index) => ({ sequence: index + 1, payload })),
+    commands,
+    commandResults: undefined,
+  });
+}
+
 function initialState(): ConnectorState {
   return {
-    format: 1,
+    format: 2,
     connectorEpoch: crypto.randomUUID(),
     nextEventSequence: 0,
     acknowledgedSequence: 0,
     events: [],
-    commandResults: [],
+    commands: [],
     sessions: {},
   };
 }
@@ -144,6 +365,8 @@ function initialState(): ConnectorState {
 export class ConnectorStateJournal {
   private writeTail = Promise.resolve();
   private saveTimer: NodeJS.Timeout | undefined;
+  private lifecycle: "open" | "closing" | "closed" = "open";
+  private closePromise: Promise<void> | undefined;
 
   private constructor(
     private readonly file: string,
@@ -152,13 +375,24 @@ export class ConnectorStateJournal {
 
   static async open(file: string): Promise<ConnectorStateJournal> {
     let state: ConnectorState;
+    let migrated = false;
     try {
-      state = parseState(JSON.parse(await readFile(file, "utf8")));
+      let raw = await readFile(file, "utf8");
+      const format = /^\s*\{\s*"format"\s*:\s*(\d+)/u.exec(raw)?.[1];
+      if (format === "1") {
+        raw = compactLegacyState(raw);
+        state = migrateLegacyState(JSON.parse(raw));
+        migrated = true;
+      } else {
+        state = parseState(JSON.parse(raw));
+      }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       state = initialState();
     }
-    return new ConnectorStateJournal(file, state);
+    const journal = new ConnectorStateJournal(file, state);
+    if (migrated) await journal.save();
+    return journal;
   }
 
   get connectorEpoch(): string {
@@ -166,6 +400,7 @@ export class ConnectorStateJournal {
   }
 
   enqueue(payload: HostConnectorEventPayload): HostConnectorEvent {
+    this.assertOpen();
     const event = {
       sequence: ++this.state.nextEventSequence,
       payload,
@@ -179,13 +414,35 @@ export class ConnectorStateJournal {
     return this.state.events.slice(0, HOST_CONNECTOR_EVENT_BATCH_LIMIT);
   }
 
-  async acknowledge(ack: HostConnectorEventAck): Promise<void> {
+  async acknowledge(
+    ack: HostConnectorEventAck,
+  ): Promise<"acknowledged" | "rebased"> {
+    this.assertOpen();
     if (ack.connectorEpoch !== this.state.connectorEpoch) {
       throw new Error("OvertChat acknowledged a different connector epoch.");
     }
     if (
+      Number.isSafeInteger(ack.acknowledgedSequence) &&
+      ack.acknowledgedSequence >= 0 &&
+      ack.acknowledgedSequence < this.state.acknowledgedSequence
+    ) {
+      // Servers released before session-sync-v1 kept their receive cursor only
+      // in memory. After one restarts it acknowledges 0 for a durable sender
+      // that may be at 20,000+. Rotate only the transport identity and renumber
+      // pending, already-produced events; daemon commands are never rerun.
+      this.state.connectorEpoch = crypto.randomUUID();
+      this.state.acknowledgedSequence = 0;
+      this.state.events = this.state.events.map((event, index) => ({
+        ...event,
+        sequence: index + 1,
+      }));
+      this.state.nextEventSequence = this.state.events.length;
+      await this.save();
+      return "rebased";
+    }
+    if (
       !Number.isSafeInteger(ack.acknowledgedSequence) ||
-      ack.acknowledgedSequence < this.state.acknowledgedSequence ||
+      ack.acknowledgedSequence < 0 ||
       ack.acknowledgedSequence > this.state.nextEventSequence
     ) {
       throw new Error("OvertChat returned an invalid connector acknowledgement.");
@@ -195,27 +452,81 @@ export class ConnectorStateJournal {
       (event) => event.sequence > ack.acknowledgedSequence,
     );
     await this.save();
+    return "acknowledged";
   }
 
-  commandResult(commandId: string): CachedCommandResult | undefined {
-    return new Map(this.state.commandResults).get(commandId);
+  commandEntry(commandId: string): CommandJournalEntry | undefined {
+    return this.state.commands.find((entry) => entry.commandId === commandId);
   }
 
-  async recordCommandResult(
+  async beginCommand(
     commandId: string,
+    sessionId: string,
+    fingerprint: string,
+  ): Promise<BeginCommandResult> {
+    this.assertOpen();
+    if (!isCommandIdentity(commandId, sessionId, fingerprint)) {
+      throw new Error("Invalid command ledger identity.");
+    }
+    const existing = this.commandEntry(commandId);
+    if (existing) {
+      if (
+        existing.sessionId === null ||
+        existing.fingerprint === null
+      ) {
+        return existing.status === "completed"
+          ? { status: "completed", result: existing.result }
+          : { status: "pending" };
+      }
+      if (
+        existing.sessionId !== sessionId ||
+        existing.fingerprint !== fingerprint
+      ) {
+        throw new Error("A command identity was reused for different work.");
+      }
+      return existing.status === "completed"
+        ? { status: "completed", result: existing.result }
+        : { status: "pending" };
+    }
+    this.state.commands.push({
+      commandId,
+      sessionId,
+      fingerprint,
+      status: "pending",
+    });
+    await this.save();
+    return { status: "execute" };
+  }
+
+  async completeCommand(
+    commandId: string,
+    sessionId: string,
+    fingerprint: string,
     result: CachedCommandResult,
   ): Promise<void> {
-    const existing = this.state.commandResults.findIndex(
-      ([storedId]) => storedId === commandId,
-    );
-    if (existing >= 0) this.state.commandResults.splice(existing, 1);
-    this.state.commandResults.push([commandId, result]);
-    if (this.state.commandResults.length > COMMAND_RESULT_LIMIT) {
-      this.state.commandResults.splice(
-        0,
-        this.state.commandResults.length - COMMAND_RESULT_LIMIT,
-      );
+    this.assertOpen();
+    if (!isCommandIdentity(commandId, sessionId, fingerprint)) {
+      throw new Error("Invalid command ledger identity.");
     }
+    const existing = this.commandEntry(commandId);
+    if (
+      !existing ||
+      existing.sessionId !== sessionId ||
+      existing.fingerprint !== fingerprint
+    ) {
+      throw new Error("The command ledger entry changed before completion.");
+    }
+    if (existing.status === "completed") {
+      throw new Error("The command ledger entry was already completed.");
+    }
+    const index = this.state.commands.indexOf(existing);
+    this.state.commands[index] = {
+      commandId,
+      sessionId,
+      fingerprint,
+      status: "completed",
+      result: stableCommandResult(result),
+    };
     await this.save();
   }
 
@@ -227,14 +538,30 @@ export class ConnectorStateJournal {
     return Object.keys(this.state.sessions);
   }
 
-  async retainSessions(sessionIds: ReadonlySet<string>): Promise<void> {
-    this.deleteMatchingSessions(
+  sessionIdsForWorkspace(workspaceId: string): string[] {
+    return Object.values(this.state.sessions)
+      .filter((session) => session.descriptor.workspaceId === workspaceId)
+      .map((session) => session.descriptor.sessionId);
+  }
+
+  sessionIdsForConnection(connectionId: string): string[] {
+    return Object.values(this.state.sessions)
+      .filter((session) => session.descriptor.connectionId === connectionId)
+      .map((session) => session.descriptor.sessionId);
+  }
+
+  async retainSessions(sessionIds: ReadonlySet<string>): Promise<string[]> {
+    this.assertOpen();
+    const removed = this.deleteMatchingSessions(
       (session) => !sessionIds.has(session.descriptor.sessionId),
     );
+    this.retainCommandsForSessions(sessionIds);
     await this.save();
+    return removed;
   }
 
   async recordSession(descriptor: AgentDaemonSessionDescriptor): Promise<void> {
+    this.assertOpen();
     const current = this.state.sessions[descriptor.sessionId];
     this.state.sessions[descriptor.sessionId] = {
       descriptor,
@@ -247,6 +574,7 @@ export class ConnectorStateJournal {
     sessionId: string,
     messages: readonly AgentQueuedMessage[],
   ): Promise<void> {
+    this.assertOpen();
     const current = this.state.sessions[sessionId];
     if (!current) return;
     current.queuedMessages = messages.map((message) => ({
@@ -256,31 +584,49 @@ export class ConnectorStateJournal {
     await this.save();
   }
 
-  async deleteSession(sessionId: string): Promise<void> {
-    delete this.state.sessions[sessionId];
+  async deleteSession(sessionId: string): Promise<string[]> {
+    this.assertOpen();
+    const removed = Boolean(this.state.sessions[sessionId]);
+    if (removed) delete this.state.sessions[sessionId];
+    const removedCommands = this.deleteCommandsForSessions(
+      new Set([sessionId]),
+    );
+    if (!removed && !removedCommands) return [];
     await this.save();
+    return removed ? [sessionId] : [];
   }
 
-  async deleteWorkspace(workspaceId: string): Promise<void> {
-    this.deleteMatchingSessions(
+  async deleteWorkspace(workspaceId: string): Promise<string[]> {
+    this.assertOpen();
+    const removed = this.deleteMatchingSessions(
       (session) => session.descriptor.workspaceId === workspaceId,
     );
     await this.save();
+    return removed;
   }
 
-  async deleteConnection(connectionId: string): Promise<void> {
-    this.deleteMatchingSessions(
+  async deleteConnection(connectionId: string): Promise<string[]> {
+    this.assertOpen();
+    const removed = this.deleteMatchingSessions(
       (session) => session.descriptor.connectionId === connectionId,
     );
     await this.save();
+    return removed;
   }
 
-  async deleteAllSessions(): Promise<void> {
+  async deleteAllSessions(): Promise<string[]> {
+    this.assertOpen();
+    const removed = Object.keys(this.state.sessions);
     this.state.sessions = {};
+    this.state.commands = this.state.commands.filter(
+      (entry) => entry.sessionId === null,
+    );
     await this.save();
+    return removed;
   }
 
-  async close(): Promise<void> {
+  async flush(): Promise<void> {
+    this.assertOpen();
     if (this.saveTimer) {
       clearTimeout(this.saveTimer);
       this.saveTimer = undefined;
@@ -289,12 +635,58 @@ export class ConnectorStateJournal {
     await this.writeTail;
   }
 
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.lifecycle = "closing";
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
+      this.saveTimer = undefined;
+    }
+    this.closePromise = (async () => {
+      try {
+        await this.writeState();
+        await this.writeTail;
+      } finally {
+        this.lifecycle = "closed";
+      }
+    })();
+    return this.closePromise;
+  }
+
+  private assertOpen(): void {
+    if (this.lifecycle !== "open") {
+      throw new Error("Host Connector state journal is closed.");
+    }
+  }
+
   private deleteMatchingSessions(
     predicate: (session: SessionState) => boolean,
-  ): void {
+  ): string[] {
+    const removed: string[] = [];
     for (const [sessionId, session] of Object.entries(this.state.sessions)) {
-      if (predicate(session)) delete this.state.sessions[sessionId];
+      if (!predicate(session)) continue;
+      delete this.state.sessions[sessionId];
+      removed.push(sessionId);
     }
+    this.deleteCommandsForSessions(new Set(removed));
+    return removed;
+  }
+
+  private deleteCommandsForSessions(
+    sessionIds: ReadonlySet<string>,
+  ): boolean {
+    if (sessionIds.size === 0) return false;
+    const previousLength = this.state.commands.length;
+    this.state.commands = this.state.commands.filter(
+      (entry) => entry.sessionId === null || !sessionIds.has(entry.sessionId),
+    );
+    return this.state.commands.length !== previousLength;
+  }
+
+  private retainCommandsForSessions(sessionIds: ReadonlySet<string>): void {
+    this.state.commands = this.state.commands.filter(
+      (entry) => entry.sessionId === null || sessionIds.has(entry.sessionId),
+    );
   }
 
   private scheduleSave(): void {
@@ -313,16 +705,45 @@ export class ConnectorStateJournal {
   }
 
   private save(): Promise<void> {
+    this.assertOpen();
+    return this.writeState();
+  }
+
+  private writeState(): Promise<void> {
     const serialized = `${JSON.stringify(this.state)}\n`;
     const operation = this.writeTail.then(async () => {
-      await mkdir(path.dirname(this.file), { recursive: true, mode: 0o700 });
-      const temporary = `${this.file}.${process.pid}.tmp`;
-      await writeFile(temporary, serialized, {
-        encoding: "utf8",
-        mode: 0o600,
-      });
-      await rename(temporary, this.file);
-      await chmod(this.file, 0o600);
+      const directory = path.dirname(this.file);
+      await mkdir(directory, { recursive: true, mode: 0o700 });
+      const temporary = `${this.file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+      try {
+        const handle = await open(temporary, "wx", 0o600);
+        try {
+          await handle.writeFile(serialized, "utf8");
+          await handle.chmod(0o600);
+          await handle.sync();
+        } finally {
+          await handle.close();
+        }
+        await rename(temporary, this.file);
+        let directoryHandle: Awaited<ReturnType<typeof open>> | undefined;
+        try {
+          directoryHandle = await open(directory, "r");
+          await directoryHandle.sync();
+        } catch (error) {
+          if (
+            !["EINVAL", "ENOTSUP", "EISDIR", "EPERM"].includes(
+              String((error as NodeJS.ErrnoException).code),
+            )
+          ) {
+            throw error;
+          }
+        } finally {
+          await directoryHandle?.close();
+        }
+      } catch (error) {
+        await rm(temporary, { force: true }).catch(() => {});
+        throw error;
+      }
     });
     this.writeTail = operation.catch(() => {});
     return operation;

--- a/apps/connector/src/timeline.test.ts
+++ b/apps/connector/src/timeline.test.ts
@@ -1,0 +1,671 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import {
+  appendFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  AgentRuntimeEnvelope,
+  AgentRuntimeSnapshot,
+} from "@overtchat/agent-bridge";
+import { ConnectorTimelineStore } from "./timeline.js";
+
+const SESSION_ID = "session";
+const PROVIDER_SESSION_ID = "provider-session";
+const directories: string[] = [];
+const stores: ConnectorTimelineStore[] = [];
+
+function snapshot(
+  sessionId = SESSION_ID,
+  state: Record<string, unknown> = { isStreaming: false },
+): AgentRuntimeSnapshot {
+  return {
+    sessionId,
+    provider: "pi",
+    capabilities: { steer: true },
+    status: "idle",
+    activeTurn: null,
+    state,
+    messages: [],
+    models: [],
+    thinkingLevels: ["off"],
+    commands: [],
+    queuedMessages: [],
+    stats: {
+      sessionFile: null,
+      sessionId: null,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      toolResults: 0,
+      totalMessages: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+      cost: 0,
+    },
+  };
+}
+
+function runtimeEvent(
+  data: Extract<AgentRuntimeEnvelope, { type: "runtime_event" }>["data"],
+): AgentRuntimeEnvelope {
+  return {
+    epoch: "provider-runtime",
+    sequence: 1,
+    type: "runtime_event",
+    data,
+  };
+}
+
+function timelineFile(directory: string, sessionId = SESSION_ID): string {
+  const name = createHash("sha256").update(sessionId).digest("hex");
+  return path.join(directory, `${name}.jsonl`);
+}
+
+async function createStore(): Promise<{
+  directory: string;
+  file: string;
+  store: ConnectorTimelineStore;
+}> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "overtchat-timeline-"),
+  );
+  directories.push(directory);
+  const store = await ConnectorTimelineStore.open(directory);
+  stores.push(store);
+  return { directory, file: timelineFile(directory), store };
+}
+
+async function reopen(directory: string): Promise<ConnectorTimelineStore> {
+  const store = await ConnectorTimelineStore.open(directory);
+  stores.push(store);
+  return store;
+}
+
+async function commit(
+  store: ConnectorTimelineStore,
+  data: Extract<AgentRuntimeEnvelope, { type: "runtime_event" }>["data"],
+): Promise<AgentRuntimeEnvelope | null> {
+  const pending = store.commit(SESSION_ID, runtimeEvent(data));
+  await store.flush(SESSION_ID);
+  return pending;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    stores.splice(0).map((store) => store.close().catch(() => {})),
+  );
+  await Promise.all(
+    directories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("connector session timeline", () => {
+  it("persists an event before live delivery and restores its exact cursor", async () => {
+    const { directory, file, store } = await createStore();
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(),
+    );
+    const delivered: AgentRuntimeEnvelope[] = [];
+    const subscription = await store.subscribe(
+      SESSION_ID,
+      initial,
+      (envelope) => {
+        expect(readFileSync(file, "utf8")).toContain(
+          `"sequence":${envelope.sequence}`,
+        );
+        delivered.push(envelope);
+      },
+    );
+
+    const canonical = await commit(store, {
+      type: "overtchat_status",
+      status: "running",
+      startedAt: 42,
+    });
+
+    expect(canonical).toMatchObject({
+      epoch: initial.epoch,
+      sequence: 1,
+      type: "runtime_event",
+    });
+    expect(delivered).toEqual([canonical]);
+    subscription.unsubscribe();
+    await store.close();
+
+    const restored = await reopen(directory);
+    await expect(restored.sync(SESSION_ID, initial)).resolves.toEqual({
+      reset: false,
+      cursor: { epoch: initial.epoch, sequence: 1 },
+      events: [canonical],
+    });
+    await expect(
+      restored.sync(SESSION_ID, {
+        epoch: initial.epoch,
+        sequence: 1,
+      }),
+    ).resolves.toEqual({
+      reset: false,
+      cursor: { epoch: initial.epoch, sequence: 1 },
+      events: [],
+    });
+  });
+
+  it("replays reducer-derived timestamps into a deeply identical snapshot", async () => {
+    const { directory, file, store } = await createStore();
+    await store.openSession(SESSION_ID, PROVIDER_SESSION_ID, snapshot());
+    const source = runtimeEvent({ type: "agent_start" });
+    const commits = [
+      store.commit(SESSION_ID, source),
+      store.commit(
+        SESSION_ID,
+        runtimeEvent({ type: "command_output", text: "Current model" }),
+      ),
+      store.commit(
+        SESSION_ID,
+        runtimeEvent({
+          type: "tool_execution_update",
+          toolCallId: "call",
+          toolName: "bash",
+          partialResult: {
+            content: [{ type: "text", text: "partial output" }],
+          },
+        }),
+      ),
+    ];
+    await store.flush(SESSION_ID);
+    const canonical = await Promise.all(commits);
+    const before = await store.sync(SESSION_ID);
+
+    expect(source.data).not.toHaveProperty("overtchatRecordedAt");
+    expect(canonical).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ overtchatRecordedAt: expect.any(Number) }),
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({ overtchatRecordedAt: expect.any(Number) }),
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({ overtchatRecordedAt: expect.any(Number) }),
+      }),
+    ]);
+    expect(await readFile(file, "utf8")).toContain("overtchatRecordedAt");
+    expect(before).toMatchObject({
+      reset: true,
+      cursor: { sequence: 3 },
+      snapshot: {
+        activeTurn: { startedAt: expect.any(Number) },
+        messages: [
+          expect.objectContaining({ role: "custom", timestamp: expect.any(Number) }),
+          expect.objectContaining({
+            role: "toolResult",
+            timestamp: expect.any(Number),
+          }),
+        ],
+      },
+    });
+
+    await store.close();
+    const restored = await reopen(directory);
+    const after = await restored.sync(SESSION_ID);
+    expect(after).toEqual(before);
+  });
+
+  it("does not duplicate a recorded output when a later runtime snapshot includes it", async () => {
+    const { store } = await createStore();
+    await store.openSession(SESSION_ID, PROVIDER_SESSION_ID, snapshot());
+    await commit(store, {
+      type: "command_output",
+      text: "Current model: GPT-5.6",
+      overtchatRecordedAt: 2_345,
+    });
+    const pending = store.commit(SESSION_ID, {
+      epoch: "provider-runtime",
+      sequence: 2,
+      type: "snapshot",
+      data: {
+        ...snapshot(),
+        messages: [
+          {
+            role: "custom",
+            content: "Current model: GPT-5.6",
+            display: true,
+            timestamp: 2_345,
+          },
+        ],
+      },
+    });
+    await store.flush(SESSION_ID);
+    await pending;
+
+    await expect(store.sync(SESSION_ID)).resolves.toMatchObject({
+      reset: true,
+      snapshot: {
+        messages: [
+          {
+            role: "custom",
+            content: "Current model: GPT-5.6",
+            display: true,
+            timestamp: 2_345,
+          },
+        ],
+      },
+    });
+  });
+
+  it("closes the subscribe catch-up race without duplicating live events", async () => {
+    const { store } = await createStore();
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(),
+    );
+    const firstCommit = store.commit(
+      SESSION_ID,
+      runtimeEvent({ type: "overtchat_status", status: "running" }),
+    );
+    const live: AgentRuntimeEnvelope[] = [];
+    const subscriptionPromise = store.subscribe(
+      SESSION_ID,
+      initial,
+      (envelope) => live.push(envelope),
+    );
+
+    const [first, subscription] = await Promise.all([
+      firstCommit,
+      subscriptionPromise,
+    ]);
+    expect(subscription.sync).toEqual({
+      reset: false,
+      cursor: { epoch: initial.epoch, sequence: 1 },
+      events: [first],
+    });
+    expect(live).toEqual([]);
+
+    const second = await commit(store, {
+      type: "overtchat_status",
+      status: "idle",
+    });
+    expect(second).toMatchObject({ sequence: 2 });
+    expect(live).toEqual([second]);
+    subscription.unsubscribe();
+  });
+
+  it("returns deltas only for a retained cursor and resets invalid cursors", async () => {
+    const { store } = await createStore();
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(),
+    );
+    const first = await commit(store, {
+      type: "overtchat_status",
+      status: "running",
+      startedAt: 42,
+    });
+    const second = await commit(store, {
+      type: "overtchat_status",
+      status: "idle",
+    });
+
+    await expect(
+      store.sync(SESSION_ID, {
+        epoch: initial.epoch,
+        sequence: 1,
+      }),
+    ).resolves.toEqual({
+      reset: false,
+      cursor: { epoch: initial.epoch, sequence: 2 },
+      events: [second],
+    });
+    await expect(store.sync(SESSION_ID, initial)).resolves.toMatchObject({
+      reset: false,
+      events: [first, second],
+    });
+    await expect(store.sync(SESSION_ID)).resolves.toMatchObject({
+      reset: true,
+      cursor: { epoch: initial.epoch, sequence: 2 },
+      snapshot: { status: "idle" },
+    });
+    await expect(
+      store.sync(SESSION_ID, { epoch: "stale-epoch", sequence: 2 }),
+    ).resolves.toMatchObject({ reset: true });
+    await expect(
+      store.sync(SESSION_ID, { epoch: initial.epoch, sequence: 3 }),
+    ).resolves.toMatchObject({ reset: true });
+  });
+
+  it("does not duplicate plain provider history across repeated resumes", async () => {
+    const { store } = await createStore();
+    const messages = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hello back" },
+    ];
+    const providerSnapshot = { ...snapshot(), messages };
+
+    await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      providerSnapshot,
+    );
+    await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      providerSnapshot,
+    );
+    await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      providerSnapshot,
+    );
+
+    await expect(store.sync(SESSION_ID)).resolves.toMatchObject({
+      reset: true,
+      snapshot: { messages },
+    });
+  });
+
+  it("accepts authoritative restart checkpoints and publishes provider rotation", async () => {
+    const { directory, store } = await createStore();
+    const durable = {
+      ...snapshot(),
+      messages: [
+        {
+          role: "user",
+          content: "Queued before the provider persisted it",
+          overtchatSubmissionId: "submission-1",
+        },
+      ],
+    };
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      durable,
+    );
+    await commit(store, {
+      type: "overtchat_status",
+      status: "running",
+    });
+
+    const refreshed = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      {
+        ...snapshot(SESSION_ID, { generation: 2 }),
+        messages: [
+          { id: "provider-message", role: "assistant", content: "Caught up" },
+        ],
+      },
+    );
+    expect(refreshed).toEqual({ epoch: initial.epoch, sequence: 2 });
+    await expect(
+      store.sync(SESSION_ID),
+    ).resolves.toMatchObject({
+      reset: true,
+      cursor: refreshed,
+      snapshot: {
+        state: { generation: 2 },
+        status: "idle",
+        messages: [expect.objectContaining({ id: "provider-message" })],
+      },
+    });
+
+    const runtimeSnapshot = store.commit(SESSION_ID, {
+      epoch: "replacement-runtime-ephemeral",
+      sequence: 99,
+      type: "snapshot",
+      data: snapshot(SESSION_ID, { generation: 3 }),
+    });
+    await store.flush(SESSION_ID);
+    await expect(runtimeSnapshot).resolves.toMatchObject({
+      epoch: initial.epoch,
+      sequence: 3,
+      type: "snapshot",
+      data: { messages: [] },
+    });
+
+    const delivered: AgentRuntimeEnvelope[] = [];
+    const subscription = await store.subscribe(
+      SESSION_ID,
+      { epoch: initial.epoch, sequence: 3 },
+      (envelope) => delivered.push(envelope),
+    );
+
+    const rotated = await store.openSession(
+      SESSION_ID,
+      "replacement-provider-session",
+      snapshot(SESSION_ID, { generation: 3 }),
+    );
+    expect(rotated.sequence).toBe(1);
+    expect(rotated.epoch).not.toBe(initial.epoch);
+    expect(delivered).toEqual([
+      expect.objectContaining({
+        ...rotated,
+        type: "snapshot",
+        data: expect.objectContaining({ state: { generation: 3 } }),
+      }),
+    ]);
+    subscription.unsubscribe();
+    await store.close();
+
+    const restored = await reopen(directory);
+    await expect(restored.sync(SESSION_ID, refreshed)).resolves.toMatchObject({
+      reset: true,
+      cursor: rotated,
+      snapshot: { state: { generation: 3 } },
+    });
+  });
+
+  it("checkpoints an oversized tail and resets stale cursors after reopen", async () => {
+    const { directory, file, store } = await createStore();
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(),
+    );
+    const commits = Array.from({ length: 501 }, (_, index) =>
+      store.commit(
+        SESSION_ID,
+        runtimeEvent({
+          type: "overtchat_status",
+          status: index % 2 === 0 ? "running" : "idle",
+          startedAt: index,
+        }),
+      ),
+    );
+    await store.flush(SESSION_ID);
+    await Promise.all(commits);
+
+    expect((await readFile(file, "utf8")).trim().split("\n")).toHaveLength(1);
+    await expect(store.sync(SESSION_ID, initial)).resolves.toMatchObject({
+      reset: true,
+      cursor: { epoch: initial.epoch, sequence: 501 },
+    });
+    await store.close();
+
+    const restored = await reopen(directory);
+    await expect(restored.sync(SESSION_ID, initial)).resolves.toMatchObject({
+      reset: true,
+      cursor: { epoch: initial.epoch, sequence: 501 },
+    });
+  });
+
+  it.each([
+    {
+      name: "a partial final record",
+      damage: (raw: string) =>
+        `${raw}{"format":1,"type":"event","envelope":`,
+    },
+    {
+      name: "a complete record missing its final newline",
+      damage: (raw: string) => raw.slice(0, -1),
+    },
+  ])("repairs $name before accepting another event", async ({ damage }) => {
+    const { directory, file, store } = await createStore();
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(),
+    );
+    const first = await commit(store, {
+      type: "overtchat_status",
+      status: "running",
+      startedAt: 42,
+    });
+    await store.close();
+    const raw = await readFile(file, "utf8");
+    await writeFile(file, damage(raw), "utf8");
+
+    const restored = await reopen(directory);
+    await expect(restored.sync(SESSION_ID, initial)).resolves.toMatchObject({
+      reset: true,
+      cursor: { epoch: initial.epoch, sequence: 1 },
+      snapshot: { status: "running" },
+    });
+    const repaired = await readFile(file, "utf8");
+    expect(repaired.endsWith("\n")).toBe(true);
+    expect(repaired.trim().split("\n")).toHaveLength(1);
+
+    const second = await commit(restored, {
+      type: "overtchat_status",
+      status: "idle",
+    });
+    expect(first).toMatchObject({ sequence: 1 });
+    expect(second).toMatchObject({ sequence: 2 });
+    await restored.close();
+
+    const reopened = await reopen(directory);
+    await expect(
+      reopened.sync(SESSION_ID, {
+        epoch: initial.epoch,
+        sequence: 1,
+      }),
+    ).resolves.toEqual({
+      reset: false,
+      cursor: { epoch: initial.epoch, sequence: 2 },
+      events: [second],
+    });
+  });
+
+  it("makes an append failure terminal and never publishes the event", async () => {
+    const { file, store } = await createStore();
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(),
+    );
+    const delivered: AgentRuntimeEnvelope[] = [];
+    await store.subscribe(SESSION_ID, initial, (envelope) => {
+      delivered.push(envelope);
+    });
+    await rm(file);
+    await mkdir(file);
+
+    const pending = store.commit(
+      SESSION_ID,
+      runtimeEvent({ type: "overtchat_status", status: "running" }),
+    );
+    const flushing = store.flush(SESSION_ID);
+    const failure = await pending.catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain(
+      "timeline persistence failed",
+    );
+    await expect(flushing).rejects.toBe(failure);
+    expect(delivered).toEqual([]);
+    expect(() =>
+      store.commit(
+        SESSION_ID,
+        runtimeEvent({ type: "overtchat_status", status: "idle" }),
+      ),
+    ).toThrow(failure as Error);
+    await expect(store.sync(SESSION_ID, initial)).rejects.toBe(failure);
+    await expect(store.close()).rejects.toBe(failure);
+  });
+
+  it("cleans its temporary checkpoint when atomic replacement fails", async () => {
+    const { directory, file, store } = await createStore();
+    await mkdir(file);
+
+    await expect(
+      store.openSession(SESSION_ID, PROVIDER_SESSION_ID, snapshot()),
+    ).rejects.toThrow("timeline persistence failed");
+    expect((await readdir(directory)).filter((name) => name.endsWith(".tmp"))).toEqual(
+      [],
+    );
+    await expect(store.close()).rejects.toThrow("timeline persistence failed");
+  });
+
+  it("serializes a pending commit ahead of deletion and durably rotates on reopen", async () => {
+    const { directory, file, store } = await createStore();
+    const initial = await store.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(),
+    );
+    const pending = store.commit(
+      SESSION_ID,
+      runtimeEvent({ type: "overtchat_status", status: "running" }),
+    );
+    const deletion = store.deleteSession(SESSION_ID);
+    const late = store.commit(
+      SESSION_ID,
+      runtimeEvent({ type: "overtchat_status", status: "idle" }),
+    );
+    const lateRejection = expect(late).rejects.toThrow(
+      "timeline has been deleted",
+    );
+
+    await expect(pending).resolves.toMatchObject({ sequence: 1 });
+    await lateRejection;
+    await deletion;
+    await expect(stat(file)).rejects.toMatchObject({ code: "ENOENT" });
+    await store.close();
+
+    const restored = await reopen(directory);
+    await expect(restored.sync(SESSION_ID)).rejects.toThrow(
+      "timeline is not initialized",
+    );
+    const rotated = await restored.openSession(
+      SESSION_ID,
+      PROVIDER_SESSION_ID,
+      snapshot(SESSION_ID, { generation: 2 }),
+    );
+    expect(rotated).toMatchObject({ sequence: 0 });
+    expect(rotated.epoch).not.toBe(initial.epoch);
+  });
+
+  it("treats newline-terminated corruption as fatal instead of a torn tail", async () => {
+    const { directory, file, store } = await createStore();
+    await store.openSession(SESSION_ID, PROVIDER_SESSION_ID, snapshot());
+    await store.close();
+    await appendFile(file, "not-json\n", "utf8");
+
+    const restored = await reopen(directory);
+    await expect(restored.sync(SESSION_ID)).rejects.toThrow(
+      "timeline persistence failed",
+    );
+    await expect(restored.close()).rejects.toThrow(
+      "timeline persistence failed",
+    );
+  });
+});

--- a/apps/connector/src/timeline.ts
+++ b/apps/connector/src/timeline.ts
@@ -1,0 +1,730 @@
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  rm,
+  type FileHandle,
+} from "node:fs/promises";
+import path from "node:path";
+import {
+  applyAgentRuntimeEnvelope,
+  isAgentRuntimeEnvelope,
+  type AgentRuntimeCursor,
+  type AgentRuntimeEnvelope,
+  type AgentRuntimeSnapshot,
+  type AgentSessionSync,
+  reconcileAgentRuntimeSnapshot,
+} from "@overtchat/agent-bridge";
+
+const FORMAT = 1;
+const COMMIT_DELAY_MS = 25;
+const MAX_TAIL_EVENTS = 500;
+const MAX_TAIL_BYTES = 8 * 1024 * 1024;
+
+type CheckpointRecord = {
+  format: 1;
+  type: "checkpoint";
+  sessionId: string;
+  providerSessionId: string;
+  epoch: string;
+  sequence: number;
+  snapshot: AgentRuntimeSnapshot;
+};
+
+type EventRecord = {
+  format: 1;
+  type: "event";
+  envelope: AgentRuntimeEnvelope;
+};
+
+type TimelineState = {
+  sessionId: string;
+  providerSessionId: string;
+  file: string;
+  epoch: string;
+  sequence: number;
+  snapshot: AgentRuntimeSnapshot;
+  events: AgentRuntimeEnvelope[];
+  tailBytes: number;
+  subscribers: Set<(envelope: AgentRuntimeEnvelope) => void>;
+};
+
+type PendingCommit = {
+  envelope: AgentRuntimeEnvelope;
+  resolve: (envelope: AgentRuntimeEnvelope | null) => void;
+  reject: (error: Error) => void;
+};
+
+type PendingBatch = {
+  commits: PendingCommit[];
+  timer: NodeJS.Timeout;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorValue(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function timelineFilename(sessionId: string): string {
+  return `${createHash("sha256").update(sessionId).digest("hex")}.jsonl`;
+}
+
+function serializeRecord(record: CheckpointRecord | EventRecord): string {
+  return `${JSON.stringify(record)}\n`;
+}
+
+function checkpointRecord(state: TimelineState): CheckpointRecord {
+  return {
+    format: FORMAT,
+    type: "checkpoint",
+    sessionId: state.sessionId,
+    providerSessionId: state.providerSessionId,
+    epoch: state.epoch,
+    sequence: state.sequence,
+    snapshot: state.snapshot,
+  };
+}
+
+function isSnapshot(value: unknown): value is AgentRuntimeSnapshot {
+  return (
+    isRecord(value) &&
+    typeof value.sessionId === "string" &&
+    value.sessionId.length > 0 &&
+    ["idle", "running", "exited"].includes(String(value.status))
+  );
+}
+
+function parseCheckpoint(value: unknown): CheckpointRecord {
+  if (
+    !isRecord(value) ||
+    value.format !== FORMAT ||
+    value.type !== "checkpoint" ||
+    typeof value.sessionId !== "string" ||
+    !value.sessionId ||
+    typeof value.providerSessionId !== "string" ||
+    !value.providerSessionId ||
+    typeof value.epoch !== "string" ||
+    !value.epoch ||
+    !Number.isSafeInteger(value.sequence) ||
+    Number(value.sequence) < 0 ||
+    !isSnapshot(value.snapshot) ||
+    value.snapshot.sessionId !== value.sessionId
+  ) {
+    throw new Error("Invalid Host Connector timeline checkpoint.");
+  }
+  return value as CheckpointRecord;
+}
+
+function coalesceCommits(commits: PendingCommit[]): PendingCommit[][] {
+  const groups: PendingCommit[][] = [];
+  for (const commit of commits) {
+    const previous = groups.at(-1);
+    const previousEnvelope = previous?.at(-1)?.envelope;
+    const current = commit.envelope;
+    const replaceableSnapshot =
+      current.type === "snapshot" && previousEnvelope?.type === "snapshot";
+    const replaceableTurn =
+      current.type === "runtime_event" &&
+      previousEnvelope?.type === "runtime_event" &&
+      current.data.type === "overtchat_turn_update" &&
+      previousEnvelope.data.type === "overtchat_turn_update" &&
+      current.data.turnId === previousEnvelope.data.turnId;
+    if (previous && (replaceableSnapshot || replaceableTurn)) {
+      previous.push(commit);
+    } else {
+      groups.push([commit]);
+    }
+  }
+  return groups;
+}
+
+function canonicalizeCommit(
+  envelope: AgentRuntimeEnvelope,
+): AgentRuntimeEnvelope {
+  if (envelope.type === "snapshot") return envelope;
+  const recordedAt = envelope.data.overtchatRecordedAt;
+  return {
+    ...envelope,
+    data: {
+      ...envelope.data,
+      // Reducer-created fields must be replayable byte-for-byte. Capture the
+      // connector's wall clock once, before events can be coalesced, instead
+      // of consulting it again while rebuilding the journal.
+      overtchatRecordedAt:
+        typeof recordedAt === "number" && Number.isFinite(recordedAt)
+          ? recordedAt
+          : Date.now(),
+    },
+  };
+}
+
+export class ConnectorTimelineStore {
+  private readonly states = new Map<string, TimelineState>();
+  private readonly tails = new Map<string, Promise<void>>();
+  private readonly pending = new Map<string, PendingBatch>();
+  private readonly deleted = new Set<string>();
+  private fatal: Error | null = null;
+  private closed = false;
+
+  private constructor(private readonly directory: string) {}
+
+  static async open(directory: string): Promise<ConnectorTimelineStore> {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700);
+    return new ConnectorTimelineStore(directory);
+  }
+
+  async openSession(
+    sessionId: string,
+    providerSessionId: string,
+    snapshot: AgentRuntimeSnapshot,
+  ): Promise<AgentRuntimeCursor> {
+    this.assertOpen();
+    if (snapshot.sessionId !== sessionId) {
+      throw new Error("The timeline snapshot belongs to a different session.");
+    }
+    await this.flushPending(sessionId);
+    this.assertOpen();
+    return this.enqueue(sessionId, async () => {
+      this.deleted.delete(sessionId);
+      let state = await this.load(sessionId);
+      if (!state) {
+        state = {
+          sessionId,
+          providerSessionId,
+          file: this.fileFor(sessionId),
+          epoch: crypto.randomUUID(),
+          sequence: 0,
+          snapshot,
+          events: [],
+          tailBytes: 0,
+          subscribers: new Set(),
+        };
+        await this.writeCheckpoint(state);
+        this.assertHealthy();
+        this.states.set(sessionId, state);
+        return { epoch: state.epoch, sequence: state.sequence };
+      }
+
+      if (state.providerSessionId !== providerSessionId) {
+        const envelope: AgentRuntimeEnvelope = {
+          epoch: crypto.randomUUID(),
+          sequence: 1,
+          type: "snapshot",
+          data: snapshot,
+        };
+        const replacement: TimelineState = {
+          sessionId,
+          providerSessionId,
+          file: state.file,
+          epoch: envelope.epoch,
+          sequence: envelope.sequence,
+          snapshot,
+          events: [],
+          tailBytes: 0,
+          // Keep the same Set instance so existing unsubscribe closures remain
+          // valid while the committed reset wakes every active subscriber.
+          subscribers: state.subscribers,
+        };
+        await this.writeCheckpoint(replacement);
+        this.assertHealthy();
+        this.states.set(sessionId, replacement);
+        this.notify(replacement, [envelope]);
+        return {
+          epoch: replacement.epoch,
+          sequence: replacement.sequence,
+        };
+      }
+
+      const reconciled = reconcileAgentRuntimeSnapshot(state.snapshot, snapshot);
+      const envelope: AgentRuntimeEnvelope = {
+        epoch: state.epoch,
+        sequence: state.sequence + 1,
+        type: "snapshot",
+        data: reconciled,
+      };
+      const checkpoint: TimelineState = {
+        ...state,
+        sequence: envelope.sequence,
+        snapshot: reconciled,
+        events: [],
+        tailBytes: 0,
+      };
+      await this.writeCheckpoint(checkpoint);
+      this.assertHealthy();
+      state.sequence = checkpoint.sequence;
+      state.snapshot = checkpoint.snapshot;
+      state.events = checkpoint.events;
+      state.tailBytes = checkpoint.tailBytes;
+      this.notify(state, [envelope]);
+      return { epoch: state.epoch, sequence: state.sequence };
+    });
+  }
+
+  commit(
+    sessionId: string,
+    envelope: AgentRuntimeEnvelope,
+  ): Promise<AgentRuntimeEnvelope | null> {
+    this.assertOpen();
+    if (this.deleted.has(sessionId)) {
+      return Promise.reject(new Error("The session timeline has been deleted."));
+    }
+    const canonicalEnvelope = canonicalizeCommit(envelope);
+    return new Promise((resolve, reject) => {
+      const current = this.pending.get(sessionId);
+      if (current) {
+        current.commits.push({ envelope: canonicalEnvelope, resolve, reject });
+        return;
+      }
+      const commits = [{ envelope: canonicalEnvelope, resolve, reject }];
+      const timer = setTimeout(() => {
+        void this.drainPending(sessionId).catch(() => {});
+      }, COMMIT_DELAY_MS);
+      timer.unref();
+      this.pending.set(sessionId, { commits, timer });
+    });
+  }
+
+  async sync(
+    sessionId: string,
+    after?: AgentRuntimeCursor,
+  ): Promise<AgentSessionSync> {
+    this.assertOpen();
+    await this.flushPending(sessionId);
+    this.assertOpen();
+    return this.enqueue(sessionId, async () => {
+      const state = await this.requireState(sessionId);
+      this.assertHealthy();
+      return this.syncState(state, after);
+    });
+  }
+
+  async subscribe(
+    sessionId: string,
+    after: AgentRuntimeCursor | undefined,
+    subscriber: (envelope: AgentRuntimeEnvelope) => void,
+  ): Promise<{ sync: AgentSessionSync; unsubscribe: () => void }> {
+    this.assertOpen();
+    await this.flushPending(sessionId);
+    this.assertOpen();
+    return this.enqueue(sessionId, async () => {
+      const state = await this.requireState(sessionId);
+      this.assertHealthy();
+      state.subscribers.add(subscriber);
+      return {
+        sync: this.syncState(state, after),
+        unsubscribe: () => state.subscribers.delete(subscriber),
+      };
+    });
+  }
+
+  async flush(sessionId: string): Promise<void> {
+    this.assertOpen();
+    await this.flushPending(sessionId);
+    await (this.tails.get(sessionId) ?? Promise.resolve());
+    this.assertOpen();
+  }
+
+  async releaseSession(sessionId: string): Promise<void> {
+    this.assertOpen();
+    await this.flushPending(sessionId);
+    this.assertOpen();
+    await this.enqueue(sessionId, async () => {
+      const state = this.states.get(sessionId);
+      if (!state || state.subscribers.size > 0) return;
+      this.states.delete(sessionId);
+    });
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    this.assertOpen();
+    this.deleted.add(sessionId);
+    await this.flushPending(sessionId);
+    this.assertOpen();
+    await this.enqueue(sessionId, async () => {
+      const state = this.states.get(sessionId);
+      await this.removeTimeline(this.fileFor(sessionId));
+      this.assertHealthy();
+      state?.subscribers.clear();
+      this.states.delete(sessionId);
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      if (this.fatal) throw this.fatal;
+      return;
+    }
+    this.closed = true;
+    await Promise.allSettled(
+      [...this.pending.keys()].map((sessionId) =>
+        this.flushPending(sessionId),
+      ),
+    );
+    await Promise.allSettled(this.tails.values());
+    this.states.clear();
+    if (this.fatal) throw this.fatal;
+  }
+
+  private async drainPending(sessionId: string): Promise<void> {
+    const batch = this.pending.get(sessionId);
+    if (!batch) return;
+    clearTimeout(batch.timer);
+    this.pending.delete(sessionId);
+    try {
+      const results = await this.enqueue(sessionId, async () => {
+        const state = await this.requireState(sessionId);
+        const groups = coalesceCommits(batch.commits);
+        const canonical: AgentRuntimeEnvelope[] = [];
+        let snapshot = state.snapshot;
+        let sequence = state.sequence;
+        for (const group of groups) {
+          const source = group.at(-1)!.envelope;
+          const envelope = {
+            epoch: state.epoch,
+            sequence: ++sequence,
+            type: source.type,
+            data:
+              source.type === "snapshot"
+                ? reconcileAgentRuntimeSnapshot(snapshot, source.data)
+                : source.data,
+          } as AgentRuntimeEnvelope;
+          const nextSnapshot = applyAgentRuntimeEnvelope(snapshot, envelope);
+          if (!nextSnapshot) {
+            throw new Error("Unable to apply a Host Connector timeline event.");
+          }
+          snapshot = nextSnapshot;
+          canonical.push(envelope);
+        }
+
+        const serialized = canonical.map((envelope) =>
+          serializeRecord({ format: FORMAT, type: "event", envelope }),
+        );
+        const addedBytes = serialized.reduce(
+          (total, line) => total + Buffer.byteLength(line),
+          0,
+        );
+        const checkpoint =
+          canonical.some((envelope) => envelope.type === "snapshot") ||
+          state.events.length + canonical.length > MAX_TAIL_EVENTS ||
+          state.tailBytes + addedBytes > MAX_TAIL_BYTES;
+        const next: TimelineState = {
+          ...state,
+          sequence,
+          snapshot,
+          events: checkpoint ? [] : [...state.events, ...canonical],
+          tailBytes: checkpoint ? 0 : state.tailBytes + addedBytes,
+        };
+        if (checkpoint) {
+          await this.writeCheckpoint(next);
+        } else {
+          await this.append(next.file, serialized.join(""));
+        }
+        this.assertHealthy();
+        state.sequence = next.sequence;
+        state.snapshot = next.snapshot;
+        state.events = next.events;
+        state.tailBytes = next.tailBytes;
+        this.notify(state, canonical);
+        return { groups, canonical };
+      });
+
+      results.groups.forEach((group, index) => {
+        const delivered = results.canonical[index]!;
+        group.forEach((commit, groupIndex) =>
+          commit.resolve(groupIndex === group.length - 1 ? delivered : null),
+        );
+      });
+    } catch (error) {
+      const failure = errorValue(error);
+      for (const commit of batch.commits) commit.reject(failure);
+      throw failure;
+    }
+  }
+
+  private flushPending(sessionId: string): Promise<void> {
+    if (!this.pending.has(sessionId)) return Promise.resolve();
+    return this.drainPending(sessionId);
+  }
+
+  private syncState(
+    state: TimelineState,
+    after?: AgentRuntimeCursor,
+  ): AgentSessionSync {
+    const cursor = { epoch: state.epoch, sequence: state.sequence };
+    const reset = (): AgentSessionSync => ({
+      reset: true,
+      cursor,
+      snapshot: state.snapshot,
+    });
+    if (
+      !after ||
+      after.epoch !== state.epoch ||
+      after.sequence > state.sequence
+    ) {
+      return reset();
+    }
+    if (after.sequence === state.sequence) {
+      return { reset: false, cursor, events: [] };
+    }
+    const first = state.events[0]?.sequence;
+    if (first === undefined || after.sequence < first - 1) return reset();
+    const events = state.events.filter(
+      (envelope) => envelope.sequence > after.sequence,
+    );
+    if (
+      events[0]?.sequence !== after.sequence + 1 ||
+      events.at(-1)?.sequence !== state.sequence
+    ) {
+      return reset();
+    }
+    return { reset: false, cursor, events };
+  }
+
+  private async load(sessionId: string): Promise<TimelineState | null> {
+    const cached = this.states.get(sessionId);
+    if (cached) return cached;
+    const file = this.fileFor(sessionId);
+    let raw: string;
+    try {
+      raw = await readFile(file, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw this.failPersistence(error);
+    }
+    try {
+      const unterminatedFinalRecord = !raw.endsWith("\n");
+      const sourceLines = raw.split("\n");
+      if (!unterminatedFinalRecord) sourceLines.pop();
+      if (sourceLines.length === 0) {
+        throw new Error("Empty Host Connector timeline journal.");
+      }
+      let checkpoint: CheckpointRecord;
+      try {
+        checkpoint = parseCheckpoint(JSON.parse(sourceLines[0]!));
+      } catch (error) {
+        throw new Error("Unable to read Host Connector timeline checkpoint.", {
+          cause: error,
+        });
+      }
+      if (checkpoint.sessionId !== sessionId) {
+        throw new Error("Host Connector timeline session identity mismatch.");
+      }
+      let snapshot = checkpoint.snapshot;
+      let sequence = checkpoint.sequence;
+      const events: AgentRuntimeEnvelope[] = [];
+      let tailBytes = 0;
+      const repair = unterminatedFinalRecord;
+      for (let index = 1; index < sourceLines.length; index += 1) {
+        const line = sourceLines[index]!;
+        const recoverableFinalRecord =
+          unterminatedFinalRecord && index === sourceLines.length - 1;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch (error) {
+          if (recoverableFinalRecord) break;
+          throw new Error("Corrupt Host Connector timeline journal.", {
+            cause: error,
+          });
+        }
+        if (
+          !isRecord(parsed) ||
+          parsed.format !== FORMAT ||
+          parsed.type !== "event" ||
+          !isAgentRuntimeEnvelope(parsed.envelope) ||
+          parsed.envelope.epoch !== checkpoint.epoch ||
+          parsed.envelope.sequence !== sequence + 1
+        ) {
+          if (recoverableFinalRecord) break;
+          throw new Error("Invalid Host Connector timeline event journal.");
+        }
+        const next = applyAgentRuntimeEnvelope(snapshot, parsed.envelope);
+        if (!next) {
+          if (recoverableFinalRecord) break;
+          throw new Error("Invalid Host Connector timeline state.");
+        }
+        snapshot = next;
+        sequence = parsed.envelope.sequence;
+        events.push(parsed.envelope);
+        tailBytes += Buffer.byteLength(`${line}\n`);
+      }
+      const state: TimelineState = {
+        sessionId,
+        providerSessionId: checkpoint.providerSessionId,
+        file,
+        epoch: checkpoint.epoch,
+        sequence,
+        snapshot,
+        events,
+        tailBytes,
+        subscribers: new Set(),
+      };
+      if (repair) {
+        await this.writeCheckpoint(state);
+        this.assertHealthy();
+        state.events = [];
+        state.tailBytes = 0;
+      }
+      this.states.set(sessionId, state);
+      return state;
+    } catch (error) {
+      throw this.failPersistence(error);
+    }
+  }
+
+  private async requireState(sessionId: string): Promise<TimelineState> {
+    const state = await this.load(sessionId);
+    if (!state) throw new Error("The session timeline is not initialized.");
+    return state;
+  }
+
+  private enqueue<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(sessionId) ?? Promise.resolve();
+    const result = previous.then(() => {
+      this.assertHealthy();
+      return operation();
+    });
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(sessionId, tail);
+    void tail.finally(() => {
+      if (this.tails.get(sessionId) === tail) this.tails.delete(sessionId);
+    });
+    return result;
+  }
+
+  private async append(file: string, value: string): Promise<void> {
+    try {
+      const handle = await open(
+        file,
+        fsConstants.O_WRONLY | fsConstants.O_APPEND,
+      );
+      try {
+        await handle.writeFile(value, "utf8");
+        await handle.chmod(0o600);
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+    } catch (error) {
+      throw this.failPersistence(error);
+    }
+  }
+
+  private async writeCheckpoint(state: TimelineState): Promise<void> {
+    let temporary: string | undefined;
+    try {
+      await mkdir(this.directory, { recursive: true, mode: 0o700 });
+      temporary = `${state.file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+      const handle = await open(temporary, "wx", 0o600);
+      try {
+        await handle.writeFile(
+          serializeRecord(checkpointRecord(state)),
+          "utf8",
+        );
+        await handle.chmod(0o600);
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      await rename(temporary, state.file);
+      temporary = undefined;
+      await this.syncDirectory();
+    } catch (error) {
+      let failure = errorValue(error);
+      if (temporary) {
+        try {
+          await rm(temporary, { force: true });
+        } catch (cleanupError) {
+          failure = new AggregateError(
+            [failure, errorValue(cleanupError)],
+            "Timeline checkpoint and temporary-file cleanup both failed.",
+          );
+        }
+      }
+      throw this.failPersistence(failure);
+    }
+  }
+
+  private async removeTimeline(file: string): Promise<void> {
+    try {
+      await rm(file, { force: true });
+      await this.syncDirectory();
+    } catch (error) {
+      throw this.failPersistence(error);
+    }
+  }
+
+  private async syncDirectory(): Promise<void> {
+    let handle: FileHandle | undefined;
+    try {
+      handle = await open(this.directory, "r");
+      await handle.sync();
+    } catch (error) {
+      if (
+        ["EINVAL", "ENOTSUP", "EISDIR", "EPERM"].includes(
+          String((error as NodeJS.ErrnoException).code),
+        )
+      ) {
+        return;
+      }
+      throw error;
+    } finally {
+      await handle?.close();
+    }
+  }
+
+  private notify(
+    state: TimelineState,
+    envelopes: AgentRuntimeEnvelope[],
+  ): void {
+    for (const envelope of envelopes) {
+      for (const subscriber of state.subscribers) {
+        try {
+          subscriber(envelope);
+        } catch (error) {
+          console.error("Host Connector timeline subscriber failed.", error);
+        }
+      }
+    }
+  }
+
+  private failPersistence(error: unknown): Error {
+    if (this.fatal) return this.fatal;
+    const cause = errorValue(error);
+    const failure = new Error(
+      `Host Connector timeline persistence failed: ${cause.message}`,
+      { cause },
+    );
+    this.fatal = failure;
+    for (const [sessionId, batch] of this.pending) {
+      clearTimeout(batch.timer);
+      this.pending.delete(sessionId);
+      for (const commit of batch.commits) commit.reject(failure);
+    }
+    return failure;
+  }
+
+  private fileFor(sessionId: string): string {
+    return path.join(this.directory, timelineFilename(sessionId));
+  }
+
+  private assertOpen(): void {
+    this.assertHealthy();
+    if (this.closed) throw new Error("The Host Connector timeline store is closed.");
+  }
+
+  private assertHealthy(): void {
+    if (this.fatal) throw this.fatal;
+  }
+}

--- a/apps/site/lib/install-redirect.test.ts
+++ b/apps/site/lib/install-redirect.test.ts
@@ -1,6 +1,260 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function writeExecutable(filePath: string, contents: string) {
+  writeFileSync(filePath, contents);
+  chmodSync(filePath, 0o755);
+}
+
+function createUpgradeFixture(
+  newServiceBehavior: "stable" | "inactive" | "active-once",
+  options: {
+    binaryBackupExists?: boolean;
+    effectiveExecStart?: "managed" | "custom";
+    preflightFails?: boolean;
+    signalAfterStop?: boolean;
+    stopFails?: boolean;
+    stateExists?: boolean;
+  } = {},
+) {
+  const fixtureDirectory = mkdtempSync(
+    path.join(os.tmpdir(), "overtchat-installer-test-"),
+  );
+  temporaryDirectories.push(fixtureDirectory);
+
+  const homeDirectory = path.join(fixtureDirectory, "home");
+  const mockBinDirectory = path.join(fixtureDirectory, "bin");
+  const systemctlCalls = path.join(fixtureDirectory, "systemctl-calls");
+  const systemctlStarts = path.join(fixtureDirectory, "systemctl-starts");
+  const systemctlServiceState = path.join(
+    fixtureDirectory,
+    "systemctl-service-state",
+  );
+  const systemctlActiveChecks = path.join(
+    fixtureDirectory,
+    "systemctl-active-checks",
+  );
+  const installDirectory = path.join(homeDirectory, ".local/bin");
+  const installPath = path.join(installDirectory, "overtchat-connector");
+  const configPath = path.join(
+    homeDirectory,
+    ".config/overtchat/connector.json",
+  );
+  const statePath = path.join(
+    homeDirectory,
+    ".config/overtchat",
+    "connector-connector-test.state.json",
+  );
+  const configContents = `${JSON.stringify(
+    {
+      serverUrl: "https://chat.example.com",
+      connectorId: "connector-test",
+      token: "pairing-token",
+    },
+    null,
+    2,
+  )}\n`;
+  const legacyState = '{"format":1,"connectorEpoch":"legacy-state"}\n';
+  mkdirSync(path.join(homeDirectory, ".config/overtchat"), { recursive: true });
+  mkdirSync(installDirectory, { recursive: true });
+  mkdirSync(mockBinDirectory);
+  writeFileSync(configPath, configContents, { mode: 0o600 });
+  writeFileSync(systemctlServiceState, "active\n");
+  if (options.stateExists !== false) {
+    writeFileSync(statePath, legacyState, { mode: 0o640 });
+    chmodSync(statePath, 0o640);
+  }
+  writeFileSync(installPath, "old connector\n", { mode: 0o755 });
+  if (options.binaryBackupExists === true) {
+    writeFileSync(`${installPath}.previous`, "interrupted backup\n", {
+      mode: 0o755,
+    });
+  }
+
+  const newConnector = `#!/bin/sh
+if [ "\${1:-}" = "preflight" ]; then
+  printf '{"format":2,"migrated":true}\\n' > "$MOCK_CONNECTOR_STATE"
+  chmod 600 "$MOCK_CONNECTOR_STATE"
+  [ "$MOCK_PREFLIGHT_FAILS" != "true" ] || exit 1
+fi
+exit 0
+`;
+  const checksum = createHash("sha256").update(newConnector).digest("hex");
+
+  writeExecutable(
+    path.join(mockBinDirectory, "uname"),
+    `#!/bin/sh
+if [ "\${1:-}" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+`,
+  );
+  writeExecutable(
+    path.join(mockBinDirectory, "curl"),
+    `#!/bin/sh
+set -eu
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -fsSLo)
+      output=$2
+      shift 2
+      ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+case "$url" in
+  */connector-checksums.txt)
+    printf '%s  overtchat-connector-linux-amd64\\n' "$MOCK_ASSET_SHA256" > "$output"
+    ;;
+  *)
+    cat > "$output" <<'MOCK_CONNECTOR'
+${newConnector}MOCK_CONNECTOR
+    ;;
+esac
+`,
+  );
+  writeExecutable(
+    path.join(mockBinDirectory, "systemctl"),
+    `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "$MOCK_SYSTEMCTL_CALLS"
+case "\${2:-}" in
+  cat)
+    printf '%s\\n' 'ExecStart="'"$HOME"'/.local/bin/overtchat-connector" "run"'
+    exit 0
+    ;;
+  show)
+    if [ "$MOCK_EFFECTIVE_EXEC_START" = "managed" ]; then
+      printf '{ path=%s/.local/bin/overtchat-connector ; argv[]=%s/.local/bin/overtchat-connector run ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }\\n' "$HOME" "$HOME"
+    else
+      printf '{ path=/tmp/custom-connector ; argv[]=/tmp/custom-connector run ; }\\n'
+    fi
+    exit 0
+    ;;
+  show-environment)
+    exit 0
+    ;;
+  stop)
+    [ "$MOCK_STOP_FAILS" != "true" ] || exit 1
+    printf 'inactive\\n' > "$MOCK_SYSTEMCTL_SERVICE_STATE"
+    if [ "$(cat "$MOCK_SIGNAL_AFTER_STOP_FILE")" = "true" ]; then
+      printf 'false\\n' > "$MOCK_SIGNAL_AFTER_STOP_FILE"
+      kill -TERM "$PPID"
+    fi
+    exit 0
+    ;;
+  start)
+    printf 'active\\n' > "$MOCK_SYSTEMCTL_SERVICE_STATE"
+    printf '0\\n' > "$MOCK_SYSTEMCTL_ACTIVE_CHECKS"
+    printf 'start\\n' >> "$MOCK_SYSTEMCTL_STARTS"
+    start_count=$(wc -l < "$MOCK_SYSTEMCTL_STARTS")
+    exit 0
+    ;;
+  is-active)
+    [ "$(cat "$MOCK_SYSTEMCTL_SERVICE_STATE")" = "active" ] || exit 3
+    if [ -f "$MOCK_SYSTEMCTL_STARTS" ]; then
+      start_count=$(wc -l < "$MOCK_SYSTEMCTL_STARTS")
+    else
+      start_count=0
+    fi
+    active_checks=$(cat "$MOCK_SYSTEMCTL_ACTIVE_CHECKS")
+    active_checks=$((active_checks + 1))
+    printf '%s\\n' "$active_checks" > "$MOCK_SYSTEMCTL_ACTIVE_CHECKS"
+    if [ "$start_count" -eq 1 ]; then
+      case "$MOCK_NEW_SERVICE_BEHAVIOR" in
+        inactive)
+          exit 3
+          ;;
+        active-once)
+          [ "$active_checks" -eq 1 ] && exit 0
+          exit 3
+          ;;
+      esac
+    fi
+    exit 0
+    ;;
+esac
+exit 1
+`,
+  );
+  writeExecutable(path.join(mockBinDirectory, "sleep"), "#!/bin/sh\nexit 0\n");
+
+  const installer = path.resolve(
+    process.cwd(),
+    "../../scripts/install-connector.sh",
+  );
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDirectory,
+    MOCK_ASSET_SHA256: checksum,
+    MOCK_CONNECTOR_STATE: statePath,
+    MOCK_EFFECTIVE_EXEC_START: options.effectiveExecStart ?? "managed",
+    MOCK_NEW_SERVICE_BEHAVIOR: newServiceBehavior,
+    MOCK_PREFLIGHT_FAILS: String(options.preflightFails === true),
+    MOCK_SIGNAL_AFTER_STOP: String(options.signalAfterStop === true),
+    MOCK_SIGNAL_AFTER_STOP_FILE: path.join(
+      fixtureDirectory,
+      "signal-after-stop",
+    ),
+    MOCK_SYSTEMCTL_ACTIVE_CHECKS: systemctlActiveChecks,
+    MOCK_SYSTEMCTL_CALLS: systemctlCalls,
+    MOCK_SYSTEMCTL_SERVICE_STATE: systemctlServiceState,
+    MOCK_SYSTEMCTL_STARTS: systemctlStarts,
+    MOCK_STOP_FAILS: String(options.stopFails === true),
+    PATH: `${mockBinDirectory}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+  };
+  writeFileSync(
+    environment.MOCK_SIGNAL_AFTER_STOP_FILE!,
+    String(options.signalAfterStop === true),
+  );
+  delete environment.OVERTCHAT_CONNECTOR_CONFIG;
+  delete environment.OVERTCHAT_CONNECTOR_STATE;
+  const result = spawnSync("/bin/sh", [installer, "--upgrade"], {
+    encoding: "utf8",
+    env: environment,
+    timeout: 5_000,
+  });
+
+  return {
+    configContents,
+    configPath,
+    installPath,
+    legacyState,
+    newConnector,
+    result,
+    statePath,
+    systemctlCalls,
+    systemctlServiceState,
+  };
+}
 
 describe("Host Connector installer redirect", () => {
   it("keeps generated commands pinned to an immutable connector release", () => {
@@ -28,5 +282,193 @@ describe("Host Connector installer redirect", () => {
     expect(installer).toContain(
       `connector_version="${packageMetadata.version}"`,
     );
+  });
+
+  it("atomically upgrades and preserves the previous executable", () => {
+    const {
+      configContents,
+      configPath,
+      installPath,
+      newConnector,
+      result,
+      statePath,
+      systemctlCalls,
+    } = createUpgradeFixture("stable");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Host Connector upgraded to 0.3.0");
+    expect(readFileSync(installPath, "utf8")).toBe(newConnector);
+    expect(existsSync(`${installPath}.previous`)).toBe(false);
+    expect(readFileSync(systemctlCalls, "utf8")).toContain(
+      "--user is-active --quiet overtchat-connector.service",
+    );
+    expect(readFileSync(statePath, "utf8")).toBe(
+      '{"format":2,"migrated":true}\n',
+    );
+    expect(existsSync(`${statePath}.previous`)).toBe(false);
+    expect(readFileSync(configPath, "utf8")).toBe(configContents);
+  });
+
+  it("restores and restarts the previous executable when startup fails", () => {
+    const {
+      configContents,
+      configPath,
+      installPath,
+      legacyState,
+      result,
+      statePath,
+      systemctlCalls,
+    } = createUpgradeFixture("inactive");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("did not start");
+    expect(result.stderr).toContain("state were restored and restarted");
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(existsSync(`${installPath}.previous`)).toBe(false);
+    expect(readFileSync(statePath, "utf8")).toBe(legacyState);
+    expect(statSync(statePath).mode & 0o777).toBe(0o640);
+    expect(existsSync(`${statePath}.previous`)).toBe(false);
+    expect(readFileSync(configPath, "utf8")).toBe(configContents);
+    expect(
+      readFileSync(systemctlCalls, "utf8")
+        .split("\n")
+        .filter((call) =>
+          call.includes("--user start overtchat-connector.service"),
+        ),
+    ).toHaveLength(2);
+  });
+
+  it("rolls back when the upgraded service is active only once", () => {
+    const {
+      installPath,
+      legacyState,
+      result,
+      statePath,
+      systemctlCalls,
+    } = createUpgradeFixture("active-once");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("did not start");
+    expect(result.stderr).toContain("state were restored and restarted");
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(readFileSync(statePath, "utf8")).toBe(legacyState);
+    expect(statSync(statePath).mode & 0o777).toBe(0o640);
+    expect(
+      readFileSync(systemctlCalls, "utf8")
+        .split("\n")
+        .filter((call) =>
+          call.includes("--user start overtchat-connector.service"),
+        ),
+    ).toHaveLength(2);
+  });
+
+  it("removes newly created state on rollback when no old state existed", () => {
+    const { installPath, result, statePath } = createUpgradeFixture(
+      "active-once",
+      { stateExists: false },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("state were restored and restarted");
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(existsSync(statePath)).toBe(false);
+    expect(existsSync(`${statePath}.previous`)).toBe(false);
+  });
+
+  it("restores the old service when stopped preflight fails", () => {
+    const {
+      installPath,
+      legacyState,
+      result,
+      statePath,
+      systemctlCalls,
+    } = createUpgradeFixture("stable", { preflightFails: true });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("could not safely open");
+    expect(result.stderr).toContain("state were restored and restarted");
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(readFileSync(statePath, "utf8")).toBe(legacyState);
+    expect(statSync(statePath).mode & 0o777).toBe(0o640);
+    expect(
+      readFileSync(systemctlCalls, "utf8")
+        .split("\n")
+        .filter((call) =>
+          call.includes("--user start overtchat-connector.service"),
+        ),
+    ).toHaveLength(1);
+  });
+
+  it("refuses to upgrade a service with a custom effective command", () => {
+    const { installPath, legacyState, result, statePath, systemctlCalls } =
+      createUpgradeFixture("stable", { effectiveExecStart: "custom" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("effective command is not installer-managed");
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(readFileSync(statePath, "utf8")).toBe(legacyState);
+    expect(readFileSync(systemctlCalls, "utf8")).not.toContain("--user stop");
+  });
+
+  it("keeps the old service running when the initial stop fails", () => {
+    const {
+      installPath,
+      legacyState,
+      result,
+      statePath,
+      systemctlCalls,
+      systemctlServiceState,
+    } = createUpgradeFixture("stable", { stopFails: true });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("nothing was upgraded");
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(readFileSync(statePath, "utf8")).toBe(legacyState);
+    expect(readFileSync(systemctlServiceState, "utf8")).toBe("active\n");
+    expect(
+      readFileSync(systemctlCalls, "utf8")
+        .split("\n")
+        .filter((call) =>
+          call.includes("--user start overtchat-connector.service"),
+        ),
+    ).toHaveLength(1);
+  });
+
+  it("restarts the old service when interrupted immediately after stop", () => {
+    const {
+      installPath,
+      legacyState,
+      result,
+      statePath,
+      systemctlCalls,
+      systemctlServiceState,
+    } = createUpgradeFixture("stable", { signalAfterStop: true });
+
+    expect(result.status).not.toBe(0);
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(readFileSync(statePath, "utf8")).toBe(legacyState);
+    expect(readFileSync(systemctlServiceState, "utf8")).toBe("active\n");
+    expect(
+      readFileSync(systemctlCalls, "utf8")
+        .split("\n")
+        .filter((call) =>
+          call.includes("--user start overtchat-connector.service"),
+        ),
+    ).toHaveLength(1);
+  });
+
+  it("preserves evidence from an interrupted earlier upgrade", () => {
+    const { installPath, result, systemctlCalls } = createUpgradeFixture(
+      "stable",
+      { binaryBackupExists: true },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("binary rollback file already exists");
+    expect(readFileSync(installPath, "utf8")).toBe("old connector\n");
+    expect(readFileSync(`${installPath}.previous`, "utf8")).toBe(
+      "interrupted backup\n",
+    );
+    expect(readFileSync(systemctlCalls, "utf8")).not.toContain("--user stop");
   });
 });

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -3,6 +3,7 @@
 
 # Generated setup commands use immutable connector versions.
 /install/connector/0.2.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.2.0/install-connector.sh 302
+/install/connector/0.3.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.0/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.2.0 302
+/install-connector.sh /install/connector/0.3.0 302

--- a/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
+++ b/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
@@ -82,6 +82,7 @@ export function ConnectionsPanel({
   const [addOpen, setAddOpen] = useState(initialAddOpen);
   const [pairing, setPairing] = useState<HostConnectorPairing | null>(null);
   const [commandCopied, setCommandCopied] = useState(false);
+  const [upgradeCopied, setUpgradeCopied] = useState(false);
   const [workspaceConnection, setWorkspaceConnection] =
     useState<AgentConnectionListItem | null>(null);
   const [pendingDetach, setPendingDetach] = useState<PendingDetach | null>(null);
@@ -186,6 +187,12 @@ export function ConnectionsPanel({
     if (!pairing) return;
     await navigator.clipboard.writeText(pairing.command);
     setCommandCopied(true);
+  }
+
+  async function copyUpgradeCommand() {
+    if (!connector?.upgrade) return;
+    await navigator.clipboard.writeText(connector.upgrade.command);
+    setUpgradeCopied(true);
   }
 
   function setAddDialogOpen(open: boolean) {
@@ -344,6 +351,34 @@ export function ConnectionsPanel({
               )}
               Set up
             </Button>
+          </div>
+        )}
+        {connector?.upgrade && (
+          <div className="border-t px-4 py-4">
+            <p className="text-sm font-medium">
+              Host Connector {connector.upgrade.version} is available
+            </p>
+            <p className="mb-3 mt-1 text-xs text-muted-foreground">
+              Run this on the connector host. It updates the binary and restarts
+              the service without changing the existing pairing or settings.
+            </p>
+            <div className="flex items-center gap-2">
+              <code
+                aria-label="Host Connector upgrade command"
+                className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded-md bg-muted px-3 py-2 text-xs"
+              >
+                {connector.upgrade.command}
+              </code>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => void copyUpgradeCommand()}
+                aria-label="Copy connector upgrade command"
+                title="Copy connector upgrade command"
+              >
+                {upgradeCopied ? <Check /> : <Clipboard />}
+              </Button>
+            </div>
           </div>
         )}
         {pairing && !connector && (

--- a/apps/web/app/api/agent-sessions/[id]/events/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/events/route.test.ts
@@ -77,7 +77,7 @@ describe("agent session event stream", () => {
           type: "snapshot",
           data: { sessionId: "session", status: "idle" },
         });
-        return mocks.unsubscribe;
+        return { authoritative: false, unsubscribe: mocks.unsubscribe };
       },
     );
   });
@@ -105,9 +105,200 @@ describe("agent session event stream", () => {
       { epoch: "runtime", sequence: 7 },
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     await reader.cancel();
     expect(mocks.unsubscribe).toHaveBeenCalled();
+  });
+
+  it("emits the connector-owned reconciliation before buffered live events", async () => {
+    mocks.subscribeSession.mockImplementation(
+      async (
+        _connectorId: string,
+        _session: unknown,
+        _after: unknown,
+        listener: (event: Record<string, unknown>) => void,
+      ) => {
+        listener({
+          epoch: "runtime",
+          sequence: 9,
+          type: "runtime_event",
+          data: { type: "turn_start" },
+        });
+        return {
+          authoritative: true,
+          sync: {
+            reset: true,
+            cursor: { epoch: "runtime", sequence: 8 },
+            snapshot: { sessionId: "session", status: "idle" },
+          },
+          unsubscribe: mocks.unsubscribe,
+        };
+      },
+    );
+
+    const response = await GET(
+      new Request("http://server.test/events?sync=1&after=runtime%3A7"),
+      context,
+    );
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    const first = decoder.decode((await reader.read()).value);
+    const second = decoder.decode((await reader.read()).value);
+
+    expect(first).toContain("event: sync");
+    expect(first).toContain("id: runtime:8");
+    expect(second).toContain("event: runtime");
+    expect(second).toContain("id: runtime:9");
+    await reader.cancel();
+  });
+
+  it("forwards an authoritative sync produced when the connector reconnects", async () => {
+    let synchronize:
+      | ((sync: {
+          reset: true;
+          cursor: { epoch: string; sequence: number };
+          snapshot: Record<string, unknown>;
+        }) => void)
+      | undefined;
+    mocks.subscribeSession.mockImplementation(
+      async (
+        _connectorId: string,
+        _session: unknown,
+        _after: unknown,
+        _listener: unknown,
+        onSync: typeof synchronize,
+      ) => {
+        synchronize = onSync;
+        return { authoritative: true, unsubscribe: mocks.unsubscribe };
+      },
+    );
+    const response = await GET(
+      new Request("http://server.test/events?sync=1&after=runtime%3A9"),
+      context,
+    );
+    const reader = response.body!.getReader();
+
+    synchronize?.({
+      reset: true,
+      cursor: { epoch: "restarted-runtime", sequence: 2 },
+      snapshot: { sessionId: "session", status: "running" },
+    });
+    const event = new TextDecoder().decode((await reader.read()).value);
+
+    expect(event).toContain("event: sync");
+    expect(event).toContain("id: restarted-runtime:2");
+    await reader.cancel();
+  });
+
+  it("keeps a legacy connector stream explicit for opted-in browsers", async () => {
+    const response = await GET(
+      new Request("http://server.test/events?sync=1"),
+      context,
+    );
+    const reader = response.body!.getReader();
+    const event = new TextDecoder().decode((await reader.read()).value);
+
+    expect(event).toContain("event: legacy-runtime");
+    expect(event).toContain("id: runtime:1");
+    await reader.cancel();
+  });
+
+  it("translates authoritative sync into runtime frames for old browsers", async () => {
+    let synchronize:
+      | ((sync: {
+          reset: false;
+          cursor: { epoch: string; sequence: number };
+          events: Array<Record<string, unknown>>;
+        }) => void)
+      | undefined;
+    mocks.subscribeSession.mockImplementation(
+      async (
+        _connectorId: string,
+        _session: unknown,
+        _after: unknown,
+        _listener: unknown,
+        onSync: typeof synchronize,
+      ) => {
+        synchronize = onSync;
+        return {
+          authoritative: true,
+          sync: {
+            reset: true,
+            cursor: { epoch: "runtime", sequence: 0 },
+            snapshot: { sessionId: "session", status: "idle" },
+          },
+          unsubscribe: mocks.unsubscribe,
+        };
+      },
+    );
+    const response = await GET(
+      new Request("http://server.test/events"),
+      context,
+    );
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    const initial = decoder.decode((await reader.read()).value);
+
+    expect(initial).toContain("event: runtime");
+    expect(initial).toContain("id: runtime:0");
+    expect(initial).not.toContain("event: sync");
+
+    synchronize?.({
+      reset: false,
+      cursor: { epoch: "runtime", sequence: 2 },
+      events: [
+        {
+          epoch: "runtime",
+          sequence: 1,
+          type: "runtime_event",
+          data: { type: "turn_start" },
+        },
+        {
+          epoch: "runtime",
+          sequence: 2,
+          type: "runtime_event",
+          data: { type: "turn_end" },
+        },
+      ],
+    });
+    const firstSuffix = decoder.decode((await reader.read()).value);
+    const secondSuffix = decoder.decode((await reader.read()).value);
+    expect(firstSuffix).toContain("event: runtime");
+    expect(firstSuffix).toContain("id: runtime:1");
+    expect(secondSuffix).toContain("id: runtime:2");
+    await reader.cancel();
+  });
+
+  it("releases a connector subscription when the request aborts while subscribing", async () => {
+    let resolveSubscription!: (value: {
+      authoritative: boolean;
+      unsubscribe: () => void;
+    }) => void;
+    mocks.subscribeSession.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubscription = resolve;
+        }),
+    );
+    const abort = new AbortController();
+    const responsePending = GET(
+      new Request("http://server.test/events?sync=1", {
+        signal: abort.signal,
+      }),
+      context,
+    );
+    await vi.waitFor(() => expect(mocks.subscribeSession).toHaveBeenCalled());
+
+    abort.abort();
+    resolveSubscription({
+      authoritative: true,
+      unsubscribe: mocks.unsubscribe,
+    });
+
+    const response = await responsePending;
+    expect(response.status).toBe(204);
+    expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
 
   it("does not subscribe to a session owned by another user", async () => {

--- a/apps/web/app/api/agent-sessions/[id]/events/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/events/route.ts
@@ -5,30 +5,45 @@ import {
 } from "@/lib/agents/access";
 import { daemonSession } from "@/lib/agents/connector/descriptors";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import type { AgentRuntimeEnvelope } from "@overtchat/agent-bridge";
+import {
+  type AgentRuntimeEnvelope,
+  type AgentSessionSync,
+} from "@overtchat/agent-bridge";
+import {
+  formatAgentRuntimeCursor,
+  parseAgentRuntimeCursor,
+} from "@/lib/agents/sessionReplica";
 import { getOwnedAgentSession } from "@/lib/db/agentConnections";
 import { isAgentProviderId } from "@overtchat/agent-bridge";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
-function encodeEvent(envelope: AgentRuntimeEnvelope): Uint8Array {
+function encodeEvent(
+  envelope: AgentRuntimeEnvelope,
+  event: "runtime" | "legacy-runtime" = "runtime",
+): Uint8Array {
   return new TextEncoder().encode(
-    `id: ${envelope.epoch}:${envelope.sequence}\nevent: runtime\ndata: ${JSON.stringify(envelope)}\n\n`,
+    `id: ${envelope.epoch}:${envelope.sequence}\nevent: ${event}\ndata: ${JSON.stringify(envelope)}\n\n`,
   );
 }
 
-function parseCursor(value: string | null):
-  | { epoch: string; sequence: number }
-  | undefined {
-  if (!value) return undefined;
-  const separator = value.lastIndexOf(":");
-  if (separator <= 0) return undefined;
-  const epoch = value.slice(0, separator);
-  const sequence = Number(value.slice(separator + 1));
-  return Number.isSafeInteger(sequence) && sequence >= 0
-    ? { epoch, sequence }
-    : undefined;
+function encodeSync(sync: AgentSessionSync): Uint8Array {
+  return new TextEncoder().encode(
+    `id: ${formatAgentRuntimeCursor(sync.cursor)}\nevent: sync\ndata: ${JSON.stringify(sync)}\n\n`,
+  );
+}
+
+function runtimeEventsFromSync(sync: AgentSessionSync): AgentRuntimeEnvelope[] {
+  if (!sync.reset) return sync.events;
+  return [
+    {
+      epoch: sync.cursor.epoch,
+      sequence: sync.cursor.sequence,
+      type: "snapshot",
+      data: sync.snapshot,
+    },
+  ];
 }
 
 export async function GET(
@@ -45,35 +60,96 @@ export async function GET(
   const owned = await getOwnedAgentSession(id, session.user.id);
   if (!owned) return new Response("Not found", { status: 404 });
 
-  const pending: AgentRuntimeEnvelope[] = [];
+  const pending: Array<
+    | { type: "runtime"; envelope: AgentRuntimeEnvelope }
+    | { type: "sync"; sync: AgentSessionSync }
+  > = [];
   let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
   let closed = false;
   let closeStream = () => {};
+  let authoritative = false;
+  let aborted = req.signal.aborted;
+  const handleAbort = () => {
+    aborted = true;
+    if (controller) closeStream();
+    else closed = true;
+  };
+  req.signal.addEventListener("abort", handleAbort, { once: true });
   try {
-    const unsubscribe = await hostConnectorBroker.subscribeSession(
+    const supportsSessionSync =
+      new URL(req.url).searchParams.get("sync") === "1";
+    const after =
+      parseAgentRuntimeCursor(req.headers.get("last-event-id")) ??
+      parseAgentRuntimeCursor(new URL(req.url).searchParams.get("after"));
+
+    const encode = (
+      item:
+        | { type: "runtime"; envelope: AgentRuntimeEnvelope }
+        | { type: "sync"; sync: AgentSessionSync },
+    ): Uint8Array[] => {
+      if (!supportsSessionSync) {
+        return item.type === "runtime"
+          ? [encodeEvent(item.envelope)]
+          : runtimeEventsFromSync(item.sync).map((envelope) =>
+              encodeEvent(envelope),
+            );
+      }
+      if (item.type === "sync") return [encodeSync(item.sync)];
+      return [
+        encodeEvent(
+          item.envelope,
+          authoritative ? "runtime" : "legacy-runtime",
+        ),
+      ];
+    };
+
+    const enqueue = (
+      item:
+        | { type: "runtime"; envelope: AgentRuntimeEnvelope }
+        | { type: "sync"; sync: AgentSessionSync },
+    ) => {
+      if (!controller) {
+        pending.push(item);
+        return;
+      }
+      try {
+        for (const chunk of encode(item)) controller.enqueue(chunk);
+      } catch {
+        closeStream();
+      }
+    };
+
+    const subscription = await hostConnectorBroker.subscribeSession(
       owned.host.connectorId,
       daemonSession(owned),
-      parseCursor(req.headers.get("last-event-id")),
+      after,
       (envelope) => {
         if (closed) return;
-        if (!controller) {
-          pending.push(envelope);
-          return;
-        }
-        try {
-          controller.enqueue(encodeEvent(envelope));
-        } catch {
-          closeStream();
-        }
+        enqueue({ type: "runtime", envelope });
+      },
+      (sync) => {
+        if (closed) return;
+        enqueue({ type: "sync", sync });
       },
       () => closeStream(),
     );
+    if (aborted) {
+      subscription.unsubscribe();
+      req.signal.removeEventListener("abort", handleAbort);
+      return new Response(null, { status: 204 });
+    }
+    authoritative = subscription.authoritative;
 
     const body = new ReadableStream<Uint8Array>({
       start(streamController) {
         controller = streamController;
-        for (const envelope of pending.splice(0)) {
-          streamController.enqueue(encodeEvent(envelope));
+        if (subscription.sync) {
+          for (const chunk of encode({ type: "sync", sync: subscription.sync })) {
+            streamController.enqueue(chunk);
+          }
+        }
+        for (const item of pending.splice(0)) {
+          for (const chunk of encode(item)) streamController.enqueue(chunk);
         }
         const keepAlive = setInterval(() => {
           if (closed) return;
@@ -89,14 +165,14 @@ export async function GET(
           if (closed) return;
           closed = true;
           clearInterval(keepAlive);
-          unsubscribe();
+          req.signal.removeEventListener("abort", handleAbort);
+          subscription.unsubscribe();
           try {
             streamController.close();
           } catch {
             // The browser may already have closed the stream.
           }
         };
-        req.signal.addEventListener("abort", closeStream, { once: true });
       },
       cancel() {
         closeStream();
@@ -112,6 +188,7 @@ export async function GET(
     });
   } catch (error) {
     closed = true;
+    req.signal.removeEventListener("abort", handleAbort);
     return Response.json(
       {
         error: connectionErrorMessage(

--- a/apps/web/app/api/agent-sessions/[id]/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.test.ts
@@ -129,6 +129,30 @@ describe("agent session route", () => {
     });
   });
 
+  it("requests and returns an authoritative sync after the browser cursor", async () => {
+    const sync = {
+      reset: true,
+      cursor: { epoch: "new-runtime", sequence: 11 },
+      snapshot,
+    };
+    mocks.daemonRequest.mockResolvedValue({ snapshot, sync });
+
+    const response = await GET(
+      new Request(
+        "http://server.test/api/agent-sessions/session?after=old-runtime%3A7",
+      ),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ snapshot, sync });
+    expect(mocks.daemonRequest).toHaveBeenCalledWith("connector", {
+      type: "open_session",
+      session: sessionDescriptor,
+      after: { epoch: "old-runtime", sequence: 7 },
+    });
+  });
+
   it("forwards submissions with the browser message identity intact", async () => {
     const response = await POST(
       request("POST", {

--- a/apps/web/app/api/agent-sessions/[id]/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.ts
@@ -3,8 +3,14 @@ import {
   connectionErrorMessage,
   storedConnectionAccessError,
 } from "@/lib/agents/access";
-import { agentSessionCommandSchema } from "@overtchat/agent-bridge";
+import {
+  agentSessionCommandSchema,
+  isAgentSessionSync,
+  type AgentRuntimeSnapshot,
+  type AgentSessionSync,
+} from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import { parseAgentRuntimeCursor } from "@/lib/agents/sessionReplica";
 import {
   daemonSession,
   daemonWorkspace,
@@ -51,13 +57,41 @@ export async function GET(
   const authorized = await authorize(req, id);
   if ("error" in authorized) return authorized.error;
   try {
+    const after = parseAgentRuntimeCursor(
+      new URL(req.url).searchParams.get("after"),
+    );
     const result = await hostConnectorBroker.request<{
-      snapshot: unknown;
+      snapshot: AgentRuntimeSnapshot;
+      sync?: unknown;
     }>(authorized.owned.host.connectorId, {
       type: "open_session",
       session: daemonSession(authorized.owned),
+      ...(after ? { after } : {}),
     });
-    return Response.json({ snapshot: result.snapshot });
+    if (result.snapshot?.sessionId !== id) {
+      throw new Error("The Host Connector opened a different session.");
+    }
+    let sync: AgentSessionSync | undefined;
+    if (result.sync !== undefined) {
+      if (!isAgentSessionSync(result.sync)) {
+        throw new Error("The Host Connector returned an invalid session sync.");
+      }
+      if (
+        (result.sync.reset && result.sync.snapshot.sessionId !== id) ||
+        (!result.sync.reset &&
+          result.sync.events.some(
+            (event) =>
+              event.type === "snapshot" && event.data.sessionId !== id,
+          ))
+      ) {
+        throw new Error("The Host Connector synchronized a different session.");
+      }
+      sync = result.sync;
+    }
+    return Response.json({
+      snapshot: result.snapshot,
+      ...(sync ? { sync } : {}),
+    });
   } catch (error) {
     return Response.json(
       {

--- a/apps/web/app/api/host-connectors/channel/route.test.ts
+++ b/apps/web/app/api/host-connectors/channel/route.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_RELEASE_VERSION,
+  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
 } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
@@ -28,11 +29,21 @@ vi.mock("@/lib/db/agentConnections", () => ({
 
 import { GET } from "./route";
 
-function request(version: string, protocol: number): Request {
+function request(
+  version = HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  protocol = HOST_CONNECTOR_PROTOCOL_VERSION,
+  options: { buildVersion?: string; capabilities?: string } = {},
+): Request {
   return new Request("http://server.test/api/host-connectors/channel", {
     headers: {
       "X-OvertChat-Connector-Version": version,
       "X-OvertChat-Connector-Protocol": String(protocol),
+      ...(options.buildVersion
+        ? { "X-OvertChat-Connector-Build-Version": options.buildVersion }
+        : {}),
+      ...(options.capabilities
+        ? { "X-OvertChat-Connector-Capabilities": options.capabilities }
+        : {}),
     },
   });
 }
@@ -58,10 +69,8 @@ describe("Host Connector command channel", () => {
     mocks.listActiveSessions.mockResolvedValue(["session"]);
   });
 
-  it("opens only for the exact connector release and protocol", async () => {
-    const response = await GET(
-      request(HOST_CONNECTOR_RELEASE_VERSION, HOST_CONNECTOR_PROTOCOL_VERSION),
-    );
+  it("opens for the protocol-1 compatibility baseline", async () => {
+    const response = await GET(request());
 
     expect(response.status).toBe(200);
     const reader = response.body!.getReader();
@@ -71,24 +80,50 @@ describe("Host Connector command channel", () => {
       "connector",
       ["session"],
       expect.any(Function),
+      [],
     );
     expect(mocks.touch).toHaveBeenCalledWith(
       "connector",
-      HOST_CONNECTOR_RELEASE_VERSION,
+      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     );
     await reader.cancel();
     expect(mocks.unregister).toHaveBeenCalled();
   });
 
-  it("rejects any other release or protocol without opening a channel", async () => {
-    const wrongRelease = await GET(
-      request("9.9.9", HOST_CONNECTOR_PROTOCOL_VERSION),
+  it("uses the build version for display without gating the wire", async () => {
+    const response = await GET(
+      request(
+        HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+        HOST_CONNECTOR_PROTOCOL_VERSION,
+        {
+          buildVersion: "9.9.9",
+          capabilities: `${HOST_CONNECTOR_CAPABILITIES[0]},future-capability`,
+        },
+      ),
     );
+
+    expect(response.status).toBe(200);
+    expect(mocks.register).toHaveBeenCalledWith(
+      "connector",
+      ["session"],
+      expect.any(Function),
+      [HOST_CONNECTOR_CAPABILITIES[0]],
+    );
+    expect(mocks.touch).toHaveBeenCalledWith("connector", "9.9.9");
+    await response.body!.cancel();
+  });
+
+  it("rejects an incompatible wire shape or protocol", async () => {
+    const wrongRelease = await GET(request("0.1.0"));
     expect(wrongRelease.status).toBe(409);
+    await expect(wrongRelease.json()).resolves.toMatchObject({
+      code: "unsupported_connector_protocol",
+      compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+    });
 
     const wrongProtocol = await GET(
       request(
-        HOST_CONNECTOR_RELEASE_VERSION,
+        HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
         HOST_CONNECTOR_PROTOCOL_VERSION + 1,
       ),
     );
@@ -99,9 +134,7 @@ describe("Host Connector command channel", () => {
   it("requires a connector credential", async () => {
     mocks.authenticate.mockReturnValue(null);
 
-    const response = await GET(
-      request(HOST_CONNECTOR_RELEASE_VERSION, HOST_CONNECTOR_PROTOCOL_VERSION),
-    );
+    const response = await GET(request());
 
     expect(response.status).toBe(401);
     expect(mocks.register).not.toHaveBeenCalled();

--- a/apps/web/app/api/host-connectors/channel/route.ts
+++ b/apps/web/app/api/host-connectors/channel/route.ts
@@ -1,7 +1,8 @@
 import {
-  HOST_CONNECTOR_RELEASE_VERSION,
   HOST_CONNECTOR_PROTOCOL_VERSION,
+  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
   isHostConnectorProtocolVersion,
+  parseHostConnectorCapabilities,
   type HostConnectorCommand,
 } from "@overtchat/agent-bridge";
 import { authenticateHostConnector } from "@/lib/agents/connector/auth";
@@ -21,21 +22,27 @@ export async function GET(request: Request) {
   const connectorVersion = request.headers.get(
     "x-overtchat-connector-version",
   );
+  const connectorBuildVersion = request.headers
+    .get("x-overtchat-connector-build-version")
+    ?.trim();
   if (
     !isHostConnectorProtocolVersion(protocol) ||
-    connectorVersion !== HOST_CONNECTOR_RELEASE_VERSION
+    connectorVersion !== HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE
   ) {
     return Response.json(
       {
-        error: `Connector ${connectorVersion ?? "unknown"} does not match this server. Reinstall OvertChat Connector ${HOST_CONNECTOR_RELEASE_VERSION} (protocol ${HOST_CONNECTOR_PROTOCOL_VERSION}).`,
+        error: `This server requires the Host Connector protocol ${HOST_CONNECTOR_PROTOCOL_VERSION} agent-daemon wire shape.`,
+        code: "unsupported_connector_protocol",
+        supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
+        compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
       },
       { status: 409 },
     );
   }
-  touchHostConnector(
-    connector.id,
-    connectorVersion,
+  const capabilities = parseHostConnectorCapabilities(
+    request.headers.get("x-overtchat-connector-capabilities"),
   );
+  touchHostConnector(connector.id, connectorBuildVersion || connectorVersion);
   const activeSessionIds = await listActiveAgentSessionIds(connector.id);
 
   let close = () => {};
@@ -51,6 +58,7 @@ export async function GET(request: Request) {
         connector.id,
         activeSessionIds,
         send,
+        capabilities,
       );
       const keepAlive = setInterval(() => {
         if (!closed) {

--- a/apps/web/app/api/host-connectors/events/route.test.ts
+++ b/apps/web/app/api/host-connectors/events/route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_RELEASE_VERSION,
+  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
 } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
@@ -28,16 +28,24 @@ import { POST } from "./route";
 
 function request(
   body: unknown,
-  version = HOST_CONNECTOR_RELEASE_VERSION,
+  options: {
+    version?: string;
+    protocol?: number;
+    buildVersion?: string;
+  } = {},
 ): Request {
   return new Request("http://server.test/api/host-connectors/events", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-OvertChat-Connector-Version": version,
+      "X-OvertChat-Connector-Version":
+        options.version ?? HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
       "X-OvertChat-Connector-Protocol": String(
-        HOST_CONNECTOR_PROTOCOL_VERSION,
+        options.protocol ?? HOST_CONNECTOR_PROTOCOL_VERSION,
       ),
+      ...(options.buildVersion
+        ? { "X-OvertChat-Connector-Build-Version": options.buildVersion }
+        : {}),
     },
     body: JSON.stringify(body),
   });
@@ -47,7 +55,7 @@ describe("Host Connector event route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.authenticate.mockReturnValue({ id: "connector" });
-    mocks.acceptBatch.mockReturnValue({
+    mocks.acceptBatch.mockResolvedValue({
       connectorEpoch: "daemon",
       acknowledgedSequence: 1,
     });
@@ -81,7 +89,36 @@ describe("Host Connector event route", () => {
       "daemon",
       [event],
     );
-    expect(mocks.touch).toHaveBeenCalledWith("connector");
+    expect(mocks.touch).toHaveBeenCalledWith(
+      "connector",
+      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+    );
+  });
+
+  it("records a newer build without requiring its release to match", async () => {
+    const response = await POST(
+      request(
+        {
+          protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
+          connectorEpoch: "daemon",
+          events: [
+            {
+              sequence: 1,
+              payload: {
+                type: "response",
+                requestId: "request",
+                success: true,
+                data: null,
+              },
+            },
+          ],
+        },
+        { buildVersion: "9.9.9" },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.touch).toHaveBeenCalledWith("connector", "9.9.9");
   });
 
   it("rejects malformed events before they reach the broker", async () => {
@@ -121,44 +158,111 @@ describe("Host Connector event route", () => {
     expect(mocks.acceptBatch).not.toHaveBeenCalled();
   });
 
-  it("rejects unsupported connector protocol versions", async () => {
-    const response = await POST(new Request(
-      "http://server.test/api/host-connectors/events",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-OvertChat-Connector-Version": HOST_CONNECTOR_RELEASE_VERSION,
-          "X-OvertChat-Connector-Protocol": String(
-            HOST_CONNECTOR_PROTOCOL_VERSION + 1,
-          ),
-        },
-        body: JSON.stringify({
-        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION + 1,
+  it("rejects empty event batches", async () => {
+    const response = await POST(
+      request({
+        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
         connectorEpoch: "daemon",
         events: [],
-        }),
-      },
-    ));
+      }),
+    );
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(400);
     expect(mocks.acceptBatch).not.toHaveBeenCalled();
   });
 
-  it("rejects a different connector release", async () => {
+  it("rejects unsupported connector protocol versions", async () => {
     const response = await POST(
       request(
         {
-          protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
+          protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION + 1,
           connectorEpoch: "daemon",
-          events: [],
+          events: [
+            {
+              sequence: 1,
+              payload: {
+                type: "response",
+                requestId: "request",
+                success: true,
+                data: null,
+              },
+            },
+          ],
         },
-        "9.9.9",
+        { protocol: HOST_CONNECTOR_PROTOCOL_VERSION + 1 },
       ),
     );
 
     expect(response.status).toBe(409);
     expect(mocks.acceptBatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects the incompatible pre-agent-daemon wire shape", async () => {
+    const response = await POST(
+      request(
+        {
+          protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
+          connectorEpoch: "daemon",
+          events: [
+            {
+              sequence: 1,
+              payload: {
+                type: "response",
+                requestId: "request",
+                success: true,
+                data: null,
+              },
+            },
+          ],
+        },
+        { version: "0.1.0" },
+      ),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "unsupported_connector_protocol",
+      compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+    });
+    expect(mocks.acceptBatch).not.toHaveBeenCalled();
+  });
+
+  it("returns a client error when the broker rejects a noncontiguous batch", async () => {
+    mocks.acceptBatch.mockRejectedValueOnce(
+      new Error("The Host Connector event batch is not contiguous."),
+    );
+    const response = await POST(
+      request({
+        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
+        connectorEpoch: "daemon",
+        events: [
+          {
+            sequence: 4,
+            payload: {
+              type: "response",
+              requestId: "request-1",
+              success: true,
+              data: null,
+            },
+          },
+          {
+            sequence: 6,
+            payload: {
+              type: "response",
+              requestId: "request-2",
+              success: true,
+              data: null,
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "The Host Connector event batch is not contiguous.",
+    });
+    expect(mocks.touch).not.toHaveBeenCalled();
   });
 
   it("requires a connector credential", async () => {

--- a/apps/web/app/api/host-connectors/events/route.ts
+++ b/apps/web/app/api/host-connectors/events/route.ts
@@ -1,6 +1,7 @@
 import {
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
-  HOST_CONNECTOR_RELEASE_VERSION,
+  HOST_CONNECTOR_PROTOCOL_VERSION,
+  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
   isHostConnectorEvent,
   isHostConnectorProtocolVersion,
   type HostConnectorEventBatch,
@@ -12,15 +13,21 @@ import { touchHostConnector } from "@/lib/db/hostConnectors";
 export async function POST(request: Request) {
   const connector = authenticateHostConnector(request);
   if (!connector) return new Response("Unauthorized", { status: 401 });
+  const protocol = Number(
+    request.headers.get("x-overtchat-connector-protocol"),
+  );
   if (
     request.headers.get("x-overtchat-connector-version") !==
-      HOST_CONNECTOR_RELEASE_VERSION ||
-    !isHostConnectorProtocolVersion(
-      Number(request.headers.get("x-overtchat-connector-protocol")),
-    )
+      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE ||
+    !isHostConnectorProtocolVersion(protocol)
   ) {
     return Response.json(
-      { error: "The Host Connector release does not match this server." },
+      {
+        error: `This server requires the Host Connector protocol ${HOST_CONNECTOR_PROTOCOL_VERSION} agent-daemon wire shape.`,
+        code: "unsupported_connector_protocol",
+        supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
+        compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+      },
       { status: 409 },
     );
   }
@@ -33,16 +40,35 @@ export async function POST(request: Request) {
     typeof batch.connectorEpoch !== "string" ||
     batch.connectorEpoch.length === 0 ||
     !Array.isArray(batch.events) ||
+    batch.events.length === 0 ||
     batch.events.length > HOST_CONNECTOR_EVENT_BATCH_LIMIT ||
     !batch.events.every(isHostConnectorEvent)
   ) {
     return Response.json({ error: "Invalid connector event batch." }, { status: 400 });
   }
-  const ack = hostConnectorBroker.acceptBatch(
-    connector.id,
-    batch.connectorEpoch,
-    batch.events,
-  );
-  touchHostConnector(connector.id);
-  return Response.json(ack);
+  try {
+    const ack = await hostConnectorBroker.acceptBatch(
+      connector.id,
+      batch.connectorEpoch,
+      batch.events,
+    );
+    const connectorBuildVersion = request.headers
+      .get("x-overtchat-connector-build-version")
+      ?.trim();
+    touchHostConnector(
+      connector.id,
+      connectorBuildVersion || HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+    );
+    return Response.json(ack);
+  } catch (error) {
+    return Response.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Invalid connector event batch.",
+      },
+      { status: 400 },
+    );
+  }
 }

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,9 +80,68 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.2.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
+  });
+
+  it("offers an in-place upgrade command for an older connector", async () => {
+    mocks.listConnectors.mockReturnValue([
+      {
+        id: "connector",
+        name: "Home server",
+        version: "0.2.0",
+        lastSeenAt: new Date(12_000),
+      },
+    ]);
+    mocks.isOnline.mockReturnValue(true);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      connectors: [
+        {
+          id: "connector",
+          name: "Home server",
+          version: "0.2.0",
+          lastSeenAt: 12_000,
+          online: true,
+          upgrade: {
+            version: "0.3.0",
+            command:
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.0 | sh -s -- --upgrade",
+          },
+        },
+      ],
+    });
+  });
+
+  it("does not offer a reinstall or downgrade for a current or newer connector", async () => {
+    mocks.listConnectors.mockReturnValue([
+      {
+        id: "current",
+        name: "Current",
+        version: "0.3.0",
+        lastSeenAt: null,
+      },
+      {
+        id: "newer",
+        name: "Newer",
+        version: "0.4.0",
+        lastSeenAt: null,
+      },
+    ]);
+
+    const response = await GET(request());
+    const data = (await response.json()) as {
+      connectors: Array<{ upgrade: unknown }>;
+    };
+
+    expect(data.connectors.map((connector) => connector.upgrade)).toEqual([
+      null,
+      null,
+    ]);
   });
 
   it("stops active runtimes before deleting an owned connector", async () => {

--- a/apps/web/app/api/host-connectors/route.ts
+++ b/apps/web/app/api/host-connectors/route.ts
@@ -21,16 +21,41 @@ function connectorServerUrl(): string {
   );
 }
 
+function connectorInstallerUrl(): string {
+  return `https://overtchat.com/install/connector/${HOST_CONNECTOR_RELEASE_VERSION}`;
+}
+
 function installCommand(pairCode: string): string {
-  const installUrl = `https://overtchat.com/install/connector/${HOST_CONNECTOR_RELEASE_VERSION}`;
   return [
     "curl --proto '=https' --tlsv1.2 -fsSL ",
-    installUrl,
+    connectorInstallerUrl(),
     " | sh -s -- --server ",
     shellQuote(connectorServerUrl()),
     " --pair-code ",
     shellQuote(pairCode),
   ].join("");
+}
+
+function upgradeCommand(): string {
+  return [
+    "curl --proto '=https' --tlsv1.2 -fsSL ",
+    connectorInstallerUrl(),
+    " | sh -s -- --upgrade",
+  ].join("");
+}
+
+function connectorNeedsUpgrade(version: string | null): boolean {
+  if (version === HOST_CONNECTOR_RELEASE_VERSION) return false;
+  const current = /^(\d+)\.(\d+)\.(\d+)$/u.exec(
+    HOST_CONNECTOR_RELEASE_VERSION,
+  );
+  const installed = version ? /^(\d+)\.(\d+)\.(\d+)$/u.exec(version) : null;
+  if (!current || !installed) return true;
+  for (let index = 1; index <= 3; index += 1) {
+    const difference = Number(installed[index]) - Number(current[index]);
+    if (difference !== 0) return difference < 0;
+  }
+  return false;
 }
 
 async function adminUser(request: Request) {
@@ -53,13 +78,22 @@ async function adminUser(request: Request) {
 export async function GET(request: Request) {
   const result = await adminUser(request);
   if (!result.ok) return result.error;
-  const connectors = listHostConnectors(result.user.id).map((connector) => ({
-    id: connector.id,
-    name: connector.name,
-    version: connector.version,
-    lastSeenAt: connector.lastSeenAt?.getTime() ?? null,
-    online: hostConnectorBroker.isOnline(connector.id),
-  }));
+  const connectors = listHostConnectors(result.user.id).map((connector) => {
+    const needsUpgrade = connectorNeedsUpgrade(connector.version);
+    return {
+      id: connector.id,
+      name: connector.name,
+      version: connector.version,
+      lastSeenAt: connector.lastSeenAt?.getTime() ?? null,
+      online: hostConnectorBroker.isOnline(connector.id),
+      upgrade: needsUpgrade
+        ? {
+            version: HOST_CONNECTOR_RELEASE_VERSION,
+            command: upgradeCommand(),
+          }
+        : null,
+    };
+  });
   return Response.json({ connectors });
 }
 

--- a/apps/web/components/agents/AgentComposer.tsx
+++ b/apps/web/components/agents/AgentComposer.tsx
@@ -444,6 +444,7 @@ export function AgentComposer({
         >
           {queuedMessages.map((queuedMessage) => {
             const sending = queuedMessage.status === "sending";
+            const uncertain = queuedMessage.status === "uncertain";
             const imageCount = queuedMessage.images?.length ?? 0;
             return (
               <article
@@ -469,7 +470,11 @@ export function AgentComposer({
                       `${imageCount} attached ${imageCount === 1 ? "image" : "images"}`}
                   </p>
                   <p className="mt-0.5 text-[10px] font-medium text-muted-foreground">
-                    {sending ? "Sending" : "Queued"}
+                    {uncertain
+                      ? "Delivery unknown — inspect the session before resending"
+                      : sending
+                        ? "Sending"
+                        : "Queued"}
                     {imageCount > 0
                       ? ` · ${imageCount} ${imageCount === 1 ? "image" : "images"}`
                       : ""}
@@ -499,7 +504,7 @@ export function AgentComposer({
                     >
                       <Pencil />
                     </Button>
-                    {supportsSteer && running && (
+                    {supportsSteer && running && !uncertain && (
                       <Button
                         type="button"
                         variant="ghost"

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -304,6 +304,93 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
   };
 }
 
+test("requires inspection before retrying an uncertain queued message", async ({
+  page,
+}) => {
+  await page.goto("/signup");
+  await page.locator("#name").fill("Uncertain Queue E2E Admin");
+  await page
+    .locator("#email")
+    .fill("uncertain-queue-admin@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+  seedAgentSession();
+
+  const snapshot = runtimeSnapshot(Date.now() - 3_000);
+  snapshot.queuedMessages = [
+    {
+      id: "uncertain-message",
+      message: "Check whether this was delivered",
+      status: "uncertain",
+    },
+  ];
+  const submittedCommands: Array<Record<string, unknown>> = [];
+  await page.route(
+    new RegExp(`/api/agent-sessions/${SESSION_ID}(?:\\?.*)?$`),
+    async (route) => {
+      if (route.request().method() === "POST") {
+        submittedCommands.push(
+          route.request().postDataJSON() as Record<string, unknown>,
+        );
+        await route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ accepted: true, queuedMessages: [] }),
+        });
+        return;
+      }
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ snapshot }),
+      });
+    },
+  );
+  await page.addInitScript(() => {
+    class FakeEventSource extends EventTarget {
+      onopen: ((event: Event) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor() {
+        super();
+        window.setTimeout(() => this.onopen?.(new Event("open")), 0);
+      }
+
+      close() {}
+    }
+    Object.assign(window, { EventSource: FakeEventSource });
+  });
+
+  await page.goto(`/agents/${SESSION_ID}`);
+  const composer = page.getByTestId("agent-composer").getByRole("combobox");
+  const uncertainQueueItem = page
+    .locator('section[aria-label="Pending messages"] article')
+    .filter({ hasText: "Check whether this was delivered" });
+  await expect(uncertainQueueItem).toContainText(
+    "Delivery unknown — inspect the session before resending",
+  );
+  await expect(
+    uncertainQueueItem.getByRole("button", { name: "Edit queued message" }),
+  ).toBeVisible();
+  await expect(
+    uncertainQueueItem.getByRole("button", { name: "Delete queued message" }),
+  ).toBeVisible();
+  await expect(
+    uncertainQueueItem.getByRole("button", {
+      name: "Steer with queued message",
+    }),
+  ).toHaveCount(0);
+
+  await uncertainQueueItem
+    .getByRole("button", { name: "Edit queued message" })
+    .click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "remove_queued_message",
+    id: "uncertain-message",
+  });
+  await expect(composer).toHaveValue("Check whether this was delivered");
+  await expect(uncertainQueueItem).toHaveCount(0);
+});
+
 test("shows durable turn activity without changing completed tool status", async ({
   page,
 }, testInfo) => {
@@ -321,7 +408,14 @@ test("shows durable turn activity without changing completed tool status", async
   } = runtimeSnapshot(startedAt);
   let retryRequested = false;
   let interactionResponse: Record<string, unknown> | null = null;
+  let runtimeAvailable = true;
   const submittedCommands: Array<Record<string, unknown>> = [];
+  await page.exposeFunction(
+    "__setAgentRuntimeAvailable",
+    (available: boolean) => {
+      runtimeAvailable = available;
+    },
+  );
   await page.route("**/api/uploads", async (route) => {
     if (route.request().method() !== "POST") {
       await route.fallback();
@@ -347,7 +441,7 @@ test("shows durable turn activity without changing completed tool status", async
     });
   });
   await page.route(
-    new RegExp(`/api/agent-sessions/${SESSION_ID}$`),
+    new RegExp(`/api/agent-sessions/${SESSION_ID}(?:\\?.*)?$`),
     async (route) => {
       if (route.request().method() === "POST") {
         const command = route.request().postDataJSON() as {
@@ -439,9 +533,32 @@ test("shows durable turn activity without changing completed tool status", async
         });
         return;
       }
+      if (!runtimeAvailable) {
+        await route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Runtime test connector unavailable" }),
+        });
+        return;
+      }
+      const after = new URL(route.request().url()).searchParams.get("after");
+      const separator = after?.lastIndexOf(":") ?? -1;
+      const sequence = Number(after?.slice(separator + 1));
+      const cursor =
+        after &&
+        separator > 0 &&
+        Number.isSafeInteger(sequence) &&
+        sequence >= 0
+          ? { epoch: after.slice(0, separator), sequence }
+          : null;
       await route.fulfill({
         contentType: "application/json",
-        body: JSON.stringify({ snapshot }),
+        body: JSON.stringify({
+          snapshot,
+          ...(cursor
+            ? { sync: { reset: true, cursor, snapshot } }
+            : {}),
+        }),
       });
     },
   );
@@ -491,12 +608,18 @@ test("shows durable turn activity without changing completed tool status", async
     };
     type RuntimeControls = {
       emit: (envelope: RuntimeEnvelope) => void;
-      disconnect: () => void;
-      reconnect: () => void;
+      disconnect: () => Promise<void>;
+      reconnect: () => Promise<void>;
       connected: () => boolean;
     };
+    const setRuntimeAvailable = (
+      window as unknown as {
+        __setAgentRuntimeAvailable: (available: boolean) => Promise<void>;
+      }
+    ).__setAgentRuntimeAvailable;
 
     const sources: FakeEventSource[] = [];
+    let online = true;
     class FakeEventSource extends EventTarget {
       onopen: ((event: Event) => void) | null = null;
       onerror: ((event: Event) => void) | null = null;
@@ -504,7 +627,11 @@ test("shows durable turn activity without changing completed tool status", async
       constructor() {
         super();
         sources.push(this);
-        window.setTimeout(() => this.onopen?.(new Event("open")), 0);
+        window.setTimeout(() => {
+          if (online && sources.includes(this)) {
+            this.onopen?.(new Event("open"));
+          }
+        }, 0);
       }
 
       close() {
@@ -523,11 +650,19 @@ test("shows durable turn activity without changing completed tool status", async
           );
         }
       },
-      disconnect() {
-        for (const source of sources) source.onerror?.(new Event("error"));
+      async disconnect() {
+        online = false;
+        await setRuntimeAvailable(false);
+        for (const source of [...sources]) {
+          source.onerror?.(new Event("error"));
+        }
       },
-      reconnect() {
-        for (const source of sources) source.onopen?.(new Event("open"));
+      async reconnect() {
+        await setRuntimeAvailable(true);
+        online = true;
+        for (const source of [...sources]) {
+          source.onopen?.(new Event("open"));
+        }
       },
       connected() {
         return sources.length > 0;
@@ -870,12 +1005,12 @@ test("shows durable turn activity without changing completed tool status", async
   });
   await expect(genericActivity).toContainText("Compacting");
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     const controls = (
       window as unknown as {
         __agentRuntimeControls: {
           emit: (envelope: unknown) => void;
-          disconnect: () => void;
+          disconnect: () => Promise<void>;
         };
       }
     ).__agentRuntimeControls;
@@ -885,7 +1020,7 @@ test("shows durable turn activity without changing completed tool status", async
       type: "runtime_event",
       data: { type: "compaction_end", reason: "auto" },
     });
-    controls.disconnect();
+    await controls.disconnect();
   });
   await expect(genericActivity).toContainText("Reconnecting");
   await page.setViewportSize({ width: 390, height: 844 });
@@ -921,16 +1056,32 @@ test("shows durable turn activity without changing completed tool status", async
   });
   await page.getByRole("button", { name: "Collapse sidebar" }).click();
 
+  await page.evaluate(async () => {
+    const controls = (
+      window as unknown as {
+        __agentRuntimeControls: {
+          reconnect: () => Promise<void>;
+        };
+      }
+    ).__agentRuntimeControls;
+    await controls.reconnect();
+  });
+  await page.waitForFunction(
+    () =>
+      (
+        window as unknown as {
+          __agentRuntimeControls: { connected: () => boolean };
+        }
+      ).__agentRuntimeControls.connected(),
+  );
   await page.evaluate(() => {
     const controls = (
       window as unknown as {
         __agentRuntimeControls: {
-          reconnect: () => void;
           emit: (envelope: unknown) => void;
         };
       }
     ).__agentRuntimeControls;
-    controls.reconnect();
     controls.emit({
       epoch: "runtime-test",
       sequence: 4,

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -86,7 +86,7 @@ async function startHostConnector(
   );
   await page.keyboard.press("Escape");
   const command = await page.getByLabel("Host Connector install command").textContent();
-  expect(command).toContain("https://overtchat.com/install/connector/0.2.0");
+  expect(command).toContain("https://overtchat.com/install/connector/0.3.0");
   expect(command).toContain("--server 'http://127.0.0.1:4718'");
   const pairCode = /--pair-code '([^']+)'/u.exec(command ?? "")?.[1];
   if (!pairCode) throw new Error("The Host Connector pairing code was missing.");
@@ -275,6 +275,51 @@ test("explains agent access before setup", async ({ page }, testInfo) => {
         document.documentElement.clientWidth,
     ),
   ).toBe(true);
+});
+
+test("shows the no-re-pair upgrade command for an older connector", async ({
+  page,
+}) => {
+  const upgradeCommand =
+    "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.0 | sh -s -- --upgrade";
+  await page.route("**/api/host-connectors", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        connectors: [
+          {
+            id: "older-connector",
+            name: "Home server",
+            version: "0.2.0",
+            lastSeenAt: Date.now(),
+            online: true,
+            upgrade: { version: "0.3.0", command: upgradeCommand },
+          },
+        ],
+      }),
+    });
+  });
+  await page.goto("/signup");
+  await page.locator("#name").fill("Connector Upgrade Admin");
+  await page.locator("#email").fill("connector-upgrade@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/", { timeout: 15_000 });
+
+  await page.goto("/settings/connections");
+
+  await expect(
+    page.getByText("Host Connector 0.3.0 is available", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByLabel("Host Connector upgrade command")).toHaveText(
+    upgradeCommand,
+  );
+  await expect(
+    page.getByRole("button", { name: "Copy connector upgrade command" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/without changing the existing pairing or settings/u),
+  ).toBeVisible();
 });
 
 test("shows the Add agent flow after setup", async ({ page }, testInfo) => {

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
   AgentDaemonSessionDescriptor,
+  AgentRuntimeSnapshot,
   HostConnectorCommand,
   HostConnectorEvent,
 } from "@overtchat/agent-bridge";
@@ -22,6 +23,31 @@ const session: AgentDaemonSessionDescriptor = {
   sessionId: "session",
   providerSessionId: "thread",
   providerSessionPath: "/thread.jsonl",
+};
+
+const runtimeSnapshot: AgentRuntimeSnapshot = {
+  sessionId: "session",
+  provider: "codex",
+  capabilities: { steer: true },
+  status: "idle",
+  activeTurn: null,
+  state: {},
+  messages: [],
+  models: [],
+  thinkingLevels: [],
+  commands: [],
+  stats: {
+    sessionFile: null,
+    sessionId: null,
+    userMessages: 0,
+    assistantMessages: 0,
+    toolCalls: 0,
+    toolResults: 0,
+    totalMessages: 0,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    cost: 0,
+  },
+  queuedMessages: [],
 };
 
 function response(
@@ -53,12 +79,295 @@ describe("host connector daemon broker", () => {
     });
     if (request?.type !== "request") throw new Error("missing request");
 
-    expect(
+    await expect(
       broker.acceptBatch("connector", "daemon-epoch", [
         response(1, request.requestId, { snapshot: "ready" }),
       ]),
-    ).toEqual({ connectorEpoch: "daemon-epoch", acknowledgedSequence: 1 });
+    ).resolves.toEqual({
+      connectorEpoch: "daemon-epoch",
+      acknowledgedSequence: 1,
+    });
     await expect(pending).resolves.toEqual({ snapshot: "ready" });
+  });
+
+  it("replays ledger-backed session commands across connector replacement", async () => {
+    const firstCommands: HostConnectorCommand[] = [];
+    const secondCommands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      [],
+      (command) => firstCommands.push(command),
+      ["command-wal-v1"],
+    );
+    const pending = broker.request("connector", {
+      type: "session_command",
+      commandId: "command-1",
+      clientMessageId: "message-1",
+      session,
+      command: {
+        type: "queue",
+        message: "Run tests",
+        clientMessageId: "message-1",
+      },
+    });
+    const original = firstCommands.at(-1);
+    if (
+      original?.type !== "request" ||
+      original.request.type !== "session_command"
+    ) {
+      throw new Error("missing original session command");
+    }
+
+    broker.register(
+      "connector",
+      [],
+      (command) => secondCommands.push(command),
+      ["command-wal-v1"],
+    );
+    const replay = secondCommands.at(-1);
+    if (replay?.type !== "request") {
+      throw new Error("missing replayed session command");
+    }
+
+    expect(secondCommands[0]?.type).toBe("sync");
+    expect(replay.requestId).toBe(original.requestId);
+    expect(replay.request).toEqual(original.request);
+    expect(replay.request).toMatchObject({
+      type: "session_command",
+      commandId: "command-1",
+      clientMessageId: "message-1",
+      command: { clientMessageId: "message-1" },
+    });
+    await broker.acceptBatch("connector", "replacement-epoch", [
+      response(1, replay.requestId, { queuedMessages: [] }),
+    ]);
+    await expect(pending).resolves.toEqual({ queuedMessages: [] });
+  });
+
+  it("rejects a pending session command when the replacement lacks a WAL", async () => {
+    const firstCommands: HostConnectorCommand[] = [];
+    const replacementCommands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      [],
+      (command) => firstCommands.push(command),
+      ["command-wal-v1"],
+    );
+    const pending = broker.request("connector", {
+      type: "session_command",
+      commandId: "command-1",
+      session,
+      command: { type: "prompt", message: "Run tests" },
+    });
+    const rejected = expect(pending).rejects.toThrow(
+      "command outcome is unknown",
+    );
+
+    broker.register("connector", [], (command) =>
+      replacementCommands.push(command),
+    );
+
+    await rejected;
+    expect(firstCommands.at(-1)?.type).toBe("request");
+    expect(replacementCommands).toHaveLength(1);
+    expect(replacementCommands[0]?.type).toBe("sync");
+  });
+
+  it("does not replay a command originally sent to a connector without a WAL", async () => {
+    const replacementCommands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register("connector", [], () => {});
+    const pending = broker.request("connector", {
+      type: "session_command",
+      commandId: "command-1",
+      session,
+      command: { type: "prompt", message: "Run tests" },
+    });
+    const rejected = expect(pending).rejects.toThrow(
+      "command outcome is unknown",
+    );
+
+    broker.register(
+      "connector",
+      [],
+      (command) => replacementCommands.push(command),
+      ["command-wal-v1"],
+    );
+
+    await rejected;
+    expect(replacementCommands).toHaveLength(1);
+    expect(replacementCommands[0]?.type).toBe("sync");
+  });
+
+  it("replays a WAL-backed command after the disconnect grace expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const originalCommands: HostConnectorCommand[] = [];
+      const replacementCommands: HostConnectorCommand[] = [];
+      const broker = new HostConnectorBroker(100);
+      const unregister = broker.register(
+        "connector",
+        [],
+        (command) => originalCommands.push(command),
+        ["command-wal-v1"],
+      );
+      const pending = broker.request("connector", {
+        type: "session_command",
+        commandId: "command-1",
+        session,
+        command: { type: "prompt", message: "Run tests" },
+      });
+      const original = originalCommands.at(-1);
+      if (original?.type !== "request") {
+        throw new Error("missing original command");
+      }
+
+      unregister();
+      await vi.advanceTimersByTimeAsync(101);
+      broker.register(
+        "connector",
+        [],
+        (command) => replacementCommands.push(command),
+        ["command-wal-v1"],
+      );
+      const replay = replacementCommands.at(-1);
+      if (replay?.type !== "request") {
+        throw new Error("missing replayed command");
+      }
+
+      expect(replay.requestId).toBe(original.requestId);
+      expect(replay.request).toEqual(original.request);
+      await broker.acceptBatch("connector", "replacement-epoch", [
+        response(1, replay.requestId, { accepted: true }),
+      ]);
+      await expect(pending).resolves.toEqual({ accepted: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects reads and subscriptions when the disconnect grace expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const broker = new HostConnectorBroker(100);
+      const unregister = broker.register("connector", ["session"], () => {});
+      const read = broker.request("connector", { type: "list_ssh_hosts" });
+      const subscribed = broker.subscribeSession(
+        "connector",
+        session,
+        undefined,
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+      );
+      const readRejected = expect(read).rejects.toThrow(
+        "Host Connector is offline",
+      );
+      const subscriptionRejected = expect(subscribed).rejects.toThrow(
+        "Host Connector is offline",
+      );
+
+      unregister();
+      await vi.advanceTimersByTimeAsync(101);
+
+      await Promise.all([readRejected, subscriptionRejected]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports an unknown outcome when a WAL-backed command times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const broker = new HostConnectorBroker();
+      broker.register("connector", [], () => {}, ["command-wal-v1"]);
+      const pending = broker.request("connector", {
+        type: "session_command",
+        commandId: "command-1",
+        session,
+        command: { type: "prompt", message: "Run tests" },
+      });
+      const rejected = expect(pending).rejects.toThrow(
+        "command outcome is unknown; inspect the session before retrying",
+      );
+
+      await vi.advanceTimersByTimeAsync(180_000);
+      await rejected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects pending reads and non-idempotent operations on replacement", async () => {
+    const firstCommands: HostConnectorCommand[] = [];
+    const secondCommands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register("connector", [], (command) => firstCommands.push(command));
+    const read = broker.request("connector", { type: "list_ssh_hosts" });
+    const create = broker.request("connector", {
+      type: "create_session",
+      sessionId: "new-session",
+      workspace: session,
+    });
+    const readRejected = expect(read).rejects.toThrow(
+      "reconnected before the request completed",
+    );
+    const createRejected = expect(create).rejects.toThrow(
+      "reconnected before the request completed",
+    );
+
+    broker.register("connector", [], (command) => secondCommands.push(command));
+
+    await Promise.all([readRejected, createRejected]);
+    expect(secondCommands).toHaveLength(1);
+    expect(secondCommands[0]?.type).toBe("sync");
+  });
+
+  it("rejects and removes a replay when the replacement send fails", async () => {
+    const firstCommands: HostConnectorCommand[] = [];
+    const secondCommands: HostConnectorCommand[] = [];
+    const thirdCommands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      [],
+      (command) => firstCommands.push(command),
+      ["command-wal-v1"],
+    );
+    const pending = broker.request("connector", {
+      type: "session_command",
+      commandId: "command-1",
+      clientMessageId: "message-1",
+      session,
+      command: {
+        type: "queue",
+        message: "Run tests",
+        clientMessageId: "message-1",
+      },
+    });
+    const replayFailure = new Error("replacement send failed");
+    const rejected = expect(pending).rejects.toBe(replayFailure);
+
+    broker.register(
+      "connector",
+      [],
+      (command) => {
+        secondCommands.push(command);
+        if (command.type === "request") throw replayFailure;
+      },
+      ["command-wal-v1"],
+    );
+
+    await rejected;
+    expect(secondCommands.map((command) => command.type)).toEqual([
+      "sync",
+      "request",
+    ]);
+    broker.register("connector", [], (command) => thirdCommands.push(command));
+    expect(thirdCommands).toHaveLength(1);
+    expect(thirdCommands[0]?.type).toBe("sync");
   });
 
   it("acknowledges duplicate transport events without applying them twice", async () => {
@@ -70,33 +379,61 @@ describe("host connector daemon broker", () => {
     if (request?.type !== "request") throw new Error("missing request");
     const event = response(1, request.requestId, []);
 
-    broker.acceptBatch("connector", "daemon-epoch", [event]);
-    broker.acceptBatch("connector", "daemon-epoch", [event]);
+    await broker.acceptBatch("connector", "daemon-epoch", [event]);
+    await broker.acceptBatch("connector", "daemon-epoch", [event]);
 
     await expect(pending).resolves.toEqual([]);
-    expect(
+    await expect(
       broker.acceptBatch("connector", "daemon-epoch", [event]),
-    ).toEqual({ connectorEpoch: "daemon-epoch", acknowledgedSequence: 1 });
+    ).resolves.toEqual({
+      connectorEpoch: "daemon-epoch",
+      acknowledgedSequence: 1,
+    });
   });
 
-  it("tracks overlapping connector epochs independently", () => {
+  it("acknowledges each connector epoch at the delivered batch tail", async () => {
     const broker = new HostConnectorBroker();
 
-    expect(
+    await expect(
       broker.acceptBatch("connector", "epoch-a", [
         response(1, "request-a", null),
       ]),
-    ).toEqual({ connectorEpoch: "epoch-a", acknowledgedSequence: 1 });
-    expect(
+    ).resolves.toEqual({ connectorEpoch: "epoch-a", acknowledgedSequence: 1 });
+    await expect(
       broker.acceptBatch("connector", "epoch-b", [
         response(1, "request-b", null),
       ]),
-    ).toEqual({ connectorEpoch: "epoch-b", acknowledgedSequence: 1 });
-    expect(
+    ).resolves.toEqual({ connectorEpoch: "epoch-b", acknowledgedSequence: 1 });
+    await expect(
       broker.acceptBatch("connector", "epoch-a", [
         response(2, "request-a2", null),
       ]),
-    ).toEqual({ connectorEpoch: "epoch-a", acknowledgedSequence: 2 });
+    ).resolves.toEqual({ connectorEpoch: "epoch-a", acknowledgedSequence: 2 });
+  });
+
+  it("accepts a high sequence after the web broker restarts", async () => {
+    const restarted = new HostConnectorBroker();
+
+    await expect(
+      restarted.acceptBatch("connector", "durable-connector-epoch", [
+        response(26_618, "stale-request", null),
+        response(26_619, "stale-request-2", null),
+      ]),
+    ).resolves.toEqual({
+      connectorEpoch: "durable-connector-epoch",
+      acknowledgedSequence: 26_619,
+    });
+  });
+
+  it("rejects gaps inside one delivered batch", async () => {
+    const broker = new HostConnectorBroker();
+
+    await expect(
+      broker.acceptBatch("connector", "daemon-epoch", [
+        response(4, "request-a", null),
+        response(6, "request-b", null),
+      ]),
+    ).rejects.toThrow("not contiguous");
   });
 
   it("deduplicates session timeline events by daemon epoch and sequence", async () => {
@@ -110,13 +447,14 @@ describe("host connector daemon broker", () => {
       undefined,
       (envelope) => received.push(envelope.sequence),
       vi.fn(),
+      vi.fn(),
     );
     const request = commands.at(-1);
     if (request?.type !== "request") throw new Error("missing request");
-    broker.acceptBatch("connector", "daemon-epoch", [
+    await broker.acceptBatch("connector", "daemon-epoch", [
       response(1, request.requestId, { subscribed: true }),
     ]);
-    const unsubscribe = await subscribed;
+    const { unsubscribe } = await subscribed;
     const event: HostConnectorEvent = {
       sequence: 2,
       payload: {
@@ -134,9 +472,9 @@ describe("host connector daemon broker", () => {
         },
       },
     };
-    broker.acceptBatch("connector", "daemon-epoch", [event]);
-    broker.acceptBatch("connector", "daemon-epoch", [event]);
-    broker.acceptBatch("connector", "daemon-epoch", [
+    await broker.acceptBatch("connector", "daemon-epoch", [event]);
+    await broker.acceptBatch("connector", "daemon-epoch", [event]);
+    await broker.acceptBatch("connector", "daemon-epoch", [
       {
         ...event,
         sequence: 3,
@@ -145,5 +483,474 @@ describe("host connector daemon broker", () => {
 
     expect(received).toEqual([1]);
     unsubscribe();
+  });
+
+  it("advances across legacy private-snapshot gaps before reconnecting", async () => {
+    const commands: HostConnectorCommand[] = [];
+    const received: number[] = [];
+    const broker = new HostConnectorBroker(1_000);
+    const unregister = broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+    );
+    const subscribed = broker.subscribeSession(
+      "connector",
+      session,
+      undefined,
+      (envelope) => received.push(envelope.sequence),
+      vi.fn(),
+      vi.fn(),
+    );
+    const initial = commands.at(-1);
+    if (
+      initial?.type !== "request" ||
+      initial.request.type !== "subscribe_session"
+    ) {
+      throw new Error("missing initial subscription");
+    }
+    await broker.acceptBatch("connector", "transport", [
+      response(1, initial.requestId, { subscribed: true }),
+    ]);
+    const subscription = await subscribed;
+    await broker.acceptBatch("connector", "transport", [
+      {
+        sequence: 2,
+        payload: {
+          type: "session_event",
+          subscriptionId: initial.request.subscriptionId,
+          sessionId: "session",
+          envelope: {
+            epoch: "legacy-runtime",
+            sequence: 1,
+            type: "snapshot",
+            data: runtimeSnapshot,
+          },
+        },
+      },
+      {
+        sequence: 3,
+        payload: {
+          type: "session_event",
+          subscriptionId: initial.request.subscriptionId,
+          sessionId: "session",
+          envelope: {
+            epoch: "legacy-runtime",
+            sequence: 3,
+            type: "runtime_event",
+            data: { type: "turn_start" },
+          },
+        },
+      },
+    ]);
+    expect(received).toEqual([1, 3]);
+    unregister();
+
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+    );
+    await vi.waitFor(() => {
+      expect(
+        commands.some(
+          (command) =>
+            command.type === "request" &&
+            command.request.type === "subscribe_session" &&
+            command.request.after?.sequence === 3,
+        ),
+      ).toBe(true);
+    });
+    const reconnect = commands.findLast(
+      (command) =>
+        command.type === "request" &&
+        command.request.type === "subscribe_session" &&
+        command.request.after?.sequence === 3,
+    );
+    if (reconnect?.type !== "request") {
+      throw new Error("missing reconnect subscription");
+    }
+    await broker.acceptBatch("connector", "transport", [
+      response(4, reconnect.requestId, { subscribed: true }),
+    ]);
+    subscription.unsubscribe();
+  });
+
+  it("delivers an authoritative sync when the connector channel reconnects", async () => {
+    const commands: HostConnectorCommand[] = [];
+    const order: string[] = [];
+    const synchronize = vi.fn((sync: { cursor: { sequence: number } }) => {
+      order.push(`sync:${sync.cursor.sequence}`);
+    });
+    const broker = new HostConnectorBroker(1_000);
+    const unregister = broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["session-sync-v1"],
+    );
+    const subscribed = broker.subscribeSession(
+      "connector",
+      session,
+      undefined,
+      (envelope) => order.push(`runtime:${envelope.sequence}`),
+      synchronize,
+      vi.fn(),
+    );
+    const initial = commands.at(-1);
+    if (initial?.type !== "request") throw new Error("missing request");
+    const initialSync = {
+      reset: true as const,
+      cursor: { epoch: "runtime-epoch", sequence: 5 },
+      snapshot: { ...runtimeSnapshot, status: "running" as const },
+    };
+    await broker.acceptBatch("connector", "transport", [
+      response(1, initial.requestId, {
+        subscribed: true,
+        sync: initialSync,
+      }),
+    ]);
+    const subscription = await subscribed;
+    expect(subscription.sync).toEqual(initialSync);
+    expect(subscription.authoritative).toBe(true);
+    expect(broker.runtimeStatusForSession("session")).toBe("running");
+    unregister();
+
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["session-sync-v1"],
+    );
+    await vi.waitFor(() => {
+      expect(
+        commands.some(
+          (command) =>
+            command.type === "request" &&
+            command.request.type === "subscribe_session" &&
+            command.request.after?.sequence === 5,
+        ),
+      ).toBe(true);
+    });
+    const reconnect = commands.findLast(
+      (command) =>
+        command.type === "request" &&
+        command.request.type === "subscribe_session" &&
+        command.request.after?.sequence === 5,
+    );
+    if (reconnect?.type !== "request") throw new Error("missing reconnect");
+    if (reconnect.request.type !== "subscribe_session") {
+      throw new Error("missing reconnect subscription");
+    }
+    await broker.acceptBatch("connector", "transport", [
+      {
+        sequence: 2,
+        payload: {
+          type: "session_event",
+          subscriptionId: reconnect.request.subscriptionId,
+          sessionId: "session",
+          envelope: {
+            epoch: "runtime-epoch",
+            sequence: 8,
+            type: "runtime_event",
+            data: { type: "turn_end" },
+          },
+        },
+      },
+    ]);
+    expect(order).toEqual([]);
+    const reconnectSync = {
+      reset: false as const,
+      cursor: { epoch: "runtime-epoch", sequence: 7 },
+      events: [
+        {
+          epoch: "runtime-epoch",
+          sequence: 6,
+          type: "snapshot" as const,
+          data: { ...runtimeSnapshot, status: "running" as const },
+        },
+        {
+          epoch: "runtime-epoch",
+          sequence: 7,
+          type: "runtime_event" as const,
+          data: { type: "overtchat_status", status: "exited" },
+        },
+      ],
+    };
+    await broker.acceptBatch("connector", "transport", [
+      response(3, reconnect.requestId, {
+        subscribed: true,
+        sync: reconnectSync,
+      }),
+    ]);
+    await vi.waitFor(() => expect(synchronize).toHaveBeenCalledWith(reconnectSync));
+    expect(order).toEqual(["sync:7", "runtime:8"]);
+    expect(broker.runtimeStatusForSession("session")).toBe("exited");
+    subscription.unsubscribe();
+  });
+
+  it("rejects an initial subscription when its connector is superseded", async () => {
+    const firstCommands: HostConnectorCommand[] = [];
+    const secondCommands: HostConnectorCommand[] = [];
+    const subscriber = vi.fn();
+    const synchronize = vi.fn();
+    const broker = new HostConnectorBroker(1_000);
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => firstCommands.push(command),
+      ["session-sync-v1"],
+    );
+    const subscribed = broker.subscribeSession(
+      "connector",
+      session,
+      undefined,
+      subscriber,
+      synchronize,
+      vi.fn(),
+    );
+    const initial = firstCommands.at(-1);
+    if (
+      initial?.type !== "request" ||
+      initial.request.type !== "subscribe_session"
+    ) {
+      throw new Error("missing initial subscription");
+    }
+
+    const rejected = expect(subscribed).rejects.toThrow(
+      "reconnected before the request completed",
+    );
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => secondCommands.push(command),
+      ["session-sync-v1"],
+    );
+    await rejected;
+    await broker.acceptBatch("connector", "first-transport", [
+      response(1, initial.requestId, {
+        subscribed: true,
+        sync: {
+          reset: true,
+          cursor: { epoch: "stale-runtime", sequence: 1 },
+          snapshot: runtimeSnapshot,
+        },
+      }),
+    ]);
+
+    expect(synchronize).not.toHaveBeenCalled();
+    expect(subscriber).not.toHaveBeenCalled();
+    expect(
+      secondCommands.some(
+        (command) =>
+          command.type === "request" &&
+          command.request.type === "subscribe_session",
+      ),
+    ).toBe(false);
+    expect(secondCommands).toContainEqual(
+      expect.objectContaining({
+        type: "request",
+        request: {
+          type: "unsubscribe_session",
+          subscriptionId: initial.request.subscriptionId,
+        },
+      }),
+    );
+  });
+
+  it("does not return a zombie initial subscription after a mode change", async () => {
+    const firstCommands: HostConnectorCommand[] = [];
+    const secondCommands: HostConnectorCommand[] = [];
+    const disconnect = vi.fn();
+    const broker = new HostConnectorBroker(1_000);
+    broker.register("connector", ["session"], (command) =>
+      firstCommands.push(command),
+    );
+    const subscribed = broker.subscribeSession(
+      "connector",
+      session,
+      undefined,
+      vi.fn(),
+      vi.fn(),
+      disconnect,
+    );
+    const initial = firstCommands.at(-1);
+    if (
+      initial?.type !== "request" ||
+      initial.request.type !== "subscribe_session"
+    ) {
+      throw new Error("missing initial subscription");
+    }
+
+    const rejected = expect(subscribed).rejects.toThrow(
+      "reconnected before the request completed",
+    );
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => secondCommands.push(command),
+      ["session-sync-v1"],
+    );
+    await rejected;
+    await broker.acceptBatch("connector", "first-transport", [
+      response(1, initial.requestId, { subscribed: true }),
+    ]);
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(
+      secondCommands.some(
+        (command) =>
+          command.type === "request" &&
+          command.request.type === "subscribe_session",
+      ),
+    ).toBe(false);
+    expect(secondCommands).toContainEqual(
+      expect.objectContaining({
+        type: "request",
+        request: {
+          type: "unsubscribe_session",
+          subscriptionId: initial.request.subscriptionId,
+        },
+      }),
+    );
+  });
+
+  it("releases the connector lease when the initial sync is invalid", async () => {
+    const commands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["session-sync-v1"],
+    );
+    const subscribed = broker.subscribeSession(
+      "connector",
+      session,
+      undefined,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+    );
+    const request = commands.at(-1);
+    if (
+      request?.type !== "request" ||
+      request.request.type !== "subscribe_session"
+    ) {
+      throw new Error("missing subscription request");
+    }
+
+    await broker.acceptBatch("connector", "transport", [
+      response(1, request.requestId, {
+        subscribed: true,
+        sync: { reset: "not-a-boolean" },
+      }),
+    ]);
+
+    await expect(subscribed).rejects.toThrow("invalid session sync");
+    expect(commands).toContainEqual(
+      expect.objectContaining({
+        type: "request",
+        request: {
+          type: "unsubscribe_session",
+          subscriptionId: request.request.subscriptionId,
+        },
+      }),
+    );
+  });
+
+  it("disconnects a browser stream when connector resubscription fails", async () => {
+    const commands: HostConnectorCommand[] = [];
+    const disconnect = vi.fn();
+    const broker = new HostConnectorBroker(1_000);
+    const unregister = broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["session-sync-v1"],
+    );
+    const subscribed = broker.subscribeSession(
+      "connector",
+      session,
+      undefined,
+      vi.fn(),
+      vi.fn(),
+      disconnect,
+    );
+    const initial = commands.at(-1);
+    if (
+      initial?.type !== "request" ||
+      initial.request.type !== "subscribe_session"
+    ) {
+      throw new Error("missing initial subscription");
+    }
+    await broker.acceptBatch("connector", "transport", [
+      response(1, initial.requestId, {
+        subscribed: true,
+        sync: {
+          reset: true,
+          cursor: { epoch: "runtime", sequence: 1 },
+          snapshot: { sessionId: "session", status: "idle" },
+        },
+      }),
+    ]);
+    await subscribed;
+    unregister();
+
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["session-sync-v1"],
+    );
+    await vi.waitFor(() => {
+      expect(
+        commands.some(
+          (command) =>
+            command.type === "request" &&
+            command.request.type === "subscribe_session" &&
+            command.request.after?.sequence === 1,
+        ),
+      ).toBe(true);
+    });
+    const reconnect = commands.findLast(
+      (command) =>
+        command.type === "request" &&
+        command.request.type === "subscribe_session" &&
+        command.request.after?.sequence === 1,
+    );
+    if (
+      reconnect?.type !== "request" ||
+      reconnect.request.type !== "subscribe_session"
+    ) {
+      throw new Error("missing reconnect subscription");
+    }
+
+    await broker.acceptBatch("connector", "transport", [
+      {
+        sequence: 2,
+        payload: {
+          type: "response",
+          requestId: reconnect.requestId,
+          success: false,
+          error: "could not restore subscription",
+        },
+      },
+    ]);
+
+    await vi.waitFor(() =>
+      expect(disconnect).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "could not restore subscription" }),
+      ),
+    );
+    expect(commands).toContainEqual(
+      expect.objectContaining({
+        type: "request",
+        request: {
+          type: "unsubscribe_session",
+          subscriptionId: reconnect.request.subscriptionId,
+        },
+      }),
+    );
   });
 });

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -1,12 +1,17 @@
 import "server-only";
 import {
+  HOST_CONNECTOR_CAPABILITIES,
+  HOST_CONNECTOR_PROTOCOL_VERSION,
+  isAgentSessionSync,
   isConnectorSshHost,
   type AgentDaemonRequest,
   type AgentDaemonSessionDescriptor,
   type AgentRuntimeEnvelope,
+  type AgentSessionSync,
   type AgentRuntimeStatus,
   type ConnectorSshHost,
   type HostConnectorCommand,
+  type HostConnectorCapability,
   type HostConnectorEvent,
   type HostConnectorEventAck,
   type HostConnectorEventPayload,
@@ -16,10 +21,15 @@ import { updateAgentSessionMetadata } from "@/lib/db/agentConnections";
 const REQUEST_TIMEOUT_MS = 180_000;
 const CONNECTOR_DISCONNECT_GRACE_MS = 5_000;
 
-type Channel = { send: (command: HostConnectorCommand) => void };
+type Channel = {
+  send: (command: HostConnectorCommand) => void;
+  capabilities: Set<HostConnectorCapability>;
+};
 
 type PendingRequest = {
   connectorId: string;
+  request: AgentDaemonRequest;
+  replaySafe: boolean;
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
   timeout: NodeJS.Timeout;
@@ -28,16 +38,19 @@ type PendingRequest = {
 type SessionSubscription = {
   connectorId: string;
   session: AgentDaemonSessionDescriptor;
+  authoritative: boolean;
+  initialized: boolean;
   after?: { epoch: string; sequence: number };
   subscriber: (envelope: AgentRuntimeEnvelope) => void;
+  synchronize: (sync: AgentSessionSync) => void;
   disconnect: (error: Error) => void;
+  replayBuffer: AgentRuntimeEnvelope[] | null;
 };
 
 export class HostConnectorBroker {
   private readonly channels = new Map<string, Channel>();
   private readonly pending = new Map<string, PendingRequest>();
   private readonly subscriptions = new Map<string, SessionSubscription>();
-  private readonly cursors = new Map<string, number>();
   private readonly sessionStatuses = new Map<string, AgentRuntimeStatus>();
   private readonly disconnectTimers = new Map<string, NodeJS.Timeout>();
 
@@ -57,16 +70,26 @@ export class HostConnectorBroker {
     connectorId: string,
     activeSessionIds: string[],
     send: (command: HostConnectorCommand) => void,
+    connectorCapabilities: readonly HostConnectorCapability[] = [],
   ): () => void {
     this.clearDisconnectTimer(connectorId);
-    const channel = { send };
+    const supported = new Set<string>(HOST_CONNECTOR_CAPABILITIES);
+    const capabilities = new Set(
+      connectorCapabilities.filter((capability) => supported.has(capability)),
+    );
+    const channel = { send, capabilities };
     this.channels.set(connectorId, channel);
     send({
       type: "sync",
       connectionEpoch: crypto.randomUUID(),
       activeSessionIds,
+      serverInfo: {
+        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
+        capabilities: [...capabilities],
+      },
     });
-    void this.resubscribe(connectorId);
+    this.reconcilePendingRequests(connectorId, channel);
+    void this.resubscribe(connectorId, channel);
     return () => {
       if (this.channels.get(connectorId) !== channel) return;
       this.channels.delete(connectorId);
@@ -85,14 +108,23 @@ export class HostConnectorBroker {
       );
     }
     const requestId = crypto.randomUUID();
+    const replaySafe = channel.capabilities.has("command-wal-v1");
     return new Promise<T>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pending.delete(requestId);
-        reject(new Error("Timed out waiting for the Host Connector."));
+        reject(
+          new Error(
+            request.type === "session_command" && replaySafe
+              ? "Timed out waiting for the Host Connector. The command outcome is unknown; inspect the session before retrying."
+              : "Timed out waiting for the Host Connector.",
+          ),
+        );
       }, REQUEST_TIMEOUT_MS);
       timeout.unref();
       this.pending.set(requestId, {
         connectorId,
+        request,
+        replaySafe,
         resolve: (value) => resolve(value as T),
         reject,
         timeout,
@@ -107,58 +139,143 @@ export class HostConnectorBroker {
     });
   }
 
+  private reconcilePendingRequests(
+    connectorId: string,
+    channel: Channel,
+  ): void {
+    const replaced = new Error(
+      "The OvertChat Host Connector reconnected before the request completed.",
+    );
+    const commandOutcomeUnknown = new Error(
+      "The command outcome is unknown because the Host Connector reconnected before responding. Inspect the session before retrying.",
+    );
+    for (const [requestId, pending] of this.pending) {
+      if (pending.connectorId !== connectorId) continue;
+      if (
+        pending.request.type !== "session_command" ||
+        !pending.replaySafe ||
+        !channel.capabilities.has("command-wal-v1")
+      ) {
+        clearTimeout(pending.timeout);
+        this.pending.delete(requestId);
+        pending.reject(
+          pending.request.type === "session_command"
+            ? commandOutcomeUnknown
+            : replaced,
+        );
+        continue;
+      }
+      try {
+        channel.send({
+          type: "request",
+          requestId,
+          request: pending.request,
+        });
+      } catch (error) {
+        clearTimeout(pending.timeout);
+        this.pending.delete(requestId);
+        pending.reject(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    }
+  }
+
   async subscribeSession(
     connectorId: string,
     session: AgentDaemonSessionDescriptor,
     after: { epoch: string; sequence: number } | undefined,
     subscriber: (envelope: AgentRuntimeEnvelope) => void,
+    synchronize: (sync: AgentSessionSync) => void,
     disconnect: (error: Error) => void,
-  ): Promise<() => void> {
+  ): Promise<{
+    unsubscribe: () => void;
+    authoritative: boolean;
+    sync?: AgentSessionSync;
+  }> {
+    const channel = this.channels.get(connectorId);
+    if (!channel) {
+      throw new Error("The OvertChat Host Connector is offline.");
+    }
     const subscriptionId = crypto.randomUUID();
-    this.subscriptions.set(subscriptionId, {
+    const replayBuffer: AgentRuntimeEnvelope[] = [];
+    const subscription: SessionSubscription = {
       connectorId,
       session,
+      authoritative: channel.capabilities.has("session-sync-v1"),
+      initialized: false,
       after,
       subscriber,
+      synchronize,
       disconnect,
-    });
+      replayBuffer,
+    };
+    this.subscriptions.set(subscriptionId, subscription);
+    let sync: AgentSessionSync | undefined;
     try {
-      await this.request(connectorId, {
+      const result = await this.request<{ sync?: unknown }>(connectorId, {
         type: "subscribe_session",
         subscriptionId,
         session,
         ...(after ? { after } : {}),
       });
+      if (
+        this.channels.get(connectorId) !== channel ||
+        this.subscriptions.get(subscriptionId) !== subscription ||
+        subscription.replayBuffer !== replayBuffer
+      ) {
+        throw new Error(
+          "The Host Connector channel changed while subscribing.",
+        );
+      }
+      sync = this.readSessionSync(connectorId, session, after, result?.sync);
+      if (sync) {
+        subscription.after = sync.cursor;
+        this.projectSessionSyncStatus(session.sessionId, sync);
+      }
+      subscription.initialized = true;
     } catch (error) {
-      this.subscriptions.delete(subscriptionId);
+      if (this.subscriptions.get(subscriptionId) === subscription) {
+        this.subscriptions.delete(subscriptionId);
+        this.sendUnsubscribe(connectorId, subscriptionId);
+      }
       throw error;
     }
-    return () => {
+    const buffered = replayBuffer;
+    subscription.replayBuffer = null;
+    for (const envelope of buffered) {
+      this.deliverEnvelope(subscription, envelope);
+    }
+    const unsubscribe = () => {
       if (!this.subscriptions.delete(subscriptionId)) return;
-      void this.request(connectorId, {
-        type: "unsubscribe_session",
-        subscriptionId,
-      }).catch(() => {});
+      this.sendUnsubscribe(connectorId, subscriptionId);
+    };
+    return {
+      unsubscribe,
+      authoritative: subscription.authoritative,
+      ...(sync ? { sync } : {}),
     };
   }
 
-  acceptBatch(
+  async acceptBatch(
     connectorId: string,
     connectorEpoch: string,
     events: readonly HostConnectorEvent[],
-  ): HostConnectorEventAck {
-    const cursorKey = `${connectorId}:${connectorEpoch}`;
-    let acknowledgedSequence = this.cursors.get(cursorKey) ?? 0;
-    for (const event of events) {
-      if (event.sequence <= acknowledgedSequence) continue;
-      if (event.sequence !== acknowledgedSequence + 1) break;
-      this.accept(connectorId, event.payload);
-      acknowledgedSequence = event.sequence;
+  ): Promise<HostConnectorEventAck> {
+    if (events.length === 0) {
+      throw new Error("The Host Connector sent an empty event batch.");
     }
-    this.cursors.set(cursorKey, acknowledgedSequence);
+    for (let index = 1; index < events.length; index += 1) {
+      if (events[index]!.sequence !== events[index - 1]!.sequence + 1) {
+        throw new Error("The Host Connector event batch is not contiguous.");
+      }
+    }
+    for (const event of events) {
+      await this.accept(connectorId, event.payload);
+    }
     return {
       connectorEpoch,
-      acknowledgedSequence,
+      acknowledgedSequence: events.at(-1)!.sequence,
     };
   }
 
@@ -170,7 +287,10 @@ export class HostConnectorBroker {
     return value;
   }
 
-  private accept(connectorId: string, event: HostConnectorEventPayload): void {
+  private async accept(
+    connectorId: string,
+    event: HostConnectorEventPayload,
+  ): Promise<void> {
     if (event.type === "response") {
       const pending = this.pending.get(event.requestId);
       if (!pending || pending.connectorId !== connectorId) return;
@@ -182,7 +302,7 @@ export class HostConnectorBroker {
     }
     if (event.type === "session_metadata") {
       const { providerModifiedAt, ...metadata } = event.patch;
-      void updateAgentSessionMetadata(event.sessionId, {
+      await updateAgentSessionMetadata(event.sessionId, {
         ...metadata,
         ...(providerModifiedAt !== undefined
           ? { providerModifiedAt: new Date(providerModifiedAt) }
@@ -198,47 +318,205 @@ export class HostConnectorBroker {
     ) {
       return;
     }
-    const cursor = subscription.after;
-    if (
-      cursor?.epoch === event.envelope.epoch &&
-      event.envelope.sequence <= cursor.sequence
-    ) {
+    if (subscription.replayBuffer) {
+      subscription.replayBuffer.push(event.envelope);
       return;
     }
-    subscription.after = {
-      epoch: event.envelope.epoch,
-      sequence: event.envelope.sequence,
-    };
-    if (event.envelope.type === "snapshot") {
-      this.sessionStatuses.set(event.sessionId, event.envelope.data.status);
-    } else if (
-      event.envelope.data.type === "overtchat_status" &&
-      ["idle", "running", "exited"].includes(
-        String(event.envelope.data.status),
-      )
-    ) {
-      this.sessionStatuses.set(
-        event.sessionId,
-        event.envelope.data.status as AgentRuntimeStatus,
-      );
-    }
-    subscription.subscriber(event.envelope);
+    this.deliverEnvelope(subscription, event.envelope);
   }
 
-  private async resubscribe(connectorId: string): Promise<void> {
+  private async resubscribe(
+    connectorId: string,
+    channel: Channel,
+  ): Promise<void> {
     const matching = [...this.subscriptions.entries()].filter(
       ([, subscription]) => subscription.connectorId === connectorId,
     );
-    await Promise.allSettled(
-      matching.map(([subscriptionId, subscription]) =>
-        this.request(connectorId, {
-          type: "subscribe_session",
-          subscriptionId,
-          session: subscription.session,
-          ...(subscription.after ? { after: subscription.after } : {}),
-        }),
-      ),
+    await Promise.all(
+      matching.map(async ([subscriptionId, subscription]) => {
+        if (this.channels.get(connectorId) !== channel) return;
+        if (!subscription.initialized) return;
+        const authoritative = channel.capabilities.has("session-sync-v1");
+        if (authoritative !== subscription.authoritative) {
+          if (this.subscriptions.get(subscriptionId) !== subscription) return;
+          this.subscriptions.delete(subscriptionId);
+          this.sendUnsubscribe(connectorId, subscriptionId);
+          subscription.disconnect(
+            new Error("The Host Connector streaming mode changed."),
+          );
+          return;
+        }
+        const after = subscription.after;
+        const replayBuffer: AgentRuntimeEnvelope[] = [];
+        subscription.replayBuffer = replayBuffer;
+        try {
+          const result = await this.request<{ sync?: unknown }>(connectorId, {
+            type: "subscribe_session",
+            subscriptionId,
+            session: subscription.session,
+            ...(after ? { after } : {}),
+          });
+          if (
+            this.channels.get(connectorId) !== channel ||
+            this.subscriptions.get(subscriptionId) !== subscription ||
+            subscription.replayBuffer !== replayBuffer
+          ) {
+            return;
+          }
+          const sync = this.readSessionSync(
+            connectorId,
+            subscription.session,
+            after,
+            result?.sync,
+          );
+          if (sync) {
+            subscription.after = sync.cursor;
+            this.projectSessionSyncStatus(subscription.session.sessionId, sync);
+            subscription.synchronize(sync);
+          }
+          subscription.replayBuffer = null;
+          for (const envelope of replayBuffer) {
+            this.deliverEnvelope(subscription, envelope);
+          }
+        } catch (error) {
+          if (
+            this.channels.get(connectorId) !== channel ||
+            this.subscriptions.get(subscriptionId) !== subscription ||
+            subscription.replayBuffer !== replayBuffer
+          ) {
+            return;
+          }
+          subscription.replayBuffer = null;
+          this.subscriptions.delete(subscriptionId);
+          this.sendUnsubscribe(connectorId, subscriptionId);
+          subscription.disconnect(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
+      }),
     );
+  }
+
+  private deliverEnvelope(
+    subscription: SessionSubscription,
+    envelope: AgentRuntimeEnvelope,
+  ): void {
+    const cursor = subscription.after;
+    if (
+      cursor?.epoch === envelope.epoch &&
+      envelope.sequence <= cursor.sequence
+    ) {
+      return;
+    }
+    const legacyForward =
+      !subscription.authoritative &&
+      (envelope.type === "snapshot" ||
+        !cursor ||
+        (cursor.epoch === envelope.epoch &&
+          envelope.sequence > cursor.sequence));
+    if (
+      legacyForward ||
+      !cursor ||
+      (cursor.epoch === envelope.epoch &&
+        envelope.sequence === cursor.sequence + 1)
+    ) {
+      subscription.after = {
+        epoch: envelope.epoch,
+        sequence: envelope.sequence,
+      };
+    }
+    this.projectEnvelopeStatus(subscription.session.sessionId, envelope);
+    subscription.subscriber(envelope);
+  }
+
+  private projectSessionSyncStatus(
+    sessionId: string,
+    sync: AgentSessionSync,
+  ): void {
+    if (sync.reset) {
+      this.sessionStatuses.set(sessionId, sync.snapshot.status);
+      return;
+    }
+    for (const envelope of sync.events) {
+      this.projectEnvelopeStatus(sessionId, envelope);
+    }
+  }
+
+  private projectEnvelopeStatus(
+    sessionId: string,
+    envelope: AgentRuntimeEnvelope,
+  ): void {
+    if (envelope.type === "snapshot") {
+      this.sessionStatuses.set(sessionId, envelope.data.status);
+    } else if (
+      envelope.data.type === "overtchat_status" &&
+      ["idle", "running", "exited"].includes(String(envelope.data.status))
+    ) {
+      this.sessionStatuses.set(
+        sessionId,
+        envelope.data.status as AgentRuntimeStatus,
+      );
+    }
+  }
+
+  private sendUnsubscribe(connectorId: string, subscriptionId: string): void {
+    const channel = this.channels.get(connectorId);
+    if (!channel) return;
+    try {
+      channel.send({
+        type: "request",
+        requestId: crypto.randomUUID(),
+        request: { type: "unsubscribe_session", subscriptionId },
+      });
+    } catch {
+      // The connector may have gone offline before the lease could be released.
+    }
+  }
+
+  private readSessionSync(
+    connectorId: string,
+    session: AgentDaemonSessionDescriptor,
+    after: { epoch: string; sequence: number } | undefined,
+    value: unknown,
+  ): AgentSessionSync | undefined {
+    if (value === undefined) {
+      if (
+        this.channels
+          .get(connectorId)
+          ?.capabilities.has("session-sync-v1")
+      ) {
+        throw new Error(
+          "The Host Connector omitted the authoritative session sync.",
+        );
+      }
+      return undefined;
+    }
+    if (!isAgentSessionSync(value)) {
+      throw new Error("The Host Connector returned an invalid session sync.");
+    }
+    if (
+      (value.reset && value.snapshot.sessionId !== session.sessionId) ||
+      (!value.reset &&
+        value.events.some(
+          (event) =>
+            event.type === "snapshot" &&
+            event.data.sessionId !== session.sessionId,
+        ))
+    ) {
+      throw new Error("The Host Connector synchronized a different session.");
+    }
+    if (
+      !value.reset &&
+      (!after ||
+        value.cursor.epoch !== after.epoch ||
+        (value.events[0]?.sequence ?? value.cursor.sequence + 1) !==
+          after.sequence + 1)
+    ) {
+      throw new Error(
+        "The Host Connector returned a non-contiguous session sync.",
+      );
+    }
+    return value;
   }
 
   private clearDisconnectTimer(connectorId: string): void {
@@ -261,6 +539,12 @@ export class HostConnectorBroker {
       const error = new Error("The OvertChat Host Connector is offline.");
       for (const [requestId, request] of this.pending) {
         if (request.connectorId !== connectorId) continue;
+        if (
+          request.request.type === "session_command" &&
+          request.replaySafe
+        ) {
+          continue;
+        }
         clearTimeout(request.timeout);
         this.pending.delete(requestId);
         request.reject(error);

--- a/apps/web/lib/agents/sessionReplica.test.ts
+++ b/apps/web/lib/agents/sessionReplica.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentRuntimeEnvelope,
+  AgentRuntimeSnapshot,
+} from "@overtchat/agent-bridge";
+import {
+  applyEnvelopeToReplica,
+  applyLegacyEnvelopeToReplica,
+  applySyncToReplica,
+  formatAgentRuntimeCursor,
+  parseAgentRuntimeCursor,
+  replicaFromOpenResult,
+  resolveAgentSessionFetchRace,
+  type AgentSessionReplica,
+} from "./sessionReplica";
+
+function snapshot(status: AgentRuntimeSnapshot["status"] = "idle") {
+  return {
+    sessionId: "session",
+    provider: "codex",
+    capabilities: { steer: true },
+    status,
+    activeTurn: null,
+    state: {},
+    messages: [],
+    models: [],
+    thinkingLevels: [],
+    commands: [],
+    stats: {
+      sessionFile: null,
+      sessionId: null,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      toolResults: 0,
+      totalMessages: 0,
+      tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      cost: 0,
+    },
+    queuedMessages: [],
+  } satisfies AgentRuntimeSnapshot;
+}
+
+function event(
+  sequence: number,
+  data: Record<string, unknown> = { type: "turn_start" },
+): AgentRuntimeEnvelope {
+  return {
+    epoch: "epoch",
+    sequence,
+    type: "runtime_event",
+    data: data as Extract<
+      AgentRuntimeEnvelope,
+      { type: "runtime_event" }
+    >["data"],
+  };
+}
+
+describe("agent session replica", () => {
+  it("installs an authoritative reset atomically", () => {
+    const authoritative = snapshot("running");
+    const replica = replicaFromOpenResult({
+      snapshot: snapshot(),
+      sync: {
+        reset: true,
+        cursor: { epoch: "epoch", sequence: 7 },
+        snapshot: authoritative,
+      },
+    });
+
+    expect(replica).toEqual({
+      snapshot: authoritative,
+      cursor: { epoch: "epoch", sequence: 7 },
+    });
+  });
+
+  it("rejects an authoritative reset for a different session", () => {
+    expect(() =>
+      replicaFromOpenResult({
+        snapshot: snapshot(),
+        sync: {
+          reset: true,
+          cursor: { epoch: "epoch", sequence: 1 },
+          snapshot: { ...snapshot(), sessionId: "different-session" },
+        },
+      }),
+    ).toThrow("different session");
+  });
+
+  it("applies a contiguous authoritative suffix to the returned snapshot", () => {
+    const replica = replicaFromOpenResult(
+      {
+        snapshot: snapshot("running"),
+        sync: {
+          reset: false,
+          cursor: { epoch: "epoch", sequence: 2 },
+          events: [
+            event(1),
+            event(2, { type: "overtchat_status", status: "idle" }),
+          ],
+        },
+      },
+      { snapshot: snapshot(), cursor: { epoch: "epoch", sequence: 0 } },
+    );
+
+    expect(replica.cursor).toEqual({ epoch: "epoch", sequence: 2 });
+    expect(replica.snapshot.status).toBe("idle");
+  });
+
+  it("applies only the exact next event and ignores duplicates", () => {
+    const replica: AgentSessionReplica = {
+      snapshot: snapshot(),
+      cursor: { epoch: "epoch", sequence: 4 },
+    };
+
+    const applied = applyEnvelopeToReplica(replica, event(5));
+    expect(applied.type).toBe("applied");
+    if (applied.type !== "applied") throw new Error("expected an update");
+    expect(applied.replica.cursor?.sequence).toBe(5);
+    expect(applied.replica.snapshot.status).toBe("running");
+    expect(applyEnvelopeToReplica(applied.replica, event(5)).type).toBe(
+      "duplicate",
+    );
+  });
+
+  it("requires reconciliation for gaps, epoch changes, and unanchored deltas", () => {
+    const anchored: AgentSessionReplica = {
+      snapshot: snapshot(),
+      cursor: { epoch: "epoch", sequence: 4 },
+    };
+    expect(applyEnvelopeToReplica(anchored, event(6)).type).toBe("reconcile");
+    expect(
+      applyEnvelopeToReplica(anchored, { ...event(5), epoch: "new-epoch" }).type,
+    ).toBe("reconcile");
+    expect(
+      applyEnvelopeToReplica({ snapshot: snapshot(), cursor: null }, event(1))
+        .type,
+    ).toBe("reconcile");
+  });
+
+  it("lets a legacy snapshot establish the first cursor", () => {
+    const next = applyEnvelopeToReplica(
+      { snapshot: snapshot(), cursor: null },
+      {
+        epoch: "legacy",
+        sequence: 3,
+        type: "snapshot",
+        data: snapshot("running"),
+      },
+    );
+
+    expect(next.type).toBe("applied");
+    if (next.type !== "applied") throw new Error("expected an update");
+    expect(next.replica.cursor).toEqual({ epoch: "legacy", sequence: 3 });
+    expect(next.replica.snapshot.status).toBe("running");
+  });
+
+  it("allows only legacy same-epoch gaps and treats snapshots as boundaries", () => {
+    const anchored: AgentSessionReplica = {
+      snapshot: snapshot(),
+      cursor: { epoch: "epoch", sequence: 1 },
+    };
+    const forward = applyLegacyEnvelopeToReplica(anchored, event(3));
+    expect(forward.type).toBe("applied");
+    if (forward.type !== "applied") throw new Error("expected an update");
+    expect(forward.replica.cursor).toEqual({ epoch: "epoch", sequence: 3 });
+
+    const reset = applyLegacyEnvelopeToReplica(forward.replica, {
+      epoch: "replacement",
+      sequence: 8,
+      type: "snapshot",
+      data: snapshot("idle"),
+    });
+    expect(reset.type).toBe("applied");
+    if (reset.type !== "applied") throw new Error("expected a reset");
+    expect(reset.replica.cursor).toEqual({
+      epoch: "replacement",
+      sequence: 8,
+    });
+
+    expect(applyEnvelopeToReplica(anchored, event(3)).type).toBe("reconcile");
+    expect(
+      applyLegacyEnvelopeToReplica(anchored, {
+        ...event(2),
+        epoch: "replacement",
+      }).type,
+    ).toBe("reconcile");
+  });
+
+  it("drops a stale legacy cursor after an unversioned refetch", () => {
+    expect(
+      replicaFromOpenResult(
+        { snapshot: snapshot("running") },
+        {
+          snapshot: snapshot(),
+          cursor: { epoch: "old-runtime", sequence: 12 },
+        },
+      ),
+    ).toEqual({ snapshot: snapshot("running"), cursor: null });
+  });
+
+  it("rejects a sync suffix that does not continue the local cursor", () => {
+    expect(
+      applySyncToReplica(
+        {
+          snapshot: snapshot(),
+          cursor: { epoch: "epoch", sequence: 2 },
+        },
+        {
+          reset: false,
+          cursor: { epoch: "epoch", sequence: 4 },
+          events: [event(4)],
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("round-trips runtime cursors", () => {
+    const cursor = { epoch: "runtime:epoch", sequence: 42 };
+    expect(parseAgentRuntimeCursor(formatAgentRuntimeCursor(cursor))).toEqual(
+      cursor,
+    );
+    expect(parseAgentRuntimeCursor("runtime:not-a-number")).toBeUndefined();
+  });
+
+  it("keeps whichever same-epoch replica won a fetch race", () => {
+    const baseline = {
+      snapshot: snapshot(),
+      cursor: { epoch: "epoch", sequence: 4 },
+    };
+    const live = {
+      snapshot: snapshot("running"),
+      cursor: { epoch: "epoch", sequence: 5 },
+    };
+    const fetched = {
+      snapshot: snapshot(),
+      cursor: { epoch: "epoch", sequence: 6 },
+    };
+
+    expect(resolveAgentSessionFetchRace(baseline, live, fetched)).toBe(fetched);
+    expect(
+      resolveAgentSessionFetchRace(baseline, live, {
+        ...fetched,
+        cursor: { epoch: "epoch", sequence: 4 },
+      }),
+    ).toBe(live);
+    expect(
+      resolveAgentSessionFetchRace(baseline, { ...live, cursor: null }, fetched),
+    ).toBe(fetched);
+  });
+
+  it("does not roll back a live cached replica when a remount fetch returns", () => {
+    const live = {
+      snapshot: snapshot("running"),
+      cursor: { epoch: "epoch", sequence: 5 },
+    };
+    const staleFetch = {
+      snapshot: snapshot(),
+      cursor: { epoch: "epoch", sequence: 4 },
+    };
+
+    expect(resolveAgentSessionFetchRace(undefined, live, staleFetch)).toBe(live);
+  });
+
+  it("uses an authoritative fetch to cross an epoch boundary", () => {
+    const baseline = {
+      snapshot: snapshot(),
+      cursor: { epoch: "old", sequence: 4 },
+    };
+    const live = {
+      snapshot: snapshot("running"),
+      cursor: { epoch: "old", sequence: 5 },
+    };
+    const fetched = {
+      snapshot: snapshot(),
+      cursor: { epoch: "new", sequence: 1 },
+    };
+
+    expect(resolveAgentSessionFetchRace(baseline, live, fetched)).toBe(fetched);
+  });
+
+  it("does not let a delayed old-epoch fetch overwrite a newer live epoch", () => {
+    const baseline = {
+      snapshot: snapshot(),
+      cursor: { epoch: "old", sequence: 4 },
+    };
+    const live = {
+      snapshot: snapshot("running"),
+      cursor: { epoch: "new", sequence: 2 },
+    };
+    const delayed = {
+      snapshot: snapshot(),
+      cursor: { epoch: "old", sequence: 7 },
+    };
+
+    expect(resolveAgentSessionFetchRace(baseline, live, delayed)).toBe(live);
+    expect(
+      resolveAgentSessionFetchRace(baseline, live, {
+        ...delayed,
+        cursor: { epoch: "other-new", sequence: 1 },
+      }),
+    ).toBe(live);
+  });
+});

--- a/apps/web/lib/agents/sessionReplica.ts
+++ b/apps/web/lib/agents/sessionReplica.ts
@@ -1,0 +1,213 @@
+import {
+  applyAgentRuntimeEnvelope,
+  type AgentRuntimeCursor,
+  type AgentRuntimeEnvelope,
+  type AgentRuntimeSnapshot,
+  type AgentSessionSync,
+} from "@overtchat/agent-bridge";
+
+export type AgentSessionReplica = {
+  snapshot: AgentRuntimeSnapshot;
+  cursor: AgentRuntimeCursor | null;
+};
+
+export type AgentSessionOpenResult = {
+  snapshot: AgentRuntimeSnapshot;
+  sync?: AgentSessionSync;
+};
+
+export type AgentSessionReplicaUpdate =
+  | { type: "applied"; replica: AgentSessionReplica }
+  | { type: "duplicate"; replica: AgentSessionReplica }
+  | { type: "reconcile"; replica: AgentSessionReplica };
+
+export function formatAgentRuntimeCursor(cursor: AgentRuntimeCursor): string {
+  return `${cursor.epoch}:${cursor.sequence}`;
+}
+
+export function parseAgentRuntimeCursor(
+  value: string | null,
+): AgentRuntimeCursor | undefined {
+  if (!value) return undefined;
+  const separator = value.lastIndexOf(":");
+  if (separator <= 0) return undefined;
+  const epoch = value.slice(0, separator);
+  const sequence = Number(value.slice(separator + 1));
+  return Number.isSafeInteger(sequence) && sequence >= 0
+    ? { epoch, sequence }
+    : undefined;
+}
+
+function applyEnvelope(
+  snapshot: AgentRuntimeSnapshot | undefined,
+  envelope: AgentRuntimeEnvelope,
+): AgentRuntimeSnapshot | null {
+  const next = applyAgentRuntimeEnvelope(snapshot, envelope);
+  return next && next.sessionId === snapshot?.sessionId ? next : null;
+}
+
+export function replicaFromOpenResult(
+  result: AgentSessionOpenResult,
+  current?: AgentSessionReplica,
+): AgentSessionReplica {
+  const sync = result.sync;
+  if (!sync) {
+    return {
+      snapshot: result.snapshot,
+      // A legacy snapshot has no version. Drop the old cursor so the next
+      // legacy SSE snapshot can establish the runtime's current epoch instead
+      // of looping forever after a runtime restart.
+      cursor: null,
+    };
+  }
+  if (sync.reset && sync.snapshot.sessionId !== result.snapshot.sessionId) {
+    throw new Error("The authoritative sync belongs to a different session.");
+  }
+  const replica = applySyncToReplica(current, sync);
+  if (!replica) {
+    throw new Error("Unable to apply the authoritative session sync.");
+  }
+  return replica;
+}
+
+export function applySyncToReplica(
+  current: AgentSessionReplica | undefined,
+  sync: AgentSessionSync,
+): AgentSessionReplica | null {
+  if (sync.reset) {
+    if (current && current.snapshot.sessionId !== sync.snapshot.sessionId) {
+      return null;
+    }
+    return { snapshot: sync.snapshot, cursor: sync.cursor };
+  }
+  if (
+    !current?.cursor ||
+    current.cursor.epoch !== sync.cursor.epoch ||
+    current.cursor.sequence > sync.cursor.sequence
+  ) {
+    return null;
+  }
+
+  let replica = current;
+  for (const envelope of sync.events) {
+    const update = applyEnvelopeToReplica(replica, envelope);
+    if (update.type === "reconcile") return null;
+    replica = update.replica;
+  }
+  return replica.cursor?.epoch === sync.cursor.epoch &&
+    replica.cursor.sequence === sync.cursor.sequence
+    ? replica
+    : null;
+}
+
+export function resolveAgentSessionFetchRace(
+  baseline: AgentSessionReplica | undefined,
+  live: AgentSessionReplica | null,
+  fetched: AgentSessionReplica,
+): AgentSessionReplica {
+  if (!live || live === baseline) return fetched;
+  if (!baseline) {
+    if (!fetched.cursor) return live.cursor ? live : fetched;
+    if (!live.cursor || live.cursor.epoch !== fetched.cursor.epoch) return fetched;
+    return live.cursor.sequence >= fetched.cursor.sequence ? live : fetched;
+  }
+  if (!fetched.cursor) return live;
+  if (!live.cursor) return fetched;
+  if (live.cursor.epoch !== fetched.cursor.epoch) {
+    // A live epoch observed after this fetch began is newer than a response
+    // that still belongs to the baseline epoch. If the live stream stayed on
+    // the baseline, the authoritative read is the epoch-change boundary.
+    return live.cursor.epoch !== baseline.cursor?.epoch ? live : fetched;
+  }
+  return live.cursor.sequence >= fetched.cursor.sequence ? live : fetched;
+}
+
+export function applyLegacyEnvelopeToReplica(
+  replica: AgentSessionReplica,
+  envelope: AgentRuntimeEnvelope,
+): AgentSessionReplicaUpdate {
+  const cursor = replica.cursor;
+  if (
+    cursor?.epoch === envelope.epoch &&
+    envelope.sequence <= cursor.sequence
+  ) {
+    return { type: "duplicate", replica };
+  }
+
+  // Connector v0.2 minted a private snapshot sequence for every subscriber.
+  // A snapshot therefore establishes a fresh boundary, while a forward gap
+  // in the same epoch can only be another subscriber's private snapshot.
+  if (envelope.type === "snapshot") {
+    const snapshot = applyEnvelope(replica.snapshot, envelope);
+    return snapshot
+      ? {
+          type: "applied",
+          replica: {
+            snapshot,
+            cursor: { epoch: envelope.epoch, sequence: envelope.sequence },
+          },
+        }
+      : { type: "reconcile", replica };
+  }
+  if (!cursor || envelope.epoch !== cursor.epoch) {
+    return { type: "reconcile", replica };
+  }
+
+  const snapshot = applyEnvelope(replica.snapshot, envelope);
+  return snapshot
+    ? {
+        type: "applied",
+        replica: {
+          snapshot,
+          cursor: { epoch: envelope.epoch, sequence: envelope.sequence },
+        },
+      }
+    : { type: "reconcile", replica };
+}
+
+export function applyEnvelopeToReplica(
+  replica: AgentSessionReplica,
+  envelope: AgentRuntimeEnvelope,
+): AgentSessionReplicaUpdate {
+  const cursor = replica.cursor;
+
+  // Legacy connectors do not return an initial cursor. Their first snapshot
+  // establishes one; accepting an initial delta would apply it to an
+  // unversioned snapshot that may already be newer or older than the delta.
+  if (!cursor) {
+    if (envelope.type !== "snapshot") {
+      return { type: "reconcile", replica };
+    }
+    const snapshot = applyEnvelope(replica.snapshot, envelope);
+    return snapshot
+      ? {
+          type: "applied",
+          replica: {
+            snapshot,
+            cursor: { epoch: envelope.epoch, sequence: envelope.sequence },
+          },
+        }
+      : { type: "reconcile", replica };
+  }
+
+  if (envelope.epoch !== cursor.epoch) {
+    return { type: "reconcile", replica };
+  }
+  if (envelope.sequence <= cursor.sequence) {
+    return { type: "duplicate", replica };
+  }
+  if (envelope.sequence !== cursor.sequence + 1) {
+    return { type: "reconcile", replica };
+  }
+
+  const snapshot = applyEnvelope(replica.snapshot, envelope);
+  return snapshot
+    ? {
+        type: "applied",
+        replica: {
+          snapshot,
+          cursor: { epoch: envelope.epoch, sequence: envelope.sequence },
+        },
+      }
+    : { type: "reconcile", replica };
+}

--- a/apps/web/lib/queries/agentSessions.test.tsx
+++ b/apps/web/lib/queries/agentSessions.test.tsx
@@ -1,0 +1,352 @@
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { parseHTML } from "linkedom";
+import type {
+  AgentRuntimeSnapshot,
+  AgentSessionCommand,
+} from "@overtchat/agent-bridge";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  useAgentSession,
+  useAgentSessionCommand,
+} from "./agentSessions";
+import { agentSessionKeys } from "./keys";
+import type { AgentSessionReplica } from "@/lib/agents/sessionReplica";
+
+function snapshot(sessionId = "session") {
+  return {
+    sessionId,
+    provider: "codex",
+    capabilities: { steer: true },
+    status: "idle",
+    activeTurn: null,
+    state: {},
+    messages: [],
+    models: [],
+    thinkingLevels: [],
+    commands: [],
+    stats: {
+      sessionFile: null,
+      sessionId: null,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      toolResults: 0,
+      totalMessages: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+      cost: 0,
+    },
+    queuedMessages: [],
+  } satisfies AgentRuntimeSnapshot;
+}
+
+class FakeEventSource extends EventTarget {
+  static instances: FakeEventSource[] = [];
+
+  readonly url: string;
+  onopen: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string | URL) {
+    super();
+    this.url = String(url);
+    FakeEventSource.instances.push(this);
+  }
+
+  close = vi.fn();
+}
+
+function Probe({
+  sessionId,
+  onMount,
+}: {
+  sessionId: string;
+  onMount: () => void;
+}) {
+  const session = useAgentSession(sessionId);
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+  return (
+    <div data-testid="session">
+      {session.data?.sessionId ?? session.error?.message ?? "pending"}
+    </div>
+  );
+}
+
+function StreamStatusProbe({ sessionId }: { sessionId: string }) {
+  const session = useAgentSession(sessionId);
+  return <div data-testid="stream-status">{session.streamStatus}</div>;
+}
+
+function CommandProbe({
+  onReady,
+}: {
+  onReady: (run: (command: AgentSessionCommand) => Promise<unknown>) => void;
+}) {
+  const command = useAgentSessionCommand("session");
+  useEffect(() => {
+    onReady(command.mutateAsync);
+  }, [command.mutateAsync, onReady]);
+  return null;
+}
+
+describe("useAgentSession", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let queryClient: QueryClient;
+  const originalGlobals = new Map<
+    PropertyKey,
+    PropertyDescriptor | undefined
+  >();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { window } = parseHTML(
+      "<!doctype html><html><body><div id=\"root\"></div></body></html>",
+    );
+    for (const [key, value] of Object.entries({
+      window,
+      document: window.document,
+      navigator: window.navigator,
+      HTMLElement: window.HTMLElement,
+      Event: window.Event,
+      MessageEvent: window.MessageEvent,
+      EventSource: FakeEventSource,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    })) {
+      originalGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        writable: true,
+        value,
+      });
+    }
+    FakeEventSource.instances = [];
+    container = window.document.getElementById("root") as HTMLElement;
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { gcTime: Infinity } },
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    queryClient.clear();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    for (const [key, descriptor] of originalGlobals) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, key, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, key);
+      }
+    }
+    originalGlobals.clear();
+  });
+
+  it("recovers an initially offline session and starts streaming without a remount", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json(
+          { error: "The OvertChat Host Connector is offline." },
+          { status: 400 },
+        ),
+      )
+      .mockResolvedValueOnce(Response.json({ snapshot: snapshot() }));
+    vi.stubGlobal("fetch", fetchMock);
+    const onMount = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Probe sessionId="session" onMount={onMount} />
+        </QueryClientProvider>,
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("offline");
+    expect(FakeEventSource.instances).toHaveLength(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      queryClient.getQueryData<AgentSessionReplica>(
+        agentSessionKeys.detail("session"),
+      )?.snapshot.sessionId,
+    ).toBe("session");
+    expect(container.textContent).toBe("session");
+    expect(onMount).toHaveBeenCalledTimes(1);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]?.url).toBe(
+      "/api/agent-sessions/session/events?sync=1",
+    );
+  });
+
+  it("stays reconnecting until the replacement event stream opens", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ snapshot: snapshot() }))
+      .mockResolvedValueOnce(Response.json({ snapshot: snapshot() }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <StreamStatusProbe sessionId="session" />
+        </QueryClientProvider>,
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    const initial = FakeEventSource.instances[0];
+    expect(initial).toBeDefined();
+    await act(async () => initial?.onopen?.(new Event("open")));
+    expect(container.textContent).toBe("connected");
+
+    await act(async () => {
+      initial?.onerror?.(new Event("error"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(initial?.close).toHaveBeenCalledOnce();
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(container.textContent).toBe("reconnecting");
+
+    await act(async () => {
+      FakeEventSource.instances[1]?.onopen?.(new Event("open"));
+    });
+    expect(container.textContent).toBe("connected");
+  });
+
+  it.each([401, 403, 404])(
+    "does not retry a non-recoverable HTTP %s response",
+    async (status) => {
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(Response.json({ error: "No access" }, { status }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <Probe sessionId="session" onMount={() => undefined} />
+          </QueryClientProvider>,
+        );
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(FakeEventSource.instances).toHaveLength(0);
+    },
+  );
+
+  it("reuses a submission identity after an unknown outcome", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+      async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        if (bodies.length === 1) {
+          throw new TypeError("connection reset after upload");
+        }
+        return Response.json({ accepted: true });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    let mutate: (command: AgentSessionCommand) => Promise<unknown> = () =>
+      Promise.reject(new Error("Command mutation is not ready."));
+    const onReady = vi.fn(
+      (run: (command: AgentSessionCommand) => Promise<unknown>) => {
+        mutate = run;
+      },
+    );
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CommandProbe onReady={onReady} />
+        </QueryClientProvider>,
+      );
+    });
+    expect(onReady).toHaveBeenCalledOnce();
+    const run = mutate;
+    const unchanged: AgentSessionCommand = {
+      type: "prompt",
+      message: "Inspect this",
+      images: [
+        {
+          uploadId: "11111111-1111-4111-8111-111111111111",
+          filename: "first.png",
+          mediaType: "image/png",
+        },
+        {
+          uploadId: "22222222-2222-4222-8222-222222222222",
+          filename: "second.png",
+          mediaType: "image/png",
+        },
+      ],
+    };
+
+    await expect(run(unchanged)).rejects.toThrow(
+      "command outcome is unknown",
+    );
+    await expect(run(unchanged)).resolves.toEqual({ accepted: true });
+    await expect(
+      run({ ...unchanged, message: "Inspect something else" }),
+    ).resolves.toEqual({ accepted: true });
+
+    expect(bodies).toHaveLength(3);
+    expect(bodies[0]?.clientMessageId).toBe(bodies[1]?.clientMessageId);
+    expect(bodies[2]?.clientMessageId).not.toBe(
+      bodies[1]?.clientMessageId,
+    );
+    expect(bodies[0]?.images).toEqual(unchanged.images);
+  });
+});

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -4,100 +4,334 @@ import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   AgentQueuedMessage,
-  AgentRuntimeEnvelope,
   AgentRuntimeSnapshot,
+  AgentSessionSync,
   AgentSessionCommand,
   AgentUsageSnapshot,
 } from "@overtchat/agent-bridge";
-import { applyAgentRuntimeEnvelope } from "@overtchat/agent-bridge";
+import {
+  isAgentRuntimeEnvelope,
+  isAgentSessionSync,
+} from "@overtchat/agent-bridge";
+import {
+  applyEnvelopeToReplica,
+  applyLegacyEnvelopeToReplica,
+  applySyncToReplica,
+  formatAgentRuntimeCursor,
+  replicaFromOpenResult,
+  resolveAgentSessionFetchRace,
+  type AgentSessionOpenResult,
+  type AgentSessionReplica,
+} from "@/lib/agents/sessionReplica";
 import {
   agentConnectionKeys,
   agentSessionKeys,
 } from "@/lib/queries/keys";
 
+class AgentSessionHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "AgentSessionHttpError";
+  }
+}
+
 async function responseError(response: Response): Promise<Error> {
   const data = (await response.json().catch(() => null)) as {
     error?: string;
   } | null;
-  return new Error(data?.error ?? `HTTP ${response.status}`);
+  return new AgentSessionHttpError(
+    data?.error ?? `HTTP ${response.status}`,
+    response.status,
+  );
 }
 
-async function fetchAgentSession(id: string): Promise<AgentRuntimeSnapshot> {
-  const response = await fetch(`/api/agent-sessions/${id}`);
+function isRetryableSessionOpenError(error: unknown): boolean {
+  if (error instanceof AgentSessionHttpError) {
+    return (
+      error.status === 400 ||
+      error.status === 408 ||
+      error.status === 409 ||
+      error.status === 425 ||
+      error.status === 429 ||
+      error.status >= 500
+    );
+  }
+  return error instanceof TypeError;
+}
+
+async function fetchAgentSession(
+  id: string,
+  current?: AgentSessionReplica,
+): Promise<AgentSessionReplica> {
+  const after = current?.cursor
+    ? `?after=${encodeURIComponent(formatAgentRuntimeCursor(current.cursor))}`
+    : "";
+  const response = await fetch(`/api/agent-sessions/${id}${after}`, {
+    cache: "no-store",
+  });
   if (!response.ok) throw await responseError(response);
-  return ((await response.json()) as { snapshot: AgentRuntimeSnapshot })
-    .snapshot;
+  const data = (await response.json()) as {
+    snapshot?: AgentRuntimeSnapshot;
+    sync?: unknown;
+  };
+  if (data.snapshot?.sessionId !== id) {
+    throw new Error("The Host Connector opened a different session.");
+  }
+  let sync: AgentSessionSync | undefined;
+  if (data.sync !== undefined) {
+    if (!isAgentSessionSync(data.sync)) {
+      throw new Error("The Host Connector returned an invalid session sync.");
+    }
+    sync = data.sync;
+  }
+  const result: AgentSessionOpenResult = {
+    snapshot: data.snapshot,
+    ...(sync ? { sync } : {}),
+  };
+  return replicaFromOpenResult(result, current);
 }
 
 export function useAgentSession(id: string) {
   const queryClient = useQueryClient();
-  const cursor = useRef<{ epoch: string; sequence: number } | null>(null);
+  const replicaRef = useRef<AgentSessionReplica | null>(null);
+  const initialRetryRef = useRef({ id, attempt: 0 });
   const [streamStatus, setStreamStatus] = useState<
     "connecting" | "connected" | "reconnecting"
   >("connecting");
-  const query = useQuery({
+  const query = useQuery<
+    AgentSessionReplica,
+    Error,
+    AgentRuntimeSnapshot
+  >({
     queryKey: agentSessionKeys.detail(id),
-    queryFn: () => fetchAgentSession(id),
+    queryFn: async () => {
+      const cached = queryClient.getQueryData<AgentSessionReplica>(
+        agentSessionKeys.detail(id),
+      );
+      const baseline =
+        cached?.snapshot.sessionId === id
+          ? cached
+          : replicaRef.current?.snapshot.sessionId === id
+            ? replicaRef.current
+            : undefined;
+      const fetched = await fetchAgentSession(id, baseline);
+      const latestCached = queryClient.getQueryData<AgentSessionReplica>(
+        agentSessionKeys.detail(id),
+      );
+      const latest =
+        latestCached?.snapshot.sessionId === id
+          ? latestCached
+          : replicaRef.current?.snapshot.sessionId === id
+            ? replicaRef.current
+            : null;
+      return resolveAgentSessionFetchRace(baseline, latest, fetched);
+    },
+    select: (replica) => replica.snapshot,
     retry: false,
   });
 
+  const sessionReady = query.data !== undefined;
+  const retryError = query.error;
+  const retryErrorUpdatedAt = query.errorUpdatedAt;
+  const retryIsError = query.isError;
+  const retryRefetch = query.refetch;
   useEffect(() => {
-    if (!query.isSuccess) return;
-    cursor.current = null;
-    const events = new EventSource(`/api/agent-sessions/${id}/events`);
-    events.onopen = () => setStreamStatus("connected");
-    events.onerror = () => setStreamStatus("reconnecting");
-    events.addEventListener("runtime", (event) => {
-      let envelope: AgentRuntimeEnvelope;
-      try {
-        envelope = JSON.parse(
-          (event as MessageEvent<string>).data,
-        ) as AgentRuntimeEnvelope;
-      } catch {
-        void queryClient.invalidateQueries({
-          queryKey: agentSessionKeys.detail(id),
-        });
-        return;
-      }
-      const previous = cursor.current;
-      if (
-        previous?.epoch === envelope.epoch &&
-        envelope.sequence <= previous.sequence
-      ) {
-        return;
-      }
-      if (
-        envelope.type !== "snapshot" &&
-        previous?.epoch === envelope.epoch &&
-        envelope.sequence > previous.sequence + 1
-      ) {
-        void queryClient.invalidateQueries({
-          queryKey: agentSessionKeys.detail(id),
-        });
-        return;
-      }
-      cursor.current = {
-        epoch: envelope.epoch,
-        sequence: envelope.sequence,
-      };
-      queryClient.setQueryData<AgentRuntimeSnapshot>(
+    if (initialRetryRef.current.id !== id) {
+      initialRetryRef.current = { id, attempt: 0 };
+    }
+    if (sessionReady) {
+      initialRetryRef.current.attempt = 0;
+      return;
+    }
+    if (!retryIsError || !isRetryableSessionOpenError(retryError)) return;
+
+    const attempt = initialRetryRef.current.attempt++;
+    const delay = Math.min(1_000 * 2 ** attempt, 30_000);
+    const timer = setTimeout(() => {
+      void retryRefetch();
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [
+    id,
+    retryError,
+    retryErrorUpdatedAt,
+    retryIsError,
+    retryRefetch,
+    sessionReady,
+  ]);
+
+  useEffect(() => {
+    const replica = queryClient.getQueryData<AgentSessionReplica>(
+      agentSessionKeys.detail(id),
+    );
+    if (replica?.snapshot.sessionId === id) {
+      replicaRef.current = replica;
+    }
+  }, [id, query.dataUpdatedAt, queryClient]);
+
+  useEffect(() => {
+    if (!sessionReady) return;
+    const initial = queryClient.getQueryData<AgentSessionReplica>(
+      agentSessionKeys.detail(id),
+    );
+    if (!initial) return;
+    if (replicaRef.current?.snapshot.sessionId !== id) {
+      replicaRef.current = initial;
+    }
+
+    let stopped = false;
+    let events: EventSource | null = null;
+    let reconcileTimer: ReturnType<typeof setTimeout> | null = null;
+    let reconcileAttempt = 0;
+    let reconciling = false;
+
+    const commit = (replica: AgentSessionReplica) => {
+      if (stopped) return;
+      replicaRef.current = replica;
+      queryClient.setQueryData<AgentSessionReplica>(
         agentSessionKeys.detail(id),
-        (current) => applyAgentRuntimeEnvelope(current, envelope),
+        replica,
       );
-      if (envelope.type === "snapshot") {
+    };
+
+    const closeEvents = () => {
+      events?.close();
+      events = null;
+    };
+
+    const scheduleReconciliation = () => {
+      if (stopped || reconcileTimer) return;
+      const delay = Math.min(1_000 * 2 ** reconcileAttempt++, 30_000);
+      reconcileTimer = setTimeout(() => {
+        reconcileTimer = null;
+        void reconcile();
+      }, delay);
+    };
+
+    const connect = () => {
+      if (stopped) return;
+      closeEvents();
+      const cursor = replicaRef.current?.cursor;
+      const params = new URLSearchParams({ sync: "1" });
+      if (cursor) {
+        params.set("after", formatAgentRuntimeCursor(cursor));
+      }
+      const source = new EventSource(
+        `/api/agent-sessions/${id}/events?${params.toString()}`,
+      );
+      events = source;
+      source.onopen = () => {
+        if (!stopped && events === source) setStreamStatus("connected");
+      };
+      source.onerror = () => {
+        if (stopped || events !== source) return;
+        closeEvents();
+        void reconcile();
+      };
+      source.addEventListener("sync", (event) => {
+        if (stopped || events !== source) return;
+        let sync: unknown;
+        try {
+          sync = JSON.parse((event as MessageEvent<string>).data);
+        } catch {
+          void reconcile();
+          return;
+        }
+        if (!isAgentSessionSync(sync)) {
+          void reconcile();
+          return;
+        }
+        const current = replicaRef.current ?? undefined;
+        const next = applySyncToReplica(current, sync);
+        if (!next) {
+          void reconcile();
+          return;
+        }
+        commit(next);
         void queryClient.invalidateQueries({
           queryKey: agentConnectionKeys.list(),
         });
+      });
+      const applyRuntimeEvent = (event: Event, legacy: boolean) => {
+        if (stopped || events !== source) return;
+        let envelope: unknown;
+        try {
+          envelope = JSON.parse((event as MessageEvent<string>).data);
+        } catch {
+          void reconcile();
+          return;
+        }
+        if (!isAgentRuntimeEnvelope(envelope)) {
+          void reconcile();
+          return;
+        }
+        const current = replicaRef.current;
+        if (!current) {
+          void reconcile();
+          return;
+        }
+        const update = legacy
+          ? applyLegacyEnvelopeToReplica(current, envelope)
+          : applyEnvelopeToReplica(current, envelope);
+        if (update.type === "reconcile") {
+          void reconcile();
+          return;
+        }
+        if (update.type === "duplicate") return;
+        commit(update.replica);
+        if (envelope.type === "snapshot") {
+          void queryClient.invalidateQueries({
+            queryKey: agentConnectionKeys.list(),
+          });
+        }
+      };
+      source.addEventListener("runtime", (event) => {
+        applyRuntimeEvent(event, false);
+      });
+      source.addEventListener("legacy-runtime", (event) => {
+        applyRuntimeEvent(event, true);
+      });
+    };
+
+    async function reconcile(): Promise<void> {
+      if (stopped || reconciling) return;
+      reconciling = true;
+      closeEvents();
+      setStreamStatus("reconnecting");
+      try {
+        const current = replicaRef.current ?? undefined;
+        const next = await fetchAgentSession(id, current);
+        if (stopped) return;
+        commit(next);
+        reconcileAttempt = 0;
+        connect();
+      } catch {
+        scheduleReconciliation();
+      } finally {
+        reconciling = false;
       }
-    });
-    return () => events.close();
-  }, [id, query.isSuccess, queryClient]);
+    }
+
+    connect();
+    return () => {
+      stopped = true;
+      closeEvents();
+      if (reconcileTimer) clearTimeout(reconcileTimer);
+    };
+  }, [id, queryClient, sessionReady]);
 
   return { ...query, streamStatus };
 }
 
 export function useAgentSessionCommand(id: string) {
   const queryClient = useQueryClient();
+  const retainedIdentity = useRef<{
+    fingerprint: string;
+    clientMessageId: string;
+  } | null>(null);
   return useMutation({
     mutationFn: async (
       command: AgentSessionCommand,
@@ -107,33 +341,71 @@ export function useAgentSessionCommand(id: string) {
       queuedMessages?: AgentQueuedMessage[];
       usage?: AgentUsageSnapshot;
     }> => {
-      const wireCommand =
+      const needsIdentity =
         (command.type === "prompt" ||
           command.type === "queue" ||
           command.type === "implement_plan") &&
-        !command.clientMessageId
-          ? { ...command, clientMessageId: crypto.randomUUID() }
-          : command;
-      const response = await fetch(`/api/agent-sessions/${id}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(wireCommand),
-      });
+        !command.clientMessageId;
+      const fingerprint = needsIdentity ? JSON.stringify(command) : null;
+      let generatedClientMessageId: string | null = null;
+      if (fingerprint) {
+        generatedClientMessageId =
+          retainedIdentity.current?.fingerprint === fingerprint
+            ? retainedIdentity.current.clientMessageId
+            : crypto.randomUUID();
+        retainedIdentity.current = {
+          fingerprint,
+          clientMessageId: generatedClientMessageId,
+        };
+      }
+      const wireCommand = generatedClientMessageId
+        ? { ...command, clientMessageId: generatedClientMessageId }
+        : command;
+      let response: Response;
+      try {
+        response = await fetch(`/api/agent-sessions/${id}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(wireCommand),
+        });
+      } catch (cause) {
+        if (generatedClientMessageId) {
+          throw new Error(
+            "The connection was lost while sending, so the command outcome is unknown. Inspect the session before retrying; an unchanged retry will reuse the same command identity.",
+            { cause },
+          );
+        }
+        throw cause;
+      }
       if (!response.ok) throw await responseError(response);
-      return (await response.json()) as {
+      const result = (await response.json()) as {
         sessionId?: string;
         draft?: string;
         queuedMessages?: AgentQueuedMessage[];
         usage?: AgentUsageSnapshot;
       };
+      if (
+        fingerprint &&
+        retainedIdentity.current?.fingerprint === fingerprint &&
+        retainedIdentity.current.clientMessageId === generatedClientMessageId
+      ) {
+        retainedIdentity.current = null;
+      }
+      return result;
     },
     onSuccess: (data, command) => {
       if (data.queuedMessages) {
-        queryClient.setQueryData<AgentRuntimeSnapshot>(
+        queryClient.setQueryData<AgentSessionReplica>(
           agentSessionKeys.detail(id),
           (current) =>
             current
-              ? { ...current, queuedMessages: data.queuedMessages! }
+              ? {
+                  ...current,
+                  snapshot: {
+                    ...current.snapshot,
+                    queuedMessages: data.queuedMessages!,
+                  },
+                }
               : current,
         );
       }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -3,8 +3,12 @@ import path from "node:path";
 
 export default defineConfig({
   resolve: {
+    // Hoisted React Query and the renderer must share one React instance.
+    dedupe: ["react", "react-dom"],
     alias: {
       "@": path.resolve(__dirname, "."),
+      react: path.resolve(__dirname, "../../node_modules/react"),
+      "react-dom": path.resolve(__dirname, "../../node_modules/react-dom"),
     },
   },
   test: {

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.4}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.5}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -47,6 +47,12 @@ docker compose up -d --build
 
 Compose only recreates the container if the image changed. Migrations run automatically on boot. Data in the `overtchat-data` volume persists across rebuilds.
 
+The Host Connector updates independently from the Docker app and does not need
+to be reinstalled after routine server updates. If **Settings → Connections**
+offers a newer connector, run the displayed upgrade command on the connector
+host. It preserves the existing pairing and configuration, replaces the binary,
+and restarts the user service.
+
 ## Pointing at your LLM
 
 The app container makes the upstream LLM calls, so the base URL you set in **Settings → API endpoint** needs to be reachable **from inside the container**, not from your browser.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -151,6 +151,10 @@ export type HostConnectorListItem = {
   version: string | null;
   lastSeenAt: number | null;
   online: boolean;
+  upgrade: {
+    version: string;
+    command: string;
+  } | null;
 };
 
 export type HostConnectorPairing = {
@@ -245,7 +249,7 @@ export type AgentQueuedMessage = {
   id: string;
   message: string;
   images?: AgentPromptImage[];
-  status: "pending" | "sending";
+  status: "pending" | "sending" | "uncertain";
 };
 
 export type AgentInteractionValue =
@@ -472,4 +476,27 @@ export type AgentRuntimeEnvelope =
         type: string;
         [key: string]: unknown;
       };
+    };
+
+export type AgentRuntimeCursor = {
+  epoch: string;
+  sequence: number;
+};
+
+/**
+ * An authoritative point-in-time reconciliation result owned by the Host
+ * Connector. Reset snapshots are deliberately not runtime envelopes: reading
+ * current state must not consume a sequence number that other subscribers can
+ * never observe.
+ */
+export type AgentSessionSync =
+  | {
+      reset: true;
+      cursor: AgentRuntimeCursor;
+      snapshot: AgentRuntimeSnapshot;
+    }
+  | {
+      reset: false;
+      cursor: AgentRuntimeCursor;
+      events: AgentRuntimeEnvelope[];
     };

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -2,7 +2,9 @@ import type {
   AgentConnectionDraft,
   AgentDiscoveryTarget,
   AgentProviderId,
+  AgentRuntimeCursor,
   AgentRuntimeEnvelope,
+  AgentSessionSync,
   AgentSessionCommand,
   ConnectorShellMode,
 } from "./agents";
@@ -15,8 +17,26 @@ import {
 } from "./agents";
 
 export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.2.0";
+/**
+ * Protocol 1 was accidentally reused for two incompatible connector designs.
+ * Release 0.2.0 is the compatibility baseline for the current agent-daemon
+ * wire shape and remains stable even when the connector build version changes.
+ */
+export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.2.0";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
+
+export const HOST_CONNECTOR_CAPABILITIES = [
+  "session-sync-v1",
+  "command-wal-v1",
+] as const;
+export type HostConnectorCapability =
+  (typeof HOST_CONNECTOR_CAPABILITIES)[number];
+
+export type HostConnectorServerInfo = {
+  protocolVersion: 1;
+  capabilities: string[];
+};
 
 export * from "./agents";
 export * from "./catalog";
@@ -70,7 +90,11 @@ export type AgentDaemonRequest =
       sessionId: string;
       workspace: AgentDaemonWorkspaceDescriptor;
     }
-  | { type: "open_session"; session: AgentDaemonSessionDescriptor }
+  | {
+      type: "open_session";
+      session: AgentDaemonSessionDescriptor;
+      after?: AgentRuntimeCursor;
+    }
   | {
       type: "session_command";
       commandId: string;
@@ -95,6 +119,7 @@ export type HostConnectorCommand =
       type: "sync";
       connectionEpoch: string;
       activeSessionIds: string[];
+      serverInfo?: HostConnectorServerInfo;
     }
   | {
       type: "request";
@@ -147,6 +172,16 @@ export type HostConnectorEventAck = {
   connectorEpoch: string;
   acknowledgedSequence: number;
 };
+
+export function parseHostConnectorCapabilities(
+  value: string | null | undefined,
+): HostConnectorCapability[] {
+  if (!value) return [];
+  const known = new Set<string>(HOST_CONNECTOR_CAPABILITIES);
+  return [...new Set(value.split(",").map((item) => item.trim()))].filter(
+    (item): item is HostConnectorCapability => known.has(item),
+  );
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -261,7 +296,10 @@ function isAgentDaemonRequest(value: unknown): value is AgentDaemonRequest {
         isAgentDaemonWorkspaceDescriptor(value.workspace)
       );
     case "open_session":
-      return isAgentDaemonSessionDescriptor(value.session);
+      return (
+        isAgentDaemonSessionDescriptor(value.session) &&
+        (value.after === undefined || isAgentRuntimeCursor(value.after))
+      );
     case "session_command":
       return (
         isNonEmptyString(value.commandId) &&
@@ -274,11 +312,7 @@ function isAgentDaemonRequest(value: unknown): value is AgentDaemonRequest {
       return (
         isNonEmptyString(value.subscriptionId) &&
         isAgentDaemonSessionDescriptor(value.session) &&
-        (value.after === undefined ||
-          (isRecord(value.after) &&
-            isNonEmptyString(value.after.epoch) &&
-            Number.isSafeInteger(value.after.sequence) &&
-            Number(value.after.sequence) >= 0))
+        (value.after === undefined || isAgentRuntimeCursor(value.after))
       );
     case "unsubscribe_session":
       return isNonEmptyString(value.subscriptionId);
@@ -304,7 +338,15 @@ export function isHostConnectorCommand(
       return (
         isNonEmptyString(value.connectionEpoch) &&
         Array.isArray(value.activeSessionIds) &&
-        value.activeSessionIds.every(isNonEmptyString)
+        value.activeSessionIds.every(isNonEmptyString) &&
+        (value.serverInfo === undefined ||
+          (isRecord(value.serverInfo) &&
+            value.serverInfo.protocolVersion ===
+              HOST_CONNECTOR_PROTOCOL_VERSION &&
+            Array.isArray(value.serverInfo.capabilities) &&
+            value.serverInfo.capabilities.every(
+              (capability) => typeof capability === "string",
+            )))
       );
     case "request":
       return (
@@ -314,6 +356,71 @@ export function isHostConnectorCommand(
     default:
       return false;
   }
+}
+
+export function isAgentRuntimeCursor(
+  value: unknown,
+): value is AgentRuntimeCursor {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.epoch) &&
+    Number.isSafeInteger(value.sequence) &&
+    Number(value.sequence) >= 0
+  );
+}
+
+export function isAgentRuntimeEnvelope(
+  value: unknown,
+): value is AgentRuntimeEnvelope {
+  if (
+    !isRecord(value) ||
+    !isNonEmptyString(value.epoch) ||
+    !Number.isSafeInteger(value.sequence) ||
+    Number(value.sequence) < 1 ||
+    !["snapshot", "runtime_event"].includes(String(value.type)) ||
+    !isRecord(value.data)
+  ) {
+    return false;
+  }
+  return value.type === "snapshot"
+    ? isNonEmptyString(value.data.sessionId) &&
+        ["idle", "running", "exited"].includes(String(value.data.status))
+    : isNonEmptyString(value.data.type);
+}
+
+export function isAgentSessionSync(value: unknown): value is AgentSessionSync {
+  if (
+    !isRecord(value) ||
+    typeof value.reset !== "boolean" ||
+    !isAgentRuntimeCursor(value.cursor)
+  ) {
+    return false;
+  }
+  if (value.reset) {
+    return (
+      isRecord(value.snapshot) &&
+      isNonEmptyString(value.snapshot.sessionId) &&
+      ["idle", "running", "exited"].includes(String(value.snapshot.status))
+    );
+  }
+  const cursor = value.cursor;
+  const events = value.events;
+  if (
+    !Array.isArray(events) ||
+    !events.every(isAgentRuntimeEnvelope) ||
+    events.some((event) => event.epoch !== cursor.epoch)
+  ) {
+    return false;
+  }
+  return (
+    events.every(
+      (event, index) =>
+        event.sequence <= cursor.sequence &&
+        (index === 0 ||
+          event.sequence === events[index - 1]!.sequence + 1),
+    ) &&
+    (events.at(-1)?.sequence ?? cursor.sequence) === cursor.sequence
+  );
 }
 
 export function isConnectorSshHost(value: unknown): value is ConnectorSshHost {
@@ -350,27 +457,13 @@ export function isHostConnectorEvent(
     );
   }
   if (payload.type === "session_event") {
-    if (
-      !(
+    return (
       isNonEmptyString(payload.subscriptionId) &&
       isNonEmptyString(payload.sessionId) &&
-      isRecord(payload.envelope) &&
-      isNonEmptyString(payload.envelope.epoch) &&
-      Number.isSafeInteger(payload.envelope.sequence) &&
-      Number(payload.envelope.sequence) >= 1 &&
-      ["snapshot", "runtime_event"].includes(String(payload.envelope.type)) &&
-      "data" in payload.envelope
-      ) ||
-      !isRecord(payload.envelope.data)
-    ) {
-      return false;
-    }
-    return payload.envelope.type === "snapshot"
-      ? payload.envelope.data.sessionId === payload.sessionId &&
-          ["idle", "running", "exited"].includes(
-            String(payload.envelope.data.status),
-          )
-      : isNonEmptyString(payload.envelope.data.type);
+      isAgentRuntimeEnvelope(payload.envelope) &&
+      (payload.envelope.type !== "snapshot" ||
+        payload.envelope.data.sessionId === payload.sessionId)
+    );
   }
   if (payload.type === "session_metadata") {
     if (!isNonEmptyString(payload.sessionId) || !isRecord(payload.patch)) {

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOST_CONNECTOR_CAPABILITIES,
+  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  isHostConnectorCommand,
+  parseHostConnectorCapabilities,
+} from "./index";
+
+describe("Host Connector protocol compatibility", () => {
+  it("keeps the agent-daemon v1 compatibility token independent of builds", () => {
+    expect(HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE).toBe("0.2.0");
+  });
+
+  it("selects known capabilities and ignores unknown additive tokens", () => {
+    expect(
+      parseHostConnectorCapabilities(
+        ` ${HOST_CONNECTOR_CAPABILITIES[0]},future-capability,${HOST_CONNECTOR_CAPABILITIES[0]} `,
+      ),
+    ).toEqual([HOST_CONNECTOR_CAPABILITIES[0]]);
+    expect(
+      parseHostConnectorCapabilities(HOST_CONNECTOR_CAPABILITIES.join(",")),
+    ).toEqual(HOST_CONNECTOR_CAPABILITIES);
+    expect(parseHostConnectorCapabilities(null)).toEqual([]);
+  });
+
+  it("accepts optional server information on the legacy sync command", () => {
+    expect(
+      isHostConnectorCommand({
+        type: "sync",
+        connectionEpoch: "connection",
+        activeSessionIds: [],
+        serverInfo: {
+          protocolVersion: 1,
+          capabilities: [...HOST_CONNECTOR_CAPABILITIES, "future-capability"],
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isHostConnectorCommand({
+        type: "sync",
+        connectionEpoch: "connection",
+        activeSessionIds: [],
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/agent-bridge/src/state.test.ts
+++ b/packages/agent-bridge/src/state.test.ts
@@ -3,7 +3,10 @@ import type {
   AgentRuntimeEnvelope,
   AgentRuntimeSnapshot,
 } from "./agents.js";
-import { applyAgentRuntimeEnvelope } from "./state.js";
+import {
+  applyAgentRuntimeEnvelope,
+  reconcileAgentRuntimeSnapshot,
+} from "./state.js";
 
 function snapshot(): AgentRuntimeSnapshot {
   return {
@@ -45,6 +48,172 @@ function event(
 }
 
 describe("agent runtime event reducer", () => {
+  it("uses a connector-recorded timestamp for replay-derived state", () => {
+    const started = applyAgentRuntimeEnvelope(
+      snapshot(),
+      event({
+        type: "agent_start",
+        overtchatRecordedAt: 1_234,
+      }),
+    )!;
+    const output = applyAgentRuntimeEnvelope(
+      started,
+      event({
+        type: "command_output",
+        text: "Current model: GPT-5.6",
+        overtchatRecordedAt: 2_345,
+      }),
+    )!;
+    const tool = applyAgentRuntimeEnvelope(
+      output,
+      event({
+        type: "tool_execution_update",
+        toolCallId: "call",
+        toolName: "bash",
+        partialResult: { content: [{ type: "text", text: "partial" }] },
+        overtchatRecordedAt: 3_456,
+      }),
+    )!;
+
+    expect(tool.activeTurn).toEqual({ startedAt: 1_234 });
+    expect(tool.messages.at(-2)).toMatchObject({ timestamp: 2_345 });
+    expect(tool.messages.at(-1)).toMatchObject({ timestamp: 3_456 });
+  });
+
+  it("reconciles resumed provider history without dropping connector-only messages", () => {
+    const durable = {
+      ...snapshot(),
+      status: "exited" as const,
+      error: "Connector stopped",
+      messages: [
+        {
+          role: "user",
+          content: "queued prompt",
+          overtchatSubmissionId: "submission-1",
+        },
+        {
+          role: "assistant",
+          content: "old partial",
+          overtchatTurnId: "turn-1",
+        },
+        { role: "custom", content: "connector command output" },
+      ],
+    };
+    const fresh = {
+      ...snapshot(),
+      status: "running" as const,
+      activeTurn: { startedAt: 42 },
+      state: { isStreaming: true },
+      messages: [
+        {
+          id: "provider-user",
+          role: "user",
+          content: "queued prompt",
+          overtchatSubmissionId: "submission-1",
+          overtchatTurnId: "turn-1",
+        },
+        {
+          id: "provider-assistant",
+          role: "assistant",
+          content: "complete",
+          overtchatTurnId: "turn-1",
+        },
+      ],
+    };
+
+    const reconciled = reconcileAgentRuntimeSnapshot(durable, fresh);
+
+    expect(reconciled).toMatchObject({
+      status: "running",
+      activeTurn: { startedAt: 42 },
+      state: { isStreaming: true },
+      messages: [
+        expect.objectContaining({ id: "provider-user" }),
+        expect.objectContaining({ id: "provider-assistant" }),
+        { role: "custom", content: "connector command output" },
+      ],
+    });
+    expect(reconciled).not.toHaveProperty("error");
+  });
+
+  it("treats plain resumed provider history as authoritative", () => {
+    const providerMessages = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hello back" },
+    ];
+    const durable = { ...snapshot(), messages: [...providerMessages] };
+    const fresh = { ...snapshot(), messages: [...providerMessages] };
+
+    const once = reconcileAgentRuntimeSnapshot(durable, fresh);
+    const twice = reconcileAgentRuntimeSnapshot(once, fresh);
+
+    expect(once.messages).toEqual(providerMessages);
+    expect(twice.messages).toEqual(providerMessages);
+  });
+
+  it("drops an optimistic row once an uncertain provider snapshot is available", () => {
+    const durable = {
+      ...snapshot(),
+      messages: [
+        {
+          role: "user",
+          content: "Run tests",
+          overtchatSubmissionId: "submission-1",
+        },
+      ],
+    };
+    const providerMessage = { role: "user", content: "Run tests" };
+    const reconciled = reconcileAgentRuntimeSnapshot(durable, {
+      ...snapshot(),
+      messages: [providerMessage],
+      queuedMessages: [
+        {
+          id: "submission-1",
+          message: "Run tests",
+          status: "uncertain",
+        },
+      ],
+    });
+
+    expect(reconciled.messages).toEqual([providerMessage]);
+    expect(reconciled.queuedMessages).toEqual([
+      {
+        id: "submission-1",
+        message: "Run tests",
+        status: "uncertain",
+      },
+    ]);
+  });
+
+  it("uses tool-call identity when fresh history completes durable output", () => {
+    const durable = {
+      ...snapshot(),
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          content: "partial",
+          timestamp: 100,
+          overtchatPartial: true,
+        },
+      ],
+    };
+    const completed = {
+      role: "toolResult",
+      toolCallId: "call-1",
+      content: "complete",
+      timestamp: 200,
+      overtchatPartial: false,
+    };
+
+    const reconciled = reconcileAgentRuntimeSnapshot(durable, {
+      ...snapshot(),
+      messages: [completed],
+    });
+
+    expect(reconciled.messages).toEqual([completed]);
+  });
+
   it("replaces the active assistant message as text streams", () => {
     const first = applyAgentRuntimeEnvelope(
       snapshot(),
@@ -460,6 +629,30 @@ describe("agent runtime event reducer", () => {
         }),
       ),
     ).toBe(current);
+  });
+
+  it("preserves delivery-uncertain queue updates", () => {
+    const updated = applyAgentRuntimeEnvelope(
+      snapshot(),
+      event({
+        type: "overtchat_queue_update",
+        queuedMessages: [
+          {
+            id: "queued:1",
+            message: "Then summarize",
+            status: "uncertain",
+          },
+        ],
+      }),
+    )!;
+
+    expect(updated.queuedMessages).toEqual([
+      {
+        id: "queued:1",
+        message: "Then summarize",
+        status: "uncertain",
+      },
+    ]);
   });
 
   it("reconciles an accepted submission with the provider user message", () => {

--- a/packages/agent-bridge/src/state.ts
+++ b/packages/agent-bridge/src/state.ts
@@ -197,9 +197,16 @@ function partialToolResult(event: Record<string, unknown>): unknown | null {
     toolName: event.toolName,
     content: Reflect.get(result, "content") ?? [],
     isError: event.type === "tool_execution_end" && event.isError === true,
-    timestamp: Date.now(),
+    timestamp: runtimeEventTimestamp(event),
     overtchatPartial: event.type === "tool_execution_update",
   };
+}
+
+function runtimeEventTimestamp(event: Record<string, unknown>): number {
+  return typeof event.overtchatRecordedAt === "number" &&
+    Number.isFinite(event.overtchatRecordedAt)
+    ? event.overtchatRecordedAt
+    : Date.now();
 }
 
 export function applyAgentRuntimeMessageEvent(
@@ -248,11 +255,123 @@ export function applyAgentRuntimeMessageEvent(
         role: "custom",
         content: event.text,
         display: true,
-        timestamp: Date.now(),
+        timestamp: runtimeEventTimestamp(event),
       },
     ];
   }
   return messages;
+}
+
+function isConnectorCheckpointMessage(message: unknown): boolean {
+  // Provider history is authoritative on resume. Keep only rows created by
+  // OvertChat itself and not yet folded into that history. Provider-projected
+  // Codex rows carry a turn id, so they must not survive a fresh projection
+  // merely because their native message is no longer present.
+  if (turnIdOf(message)) return false;
+  const role = roleOf(message);
+  return (
+    role === "custom" ||
+    (role === "toolResult" && toolCallIdOf(message) !== null)
+  );
+}
+
+function freshContainsConnectorMessage(
+  fresh: readonly unknown[],
+  durable: unknown,
+): boolean {
+  const role = roleOf(durable);
+  const submissionId = submissionIdOf(durable);
+  if (submissionId) {
+    return fresh.some(
+      (message) => submissionIdOf(message) === submissionId,
+    );
+  }
+  const toolCallId = toolCallIdOf(durable);
+  if (role === "toolResult" && toolCallId) {
+    return fresh.some(
+      (message) =>
+        roleOf(message) === "toolResult" &&
+        toolCallIdOf(message) === toolCallId,
+    );
+  }
+  const id = idOf(durable);
+  if (id) {
+    return fresh.some(
+      (message) => roleOf(message) === role && idOf(message) === id,
+    );
+  }
+  const timestamp = timestampOf(durable);
+  if (timestamp !== null) {
+    return fresh.some(
+      (message) =>
+        roleOf(message) === role && timestampOf(message) === timestamp,
+    );
+  }
+  const text = textOf(durable);
+  return (
+    role === "custom" &&
+    text !== "" &&
+    fresh.some(
+      (message) => roleOf(message) === "custom" && textOf(message) === text,
+    )
+  );
+}
+
+function endsProviderHistoryUnit(
+  messages: readonly unknown[],
+  index: number,
+): boolean {
+  const turnId = turnIdOf(messages[index]);
+  return !turnId || turnIdOf(messages[index + 1]) !== turnId;
+}
+
+/** Reconcile a freshly resumed provider projection with connector-owned
+ * messages that may not have reached the provider's history yet. All runtime
+ * metadata and provider history come from `fresh`; only identifiable
+ * connector checkpoint rows survive. */
+export function reconcileAgentRuntimeSnapshot(
+  durable: AgentRuntimeSnapshot,
+  fresh: AgentRuntimeSnapshot,
+): AgentRuntimeSnapshot {
+  const connectorRowsByProviderUnit = new Map<number, unknown[]>();
+  let providerUnit = 0;
+  for (let index = 0; index < durable.messages.length; index += 1) {
+    const message = durable.messages[index];
+    if (isConnectorCheckpointMessage(message)) {
+      if (!freshContainsConnectorMessage(fresh.messages, message)) {
+        const rows = connectorRowsByProviderUnit.get(providerUnit) ?? [];
+        rows.push(message);
+        connectorRowsByProviderUnit.set(providerUnit, rows);
+      }
+      continue;
+    }
+    if (endsProviderHistoryUnit(durable.messages, index)) providerUnit += 1;
+  }
+
+  const messages: unknown[] = [];
+  const insertedUnits = new Set<number>();
+  providerUnit = 0;
+  const insertConnectorRows = () => {
+    if (insertedUnits.has(providerUnit)) return;
+    messages.push(...(connectorRowsByProviderUnit.get(providerUnit) ?? []));
+    insertedUnits.add(providerUnit);
+  };
+  for (let index = 0; index < fresh.messages.length; index += 1) {
+    const message = fresh.messages[index];
+    if (!isConnectorCheckpointMessage(message)) insertConnectorRows();
+    messages.push(message);
+    if (
+      !isConnectorCheckpointMessage(message) &&
+      endsProviderHistoryUnit(fresh.messages, index)
+    ) {
+      providerUnit += 1;
+    }
+  }
+  insertConnectorRows();
+  for (const [unit, rows] of connectorRowsByProviderUnit) {
+    if (!insertedUnits.has(unit)) messages.push(...rows);
+  }
+  return { ...fresh, messages };
 }
 
 export function applyAgentRuntimeStateEvent(
@@ -280,7 +399,9 @@ export function applyAgentRuntimeEnvelope(
     return {
       ...current,
       status: "running",
-      activeTurn: current.activeTurn ?? { startedAt: Date.now() },
+      activeTurn: current.activeTurn ?? {
+        startedAt: runtimeEventTimestamp(event),
+      },
       state: { ...current.state, isStreaming: true },
       error: undefined,
     };
@@ -298,7 +419,7 @@ export function applyAgentRuntimeEnvelope(
               startedAt:
                 typeof event.startedAt === "number"
                   ? event.startedAt
-                  : Date.now(),
+                  : runtimeEventTimestamp(event),
             })
           : null,
       state: {
@@ -442,7 +563,7 @@ function parseQueuedMessages(value: unknown): AgentQueuedMessage[] | null {
       typeof item !== "object" ||
       typeof Reflect.get(item, "id") !== "string" ||
       typeof Reflect.get(item, "message") !== "string" ||
-      !["pending", "sending"].includes(
+      !["pending", "sending", "uncertain"].includes(
         String(Reflect.get(item, "status")),
       )
     ) {
@@ -459,7 +580,7 @@ function parseQueuedMessages(value: unknown): AgentQueuedMessage[] | null {
       id: Reflect.get(item, "id") as string,
       message: Reflect.get(item, "message") as string,
       ...(images.length > 0 ? { images } : {}),
-      status: Reflect.get(item, "status") as "pending" | "sending",
+      status: Reflect.get(item, "status") as AgentQueuedMessage["status"],
     });
   }
   return messages;

--- a/packages/agent-runtime/src/runtime/registry.test.ts
+++ b/packages/agent-runtime/src/runtime/registry.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   abort: vi.fn(),
   stop: vi.fn(),
   saveQueue: vi.fn(),
+  getState: vi.fn(),
+  getMessages: vi.fn(),
   eventSubscriber: null as ((event: AgentRuntimeEvent) => void) | null,
 }));
 
@@ -41,12 +43,8 @@ vi.mock("@overtchat/agent-runtime/providers/registry", () => ({
         mocks.eventSubscriber = subscriber;
         return vi.fn();
       }),
-      getState: vi.fn().mockResolvedValue({
-        isStreaming: false,
-        sessionId: "provider-session",
-        sessionFile: "/sessions/provider-session.jsonl",
-      }),
-      getMessages: vi.fn().mockResolvedValue({ messages: [] }),
+      getState: mocks.getState,
+      getMessages: mocks.getMessages,
       getAvailableModels: vi.fn().mockResolvedValue([
         { provider: "openai", id: "gpt-5", name: "GPT-5", input: ["text"] },
       ]),
@@ -86,10 +84,25 @@ describe("agent runtime", () => {
     mocks.abort.mockResolvedValue({ interrupted: true });
     mocks.stop.mockResolvedValue(undefined);
     mocks.saveQueue.mockResolvedValue(undefined);
+    mocks.getState.mockResolvedValue({
+      isStreaming: false,
+      sessionId: "provider-session",
+      sessionFile: "/sessions/provider-session.jsonl",
+    });
+    mocks.getMessages.mockResolvedValue({ messages: [] });
     mocks.eventSubscriber = null;
   });
 
-  it("resubmits a journaled queue item with its original message identity", async () => {
+  it("removes a restored send already accepted by the provider", async () => {
+    mocks.getMessages.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "user",
+          content: "Continue the task",
+          overtchatSubmissionId: "message-1",
+        },
+      ],
+    });
     const registry = new AgentRuntimeRegistry({
       resolveImages: async () => [],
       loadQueuedMessages: () => [
@@ -97,6 +110,398 @@ describe("agent runtime", () => {
           id: "message-1",
           message: "Continue the task",
           status: "sending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.saveQueue).toHaveBeenCalledWith("session", []);
+    });
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(runtime.snapshot().queuedMessages).toEqual([]);
+    await registry.stopAll();
+  });
+
+  it("marks an unconfirmed restored send as delivery-uncertain", async () => {
+    mocks.getState.mockResolvedValueOnce({
+      isStreaming: true,
+      sessionId: "provider-session",
+      sessionFile: "/sessions/provider-session.jsonl",
+    });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-1",
+          message: "Continue the task",
+          status: "sending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await Promise.resolve();
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(mocks.saveQueue).toHaveBeenCalledWith("session", [
+      expect.objectContaining({ id: "message-1", status: "uncertain" }),
+    ]);
+    expect(runtime.snapshot().queuedMessages).toEqual([
+      expect.objectContaining({ id: "message-1", status: "uncertain" }),
+    ]);
+    await registry.stopAll();
+  });
+
+  it("reconciles an in-flight restored send from provider history before draining", async () => {
+    mocks.getState
+      .mockResolvedValueOnce({
+        isStreaming: true,
+        sessionId: "provider-session",
+        sessionFile: "/sessions/provider-session.jsonl",
+      })
+      .mockResolvedValue({
+        isStreaming: false,
+        sessionId: "provider-session",
+        sessionFile: "/sessions/provider-session.jsonl",
+      });
+    mocks.getMessages
+      .mockResolvedValueOnce({ messages: [] })
+      .mockResolvedValue({
+        messages: [
+          {
+            role: "user",
+            content: "Continue the task",
+            overtchatSubmissionId: "message-1",
+          },
+        ],
+      });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-1",
+          message: "Continue the task",
+          status: "sending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    mocks.eventSubscriber?.({ type: "agent_end", messages: [] });
+    await vi.waitFor(() => {
+      expect(runtime.snapshot().queuedMessages).toEqual([]);
+    });
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(mocks.saveQueue).toHaveBeenCalledWith("session", []);
+    await registry.stopAll();
+  });
+
+  it("does not infer acceptance or replay from matching text alone", async () => {
+    mocks.getMessages.mockResolvedValueOnce({
+      messages: [{ role: "user", content: "Continue the task" }],
+    });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-1",
+          message: "Continue the task",
+          status: "sending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await Promise.resolve();
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(mocks.saveQueue).toHaveBeenCalledWith("session", [
+      expect.objectContaining({ id: "message-1", status: "uncertain" }),
+    ]);
+    expect(runtime.snapshot().queuedMessages).toEqual([
+      expect.objectContaining({ id: "message-1", status: "uncertain" }),
+    ]);
+    await registry.stopAll();
+  });
+
+  it("keeps a repeated identical restored send uncertain and blocks later queue items", async () => {
+    mocks.getMessages.mockResolvedValueOnce({
+      messages: [{ role: "user", content: "Repeat this" }],
+    });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-2",
+          message: "Repeat this",
+          status: "sending",
+        },
+        {
+          id: "message-3",
+          message: "This must remain behind the ambiguous send",
+          status: "pending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "pi",
+      target: { transport: "local" },
+      executable: "pi",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await Promise.resolve();
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(mocks.saveQueue).toHaveBeenCalledWith(
+      "session",
+      expect.arrayContaining([
+        expect.objectContaining({ id: "message-2", status: "uncertain" }),
+      ]),
+    );
+    expect(runtime.snapshot().queuedMessages).toEqual([
+      expect.objectContaining({
+        id: "message-2",
+        status: "uncertain",
+      }),
+      expect.objectContaining({ id: "message-3", status: "pending" }),
+    ]);
+    await registry.stopAll();
+  });
+
+  it("lets users remove an uncertain restored send without replaying it", async () => {
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-1",
+          message: "Continue the task",
+          status: "uncertain",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "pi",
+      target: { transport: "local" },
+      executable: "pi",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await runtime.command({
+      type: "remove_queued_message",
+      id: "message-1",
+    });
+
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(runtime.snapshot().queuedMessages).toEqual([]);
+    expect(mocks.saveQueue).toHaveBeenLastCalledWith("session", []);
+    await registry.stopAll();
+  });
+
+  it("clears an uncertain send when a later provider event proves its identity", async () => {
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-1",
+          message: "Continue the task",
+          status: "uncertain",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    mocks.eventSubscriber?.({
+      type: "message_start",
+      message: {
+        role: "user",
+        content: "Continue the task",
+        overtchatSubmissionId: "message-1",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(runtime.snapshot().queuedMessages).toEqual([]);
+    });
+    expect(mocks.saveQueue).toHaveBeenLastCalledWith("session", []);
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    await registry.stopAll();
+  });
+
+  it("does not infer delivery from later identical provider history", async () => {
+    mocks.getMessages.mockResolvedValueOnce({
+      messages: [
+        { role: "user", content: "Repeat this" },
+        { role: "user", content: "Repeat this" },
+      ],
+    });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-2",
+          message: "Repeat this",
+          status: "sending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "omp",
+      target: { transport: "local" },
+      executable: "omp",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.saveQueue).toHaveBeenCalledWith("session", [
+        expect.objectContaining({ id: "message-2", status: "uncertain" }),
+      ]);
+    });
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(runtime.snapshot().queuedMessages).toEqual([
+      expect.objectContaining({ id: "message-2", status: "uncertain" }),
+    ]);
+    await registry.stopAll();
+  });
+
+  it("does not infer image-only acceptance from arbitrary history advancement", async () => {
+    mocks.getMessages.mockResolvedValueOnce({
+      messages: [{ role: "user", content: "An unrelated prompt" }],
+    });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "image-message",
+          message: "",
+          images: [
+            {
+              uploadId: "11111111-1111-4111-8111-111111111111",
+              filename: "screen.png",
+              mediaType: "image/png",
+            },
+          ],
+          status: "sending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "pi",
+      target: { transport: "local" },
+      executable: "pi",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await vi.waitFor(() => {
+      expect(runtime.snapshot().queuedMessages).toEqual([
+        expect.objectContaining({
+          id: "image-message",
+          status: "uncertain",
+        }),
+      ]);
+    });
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    await registry.stopAll();
+  });
+
+  it("persists the sending state before invoking the provider", async () => {
+    let releaseSave: (() => void) | undefined;
+    mocks.saveQueue.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        }),
+    );
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "message-1",
+          message: "Continue the task",
+          status: "pending",
         },
       ],
       saveQueuedMessages: mocks.saveQueue,
@@ -114,16 +519,48 @@ describe("agent runtime", () => {
       providerSessionPath: "/sessions/provider-session.jsonl",
     });
 
-    await vi.waitFor(() => {
-      expect(mocks.prompt).toHaveBeenCalledWith(
-        "Continue the task",
-        undefined,
-        { clientMessageId: "message-1" },
-      );
+    await vi.waitFor(() => expect(mocks.saveQueue).toHaveBeenCalledOnce());
+    expect(mocks.saveQueue).toHaveBeenCalledWith("session", [
+      expect.objectContaining({
+        id: "message-1",
+        status: "sending",
+      }),
+    ]);
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    releaseSave?.();
+    await vi.waitFor(() => expect(mocks.prompt).toHaveBeenCalledOnce());
+    await registry.stopAll();
+  });
+
+  it("surfaces queue persistence failure without invoking the provider", async () => {
+    mocks.saveQueue.mockRejectedValueOnce(new Error("disk full"));
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      saveQueuedMessages: mocks.saveQueue,
     });
-    await vi.waitFor(() => {
-      expect(mocks.saveQueue).toHaveBeenLastCalledWith("session", []);
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
     });
+
+    await expect(
+      runtime.command(
+        { type: "queue", message: "Continue the task" },
+        "message-1",
+      ),
+    ).rejects.toThrow("disk full");
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(runtime.snapshot().error).toBe(
+      "Unable to persist queued messages: disk full",
+    );
+    expect(runtime.snapshot().queuedMessages).toEqual([]);
     await registry.stopAll();
   });
 
@@ -181,7 +618,169 @@ describe("agent runtime", () => {
     await registry.stopAll();
   });
 
-  it("restores a queued message when steering rejects it", async () => {
+  it("marks a queued prompt uncertain when the provider call rejects", async () => {
+    mocks.prompt.mockRejectedValueOnce(new Error("transport disconnected"));
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      loadQueuedMessages: () => [
+        {
+          id: "queued-message",
+          message: "Continue the task",
+          status: "pending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "pi",
+      target: { transport: "local" },
+      executable: "pi",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await vi.waitFor(() => expect(mocks.prompt).toHaveBeenCalledOnce());
+    await vi.waitFor(() => {
+      expect(runtime.snapshot().queuedMessages).toEqual([
+        expect.objectContaining({
+          id: "queued-message",
+          status: "uncertain",
+        }),
+      ]);
+    });
+    await Promise.resolve();
+    expect(mocks.prompt).toHaveBeenCalledOnce();
+
+    await runtime.command({
+      type: "remove_queued_message",
+      id: "queued-message",
+    });
+    expect(runtime.snapshot().queuedMessages).toEqual([]);
+    await registry.stopAll();
+  });
+
+  it.each([
+    "an identical user message without a submission ID",
+    "a terminal event without a submission ID",
+  ])(
+    "keeps a queued prompt uncertain when %s precedes a transport rejection",
+    async (eventKind) => {
+      mocks.prompt.mockImplementationOnce(async () => {
+        if (eventKind.startsWith("an identical")) {
+          mocks.eventSubscriber?.({
+            type: "message_start",
+            message: {
+              id: "provider-message",
+              role: "user",
+              content: "Continue the task",
+            },
+          });
+        } else {
+          mocks.eventSubscriber?.({ type: "agent_end", messages: [] });
+        }
+        throw new Error("transport disconnected after ambiguous provider event");
+      });
+      const registry = new AgentRuntimeRegistry({
+        resolveImages: async () => [],
+        loadQueuedMessages: () => [
+          {
+            id: "queued-message",
+            message: "Continue the task",
+            status: "pending",
+          },
+        ],
+        saveQueuedMessages: mocks.saveQueue,
+      });
+      const runtime = await registry.getOrStart({
+        connectionId: "connection",
+        workspaceId: "workspace",
+        provider: "pi",
+        target: { transport: "local" },
+        executable: "pi",
+        cwd: "/workspace",
+        sessionId: "session",
+        providerSessionId: "provider-session",
+        providerSessionPath: "/sessions/provider-session.jsonl",
+      });
+
+      await vi.waitFor(() => {
+        expect(runtime.snapshot().queuedMessages).toEqual([
+          expect.objectContaining({
+            id: "queued-message",
+            status: "uncertain",
+          }),
+        ]);
+      });
+      expect(mocks.prompt).toHaveBeenCalledOnce();
+      expect(mocks.saveQueue).not.toHaveBeenCalledWith("session", []);
+
+      mocks.eventSubscriber?.({ type: "agent_end", messages: [] });
+      await vi.waitFor(() => expect(runtime.snapshot().status).toBe("idle"));
+      expect(mocks.prompt).toHaveBeenCalledOnce();
+      expect(runtime.snapshot().queuedMessages).toEqual([
+        expect.objectContaining({
+          id: "queued-message",
+          status: "uncertain",
+        }),
+      ]);
+      expect(mocks.saveQueue).not.toHaveBeenCalledWith("session", []);
+      await registry.stopAll();
+    },
+  );
+
+  it("keeps a queued prompt pending when preparation fails before provider invocation", async () => {
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => {
+        throw new Error("attachment disappeared");
+      },
+      loadQueuedMessages: () => [
+        {
+          id: "queued-message",
+          message: "",
+          images: [
+            {
+              uploadId: "11111111-1111-4111-8111-111111111111",
+              filename: "screen.png",
+              mediaType: "image/png",
+            },
+          ],
+          status: "pending",
+        },
+      ],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "pi",
+      target: { transport: "local" },
+      executable: "pi",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.saveQueue).toHaveBeenLastCalledWith("session", [
+        expect.objectContaining({
+          id: "queued-message",
+          status: "pending",
+        }),
+      ]);
+    });
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(runtime.snapshot().queuedMessages).toEqual([
+      expect.objectContaining({ id: "queued-message", status: "pending" }),
+    ]);
+    await registry.stopAll();
+  });
+
+  it("marks a queued steer uncertain when the provider call rejects", async () => {
     const registry = new AgentRuntimeRegistry({
       resolveImages: async () => [],
     });
@@ -216,7 +815,7 @@ describe("agent runtime", () => {
     expect(runtime.snapshot().queuedMessages).toEqual([
       expect.objectContaining({
         id: "queued-message",
-        status: "pending",
+        status: "uncertain",
       }),
     ]);
     expect(
@@ -230,6 +829,11 @@ describe("agent runtime", () => {
               "queued-message",
         ),
     ).toBe(false);
+    await runtime.command({
+      type: "remove_queued_message",
+      id: "queued-message",
+    });
+    expect(runtime.snapshot().queuedMessages).toEqual([]);
     await registry.stopAll();
   });
 
@@ -628,6 +1232,117 @@ describe("agent runtime", () => {
       }),
     ]);
     expect(runtime.snapshot().error).toBeUndefined();
+    await registry.stopAll();
+  });
+
+  it("does not consume a private sequence when another subscriber joins", async () => {
+    const registry = new AgentRuntimeRegistry({ resolveImages: async () => [] });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+    const first: number[] = [];
+    const second: number[] = [];
+    const unsubscribeFirst = runtime.subscribe((event) => {
+      first.push(event.sequence);
+    });
+    mocks.eventSubscriber?.({
+      type: "overtchat_status",
+      status: "running",
+      startedAt: 1,
+    });
+    const unsubscribeSecond = runtime.subscribe((event) => {
+      second.push(event.sequence);
+    });
+    mocks.eventSubscriber?.({
+      type: "overtchat_status",
+      status: "idle",
+      startedAt: null,
+    });
+
+    expect(first).toEqual([1, 2]);
+    expect(second).toEqual([1, 2]);
+    unsubscribeFirst();
+    unsubscribeSecond();
+    await registry.stopAll();
+  });
+
+  it("stamps provider events once before updating state and publishing", async () => {
+    const registry = new AgentRuntimeRegistry({ resolveImages: async () => [] });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+    const observed: Array<Record<string, unknown>> = [];
+    runtime.observe((envelope) => {
+      if (envelope.type === "runtime_event") observed.push(envelope.data);
+    });
+    const providerEvent: AgentRuntimeEvent = {
+      type: "command_output",
+      text: "Current model: GPT-5.6",
+    };
+
+    mocks.eventSubscriber?.(providerEvent);
+
+    const recordedAt = observed[0]?.overtchatRecordedAt;
+    expect(recordedAt).toEqual(expect.any(Number));
+    expect(runtime.snapshot().messages).toEqual([
+      expect.objectContaining({
+        role: "custom",
+        content: "Current model: GPT-5.6",
+        timestamp: recordedAt,
+      }),
+    ]);
+    expect(providerEvent).not.toHaveProperty("overtchatRecordedAt");
+    await registry.stopAll();
+  });
+
+  it("resets synchronization when the cursor is from another epoch or ahead", async () => {
+    const registry = new AgentRuntimeRegistry({ resolveImages: async () => [] });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+    mocks.eventSubscriber?.({
+      type: "overtchat_status",
+      status: "running",
+      startedAt: 1,
+    });
+    const current = runtime.sync();
+    expect(current.reset).toBe(true);
+    expect(runtime.sync({ epoch: "old", sequence: 0 }).reset).toBe(true);
+    expect(
+      runtime.sync({
+        epoch: current.cursor.epoch,
+        sequence: current.cursor.sequence + 1,
+      }).reset,
+    ).toBe(true);
+    expect(runtime.sync(current.cursor)).toEqual({
+      reset: false,
+      cursor: current.cursor,
+      events: [],
+    });
     await registry.stopAll();
   });
 });

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -4,11 +4,13 @@ import type {
   AgentProviderSessionMetadata,
   AgentProviderId,
   AgentQueuedMessage,
+  AgentRuntimeCursor,
   AgentRuntimeEnvelope,
   AgentRuntimeSnapshot,
   AgentRuntimeStatus,
   AgentSlashCommand,
   AgentSessionCommand,
+  AgentSessionSync,
   AgentSessionStats,
   AgentThinkingLevel,
 } from "@overtchat/agent-bridge";
@@ -87,6 +89,10 @@ export type AgentRuntimeRegistryOptions = {
   saveQueuedMessages?: (
     sessionId: string,
     messages: readonly AgentQueuedMessage[],
+  ) => void | Promise<void>;
+  runtimeExited?: (
+    sessionId: string,
+    runtime: AgentSessionRuntime,
   ) => void | Promise<void>;
 };
 
@@ -191,11 +197,46 @@ function messageSubmissionId(message: unknown): string | null {
   return typeof id === "string" && id ? id : null;
 }
 
+function reconcileRestoredQueuedMessages(
+  queuedMessages: readonly AgentQueuedMessage[],
+  providerMessages: readonly unknown[],
+): { messages: AgentQueuedMessage[]; changed: boolean } {
+  const acceptedIds = new Set(
+    providerMessages.flatMap((message) => {
+      const id = messageSubmissionId(message);
+      return id ? [id] : [];
+    }),
+  );
+  let changed = false;
+  const messages = queuedMessages.flatMap((message) => {
+    if (message.status === "sending" || message.status === "uncertain") {
+      if (acceptedIds.has(message.id)) {
+        changed = true;
+        return [];
+      }
+    }
+    if (message.status === "sending") {
+      changed = true;
+      return [
+        {
+          ...message,
+          status: "uncertain" as const,
+          ...(message.images ? { images: [...message.images] } : {}),
+        },
+      ];
+    }
+    return [
+      {
+        ...message,
+        ...(message.images ? { images: [...message.images] } : {}),
+      },
+    ];
+  });
+  return { messages, changed };
+}
+
 function eventUserMessages(event: AgentRuntimeEvent): unknown[] {
-  if (
-    event.type === "overtchat_turn_update" &&
-    Array.isArray(event.messages)
-  ) {
+  if (Array.isArray(event.messages)) {
     return event.messages.filter((message) => messageRole(message) === "user");
   }
   return ["message_start", "message_update", "message_end"].includes(
@@ -207,6 +248,8 @@ function eventUserMessages(event: AgentRuntimeEvent): unknown[] {
 
 export class AgentSessionRuntime {
   private readonly subscribers = new Set<Subscriber>();
+  private readonly observers = new Set<Subscriber>();
+  private leaseCount = 0;
   private readonly replay: AgentRuntimeEnvelope[] = [];
   private readonly epoch = crypto.randomUUID();
   private sequence = 0;
@@ -228,6 +271,7 @@ export class AgentSessionRuntime {
     PendingSubmission
   >();
   private queueDrainPromise: Promise<void> | null = null;
+  private queuePersistenceTail: Promise<void> = Promise.resolve();
   private steerPromise: Promise<unknown> | null = null;
   private settlePromise: Promise<void> | null = null;
   private abortPromise: Promise<unknown> | null = null;
@@ -267,34 +311,57 @@ export class AgentSessionRuntime {
     this.thinkingLevels = initial.thinkingLevels;
     this.commands = initial.commands;
     this.stats = initial.stats;
-    this.queuedMessages = initialQueuedMessages.map((message) => ({
-      ...message,
-      status: "pending",
-      ...(message.images ? { images: [...message.images] } : {}),
-    }));
     this.status = initial.state.isStreaming === true ? "running" : "idle";
+    const restoredQueue = reconcileRestoredQueuedMessages(
+      initialQueuedMessages,
+      initial.messages,
+    );
+    this.queuedMessages = restoredQueue.messages;
     this.activeTurnStartedAt =
       this.status === "running" ? Date.now() : null;
     this.scheduleIdleStop();
-    if (this.queuedMessages.length > 0 && this.status === "idle") {
-      queueMicrotask(() => void this.drainQueuedMessage());
+    if (
+      restoredQueue.changed ||
+      (this.queuedMessages.length > 0 && this.status === "idle")
+    ) {
+      queueMicrotask(() => {
+        const ready = restoredQueue.changed
+          ? this.publishQueueUpdate()
+          : Promise.resolve();
+        void ready
+          .then(() => {
+            if (this.status === "idle") return this.drainQueuedMessage();
+          })
+          .catch(() => {});
+      });
     }
 
     client.onEvent((event) => {
+      event = {
+        ...event,
+        // Give reducer-created rows one identity before this event touches
+        // either the runtime projection or the connector timeline. Stamping
+        // later at persistence would make a subsequent snapshot look like a
+        // distinct command-output/tool row and duplicate it.
+        overtchatRecordedAt:
+          typeof event.overtchatRecordedAt === "number" &&
+          Number.isFinite(event.overtchatRecordedAt)
+            ? event.overtchatRecordedAt
+            : Date.now(),
+      };
       let settleRejectedPrompt = false;
       const classification = this.eventClassifier.classify(event);
       this.messages = applyAgentRuntimeMessageEvent(this.messages, event);
       this.state = applyAgentRuntimeStateEvent(this.state, event);
-      for (const userMessage of eventUserMessages(event)) {
-        const text = messageText(userMessage);
+      const userMessages = eventUserMessages(event);
+      for (const userMessage of userMessages) {
         const submissionId = messageSubmissionId(userMessage);
         const submission = submissionId
           ? this.pendingSubmissions.get(submissionId)
-          : [...this.pendingSubmissions.values()].find(
-              (candidate) => candidate.message.trim() === text,
-            );
+          : undefined;
         if (submission) submission.providerAcknowledged = true;
       }
+      this.acknowledgeQueuedMessages(userMessages);
       if (event.type === "process_exit") {
         this.stopped = true;
         this.turnGeneration += 1;
@@ -436,9 +503,6 @@ export class AgentSessionRuntime {
       }
       if (classification.terminal) {
         this.promptAwaitingStart = false;
-        for (const submission of this.pendingSubmissions.values()) {
-          submission.providerAcknowledged = true;
-        }
         this.pendingSubmissions.clear();
         this.promptSubmissionId = undefined;
         this.clearPendingInteraction();
@@ -479,25 +543,91 @@ export class AgentSessionRuntime {
 
   subscribe(
     subscriber: Subscriber,
-    after?: { epoch: string; sequence: number },
+    after?: AgentRuntimeCursor,
   ): () => void {
     this.clearIdleStop();
     this.subscribers.add(subscriber);
-    const replay =
-      after?.epoch === this.epoch
-        ? this.replay.filter(
-            (envelope) => envelope.sequence > after.sequence,
-          )
-        : [];
-    if (replay.length > 0) {
-      for (const envelope of replay) subscriber(envelope);
+    const sync = this.sync(after);
+    if (sync.reset) {
+      // Compatibility delivery for servers that predate session-sync-v1. A
+      // read-only snapshot uses the current head instead of consuming a
+      // private sequence number and creating invisible gaps for other tabs.
+      if (sync.cursor.sequence > 0) {
+        subscriber({
+          ...sync.cursor,
+          type: "snapshot",
+          data: sync.snapshot,
+        });
+      }
     } else {
-      subscriber(this.envelope("snapshot", this.snapshot()));
+      for (const envelope of sync.events) subscriber(envelope);
     }
     return () => {
       this.subscribers.delete(subscriber);
-      if (this.subscribers.size === 0) this.scheduleIdleStop();
+      if (this.subscribers.size === 0 && this.leaseCount === 0) {
+        this.scheduleIdleStop();
+      }
     };
+  }
+
+  /** Passive connector capture; unlike a UI subscriber it does not affect the
+   * runtime's idle lifetime or synthesize initial delivery. */
+  observe(subscriber: Subscriber): () => void {
+    this.observers.add(subscriber);
+    return () => this.observers.delete(subscriber);
+  }
+
+  /** Hold the provider runtime open while an external durable-timeline
+   * subscriber is attached. The connector owns delivery, but the runtime still
+   * needs the same idle-lifetime semantics as a legacy direct subscriber. */
+  acquireLease(): () => void {
+    this.clearIdleStop();
+    this.leaseCount += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.leaseCount -= 1;
+      if (this.subscribers.size === 0 && this.leaseCount === 0) {
+        this.scheduleIdleStop();
+      }
+    };
+  }
+
+  sync(after?: AgentRuntimeCursor): AgentSessionSync {
+    const cursor = { epoch: this.epoch, sequence: this.sequence };
+    const reset = (): AgentSessionSync => ({
+      reset: true,
+      cursor,
+      snapshot: this.snapshot(),
+    });
+    if (
+      !after ||
+      after.epoch !== this.epoch ||
+      after.sequence > this.sequence
+    ) {
+      return reset();
+    }
+    if (after.sequence === this.sequence) {
+      return { reset: false, cursor, events: [] };
+    }
+    const firstRetainedSequence = this.replay[0]?.sequence;
+    if (
+      firstRetainedSequence === undefined ||
+      after.sequence < firstRetainedSequence - 1
+    ) {
+      return reset();
+    }
+    const events = this.replay.filter(
+      (envelope) => envelope.sequence > after.sequence,
+    );
+    if (
+      events[0]?.sequence !== after.sequence + 1 ||
+      events.at(-1)?.sequence !== this.sequence
+    ) {
+      return reset();
+    }
+    return { reset: false, cursor, events };
   }
 
   normalizeCommand(command: AgentSessionCommand): AgentSessionCommand {
@@ -716,9 +846,9 @@ export class AgentSessionRuntime {
     this.refreshPromise = (async () => {
       const [state, messageData, stats, thinkingLevels, commands] =
         await Promise.all([
-        this.client.getState(),
-        this.client.getMessages(),
-        this.client.getSessionStats().catch(() => emptyStats()),
+          this.client.getState(),
+          this.client.getMessages(),
+          this.client.getSessionStats().catch(() => emptyStats()),
           this.client
             .getAvailableThinkingLevels()
             .catch(() => this.thinkingLevels),
@@ -730,6 +860,14 @@ export class AgentSessionRuntime {
       this.thinkingLevels = thinkingLevels;
       this.commands = this.adapter.mergeCommands(commands);
       this.status = state.isStreaming === true ? "running" : "idle";
+      const reconciledQueue = reconcileRestoredQueuedMessages(
+        this.queuedMessages,
+        this.messages,
+      );
+      if (reconciledQueue.changed) {
+        this.queuedMessages = reconciledQueue.messages;
+        await this.publishQueueUpdate();
+      }
       this.activeTurnStartedAt =
         this.status === "running"
           ? (this.activeTurnStartedAt ?? Date.now())
@@ -759,6 +897,7 @@ export class AgentSessionRuntime {
     try {
       await this.client.stop();
     } finally {
+      await this.flushQueuePersistence();
       if (this.status !== "exited") {
         this.status = "exited";
         this.activeTurnStartedAt = null;
@@ -777,7 +916,7 @@ export class AgentSessionRuntime {
     this.clearIdleStop();
     this.idleStopTimer = setTimeout(() => {
       this.idleStopTimer = undefined;
-      if (this.subscribers.size > 0) return;
+      if (this.subscribers.size > 0 || this.leaseCount > 0) return;
       if (this.status === "running") {
         this.scheduleIdleStop();
         return;
@@ -791,6 +930,14 @@ export class AgentSessionRuntime {
     if (!this.idleStopTimer) return;
     clearTimeout(this.idleStopTimer);
     this.idleStopTimer = undefined;
+  }
+
+  private async flushQueuePersistence(): Promise<void> {
+    while (true) {
+      const tail = this.queuePersistenceTail;
+      await tail.catch(() => {});
+      if (tail === this.queuePersistenceTail) return;
+    }
   }
 
   private clearPendingInteraction(): void {
@@ -846,6 +993,7 @@ export class AgentSessionRuntime {
     message: string,
     imageRefs: AgentPromptImage[],
     submissionId = `prompt:${++this.nextSubmissionId}`,
+    onProviderInvoke?: () => void,
   ): Promise<unknown> {
     const images =
       imageRefs.length > 0
@@ -869,6 +1017,7 @@ export class AgentSessionRuntime {
     this.publishStatus();
     this.publishSubmission(submission.id, submission.message, images);
     try {
+      onProviderInvoke?.();
       const result =
         images.length > 0
           ? await this.client.prompt(message, images, {
@@ -919,6 +1068,7 @@ export class AgentSessionRuntime {
     message: string,
     imageRefs: AgentPromptImage[],
     submissionId = `steer:${++this.nextSubmissionId}`,
+    onProviderInvoke?: () => void,
   ): Promise<unknown> {
     if (!message && imageRefs.length === 0) {
       return Promise.reject(new Error("Enter a message or attach an image."));
@@ -957,6 +1107,7 @@ export class AgentSessionRuntime {
       };
       this.pendingSubmissions.set(submission.id, submission);
       this.publishSubmission(submission.id, submission.message, images);
+      onProviderInvoke?.();
       const request =
         images.length > 0
           ? this.client.steer(message, images, {
@@ -1186,7 +1337,7 @@ export class AgentSessionRuntime {
     return null;
   }
 
-  private enqueueMessage(
+  private async enqueueMessage(
     message: string,
     images: AgentPromptImage[],
     clientMessageId?: string,
@@ -1196,14 +1347,16 @@ export class AgentSessionRuntime {
     }
     const imageInputError = this.imageInputError(images);
     if (imageInputError) return Promise.reject(imageInputError);
+    const previousQueuedMessages = this.queuedMessages;
     const queuedMessage = this.addQueuedMessage(
       message,
       images,
       "pending",
       clientMessageId,
     );
+    await this.persistQueueChange(previousQueuedMessages, true);
     if (this.status === "idle") void this.drainQueuedMessage();
-    return Promise.resolve({ queued: true, id: queuedMessage.id });
+    return { queued: true, id: queuedMessage.id };
   }
 
   private addQueuedMessage(
@@ -1219,42 +1372,50 @@ export class AgentSessionRuntime {
       status,
     };
     this.queuedMessages = [...this.queuedMessages, queuedMessage];
-    this.publishQueueUpdate();
     return queuedMessage;
   }
 
-  private removeQueuedMessage(id: string): Promise<void> {
+  private async removeQueuedMessage(id: string): Promise<void> {
     const message = this.queuedMessages.find((item) => item.id === id);
-    if (!message || message.status !== "pending") {
-      return Promise.reject(
-        new Error("That queued message is no longer editable."),
-      );
+    if (
+      !message ||
+      (message.status !== "pending" && message.status !== "uncertain")
+    ) {
+      throw new Error("That queued message is no longer editable.");
     }
-    this.deleteQueuedMessage(id);
-    return Promise.resolve();
+    await this.deleteQueuedMessage(id, true);
   }
 
-  private steerQueuedMessage(id: string): Promise<unknown> {
+  private async steerQueuedMessage(id: string): Promise<unknown> {
     const message = this.queuedMessages.find((item) => item.id === id);
     if (!message || message.status !== "pending") {
-      return Promise.reject(
-        new Error("That queued message is no longer pending."),
-      );
+      throw new Error("That queued message is no longer pending.");
     }
-    this.updateQueuedMessageStatus(id, "sending");
-    return this.submitSteer(
-      message.message,
-      message.images ?? [],
-      message.id,
-    )
-      .then((result) => {
-        this.deleteQueuedMessage(message.id);
-        return result;
-      })
-      .catch((error) => {
-        this.updateQueuedMessageStatus(message.id, "pending");
-        throw error;
-      });
+    await this.updateQueuedMessageStatus(id, "sending");
+    let result: unknown;
+    let providerInvoked = false;
+    try {
+      result = await this.submitSteer(
+        message.message,
+        message.images ?? [],
+        message.id,
+        () => {
+          providerInvoked = true;
+        },
+      );
+    } catch (error) {
+      await this.updateQueuedMessageStatus(
+        message.id,
+        providerInvoked ? "uncertain" : "pending",
+        false,
+      );
+      throw error;
+    }
+    // A persistence failure here must not turn an accepted provider action
+    // back into a replayable queue entry. A stable provider submission ID can
+    // clear it later; otherwise restart recovery exposes it as uncertain.
+    await this.deleteQueuedMessage(message.id);
+    return result;
   }
 
   private drainQueuedMessage(): Promise<void> {
@@ -1262,7 +1423,11 @@ export class AgentSessionRuntime {
     if (
       this.status !== "idle" ||
       this.abortPromise ||
-      this.settlePromise
+      this.settlePromise ||
+      this.queuedMessages.some(
+        (message) =>
+          message.status === "sending" || message.status === "uncertain",
+      )
     ) {
       return Promise.resolve();
     }
@@ -1270,18 +1435,33 @@ export class AgentSessionRuntime {
       (item) => item.status === "pending",
     );
     if (!message) return Promise.resolve();
-    this.updateQueuedMessageStatus(message.id, "sending");
-    const operation = this.startPrompt(
-      message.message,
-      message.images ?? [],
-      message.id,
-    )
-      .then(() => {
-        this.deleteQueuedMessage(message.id);
-      })
-      .catch(() => {
-        this.updateQueuedMessageStatus(message.id, "pending");
-      });
+    const operation = (async () => {
+      try {
+        // Commit the at-most-once boundary before asking the provider to act.
+        await this.updateQueuedMessageStatus(message.id, "sending");
+      } catch {
+        return;
+      }
+      let providerInvoked = false;
+      try {
+        await this.startPrompt(
+          message.message,
+          message.images ?? [],
+          message.id,
+          () => {
+            providerInvoked = true;
+          },
+        );
+      } catch {
+        await this.updateQueuedMessageStatus(
+          message.id,
+          providerInvoked ? "uncertain" : "pending",
+          false,
+        ).catch(() => {});
+        return;
+      }
+      await this.deleteQueuedMessage(message.id).catch(() => {});
+    })();
     const settled = operation.finally(() => {
       if (this.queueDrainPromise === settled) {
         this.queueDrainPromise = null;
@@ -1294,21 +1474,65 @@ export class AgentSessionRuntime {
   private updateQueuedMessageStatus(
     id: string,
     status: AgentQueuedMessage["status"],
-  ): void {
+    rollbackOnFailure = true,
+  ): Promise<void> {
+    const previousQueuedMessages = this.queuedMessages;
     let changed = false;
     this.queuedMessages = this.queuedMessages.map((message) => {
       if (message.id !== id || message.status === status) return message;
       changed = true;
       return { ...message, status };
     });
-    if (changed) this.publishQueueUpdate();
+    return changed
+      ? this.persistQueueChange(previousQueuedMessages, rollbackOnFailure)
+      : Promise.resolve();
   }
 
-  private deleteQueuedMessage(id: string): void {
+  private deleteQueuedMessage(
+    id: string,
+    rollbackOnFailure = false,
+  ): Promise<void> {
+    const previousQueuedMessages = this.queuedMessages;
     const next = this.queuedMessages.filter((message) => message.id !== id);
-    if (next.length === this.queuedMessages.length) return;
+    if (next.length === this.queuedMessages.length) return Promise.resolve();
     this.queuedMessages = next;
-    this.publishQueueUpdate();
+    return this.persistQueueChange(previousQueuedMessages, rollbackOnFailure);
+  }
+
+  private async persistQueueChange(
+    previousQueuedMessages: AgentQueuedMessage[],
+    rollbackOnFailure: boolean,
+  ): Promise<void> {
+    const nextQueuedMessages = this.queuedMessages;
+    try {
+      await this.publishQueueUpdate();
+    } catch (error) {
+      if (rollbackOnFailure && this.queuedMessages === nextQueuedMessages) {
+        this.queuedMessages = previousQueuedMessages;
+      }
+      throw error;
+    }
+  }
+
+  private acknowledgeQueuedMessages(userMessages: readonly unknown[]): void {
+    const acknowledged = new Set<string>();
+    for (const userMessage of userMessages) {
+      const submissionId = messageSubmissionId(userMessage);
+      if (
+        submissionId &&
+        this.queuedMessages.some(
+          (message) =>
+            (message.status === "sending" ||
+              message.status === "uncertain") &&
+            message.id === submissionId,
+        )
+      ) {
+        acknowledged.add(submissionId);
+      }
+    }
+    for (const id of acknowledged) {
+      void this.deleteQueuedMessage(id).catch(() => {});
+    }
   }
 
   private publishSubmission(
@@ -1350,14 +1574,33 @@ export class AgentSessionRuntime {
     this.publish({ type: "runtime_event", data: event });
   }
 
-  private publishQueueUpdate(): void {
-    void this.saveQueuedMessages(this.dbSessionId, this.queuedMessages);
-    this.publish({
-      type: "runtime_event",
-      data: {
-        type: "overtchat_queue_update",
-        queuedMessages: this.queuedMessages,
-      },
+  private publishQueueUpdate(): Promise<void> {
+    const queuedMessages = this.queuedMessages.map((message) => ({
+      ...message,
+      ...(message.images ? { images: [...message.images] } : {}),
+    }));
+    const operation = this.queuePersistenceTail.then(() =>
+      this.saveQueuedMessages(this.dbSessionId, queuedMessages),
+    );
+    this.queuePersistenceTail = operation.catch((error) => {
+      this.error = `Unable to persist queued messages: ${errorMessage(error)}`;
+      this.publish({
+        type: "runtime_event",
+        data: {
+          type: "rpc_error",
+          command: "queue",
+          error: this.error,
+        },
+      });
+    });
+    return operation.then(() => {
+      this.publish({
+        type: "runtime_event",
+        data: {
+          type: "overtchat_queue_update",
+          queuedMessages,
+        },
+      });
     });
   }
 
@@ -1383,6 +1626,7 @@ export class AgentSessionRuntime {
     this.replay.push(sequenced);
     if (this.replay.length > MAX_REPLAY_EVENTS) this.replay.shift();
     for (const subscriber of this.subscribers) subscriber(sequenced);
+    for (const observer of this.observers) observer(sequenced);
   }
 
   private envelope(
@@ -1566,6 +1810,7 @@ export class AgentRuntimeRegistry {
         if (this.runtimes.get(sessionId) === runtime) {
           this.runtimes.delete(sessionId);
         }
+        void this.options.runtimeExited?.(sessionId, runtime);
       },
     );
     this.runtimes.set(sessionId, runtime);

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,13 +2,16 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.2.0"
+connector_version="0.3.0"
 server=""
 pair_code=""
 connector_name=""
+upgrade="false"
 
 usage() {
-  echo "Usage: install-connector.sh --server URL --pair-code CODE [--name NAME]" >&2
+  echo "Usage:" >&2
+  echo "  install-connector.sh --server URL --pair-code CODE [--name NAME]" >&2
+  echo "  install-connector.sh --upgrade" >&2
 }
 
 while [ "$#" -gt 0 ]; do
@@ -28,6 +31,10 @@ while [ "$#" -gt 0 ]; do
       connector_name=$2
       shift 2
       ;;
+    --upgrade)
+      upgrade="true"
+      shift
+      ;;
     *)
       usage
       exit 2
@@ -35,7 +42,14 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-[ -n "$server" ] && [ -n "$pair_code" ] || { usage; exit 2; }
+if [ "$upgrade" = "true" ]; then
+  [ -z "$server" ] && [ -z "$pair_code" ] && [ -z "$connector_name" ] || {
+    usage
+    exit 2
+  }
+else
+  [ -n "$server" ] && [ -n "$pair_code" ] || { usage; exit 2; }
+fi
 [ "$(uname -s)" = "Linux" ] || {
   echo "The OvertChat Host Connector currently supports Linux." >&2
   exit 1
@@ -50,17 +64,188 @@ case "$(uname -m)" in
     ;;
 esac
 
-for command in curl sha256sum install systemctl; do
+for command in awk cp curl sed sha256sum install systemctl; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "Required command not found: $command" >&2
     exit 1
   }
 done
 
+wait_for_stable_service() {
+  attempts=0
+  active_streak=0
+  while [ "$attempts" -lt 15 ]; do
+    attempts=$((attempts + 1))
+    if systemctl --user is-active --quiet overtchat-connector.service; then
+      active_streak=$((active_streak + 1))
+      if [ "$active_streak" -ge 3 ]; then
+        return 0
+      fi
+    else
+      active_streak=0
+    fi
+    [ "$attempts" -ge 15 ] || sleep 1
+  done
+  return 1
+}
+
+wait_for_stopped_service() {
+  attempts=0
+  while [ "$attempts" -lt 15 ]; do
+    if ! systemctl --user is-active --quiet overtchat-connector.service; then
+      return 0
+    fi
+    attempts=$((attempts + 1))
+    [ "$attempts" -ge 15 ] || sleep 1
+  done
+  return 1
+}
+
+if [ "$upgrade" = "true" ]; then
+  unit_definition=$(systemctl --user cat overtchat-connector.service 2>/dev/null) || {
+    echo "The existing overtchat-connector.service user service was not found." >&2
+    echo "Set up the connector from OvertChat Settings -> Connections first." >&2
+    exit 1
+  }
+  expected_exec_start="ExecStart=\"${HOME:?}/.local/bin/overtchat-connector\" \"run\""
+  unit_exec_start=$(printf '%s\n' "$unit_definition" | sed -n '/^[[:space:]]*ExecStart=/p')
+  [ "$unit_exec_start" = "$expected_exec_start" ] || {
+    echo "The connector service does not use the installer-managed Host Connector command." >&2
+    echo "Back up custom service state manually before upgrading." >&2
+    exit 1
+  }
+  effective_exec_start=$(
+    systemctl --user show overtchat-connector.service \
+      --property=ExecStart --value
+  ) || {
+    echo "Unable to inspect the connector service command." >&2
+    exit 1
+  }
+  case "$effective_exec_start" in
+    "{ path=${HOME:?}/.local/bin/overtchat-connector ; argv[]=${HOME:?}/.local/bin/overtchat-connector run ; "*) ;;
+    *)
+      echo "The connector service's effective command is not installer-managed." >&2
+      echo "Back up custom service state manually before upgrading." >&2
+      exit 1
+      ;;
+  esac
+  case "$unit_definition" in
+    *Environment=*|*EnvironmentFile=*)
+      echo "The connector service has a custom environment that this upgrader cannot safely inspect." >&2
+      echo "Back up custom service state manually before upgrading." >&2
+      exit 1
+      ;;
+  esac
+  service_manager_environment=$(systemctl --user show-environment) || {
+    echo "Unable to inspect the systemd user service environment." >&2
+    exit 1
+  }
+  case "$service_manager_environment" in
+    *OVERTCHAT_CONNECTOR_CONFIG=*|*OVERTCHAT_CONNECTOR_STATE=*|*OVERTCHAT_CONNECTOR_TIMELINES=*|*OVERTCHAT_CONNECTOR_LOCK=*)
+      echo "The systemd user manager has custom Host Connector paths." >&2
+      echo "Back up those custom paths manually before upgrading." >&2
+      exit 1
+      ;;
+  esac
+  [ "${OVERTCHAT_CONNECTOR_CONFIG+x}" != "x" ] &&
+    [ "${OVERTCHAT_CONNECTOR_STATE+x}" != "x" ] &&
+    [ "${OVERTCHAT_CONNECTOR_TIMELINES+x}" != "x" ] &&
+    [ "${OVERTCHAT_CONNECTOR_LOCK+x}" != "x" ] || {
+      echo "Remove local OVERTCHAT_CONNECTOR_* path overrides before upgrading." >&2
+      exit 1
+    }
+
+  connector_config="${HOME:?}/.config/overtchat/connector.json"
+  [ -f "$connector_config" ] || {
+    echo "No existing Host Connector pairing was found at $connector_config." >&2
+    echo "Set up the connector from OvertChat Settings -> Connections first." >&2
+    exit 1
+  }
+
+  connector_id=$(
+    sed -n 's/.*"connectorId"[[:space:]]*:[[:space:]]*"\([A-Za-z0-9_-][A-Za-z0-9_-]*\)".*/\1/p' \
+      "$connector_config"
+  )
+  case "$connector_id" in
+    ""|*[!A-Za-z0-9_-]*)
+      echo "Unable to read a safe connectorId from $connector_config." >&2
+      exit 1
+      ;;
+  esac
+  [ "${#connector_id}" -le 128 ] || {
+    echo "The connectorId in $connector_config is too long." >&2
+    exit 1
+  }
+
+  connector_state="${HOME:?}/.config/overtchat/connector-$connector_id.state.json"
+fi
+
 asset="overtchat-connector-linux-$architecture"
 release_url="https://github.com/$repository/releases/download/connector-v$connector_version"
 temporary_directory=$(mktemp -d)
-trap 'rm -rf "$temporary_directory"' EXIT HUP INT TERM
+staged_install_path=""
+previous_stage_path=""
+state_stage_path=""
+upgrade_transaction_active="false"
+upgrade_had_state="false"
+upgrade_service_stopped="false"
+binary_backup_ready="false"
+binary_may_have_changed="false"
+state_backup_ready="false"
+state_may_have_changed="false"
+
+rollback_upgrade() {
+  [ "$upgrade_transaction_active" = "true" ] || return 0
+  upgrade_transaction_active="false"
+  trap '' HUP INT TERM
+  if [ "$state_may_have_changed" = "true" ] ||
+    [ "$binary_may_have_changed" = "true" ]; then
+    systemctl --user stop overtchat-connector.service >/dev/null 2>&1 &&
+      wait_for_stopped_service || return 1
+  fi
+  if [ "$state_may_have_changed" = "true" ]; then
+    if [ "$upgrade_had_state" = "true" ] &&
+      [ "$state_backup_ready" = "true" ]; then
+      mv -f "$state_backup_path" "$connector_state" || return 1
+    elif [ "$upgrade_had_state" = "false" ]; then
+      rm -f "$connector_state" || return 1
+    else
+      return 1
+    fi
+  elif [ "$state_backup_ready" = "true" ]; then
+    rm -f "$state_backup_path" || return 1
+  fi
+  if [ "$binary_may_have_changed" = "true" ]; then
+    if [ "$binary_backup_ready" = "true" ]; then
+      mv -f "$previous_path" "$install_path" || return 1
+    else
+      return 1
+    fi
+  elif [ "$binary_backup_ready" = "true" ]; then
+    rm -f "$previous_path" || return 1
+  fi
+  if [ "$upgrade_service_stopped" = "true" ] &&
+    systemctl --user start overtchat-connector.service &&
+    wait_for_stable_service; then
+    upgrade_service_stopped="false"
+    return 0
+  fi
+  return 1
+}
+
+cleanup() {
+  if [ "$upgrade_transaction_active" = "true" ]; then
+    rollback_upgrade ||
+      echo "Rollback did not return the previous Host Connector to a stable running state." >&2
+  fi
+  rm -rf "$temporary_directory"
+  [ -z "$staged_install_path" ] || rm -f "$staged_install_path"
+  [ -z "$previous_stage_path" ] || rm -f "$previous_stage_path"
+  [ -z "$state_stage_path" ] || rm -f "$state_stage_path"
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
 curl --proto '=https' --tlsv1.2 -fsSLo "$temporary_directory/$asset" \
   "$release_url/$asset"
@@ -84,20 +269,137 @@ actual=$(sha256sum "$temporary_directory/$asset" | awk '{ print $1 }')
 install_directory="${HOME:?}/.local/bin"
 install_path="$install_directory/overtchat-connector"
 mkdir -p "$install_directory"
-install -m 0755 "$temporary_directory/$asset" "$install_path"
 
-if [ -n "$connector_name" ]; then
+if [ "$upgrade" = "true" ]; then
+  previous_path="$install_path.previous"
+  state_backup_path="$connector_state.previous"
+  had_state="false"
+
+  [ -f "$install_path" ] || {
+    echo "The existing Host Connector binary was not found at $install_path." >&2
+    exit 1
+  }
+  [ ! -e "$previous_path" ] || {
+    echo "A Host Connector binary rollback file already exists at $previous_path." >&2
+    echo "Move it aside after checking whether it came from an interrupted upgrade." >&2
+    exit 1
+  }
+  [ ! -e "$connector_state" ] || [ -f "$connector_state" ] || {
+    echo "The Host Connector state path is not a regular file: $connector_state" >&2
+    exit 1
+  }
+  [ ! -e "$state_backup_path" ] || {
+    echo "A Host Connector state rollback file already exists at $state_backup_path." >&2
+    echo "Move it aside after checking whether it contains state from an interrupted upgrade." >&2
+    exit 1
+  }
+
+  staged_install_path=$(mktemp "$install_directory/.overtchat-connector.new.XXXXXX")
+  install -m 0755 "$temporary_directory/$asset" "$staged_install_path"
+  staged_actual=$(sha256sum "$staged_install_path" | awk '{ print $1 }')
+  [ "$staged_actual" = "$expected" ] || {
+    echo "The staged Host Connector failed checksum verification." >&2
+    exit 1
+  }
+
+  upgrade_service_stopped="true"
+  upgrade_transaction_active="true"
+  if ! systemctl --user stop overtchat-connector.service; then
+    echo "Unable to stop the existing Host Connector safely; nothing was upgraded." >&2
+    exit 1
+  fi
+  wait_for_stopped_service || {
+    echo "The existing Host Connector did not stop; nothing was upgraded." >&2
+    exit 1
+  }
+
+  previous_stage_path=$(
+    mktemp "$install_directory/.overtchat-connector.previous.XXXXXX"
+  ) || {
+    echo "Unable to stage the existing Host Connector binary for rollback." >&2
+    exit 1
+  }
+  if ! cp -p "$install_path" "$previous_stage_path" ||
+    ! mv -f "$previous_stage_path" "$previous_path"; then
+    echo "Unable to back up the existing Host Connector binary; nothing was upgraded." >&2
+    exit 1
+  fi
+  previous_stage_path=""
+  binary_backup_ready="true"
+
+  if [ -f "$connector_state" ]; then
+    state_stage_path=$(mktemp "$connector_state.previous.XXXXXX") || {
+      echo "Unable to stage the Host Connector state for rollback." >&2
+      exit 1
+    }
+    if ! cp -p "$connector_state" "$state_stage_path" ||
+      ! mv -f "$state_stage_path" "$state_backup_path"; then
+      echo "Unable to back up the Host Connector state; nothing was upgraded." >&2
+      exit 1
+    fi
+    state_stage_path=""
+    had_state="true"
+    state_backup_ready="true"
+  fi
+  upgrade_had_state=$had_state
+
+  state_may_have_changed="true"
+  if ! "$staged_install_path" preflight; then
+    echo "The new Host Connector could not safely open the existing pairing and state." >&2
+    if rollback_upgrade; then
+      echo "The previous Host Connector and its state were restored and restarted." >&2
+    else
+      echo "Rollback did not return the previous Host Connector to a stable running state." >&2
+    fi
+    exit 1
+  fi
+
+  # Both paths are in install_directory, so promotion is one atomic rename.
+  binary_may_have_changed="true"
+  if ! mv -f "$staged_install_path" "$install_path"; then
+    echo "Unable to promote the new Host Connector binary." >&2
+    exit 1
+  fi
+  staged_install_path=""
+
+  start_succeeded="false"
+  if systemctl --user start overtchat-connector.service; then
+    start_succeeded="true"
+  fi
+
+  service_active="false"
+  if [ "$start_succeeded" = "true" ] && wait_for_stable_service; then
+    service_active="true"
+  fi
+
+  if [ "$service_active" = "true" ]; then
+    upgrade_transaction_active="false"
+    rm -f "$previous_path"
+    [ "$had_state" = "false" ] || rm -f "$state_backup_path"
+    echo "OvertChat Host Connector upgraded to $connector_version. The existing pairing was preserved."
+  else
+    echo "The upgraded Host Connector did not start." >&2
+    if rollback_upgrade; then
+      echo "The previous Host Connector and its state were restored and restarted." >&2
+    else
+      echo "Rollback did not return the previous Host Connector to a stable running state." >&2
+    fi
+    exit 1
+  fi
+elif [ -n "$connector_name" ]; then
+  install -m 0755 "$temporary_directory/$asset" "$install_path"
   "$install_path" install \
     --server "$server" \
     --pair-code "$pair_code" \
     --name "$connector_name"
 else
+  install -m 0755 "$temporary_directory/$asset" "$install_path"
   "$install_path" install \
     --server "$server" \
     --pair-code "$pair_code"
 fi
 
-if command -v loginctl >/dev/null 2>&1; then
+if [ "$upgrade" = "false" ] && command -v loginctl >/dev/null 2>&1; then
   linger=$(loginctl show-user "$(id -un)" -p Linger --value 2>/dev/null || true)
   if [ "$linger" != "yes" ] && ! loginctl enable-linger "$(id -un)" >/dev/null 2>&1; then
     echo "Warning: enable user lingering to keep the connector running after logout:" >&2
@@ -105,4 +407,6 @@ if command -v loginctl >/dev/null 2>&1; then
   fi
 fi
 
-echo "OvertChat Host Connector installed."
+if [ "$upgrade" = "false" ]; then
+  echo "OvertChat Host Connector installed."
+fi


### PR DESCRIPTION
## Summary

- make the Host Connector own a durable, replayable session timeline
- reconcile browser replicas explicitly across reconnects, restarts, gaps, and mixed connector versions
- add command/queue ambiguity safeguards and transactional connector upgrades without re-pairing
- harden connector/server release ordering and prepare connector v0.3.0 plus server v0.13.5
- keep the README user-facing and move operational detail to deploy docs

## Verification

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run deps:check`
- `npm run build`
- `E2E_PORT=4741 npm run test:e2e -w apps/web --` (11 passed, 4 skipped)
- `APP_VERSION=0.13.5 docker compose config --quiet`
- workflow YAML parse, installer shell syntax, and `git diff --check`