### PR TITLE
fix(agents): make Codex usage and compaction out-of-band

### DIFF
--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   configureProcessSpawner: vi.fn(),
   create: vi.fn(),
   getOrStart: vi.fn(),
+  get: vi.fn(),
   stopAll: vi.fn(),
   stopSession: vi.fn(),
   stopWorkspace: vi.fn(),
@@ -45,6 +46,7 @@ vi.mock("@overtchat/agent-runtime", async (importOriginal) => {
       }
       create = mocks.create;
       getOrStart = mocks.getOrStart;
+      get = mocks.get;
       stopAll = mocks.stopAll;
       stopSession = mocks.stopSession;
       stopWorkspace = mocks.stopWorkspace;
@@ -189,6 +191,7 @@ beforeEach(() => {
     },
   });
   mocks.getOrStart.mockResolvedValue(runtime());
+  mocks.get.mockReturnValue(null);
   mocks.stopAll.mockResolvedValue(undefined);
   mocks.stopSession.mockResolvedValue(undefined);
   mocks.stopWorkspace.mockResolvedValue(undefined);
@@ -205,6 +208,92 @@ afterEach(async () => {
 });
 
 describe("connector daemon command identity", () => {
+  it("reads usage without entering the durable provider-command ledger", async () => {
+    const { journal, timelines } = await openJournal();
+    const events: HostConnectorEventPayload[] = [];
+    const usage = { planType: "plus", windows: [] };
+    mocks.command.mockResolvedValueOnce(usage);
+    mocks.get.mockReturnValueOnce(runtime());
+    const daemon = new ConnectorDaemon(
+      (event) => events.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+
+    await daemon.handle({
+      type: "request",
+      requestId: "usage-request",
+      request: {
+        type: "session_command",
+        commandId: "usage-command",
+        session,
+        command: { type: "show_usage" },
+      },
+    });
+
+    expect(mocks.command).toHaveBeenCalledWith({ type: "show_usage" });
+    expect(mocks.getOrStart).not.toHaveBeenCalled();
+    expect(journal.commandEntry("usage-command")).toBeUndefined();
+    expect(events).toContainEqual({
+      type: "response",
+      requestId: "usage-request",
+      success: true,
+      data: { commandResult: usage },
+    });
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("reads usage concurrently with an active provider command", async () => {
+    const { journal, timelines } = await openJournal();
+    const finishCommand = deferred<unknown>();
+    const usage = { planType: "plus", windows: [] };
+    mocks.get.mockReturnValue(runtime());
+    mocks.command.mockImplementation((input: { type?: string }) =>
+      input.type === "show_usage"
+        ? Promise.resolve(usage)
+        : finishCommand.promise,
+    );
+    const events: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => events.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+
+    const runningCommand = daemon.handle(command("provider-command"));
+    await vi.waitFor(() => expect(mocks.command).toHaveBeenCalledOnce());
+    await daemon.handle({
+      type: "request",
+      requestId: "usage-request",
+      request: {
+        type: "session_command",
+        commandId: "usage-command",
+        session,
+        command: { type: "show_usage" },
+      },
+    });
+
+    expect(events).toContainEqual({
+      type: "response",
+      requestId: "usage-request",
+      success: true,
+      data: { commandResult: usage },
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ requestId: "provider-command" }),
+    );
+
+    finishCommand.resolve({ queued: true, id: "message-1" });
+    await runningCommand;
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
   it("executes simultaneous deliveries of one command only once", async () => {
     const { journal, timelines } = await openJournal();
     const events: HostConnectorEventPayload[] = [];

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -381,6 +381,14 @@ export class ConnectorDaemon {
         };
       }
       case "session_command":
+        if (request.command.type === "show_usage") {
+          const runtime =
+            this.registry.get(request.session.sessionId) ??
+            (await this.open(request.session));
+          return {
+            commandResult: await runtime.command({ type: "show_usage" }),
+          };
+        }
         return this.runCommand(request);
       case "subscribe_session": {
         const previous = this.subscriptions.get(request.subscriptionId);

--- a/apps/web/app/api/agent-sessions/[id]/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.test.ts
@@ -260,6 +260,29 @@ describe("agent session route", () => {
     expect(mocks.updateAgentSessionMetadata).not.toHaveBeenCalled();
   });
 
+  it("returns account usage from the connector read", async () => {
+    const usage = { planType: "plus", windows: [] };
+    mocks.daemonRequest.mockResolvedValue({ commandResult: usage });
+
+    const response = await POST(
+      request("POST", { type: "show_usage" }),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      accepted: true,
+      usage,
+    });
+    expect(mocks.daemonRequest).toHaveBeenCalledWith("connector", {
+      type: "session_command",
+      commandId: expect.any(String),
+      session: sessionDescriptor,
+      command: { type: "show_usage" },
+    });
+    expect(mocks.updateAgentSessionMetadata).not.toHaveBeenCalled();
+  });
+
   it("rejects delivery modes that bypass the connector-owned queue", async () => {
     const steer = await POST(
       request("POST", {

--- a/apps/web/components/agents/AgentSessionDialogs.tsx
+++ b/apps/web/components/agents/AgentSessionDialogs.tsx
@@ -280,18 +280,22 @@ export function AgentInteractionDialog({
 export function AgentUsageDialog({
   open,
   usage,
+  pending,
+  error,
   onOpenChange,
 }: {
   open: boolean;
   usage: AgentUsageSnapshot | null;
+  pending: boolean;
+  error?: string;
   onOpenChange: (open: boolean) => void;
 }) {
-  if (!open || !usage) return null;
+  if (!open) return null;
   const activityRows = [
-    ["Lifetime tokens", usage.activity?.lifetimeTokens],
-    ["Current streak", usage.activity?.currentStreakDays],
-    ["Longest streak", usage.activity?.longestStreakDays],
-    ["Peak daily tokens", usage.activity?.peakDailyTokens],
+    ["Lifetime tokens", usage?.activity?.lifetimeTokens],
+    ["Current streak", usage?.activity?.currentStreakDays],
+    ["Longest streak", usage?.activity?.longestStreakDays],
+    ["Peak daily tokens", usage?.activity?.peakDailyTokens],
   ].filter((row): row is [string, number] => typeof row[1] === "number");
 
   return (
@@ -303,85 +307,94 @@ export function AgentUsageDialog({
             Codex usage
           </Dialog.Title>
           <Dialog.Description className="mt-1 text-sm text-muted-foreground">
-            {usage.planType
+            {usage?.planType
               ? `${formatPlanType(usage.planType)} plan`
               : "Current account limits"}
           </Dialog.Description>
 
-          <div className="mt-5 space-y-5">
-            {usage.windows.length > 0 && (
-              <div className="space-y-4">
-                {usage.windows.map((window) => (
-                  <div key={window.id} className="space-y-1.5">
-                    <div className="flex items-baseline justify-between gap-3 text-sm">
-                      <span className="min-w-0 truncate font-medium">
-                        {window.label}
-                        {window.windowDurationMins
-                          ? ` · ${formatDuration(window.windowDurationMins)}`
-                          : ""}
-                      </span>
-                      <span className="shrink-0 tabular-nums text-muted-foreground">
-                        {Math.round(window.usedPercent)}% used
-                      </span>
+          {pending ? (
+            <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
+              Loading account usage…
+            </div>
+          ) : error ? (
+            <p className="mt-5 text-sm text-destructive">{error}</p>
+          ) : usage ? (
+            <div className="mt-5 space-y-5">
+              {usage.windows.length > 0 && (
+                <div className="space-y-4">
+                  {usage.windows.map((window) => (
+                    <div key={window.id} className="space-y-1.5">
+                      <div className="flex items-baseline justify-between gap-3 text-sm">
+                        <span className="min-w-0 truncate font-medium">
+                          {window.label}
+                          {window.windowDurationMins
+                            ? ` · ${formatDuration(window.windowDurationMins)}`
+                            : ""}
+                        </span>
+                        <span className="shrink-0 tabular-nums text-muted-foreground">
+                          {Math.round(window.usedPercent)}% used
+                        </span>
+                      </div>
+                      <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                        <div
+                          className="h-full rounded-full bg-primary"
+                          style={{
+                            width: `${Math.max(0, Math.min(100, window.usedPercent))}%`,
+                          }}
+                        />
+                      </div>
+                      {window.resetsAt && (
+                        <p className="text-xs text-muted-foreground">
+                          Resets {formatResetTime(window.resetsAt)}
+                        </p>
+                      )}
                     </div>
-                    <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                      <div
-                        className="h-full rounded-full bg-primary"
-                        style={{
-                          width: `${Math.max(0, Math.min(100, window.usedPercent))}%`,
-                        }}
-                      />
+                  ))}
+                </div>
+              )}
+
+              {usage.credits && (
+                <div className="flex items-center justify-between border-t pt-4 text-sm">
+                  <span className="text-muted-foreground">Credits</span>
+                  <span className="font-medium tabular-nums">
+                    {usage.credits.unlimited
+                      ? "Unlimited"
+                      : usage.credits.balance ?? "Available"}
+                  </span>
+                </div>
+              )}
+
+              {activityRows.length > 0 && (
+                <dl className="grid grid-cols-2 gap-x-5 gap-y-3 border-t pt-4 text-sm">
+                  {activityRows.map(([label, value]) => (
+                    <div key={label}>
+                      <dt className="text-xs text-muted-foreground">{label}</dt>
+                      <dd className="mt-0.5 font-medium tabular-nums">
+                        {label.includes("streak")
+                          ? `${value.toLocaleString()} days`
+                          : value.toLocaleString()}
+                      </dd>
                     </div>
-                    {window.resetsAt && (
-                      <p className="text-xs text-muted-foreground">
-                        Resets {formatResetTime(window.resetsAt)}
-                      </p>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
+                  ))}
+                </dl>
+              )}
 
-            {usage.credits && (
-              <div className="flex items-center justify-between border-t pt-4 text-sm">
-                <span className="text-muted-foreground">Credits</span>
-                <span className="font-medium tabular-nums">
-                  {usage.credits.unlimited
-                    ? "Unlimited"
-                    : usage.credits.balance ?? "Available"}
-                </span>
-              </div>
-            )}
-
-            {activityRows.length > 0 && (
-              <dl className="grid grid-cols-2 gap-x-5 gap-y-3 border-t pt-4 text-sm">
-                {activityRows.map(([label, value]) => (
-                  <div key={label}>
-                    <dt className="text-xs text-muted-foreground">{label}</dt>
-                    <dd className="mt-0.5 font-medium tabular-nums">
-                      {label.includes("streak")
-                        ? `${value.toLocaleString()} days`
-                        : value.toLocaleString()}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            )}
-
-            {usage.windows.length === 0 &&
-              !usage.credits &&
-              activityRows.length === 0 &&
-              !usage.unavailableReason && (
+              {usage.windows.length === 0 &&
+                !usage.credits &&
+                activityRows.length === 0 &&
+                !usage.unavailableReason && (
+                  <p className="text-sm text-muted-foreground">
+                    Codex did not return usage details for this account.
+                  </p>
+                )}
+              {usage.unavailableReason && (
                 <p className="text-sm text-muted-foreground">
-                  Codex did not return usage details for this account.
+                  {usage.unavailableReason}
                 </p>
               )}
-            {usage.unavailableReason && (
-              <p className="text-sm text-muted-foreground">
-                {usage.unavailableReason}
-              </p>
-            )}
-          </div>
+            </div>
+          ) : null}
 
           <DialogActions>
             <Button type="button" size="sm" onClick={() => onOpenChange(false)}>

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -27,14 +27,14 @@ import type {
   AgentUsageSnapshot,
 } from "@overtchat/agent-bridge";
 import {
-  buildAgentPromptCommand,
-  normalizeAgentSessionCommand,
   agentProviderMetadata,
 } from "@overtchat/agent-bridge";
 import {
   useAgentSession,
   useAgentSessionCommand,
+  useAgentSessionUsage,
 } from "@/lib/queries/agentSessions";
+import { commandForAgentSessionSubmit } from "@/lib/agents/sessionCommands";
 import { motionClasses } from "@/lib/motion";
 import { AgentComposer } from "./AgentComposer";
 import {
@@ -142,9 +142,12 @@ export function AgentSessionView({
   const router = useRouter();
   const session = useAgentSession(sessionId);
   const command = useAgentSessionCommand(sessionId);
+  const usageCommand = useAgentSessionUsage(sessionId);
   const [renameOpen, setRenameOpen] = useState(false);
   const [compactOpen, setCompactOpen] = useState(false);
   const [usage, setUsage] = useState<AgentUsageSnapshot | null>(null);
+  const [usageOpen, setUsageOpen] = useState(false);
+  const [usageError, setUsageError] = useState("");
   const [dialogError, setDialogError] = useState("");
   const [composerMenuOpen, setComposerMenuOpen] = useState(false);
   const snapshot = session.data;
@@ -165,7 +168,6 @@ export function AgentSessionView({
     setDialogError("");
     try {
       const result = await command.mutateAsync(input);
-      if (result.usage) setUsage(result.usage);
       if (
         input.type === "edit_message" ||
         input.type === "fork_message"
@@ -210,24 +212,31 @@ export function AgentSessionView({
     }
   }
 
+  async function showUsage(): Promise<boolean> {
+    if (usageCommand.isPending) return false;
+    setUsage(null);
+    setUsageError("");
+    setUsageOpen(true);
+    try {
+      setUsage(await usageCommand.mutateAsync());
+      return true;
+    } catch (cause) {
+      setUsageError(
+        cause instanceof Error
+          ? cause.message
+          : "Codex account usage could not be loaded.",
+      );
+      return false;
+    }
+  }
+
   async function submit(
     message: string,
     images: AgentPromptImage[],
   ): Promise<boolean> {
     let input: AgentSessionCommand;
     try {
-      const normalized = normalizeAgentSessionCommand(
-        buildAgentPromptCommand(message, images),
-        snapshot?.state ?? {},
-      );
-      input =
-        normalized.type !== "prompt" || snapshot?.status !== "running"
-          ? normalized
-          : {
-              type: "queue",
-              message,
-              ...(images.length > 0 ? { images } : {}),
-            };
+      input = commandForAgentSessionSubmit(snapshot!, message, images);
     } catch (cause) {
       toast.error({
         title: `${providerLabel} command failed`,
@@ -239,9 +248,11 @@ export function AgentSessionView({
       return false;
     }
 
+    if (input.type === "show_usage") return showUsage();
+
     const toastTitle =
       input.type === "compact"
-        ? "Context compacted"
+        ? "Compaction started"
         : input.type === "set_session_name"
           ? "Session renamed"
           : input.type === "set_auto_compaction"
@@ -517,7 +528,7 @@ export function AgentSessionView({
               type: "compact",
               ...(customInstructions ? { customInstructions } : {}),
             },
-            { closeCompact: true, toastTitle: "Context compacted" },
+            { closeCompact: true, toastTitle: "Compaction started" },
           )
         }
       />
@@ -535,10 +546,16 @@ export function AgentSessionView({
         }
       />
       <AgentUsageDialog
-        open={Boolean(usage)}
+        open={usageOpen}
         usage={usage}
+        pending={usageCommand.isPending}
+        error={usageError}
         onOpenChange={(open) => {
-          if (!open) setUsage(null);
+          setUsageOpen(open);
+          if (!open) {
+            setUsage(null);
+            setUsageError("");
+          }
         }}
       />
     </div>

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -528,6 +528,9 @@ test("shows durable turn activity without changing completed tool status", async
           contentType: "application/json",
           body: JSON.stringify({
             accepted: true,
+            ...(command.type === "show_usage"
+              ? { usage: { planType: "plus", windows: [] } }
+              : {}),
             ...queueResult,
           }),
         });
@@ -838,6 +841,14 @@ test("shows durable turn activity without changing completed tool status", async
     page.getByLabel("Active turn message actions"),
   ).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Attach images" })).toBeVisible();
+  await composer.fill("/usage");
+  await composer.press("Enter");
+  await expect(page.getByRole("dialog", { name: "Codex usage" })).toBeVisible();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "show_usage",
+  });
+  await page.getByRole("button", { name: "Done" }).click();
+  await expect(composer).toBeEnabled();
   await composer.evaluate(async (element) => {
     const canvas = document.createElement("canvas");
     canvas.width = 96;

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -145,6 +145,37 @@ describe("host connector daemon broker", () => {
     await expect(pending).resolves.toEqual({ queuedMessages: [] });
   });
 
+  it("does not replay a read-only usage request across connector replacement", async () => {
+    const replacementCommands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      [],
+      () => {},
+      ["command-wal-v1"],
+    );
+    const pending = broker.request("connector", {
+      type: "session_command",
+      commandId: "usage-command",
+      session,
+      command: { type: "show_usage" },
+    });
+    const rejected = expect(pending).rejects.toThrow(
+      "reconnected before the request completed",
+    );
+
+    broker.register(
+      "connector",
+      [],
+      (command) => replacementCommands.push(command),
+      ["command-wal-v1"],
+    );
+
+    await rejected;
+    expect(replacementCommands).toHaveLength(1);
+    expect(replacementCommands[0]?.type).toBe("sync");
+  });
+
   it("rejects a pending session command when the replacement lacks a WAL", async () => {
     const firstCommands: HostConnectorCommand[] = [];
     const replacementCommands: HostConnectorCommand[] = [];

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -35,6 +35,13 @@ type PendingRequest = {
   timeout: NodeJS.Timeout;
 };
 
+function isLedgerProtectedCommand(request: AgentDaemonRequest): boolean {
+  return (
+    request.type === "session_command" &&
+    request.command.type !== "show_usage"
+  );
+}
+
 type SessionSubscription = {
   connectorId: string;
   session: AgentDaemonSessionDescriptor;
@@ -108,13 +115,15 @@ export class HostConnectorBroker {
       );
     }
     const requestId = crypto.randomUUID();
-    const replaySafe = channel.capabilities.has("command-wal-v1");
+    const replaySafe =
+      isLedgerProtectedCommand(request) &&
+      channel.capabilities.has("command-wal-v1");
     return new Promise<T>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pending.delete(requestId);
         reject(
           new Error(
-            request.type === "session_command" && replaySafe
+            replaySafe
               ? "Timed out waiting for the Host Connector. The command outcome is unknown; inspect the session before retrying."
               : "Timed out waiting for the Host Connector.",
           ),
@@ -159,7 +168,7 @@ export class HostConnectorBroker {
         clearTimeout(pending.timeout);
         this.pending.delete(requestId);
         pending.reject(
-          pending.request.type === "session_command"
+          isLedgerProtectedCommand(pending.request)
             ? commandOutcomeUnknown
             : replaced,
         );
@@ -540,8 +549,7 @@ export class HostConnectorBroker {
       for (const [requestId, request] of this.pending) {
         if (request.connectorId !== connectorId) continue;
         if (
-          request.request.type === "session_command" &&
-          request.replaySafe
+          isLedgerProtectedCommand(request.request) && request.replaySafe
         ) {
           continue;
         }

--- a/apps/web/lib/agents/sessionCommands.test.ts
+++ b/apps/web/lib/agents/sessionCommands.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRuntimeSnapshot } from "@overtchat/agent-bridge";
+import { commandForAgentSessionSubmit } from "./sessionCommands";
+
+function snapshot(
+  overrides: Partial<AgentRuntimeSnapshot> = {},
+): AgentRuntimeSnapshot {
+  return {
+    sessionId: "session",
+    provider: "codex",
+    capabilities: { steer: true, usage: true },
+    status: "idle",
+    activeTurn: null,
+    state: {},
+    messages: [],
+    models: [],
+    thinkingLevels: [],
+    commands: [],
+    stats: {
+      sessionFile: null,
+      sessionId: null,
+      userMessages: 0,
+      assistantMessages: 0,
+      toolCalls: 0,
+      toolResults: 0,
+      totalMessages: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+      cost: 0,
+    },
+    queuedMessages: [],
+    ...overrides,
+  };
+}
+
+describe("commandForAgentSessionSubmit", () => {
+  it("keeps usage out of the prompt queue while Codex is working", () => {
+    expect(
+      commandForAgentSessionSubmit(
+        snapshot({ status: "running" }),
+        "/usage",
+        [],
+      ),
+    ).toEqual({ type: "show_usage" });
+  });
+
+  it("queues ordinary prompts while compaction is active", () => {
+    expect(
+      commandForAgentSessionSubmit(
+        snapshot({ state: { isCompacting: true } }),
+        "Continue with the tests",
+        [],
+      ),
+    ).toEqual({ type: "queue", message: "Continue with the tests" });
+  });
+
+  it("does not intercept usage for providers that do not advertise it", () => {
+    expect(
+      commandForAgentSessionSubmit(
+        snapshot({ capabilities: { steer: true } }),
+        "/usage",
+        [],
+      ),
+    ).toEqual({ type: "prompt", message: "/usage" });
+  });
+});

--- a/apps/web/lib/agents/sessionCommands.ts
+++ b/apps/web/lib/agents/sessionCommands.ts
@@ -1,0 +1,35 @@
+import type {
+  AgentPromptImage,
+  AgentRuntimeSnapshot,
+  AgentSessionCommand,
+} from "@overtchat/agent-bridge";
+import {
+  buildAgentPromptCommand,
+  normalizeAgentSessionCommand,
+} from "@overtchat/agent-bridge";
+
+export function commandForAgentSessionSubmit(
+  snapshot: AgentRuntimeSnapshot,
+  message: string,
+  images: AgentPromptImage[],
+): AgentSessionCommand {
+  const prompt = buildAgentPromptCommand(message, images);
+  const usageCommand =
+    snapshot.capabilities.usage === true &&
+    images.length === 0 &&
+    /^\/usage\s*$/iu.test(message)
+      ? ({ type: "show_usage" } as const)
+      : null;
+  const normalized =
+    usageCommand ?? normalizeAgentSessionCommand(prompt, snapshot.state);
+  const busy =
+    snapshot.status === "running" || snapshot.state.isCompacting === true;
+
+  return normalized.type !== "prompt" || !busy
+    ? normalized
+    : {
+        type: "queue",
+        message,
+        ...(images.length > 0 ? { images } : {}),
+      };
+}

--- a/apps/web/lib/queries/agentSessions.test.tsx
+++ b/apps/web/lib/queries/agentSessions.test.tsx
@@ -17,6 +17,7 @@ import {
 import {
   useAgentSession,
   useAgentSessionCommand,
+  useAgentSessionUsage,
 } from "./agentSessions";
 import { agentSessionKeys } from "./keys";
 import type { AgentSessionReplica } from "@/lib/agents/sessionReplica";
@@ -103,6 +104,24 @@ function CommandProbe({
     onReady(command.mutateAsync);
   }, [command.mutateAsync, onReady]);
   return null;
+}
+
+function UsageProbe({
+  onReady,
+}: {
+  onReady: (load: () => Promise<unknown>) => void;
+}) {
+  const usage = useAgentSessionUsage("session");
+  const command = useAgentSessionCommand("session");
+  useEffect(() => {
+    onReady(usage.mutateAsync);
+  }, [onReady, usage.mutateAsync]);
+  return (
+    <div data-testid="pending-state">
+      {usage.isPending ? "usage-pending" : "usage-idle"}:
+      {command.isPending ? "command-pending" : "command-idle"}
+    </div>
+  );
 }
 
 describe("useAgentSession", () => {
@@ -348,5 +367,51 @@ describe("useAgentSession", () => {
       bodies[1]?.clientMessageId,
     );
     expect(bodies[0]?.images).toEqual(unchanged.images);
+  });
+
+  it("loads usage without occupying the session command mutation", async () => {
+    let finishRequest!: (response: Response) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockReturnValue(
+        new Promise<Response>((resolve) => {
+          finishRequest = resolve;
+        }),
+      ),
+    );
+    let loadUsage: () => Promise<unknown> = () =>
+      Promise.reject(new Error("Usage is not ready."));
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <UsageProbe
+            onReady={(load) => {
+              loadUsage = load;
+            }}
+          />
+        </QueryClientProvider>,
+      );
+    });
+
+    let loading!: Promise<unknown>;
+    await act(async () => {
+      loading = loadUsage();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(container.textContent).toBe("usage-pending:command-idle");
+
+    await act(async () => {
+      finishRequest(
+        Response.json({
+          accepted: true,
+          usage: { planType: "plus", windows: [] },
+        }),
+      );
+      await loading;
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(container.textContent).toBe("usage-idle:command-idle");
   });
 });

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -441,3 +441,23 @@ export function useAgentSessionCommand(id: string) {
     },
   });
 }
+
+export function useAgentSessionUsage(id: string) {
+  return useMutation({
+    mutationFn: async (): Promise<AgentUsageSnapshot> => {
+      const response = await fetch(`/api/agent-sessions/${id}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "show_usage" }),
+      });
+      if (!response.ok) throw await responseError(response);
+      const result = (await response.json()) as {
+        usage?: AgentUsageSnapshot;
+      };
+      if (!result.usage) {
+        throw new Error("The Host Connector did not return account usage.");
+      }
+      return result.usage;
+    },
+  });
+}

--- a/packages/agent-runtime/src/codex/client.test.ts
+++ b/packages/agent-runtime/src/codex/client.test.ts
@@ -41,6 +41,7 @@ class FakeCodexServer {
   readonly responses: Array<{ id: string | number; result: unknown }> = [];
   resumeError: Error | null = null;
   forkError: Error | null = null;
+  compactError: Error | null = null;
   rateLimitsError: Error | null = null;
   usageError: Error | null = null;
   collaborationModes: unknown[] = [];
@@ -247,6 +248,9 @@ class FakeCodexServer {
         reasoningEffort: "high",
       };
     }
+    if (method === "thread/compact/start" && this.compactError) {
+      throw this.compactError;
+    }
     if (method === "thread/resume") {
       if (this.resumeError) throw this.resumeError;
       return {
@@ -363,6 +367,7 @@ describe("CodexRuntimeClient", () => {
     server.responses.length = 0;
     server.resumeError = null;
     server.forkError = null;
+    server.compactError = null;
     server.rateLimitsError = null;
     server.usageError = null;
     server.collaborationModes = [];
@@ -1680,7 +1685,7 @@ describe("CodexRuntimeClient", () => {
     expect(settled).toBe(true);
   });
 
-  it("waits for the compaction turn to complete", async () => {
+  it("acknowledges compaction start without waiting for the turn", async () => {
     const client = new CodexRuntimeClient(
       { transport: "local" },
       { executable: "codex", cwd: "/workspace" },
@@ -1689,12 +1694,7 @@ describe("CodexRuntimeClient", () => {
     client.onEvent((event) => events.push(event));
     await client.getState();
 
-    let settled = false;
-    const compact = client.compact().then(() => {
-      settled = true;
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
+    await expect(client.compact()).resolves.toEqual({});
     await expect(client.getState()).resolves.toMatchObject({
       isCompacting: true,
     });
@@ -1723,9 +1723,30 @@ describe("CodexRuntimeClient", () => {
         items: [{ id: "compact-item", type: "contextCompaction" }],
       },
     });
-    await compact;
+    await vi.waitFor(async () => {
+      await expect(client.getState()).resolves.toMatchObject({
+        isCompacting: false,
+      });
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "compaction_start" }),
+        expect.objectContaining({ type: "compaction_end" }),
+      ]),
+    );
+  });
 
-    expect(settled).toBe(true);
+  it("ends the compaction lifecycle when the start request is rejected", async () => {
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    await client.getState();
+    server.compactError = new Error("Compaction is unavailable");
+
+    await expect(client.compact()).rejects.toThrow("Compaction is unavailable");
     await expect(client.getState()).resolves.toMatchObject({
       isCompacting: false,
     });

--- a/packages/agent-runtime/src/codex/client.ts
+++ b/packages/agent-runtime/src/codex/client.ts
@@ -1155,21 +1155,22 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     this.compactionWaiter = { ...completion, turnId: null };
     this.isCompacting = true;
     this.emit({ type: "compaction_start" });
+    void completion.promise.catch((error) => {
+      if (!this.finishCompaction(completion)) return;
+      this.emit({
+        type: "rpc_error",
+        command: "compact",
+        error: error.message,
+      });
+    });
     try {
-      const response = await this.server.request("thread/compact/start", {
+      return await this.server.request("thread/compact/start", {
         threadId: this.thread!.id,
       });
-      await completion.promise;
-      return response;
     } catch (error) {
       completion.cancel();
+      this.finishCompaction(completion);
       throw error;
-    } finally {
-      if (this.compactionWaiter?.promise === completion.promise) {
-        this.compactionWaiter = null;
-      }
-      this.isCompacting = false;
-      this.emit({ type: "compaction_end" });
     }
   }
 
@@ -1849,20 +1850,28 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         (this.compactionWaiter?.turnId === null &&
           turn.items.some((item) => item.type === "contextCompaction"));
       if (isCompactionTurn && this.compactionWaiter) {
+        const compaction = this.compactionWaiter;
         if (turn.status === "completed") {
-          this.compactionWaiter.resolve(turn);
+          compaction.resolve(turn);
         } else {
-          this.compactionWaiter.reject(
-            new Error(
-              turn.status === "failed"
-                ? stringOf(recordOf(turn.error), "message") ??
-                    "Codex compaction failed."
-                : "Codex compaction was interrupted.",
-            ),
+          const error = new Error(
+            turn.status === "failed"
+              ? stringOf(recordOf(turn.error), "message") ??
+                  "Codex compaction failed."
+              : "Codex compaction was interrupted.",
           );
+          compaction.reject(error);
+          if (this.finishCompaction(compaction)) {
+            this.emit({
+              type: "rpc_error",
+              command: "compact",
+              error: error.message,
+            });
+          }
         }
+        this.finishCompaction(compaction);
       }
-      if (turn.status === "failed") {
+      if (turn.status === "failed" && !isCompactionTurn) {
         const message =
           stringOf(recordOf(turn.error), "message") ?? "Codex turn failed.";
         this.emit({ type: "rpc_error", command: "prompt", error: message });
@@ -2814,9 +2823,19 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       for (const waiter of waiters) waiter.reject(error);
     }
     this.turnCompletionWaiters.clear();
-    this.compactionWaiter?.reject(error);
+    const compaction = this.compactionWaiter;
+    compaction?.reject(error);
+    if (compaction) this.finishCompaction(compaction);
+  }
+
+  private finishCompaction(
+    completion: Pick<CompletionWaiter<CodexTurn>, "promise">,
+  ): boolean {
+    if (this.compactionWaiter?.promise !== completion.promise) return false;
     this.compactionWaiter = null;
     this.isCompacting = false;
+    this.emit({ type: "compaction_end" });
+    return true;
   }
 }
 

--- a/packages/agent-runtime/src/providers/codex.test.ts
+++ b/packages/agent-runtime/src/providers/codex.test.ts
@@ -4,6 +4,18 @@ import { describe, expect, it, vi } from "vitest";
 import { codexProviderAdapter } from "./codex";
 
 describe("codexProviderAdapter", () => {
+  it("marks compaction as working before its turn notification arrives", () => {
+    const classifier = codexProviderAdapter.createEventClassifier();
+    expect(classifier.classify({ type: "compaction_start" })).toEqual({
+      started: true,
+      terminal: false,
+    });
+    expect(classifier.classify({ type: "compaction_end" })).toEqual({
+      started: false,
+      terminal: true,
+    });
+  });
+
   it("normalizes /usage without sending it to the model", () => {
     expect(
       codexProviderAdapter.normalizeCommand(

--- a/packages/agent-runtime/src/providers/codex.ts
+++ b/packages/agent-runtime/src/providers/codex.ts
@@ -48,8 +48,10 @@ class CodexEventClassifier implements AgentRuntimeEventClassifier {
 
   classify(event: AgentRuntimeEvent) {
     return {
-      started: event.type === "turn_start",
-      terminal: event.type === "turn_end",
+      started:
+        event.type === "turn_start" || event.type === "compaction_start",
+      terminal:
+        event.type === "turn_end" || event.type === "compaction_end",
     };
   }
 }

--- a/packages/agent-runtime/src/runtime/registry.test.ts
+++ b/packages/agent-runtime/src/runtime/registry.test.ts
@@ -63,8 +63,10 @@ vi.mock("@overtchat/agent-runtime/providers/registry", () => ({
     }),
     createEventClassifier: () => ({
       classify: (event: AgentRuntimeEvent) => ({
-        started: event.type === "agent_start",
-        terminal: event.type === "agent_end",
+        started:
+          event.type === "agent_start" || event.type === "compaction_start",
+        terminal:
+          event.type === "agent_end" || event.type === "compaction_end",
       }),
       reset: vi.fn(),
     }),
@@ -615,6 +617,56 @@ describe("agent runtime", () => {
       { clientMessageId: "queued-second" },
     ]);
     expect(runtime.snapshot().queuedMessages).toEqual([]);
+    await registry.stopAll();
+  });
+
+  it("holds queued prompts until compaction finishes", async () => {
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    mocks.eventSubscriber?.({ type: "compaction_start" });
+    await runtime.command(
+      { type: "queue", message: "Continue after compaction" },
+      "after-compaction",
+    );
+
+    expect(runtime.snapshot()).toMatchObject({
+      status: "running",
+      state: { isCompacting: true },
+      queuedMessages: [
+        {
+          id: "after-compaction",
+          message: "Continue after compaction",
+          status: "pending",
+        },
+      ],
+    });
+    expect(mocks.prompt).not.toHaveBeenCalled();
+
+    mocks.eventSubscriber?.({ type: "compaction_end" });
+    await vi.waitFor(() => {
+      expect(mocks.prompt).toHaveBeenCalledWith(
+        "Continue after compaction",
+        undefined,
+        { clientMessageId: "after-compaction" },
+      );
+    });
+    await vi.waitFor(() => {
+      expect(runtime.snapshot().queuedMessages).toEqual([]);
+    });
     await registry.stopAll();
   });
 

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -754,12 +754,7 @@ export class AgentSessionRuntime {
             ),
           );
       case "compact":
-        return this.client
-          .compact(command.customInstructions)
-          .then(async (value) => {
-            await this.refresh();
-            return value;
-          });
+        return this.client.compact(command.customInstructions);
       case "set_auto_compaction":
         return this.client
           .setAutoCompaction(command.enabled)


### PR DESCRIPTION
## Summary

- route /usage through an independent account-usage request and popup, without occupying the session command mutation, durable command ledger, or WAL replay path
- acknowledge Codex compaction after thread/compact/start is accepted while preserving its lifecycle until the compaction turn ends
- keep the composer available during compaction and send follow-up prompts through the existing connector-owned durable queue
- cover concurrent usage, connector replacement, compaction rejection/completion, queue draining, UI loading, and the browser flow

## Validation

- npm test
- npm run typecheck
- npm run lint
- npm run deps:check
- npm run build
- E2E_PORT=4742 npm run test:e2e (11 passed, 4 skipped)

Draft only; do not merge until the behavior is manually tested against a real Codex session.