### PR TITLE
Fix Codex connector shutdown and prepare v0.13.6

### DIFF
--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -136,7 +136,7 @@ describe.sequential("connector client compatibility", () => {
     expect(headers.get("x-overtchat-connector-version")).toBe(
       HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     );
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.0");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.1");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/site/lib/install-redirect.test.ts
+++ b/apps/site/lib/install-redirect.test.ts
@@ -296,7 +296,7 @@ describe("Host Connector installer redirect", () => {
     } = createUpgradeFixture("stable");
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Host Connector upgraded to 0.3.0");
+    expect(result.stdout).toContain("Host Connector upgraded to 0.3.1");
     expect(readFileSync(installPath, "utf8")).toBe(newConnector);
     expect(existsSync(`${installPath}.previous`)).toBe(false);
     expect(readFileSync(systemctlCalls, "utf8")).toContain(

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -4,6 +4,7 @@
 # Generated setup commands use immutable connector versions.
 /install/connector/0.2.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.2.0/install-connector.sh 302
 /install/connector/0.3.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.0/install-connector.sh 302
+/install/connector/0.3.1 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.1/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.3.0 302
+/install-connector.sh /install/connector/0.3.1 302

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,7 +80,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.1 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -108,9 +108,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.3.0",
+            version: "0.3.1",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.0 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.1 | sh -s -- --upgrade",
           },
         },
       ],
@@ -122,7 +122,7 @@ describe("Host Connectors route", () => {
       {
         id: "current",
         name: "Current",
-        version: "0.3.0",
+        version: "0.3.1",
         lastSeenAt: null,
       },
       {

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -86,7 +86,7 @@ async function startHostConnector(
   );
   await page.keyboard.press("Escape");
   const command = await page.getByLabel("Host Connector install command").textContent();
-  expect(command).toContain("https://overtchat.com/install/connector/0.3.0");
+  expect(command).toContain("https://overtchat.com/install/connector/0.3.1");
   expect(command).toContain("--server 'http://127.0.0.1:4718'");
   const pairCode = /--pair-code '([^']+)'/u.exec(command ?? "")?.[1];
   if (!pairCode) throw new Error("The Host Connector pairing code was missing.");
@@ -281,7 +281,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
   page,
 }) => {
   const upgradeCommand =
-    "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.0 | sh -s -- --upgrade";
+    "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.1 | sh -s -- --upgrade";
   await page.route("**/api/host-connectors", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -293,7 +293,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
             version: "0.2.0",
             lastSeenAt: Date.now(),
             online: true,
-            upgrade: { version: "0.3.0", command: upgradeCommand },
+            upgrade: { version: "0.3.1", command: upgradeCommand },
           },
         ],
       }),
@@ -309,7 +309,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
   await page.goto("/settings/connections");
 
   await expect(
-    page.getByText("Host Connector 0.3.0 is available", { exact: true }),
+    page.getByText("Host Connector 0.3.1 is available", { exact: true }),
   ).toBeVisible();
   await expect(page.getByLabel("Host Connector upgrade command")).toHaveText(
     upgradeCommand,

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.5}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.6}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"
@@ -9912,16 +9912,6 @@
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -27588,12 +27578,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
-        "ws": "^8.21.3",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22",
-        "@types/ws": "^8.18.1",
         "typescript": "~6.0.3",
         "vitest": "^4.1.6"
       }

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -23,7 +23,7 @@ export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
  * wire shape and remains stable even when the connector build version changes.
  */
 export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.2.0";
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.0";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.1";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -15,12 +15,10 @@
   },
   "dependencies": {
     "@overtchat/agent-bridge": "*",
-    "ws": "^8.21.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22",
-    "@types/ws": "^8.18.1",
     "typescript": "~6.0.3",
     "vitest": "^4.1.6"
   }

--- a/packages/agent-runtime/src/codex/app-server.test.ts
+++ b/packages/agent-runtime/src/codex/app-server.test.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -16,8 +15,6 @@ import type {
   AgentProcess,
   AgentProcessExit,
 } from "@overtchat/agent-runtime/runtime/process";
-
-const WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 class FakeAgentProcess implements AgentProcess {
   readonly stdin = new PassThrough();
@@ -60,145 +57,14 @@ class FakeAgentProcess implements AgentProcess {
     );
   }
 
-  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
-    this.killedWith = signal;
-    this.resolveExit({ code: null, signal });
-    return true;
-  }
-}
-
-class FailedAgentProcess implements AgentProcess {
-  readonly stdin = new PassThrough();
-  readonly stdout = new PassThrough();
-  readonly stderr = new PassThrough();
-  readonly exit: Promise<AgentProcessExit>;
-  killedWith: NodeJS.Signals | null = null;
-
-  constructor(message: string) {
-    this.stderr.end(message);
-    this.exit = Promise.resolve({ code: 1, signal: null });
-  }
-
-  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
-    this.killedWith = signal;
-    return true;
-  }
-}
-
-class FakeProxyProcess implements AgentProcess {
-  readonly stdin = new PassThrough();
-  readonly stdout = new PassThrough();
-  readonly stderr = new PassThrough();
-  readonly exit: Promise<AgentProcessExit>;
-  readonly frames: Array<Record<string, unknown>> = [];
-  killedWith: NodeJS.Signals | null = null;
-  private resolveExit: (exit: AgentProcessExit) => void = () => {};
-  private input = Buffer.alloc(0);
-  private upgraded = false;
-
-  constructor() {
-    this.exit = new Promise((resolve) => {
-      this.resolveExit = resolve;
-    });
-    this.stdin.on("data", (chunk) => {
-      this.input = Buffer.concat([this.input, Buffer.from(chunk)]);
-      this.consume();
-    });
+  exitWith(exit: AgentProcessExit): void {
+    this.resolveExit(exit);
   }
 
   kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
     this.killedWith = signal;
     this.resolveExit({ code: null, signal });
     return true;
-  }
-
-  private consume(): void {
-    if (!this.upgraded) {
-      const boundary = this.input.indexOf("\r\n\r\n");
-      if (boundary < 0) return;
-      const request = this.input.subarray(0, boundary).toString();
-      this.input = this.input.subarray(boundary + 4);
-      const key = /^Sec-WebSocket-Key:\s*(.+)$/imu.exec(request)?.[1]?.trim();
-      if (!key) throw new Error("WebSocket upgrade did not include a key.");
-      const accept = createHash("sha1")
-        .update(`${key}${WEBSOCKET_GUID}`)
-        .digest("base64");
-      this.stdout.write(
-        [
-          "HTTP/1.1 101 Switching Protocols",
-          "Upgrade: websocket",
-          "Connection: Upgrade",
-          `Sec-WebSocket-Accept: ${accept}`,
-          "",
-          "",
-        ].join("\r\n"),
-      );
-      this.upgraded = true;
-    }
-
-    for (;;) {
-      const frame = this.readFrame();
-      if (!frame) return;
-      if (frame.opcode === 0x8) return;
-      if (frame.opcode !== 0x1) continue;
-      const value = JSON.parse(frame.payload.toString()) as Record<
-        string,
-        unknown
-      >;
-      this.frames.push(value);
-      if (typeof value.id === "number" && typeof value.method === "string") {
-        this.sendJson({
-          jsonrpc: "2.0",
-          id: value.id,
-          result:
-            value.method === "model/list"
-              ? { data: [], nextCursor: null }
-              : {},
-        });
-      }
-    }
-  }
-
-  private readFrame(): { opcode: number; payload: Buffer } | null {
-    if (this.input.length < 2) return null;
-    const opcode = this.input[0] & 0x0f;
-    const masked = (this.input[1] & 0x80) !== 0;
-    let length = this.input[1] & 0x7f;
-    let offset = 2;
-    if (length === 126) {
-      if (this.input.length < 4) return null;
-      length = this.input.readUInt16BE(2);
-      offset = 4;
-    } else if (length === 127) {
-      if (this.input.length < 10) return null;
-      const extended = this.input.readBigUInt64BE(2);
-      if (extended > BigInt(Number.MAX_SAFE_INTEGER)) {
-        throw new Error("WebSocket test frame is too large.");
-      }
-      length = Number(extended);
-      offset = 10;
-    }
-    const maskLength = masked ? 4 : 0;
-    if (this.input.length < offset + maskLength + length) return null;
-    const mask = masked ? this.input.subarray(offset, offset + 4) : null;
-    offset += maskLength;
-    const payload = Buffer.from(this.input.subarray(offset, offset + length));
-    this.input = this.input.subarray(offset + length);
-    if (mask) {
-      for (let index = 0; index < payload.length; index += 1) {
-        payload[index] ^= mask[index % 4];
-      }
-    }
-    return { opcode, payload };
-  }
-
-  private sendJson(value: unknown): void {
-    const payload = Buffer.from(JSON.stringify(value));
-    const header =
-      payload.length < 126
-        ? Buffer.from([0x81, payload.length])
-        : Buffer.from([0x81, 126, payload.length >> 8, payload.length & 0xff]);
-    this.stdout.write(Buffer.concat([header, payload]));
   }
 }
 
@@ -292,8 +158,13 @@ describe("CodexAppServer", () => {
     expect(process.killedWith).toBe("SIGKILL");
   });
 
-  it("prefers the shared Codex daemon through app-server proxy", async () => {
-    const process = new FakeProxyProcess();
+  it("starts Codex app-server directly over stdio", async () => {
+    const process = new FakeAgentProcess((frame, fake) => {
+      if (frame.method === "initialize") fake.result(frame, {});
+      if (frame.method === "model/list") {
+        fake.result(frame, { data: [], nextCursor: null });
+      }
+    });
     mocks.spawnOnHost.mockReturnValueOnce(process);
 
     const server = await startCodexAppServer(
@@ -312,7 +183,7 @@ describe("CodexAppServer", () => {
       { transport: "local" },
       {
         command: "/opt/bin/codex",
-        args: ["app-server", "proxy", "--enable", "goals"],
+        args: ["app-server", "--enable", "goals", "--stdio"],
         cwd: "/workspace",
       },
     );
@@ -326,47 +197,66 @@ describe("CodexAppServer", () => {
     await server.stop();
   });
 
-  it("falls back to standalone stdio when the daemon proxy is unavailable", async () => {
-    const proxy = new FailedAgentProcess("daemon unavailable");
-    const standalone = new FakeAgentProcess((frame, fake) => {
+  it("does not report an intentional SIGTERM as a provider failure", async () => {
+    const process = new FakeAgentProcess((frame, fake) => {
       if (frame.method === "initialize") fake.result(frame, {});
-      if (frame.method === "model/list") {
-        fake.result(frame, { data: [], nextCursor: null });
-      }
     });
-    mocks.spawnOnHost
-      .mockReturnValueOnce(proxy)
-      .mockReturnValueOnce(standalone);
+    const server = new CodexAppServer(process);
+    const notifications: unknown[] = [];
+    server.onNotification((notification) => notifications.push(notification));
 
-    const server = await startCodexAppServer(
-      { transport: "ssh", alias: "devbox" },
-      "codex",
-      "/workspace",
-      { enableGoals: true },
+    await server.ready();
+    await server.stop();
+    await process.exit;
+    await Promise.resolve();
+
+    expect(process.killedWith).toBe("SIGTERM");
+    expect(notifications).not.toContainEqual(
+      expect.objectContaining({ method: "overtchat/processExit" }),
     );
-    await expect(server.request("model/list")).resolves.toEqual({
-      data: [],
-      nextCursor: null,
+  });
+
+  it("contains an unexpected process exit to the Codex client", async () => {
+    const process = new FakeAgentProcess((frame, fake) => {
+      if (frame.method === "initialize") fake.result(frame, {});
     });
+    const server = new CodexAppServer(process);
+    const notifications: unknown[] = [];
+    server.onNotification((notification) => notifications.push(notification));
+    await server.ready();
+    const request = server.request("model/list", {});
 
-    expect(mocks.spawnOnHost).toHaveBeenNthCalledWith(
-      1,
-      { transport: "ssh", alias: "devbox" },
-      {
-        command: "codex",
-        args: ["app-server", "proxy", "--enable", "goals"],
-        cwd: "/workspace",
-      },
-    );
-    expect(mocks.spawnOnHost).toHaveBeenNthCalledWith(
-      2,
-      { transport: "ssh", alias: "devbox" },
-      {
-        command: "codex",
-        args: ["app-server", "--enable", "goals", "--stdio"],
-        cwd: "/workspace",
-      },
-    );
+    process.stderr.write("provider crashed");
+    process.exitWith({ code: 17, signal: null });
+
+    await expect(request).rejects.toThrow("provider crashed");
+    await vi.waitFor(() => {
+      expect(notifications).toContainEqual({
+        method: "overtchat/processExit",
+        params: {
+          code: 17,
+          signal: null,
+          error: "provider crashed",
+        },
+      });
+    });
+  });
+
+  it("contains notification subscriber failures", async () => {
+    const process = new FakeAgentProcess((frame, fake) => {
+      if (frame.method === "initialize") fake.result(frame, {});
+    });
+    const server = new CodexAppServer(process);
+    server.onNotification(() => {
+      throw new Error("consumer crashed");
+    });
+    await server.ready();
+
+    expect(() =>
+      process.stdout.write(
+        `${JSON.stringify({ jsonrpc: "2.0", method: "turn/started" })}\n`,
+      ),
+    ).not.toThrow();
     await server.stop();
   });
 });

--- a/packages/agent-runtime/src/codex/app-server.ts
+++ b/packages/agent-runtime/src/codex/app-server.ts
@@ -1,5 +1,3 @@
-import { Duplex, PassThrough, Writable } from "node:stream";
-import WebSocket from "ws";
 import type { AgentProcess, HostTarget } from "@overtchat/agent-runtime/runtime/process";
 import { spawnOnHost } from "@overtchat/agent-runtime/runtime/process";
 import {
@@ -10,7 +8,8 @@ import {
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const INITIALIZE_TIMEOUT_MS = 60_000;
 const MAX_STDERR_CHARS = 64 * 1024;
-const PROXY_HANDSHAKE_TIMEOUT_MS = 5_000;
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 1_000;
+const FORCE_SHUTDOWN_TIMEOUT_MS = 1_000;
 
 type CodexAppServerOptions = {
   enableGoals?: boolean;
@@ -53,134 +52,21 @@ function errorText(error: JsonRpcError | undefined, fallback: string): string {
   return [error.message || fallback, detail].filter(Boolean).join(" ");
 }
 
-class AgentProcessDuplex extends Duplex {
-  constructor(private readonly process: AgentProcess) {
-    super();
-    process.stdout.on("data", (chunk) => this.push(chunk));
-    process.stdout.on("end", () => this.push(null));
-    process.stdout.on("error", (error) => this.destroy(error));
-    void process.exit.then((exit) => {
-      if (!this.destroyed) {
-        this.destroy(
-          exit.error ??
-            new Error(
-              `Codex app-server proxy exited (code=${exit.code ?? "unknown"}, signal=${exit.signal ?? "none"}).`,
-            ),
-        );
-      }
-    });
-  }
-
-  _read(): void {}
-
-  _write(
-    chunk: Buffer,
-    encoding: BufferEncoding,
-    callback: (error?: Error | null) => void,
-  ): void {
-    this.process.stdin.write(chunk, encoding, callback);
-  }
-
-  _final(callback: (error?: Error | null) => void): void {
-    this.process.stdin.end(callback);
-  }
-
-  setNoDelay(): this {
-    return this;
-  }
-
-  setTimeout(): this {
-    return this;
-  }
-}
-
-function spawnCodexProxy(
+function spawnCodexAppServer(
   target: HostTarget,
   executable: string,
   cwd?: string,
   options: CodexAppServerOptions = {},
 ): AgentProcess {
-  const proxy = spawnOnHost(target, {
+  return spawnOnHost(target, {
     command: executable,
     args: [
       "app-server",
-      "proxy",
       ...(options.enableGoals ? ["--enable", "goals"] : []),
+      "--stdio",
     ],
     cwd,
   });
-  const transport = new AgentProcessDuplex(proxy);
-  const stdout = new PassThrough();
-  let inputBuffer = "";
-  const websocket = new WebSocket("ws://localhost/rpc", {
-    createConnection: () => {
-      process.nextTick(() => transport.emit("connect"));
-      return transport;
-    },
-    handshakeTimeout: PROXY_HANDSHAKE_TIMEOUT_MS,
-    perMessageDeflate: false,
-  });
-  const ready = new Promise<void>((resolve, reject) => {
-    websocket.once("open", resolve);
-    websocket.once("error", reject);
-  });
-  websocket.on("message", (data, isBinary) => {
-    if (isBinary) return;
-    stdout.write(`${data.toString()}\n`);
-  });
-  websocket.on("close", () => stdout.end());
-  websocket.on("error", () => {
-    proxy.kill("SIGTERM");
-  });
-
-  const stdin = new Writable({
-    write(chunk, _encoding, callback) {
-      inputBuffer += chunk.toString();
-      const lines: string[] = [];
-      for (;;) {
-        const newline = inputBuffer.indexOf("\n");
-        if (newline < 0) break;
-        const line = inputBuffer.slice(0, newline);
-        inputBuffer = inputBuffer.slice(newline + 1);
-        if (line) lines.push(line);
-      }
-      void ready.then(
-        async () => {
-          for (const line of lines) {
-            await new Promise<void>((resolve, reject) => {
-              websocket.send(line, (error) =>
-                error ? reject(error) : resolve(),
-              );
-            });
-          }
-          callback();
-        },
-        (error) =>
-          callback(error instanceof Error ? error : new Error(String(error))),
-      );
-    },
-    final(callback) {
-      void ready.then(
-        () => {
-          websocket.close();
-          callback();
-        },
-        () => callback(),
-      );
-    },
-  });
-
-  return {
-    stdin,
-    stdout,
-    stderr: proxy.stderr,
-    exit: proxy.exit,
-    kill(signal = "SIGTERM") {
-      if (signal === "SIGKILL") websocket.terminate();
-      else websocket.close();
-      return proxy.kill(signal);
-    },
-  };
 }
 
 export class CodexAppServer {
@@ -195,21 +81,14 @@ export class CodexAppServer {
   private nextRequestId = 0;
   private stderr = "";
   private closed = false;
+  private stopping = false;
+  private terminationHandled = false;
   private readonly initialized: Promise<void>;
 
   constructor(private readonly process: AgentProcess) {
     process.stdin.on("error", (error) => {
-      if (this.closed) return;
-      this.closed = true;
-      this.rejectPending(error);
-      this.emitNotification({
-        method: "overtchat/processExit",
-        params: {
-          code: null,
-          signal: null,
-          error: error.message,
-        },
-      });
+      if (this.stopping) return;
+      this.handleUnexpectedTermination(error, null, null);
       process.kill("SIGKILL");
     });
     process.stdout.on("data", (chunk) => {
@@ -218,27 +97,31 @@ export class CodexAppServer {
     process.stdout.on("end", () => {
       for (const line of this.decoder.end()) this.handleLine(line);
     });
+    process.stdout.on("error", (error) => {
+      if (this.stopping) return;
+      this.handleUnexpectedTermination(error, null, null);
+      process.kill("SIGKILL");
+    });
     process.stderr.on("data", (chunk) => {
       this.stderr = `${this.stderr}${chunk.toString()}`.slice(
         -MAX_STDERR_CHARS,
       );
     });
+    process.stderr.on("error", (error) => {
+      if (this.stopping) return;
+      this.handleUnexpectedTermination(error, null, null);
+      process.kill("SIGKILL");
+    });
     void process.exit.then((exit) => {
-      this.closed = true;
       const detail = exit.error?.message ?? this.stderr.trim();
-      const error = new Error(
-        detail ||
-          `Codex app-server exited (code=${exit.code ?? "unknown"}, signal=${exit.signal ?? "none"}).`,
+      this.handleUnexpectedTermination(
+        new Error(
+          detail ||
+            `Codex app-server exited (code=${exit.code ?? "unknown"}, signal=${exit.signal ?? "none"}).`,
+        ),
+        exit.code,
+        exit.signal,
       );
-      this.rejectPending(error);
-      this.emitNotification({
-        method: "overtchat/processExit",
-        params: {
-          code: exit.code,
-          signal: exit.signal,
-          error: error.message,
-        },
-      });
     });
     this.initialized = this.initialize();
     void this.initialized.catch(() => {});
@@ -285,21 +168,18 @@ export class CodexAppServer {
 
   async stop(): Promise<void> {
     if (this.closed) return;
+    this.stopping = true;
     this.closed = true;
     this.rejectPending(new Error("The Codex app-server was stopped."));
-    this.process.stdin.end();
+    try {
+      this.process.stdin.end();
+    } catch {
+      // The process may already have closed its input while we were stopping.
+    }
     this.process.kill("SIGTERM");
-    let forceKillTimer: NodeJS.Timeout | undefined;
-    await Promise.race([
-      this.process.exit,
-      new Promise<void>((resolve) => {
-        forceKillTimer = setTimeout(() => {
-          this.process.kill("SIGKILL");
-          resolve();
-        }, 1_000);
-      }),
-    ]);
-    if (forceKillTimer) clearTimeout(forceKillTimer);
+    if (await this.waitForExit(GRACEFUL_SHUTDOWN_TIMEOUT_MS)) return;
+    this.process.kill("SIGKILL");
+    await this.waitForExit(FORCE_SHUTDOWN_TIMEOUT_MS);
   }
 
   getStderr(): string {
@@ -407,7 +287,22 @@ export class CodexAppServer {
         this.respondError(record.id, -32601, "Request is not supported.");
         return;
       }
-      for (const subscriber of this.requestSubscribers) subscriber(request);
+      for (const subscriber of this.requestSubscribers) {
+        try {
+          subscriber(request);
+        } catch (error) {
+          try {
+            this.respondError(
+              record.id,
+              -32603,
+              error instanceof Error ? error.message : "Request handler failed.",
+            );
+          } catch {
+            // The process may have exited while the handler was running.
+          }
+          return;
+        }
+      }
       return;
     }
     this.emitNotification({
@@ -437,7 +332,42 @@ export class CodexAppServer {
 
   private emitNotification(notification: CodexAppServerNotification): void {
     for (const subscriber of this.notificationSubscribers) {
-      subscriber(notification);
+      try {
+        subscriber(notification);
+      } catch {
+        // A consumer failure must not escape the provider process boundary.
+      }
+    }
+  }
+
+  private handleUnexpectedTermination(
+    error: Error,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void {
+    if (this.terminationHandled) return;
+    this.terminationHandled = true;
+    this.closed = true;
+    if (this.stopping) return;
+    this.rejectPending(error);
+    this.emitNotification({
+      method: "overtchat/processExit",
+      params: { code, signal, error: error.message },
+    });
+  }
+
+  private async waitForExit(timeoutMs: number): Promise<boolean> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        this.process.exit.then(() => true),
+        new Promise<boolean>((resolve) => {
+          timer = setTimeout(() => resolve(false), timeoutMs);
+          timer.unref();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 
@@ -466,26 +396,14 @@ export async function startCodexAppServer(
   cwd?: string,
   options: CodexAppServerOptions = {},
 ): Promise<CodexAppServer> {
-  const proxyServer = new CodexAppServer(
-    spawnCodexProxy(target, executable, cwd, options),
+  const server = new CodexAppServer(
+    spawnCodexAppServer(target, executable, cwd, options),
   );
   try {
-    await proxyServer.ready();
-    return proxyServer;
-  } catch {
-    await proxyServer.stop().catch(() => {});
+    await server.ready();
+    return server;
+  } catch (error) {
+    await server.stop().catch(() => {});
+    throw error;
   }
-  const standaloneServer = new CodexAppServer(
-    spawnOnHost(target, {
-      command: executable,
-      args: [
-        "app-server",
-        ...(options.enableGoals ? ["--enable", "goals"] : []),
-        "--stdio",
-      ],
-      cwd,
-    }),
-  );
-  await standaloneServer.ready();
-  return standaloneServer;
 }

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.3.0"
+connector_version="0.3.1"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary
- run Codex app-server directly over stdio, matching Paseo's process boundary
- distinguish intentional shutdown from unexpected provider exit and contain observer failures
- remove the obsolete proxy/WebSocket bridge
- prepare Host Connector v0.3.1 and server v0.13.6

## Verification
- real local and SSH Codex probes under Node and Bun 1.3.14
- `npm run deps:check`
- `npm run typecheck`
- `npm run test`
- `npm run lint`
- connector build and release binary build
- Connections Playwright spec (3 passed, 4 provider-dependent skipped)
- Compose resolves `ghcr.io/yoloyash/overtchat-app:0.13.6`