### PR TITLE
Fix connector site release ordering

### DIFF
--- a/.github/workflows/connector-release.yml
+++ b/.github/workflows/connector-release.yml
@@ -178,3 +178,16 @@ jobs:
         run: |
           test "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true"
           gh release edit "$TAG" --draft=false --latest=false
+
+  deploy-site:
+    if: github.event_name != 'pull_request'
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Deploy site after the connector is public
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh workflow run site.yml --ref main

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -63,7 +63,8 @@ jobs:
           NEXT_TELEMETRY_DISABLED: "1"
         run: npm run build -w apps/site --
 
-      - name: Verify public connector installer
+      - name: Resolve public connector installer
+        id: connector-installer
         if: github.event_name != 'pull_request'
         run: |
           connector_version=$(node -p "require('./apps/connector/package.json').version")
@@ -76,15 +77,25 @@ jobs:
 
           verification_directory=$(mktemp -d)
           trap 'rm -rf "$verification_directory"' EXIT HUP INT TERM
-          curl --proto '=https' --tlsv1.2 \
-            --fail --silent --show-error --location \
-            --retry 10 --retry-delay 3 --retry-all-errors --retry-max-time 120 \
-            --output "$verification_directory/install-connector.sh" \
-            "$installer_url"
+          if ! curl --proto '=https' --tlsv1.2 \
+              --fail --silent --show-error --location \
+              --retry 10 --retry-delay 3 --retry-all-errors --retry-max-time 120 \
+              --output "$verification_directory/install-connector.sh" \
+              "$installer_url"; then
+            if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+              echo "Connector v$connector_version is not public yet; deferring site deployment."
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
           cmp scripts/install-connector.sh "$verification_directory/install-connector.sh"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Deploy site to Cloudflare
-        if: github.event_name != 'pull_request'
+        if: >-
+          github.event_name != 'pull_request' &&
+          steps.connector-installer.outputs.ready == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- treat a not-yet-public connector installer on a main push as a deferred deployment instead of a failed site build
- keep byte mismatch and manual/release verification fail-closed
- explicitly dispatch the site workflow after the connector publisher has uploaded, verified, and published all release assets

## Why
GitHub does not recursively trigger workflows from releases created with `GITHUB_TOKEN`. The old flow therefore produced an expected red main-push site run and required a manual retry after connector publication.

## Verification
- both workflow files parse as YAML
- `git diff --check`