### PR TITLE
feat(providers): add first-class DeepSeek support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ I wanted a chat app I could open and use. So I wrote one.
 - **600 MB Docker image vs Open WebUI's 1.7 GB** (compressed, amd64, pulled from `ghcr.io` on 2026-05-20). About a third the size on disk, fewer layers.
 - **No plugin runtime, no pipelines, no functions framework.** Tools are two AI SDK definitions in [`apps/web/lib/tools.ts`](apps/web/lib/tools.ts): `web_search` (SearXNG) and `fetch_url` (Defuddle → markdown). That's the whole extensibility surface.
 - **No RAG, no embeddings, no vector DB.** Chat search is SQLite FTS5 + BM25, populated by triggers ([`apps/web/lib/db/search.ts`](apps/web/lib/db/search.ts)). Web search results go straight into context as JSON.
-- **Provider-aware without a plugin runtime.** OpenAI, Anthropic, Google Gemini, and Amazon Bedrock use their native API formats through a small registry; vLLM, llama.cpp, and SGLang have ready-to-edit local presets; custom endpoints explicitly choose Chat Completions, Responses, or Messages. Provider details stay out of the chat pipeline.
+- **Provider-aware without a plugin runtime.** OpenAI, Anthropic, Google Gemini, DeepSeek, and Amazon Bedrock use first-class presets through a small registry; vLLM, llama.cpp, and SGLang have ready-to-edit local presets; custom endpoints explicitly choose Chat Completions, Responses, or Messages. Provider details stay out of the chat pipeline.
 
 If you want every feature in the world — image generation, a code interpreter, knowledge graphs, a plugin marketplace — use Open WebUI or LibreChat. If you want a chat app that opens in under a second and stays out of your way, this is that.
 

--- a/apps/web/lib/model-config/schema.test.ts
+++ b/apps/web/lib/model-config/schema.test.ts
@@ -51,6 +51,26 @@ describe("provider configuration", () => {
     }
   });
 
+  it("accepts the DeepSeek preset with automatic routing and credentials", () => {
+    expect(
+      ProviderConnectionSchema.safeParse({
+        providerId: "deepseek",
+        apiFormat: "auto",
+        baseUrl: "https://api.deepseek.com",
+        apiKey: "secret",
+      }),
+    ).toMatchObject({ success: true });
+
+    expect(
+      ProviderConnectionSchema.safeParse({
+        providerId: "deepseek",
+        apiFormat: "auto",
+        baseUrl: "https://api.deepseek.com",
+        apiKey: "",
+      }).success,
+    ).toBe(false);
+  });
+
   it("rejects protocol overrides for providers that own their routing", () => {
     const result = ProviderConnectionSchema.safeParse({
       providerId: "openai",

--- a/apps/web/lib/providers/catalog.test.ts
+++ b/apps/web/lib/providers/catalog.test.ts
@@ -19,6 +19,13 @@ describe("provider catalog", () => {
   it("keeps API formats separate from provider identity", () => {
     expect(PROVIDERS.openai.defaultApiFormat).toBe("auto");
     expect(PROVIDERS.bedrock.defaultApiFormat).toBe("auto");
+    expect(PROVIDERS.deepseek).toMatchObject({
+      iconId: "deepseek",
+      defaultApiFormat: "auto",
+      defaultBaseUrl: "https://api.deepseek.com",
+      modelPlaceholder: "deepseek-v4-flash",
+      requiresApiKey: true,
+    });
     expect(PROVIDERS.vllm).toMatchObject({
       defaultApiFormat: "auto",
       defaultBaseUrl: "http://localhost:8000/v1",

--- a/apps/web/lib/providers/catalog.ts
+++ b/apps/web/lib/providers/catalog.ts
@@ -4,6 +4,7 @@ export const PROVIDER_IDS = [
   "openai",
   "anthropic",
   "google",
+  "deepseek",
   "bedrock",
   "vllm",
   "llamacpp",
@@ -60,6 +61,15 @@ export const PROVIDERS: Record<ProviderId, ProviderDefinition> = {
     defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
     defaultApiFormat: "auto",
     modelPlaceholder: "gemini-2.5-flash",
+    requiresApiKey: true,
+  },
+  deepseek: {
+    id: "deepseek",
+    label: "DeepSeek",
+    iconId: "deepseek",
+    defaultBaseUrl: "https://api.deepseek.com",
+    defaultApiFormat: "auto",
+    modelPlaceholder: "deepseek-v4-flash",
     requiresApiKey: true,
   },
   bedrock: {

--- a/apps/web/lib/providers/server/adapters/deepseek.test.ts
+++ b/apps/web/lib/providers/server/adapters/deepseek.test.ts
@@ -1,14 +1,43 @@
+import { generateText, tool } from "ai";
+import { z } from "zod";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-import { deepSeekAdapter } from "./deepseek";
+import { deepSeekAdapter, prepareDeepSeekRequest } from "./deepseek";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("DeepSeek adapter", () => {
+  it("omits forced tool choice in thinking mode", () => {
+    expect(
+      prepareDeepSeekRequest({
+        model: "deepseek-v4-flash",
+        tool_choice: "required",
+        thinking: { type: "enabled" },
+      }),
+    ).toEqual({
+      model: "deepseek-v4-flash",
+      thinking: { type: "enabled" },
+    });
+
+    const automatic = {
+      model: "deepseek-v4-flash",
+      tool_choice: "auto",
+      thinking: { type: "enabled" },
+    };
+    expect(prepareDeepSeekRequest(automatic)).toBe(automatic);
+
+    const nonThinking = {
+      model: "deepseek-v4-flash",
+      tool_choice: "required",
+      thinking: { type: "disabled" },
+    };
+    expect(prepareDeepSeekRequest(nonThinking)).toBe(nonThinking);
+  });
+
   it("discovers models through the authenticated OpenAI-compatible endpoint", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json({
@@ -46,5 +75,57 @@ describe("DeepSeek adapter", () => {
         headers: { Authorization: "Bearer secret" },
       }),
     );
+  });
+
+  it("applies thinking-mode compatibility to the serialized request", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "intentional test response",
+              type: "invalid_request_error",
+              param: null,
+              code: null,
+            },
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }),
+    );
+    const resolved = deepSeekAdapter.createLanguageModel({
+      providerId: "deepseek",
+      apiFormat: "auto",
+      baseUrl: "https://api.deepseek.com",
+      apiKey: "secret",
+      model: "deepseek-v4-flash",
+      providerOptions: null,
+    });
+
+    await expect(
+      generateText({
+        model: resolved.model,
+        prompt: "Search for overtchat.",
+        tools: {
+          web_search: tool({
+            description: "Search the web.",
+            inputSchema: z.object({ query: z.string() }),
+          }),
+        },
+        toolChoice: "required",
+      }),
+    ).rejects.toThrow("intentional test response");
+
+    expect(requestBody).toMatchObject({
+      model: "deepseek-v4-flash",
+      tools: [expect.objectContaining({ type: "function" })],
+    });
+    expect(requestBody).not.toHaveProperty("tool_choice");
   });
 });

--- a/apps/web/lib/providers/server/adapters/deepseek.test.ts
+++ b/apps/web/lib/providers/server/adapters/deepseek.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { deepSeekAdapter } from "./deepseek";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DeepSeek adapter", () => {
+  it("discovers models through the authenticated OpenAI-compatible endpoint", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        object: "list",
+        data: [
+          {
+            id: "deepseek-v4-flash",
+            object: "model",
+            owned_by: "deepseek",
+          },
+          {
+            id: "deepseek-v4-pro",
+            object: "model",
+            owned_by: "deepseek",
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      deepSeekAdapter.listModels({
+        providerId: "deepseek",
+        apiFormat: "auto",
+        baseUrl: "https://api.deepseek.com",
+        apiKey: "secret",
+      }),
+    ).resolves.toEqual([
+      { id: "deepseek-v4-flash" },
+      { id: "deepseek-v4-pro" },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.deepseek.com/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer secret" },
+      }),
+    );
+  });
+});

--- a/apps/web/lib/providers/server/adapters/deepseek.ts
+++ b/apps/web/lib/providers/server/adapters/deepseek.ts
@@ -1,4 +1,42 @@
 import "server-only";
-import { createOpenAICompatibleAdapter } from "@/lib/providers/server/adapters/openai-compatible";
+import { listOpenAIModels } from "@/lib/providers/server/http";
+import { createOpenAICompatibleChatModel } from "@/lib/providers/server/transports";
+import type { ProviderAdapter } from "@/lib/providers/server/types";
 
-export const deepSeekAdapter = createOpenAICompatibleAdapter("deepseek");
+export const deepSeekAdapter: ProviderAdapter = {
+  id: "deepseek",
+  createLanguageModel(config) {
+    return {
+      model: createOpenAICompatibleChatModel({
+        providerName: "deepseek",
+        baseUrl: config.baseUrl,
+        apiKey: config.apiKey,
+        model: config.model,
+        transformRequestBody: prepareDeepSeekRequest,
+      }),
+      providerOptionsKey: "deepseek",
+    };
+  },
+  listModels(connection) {
+    return listOpenAIModels(connection.baseUrl, connection.apiKey);
+  },
+};
+
+/** DeepSeek defaults to thinking mode, which rejects forced tool choice. */
+export function prepareDeepSeekRequest(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  if (body.tool_choice !== "required") return body;
+  const thinking = body.thinking;
+  if (
+    thinking &&
+    typeof thinking === "object" &&
+    !Array.isArray(thinking) &&
+    (thinking as Record<string, unknown>).type === "disabled"
+  ) {
+    return body;
+  }
+  const { tool_choice: _unsupported, ...compatible } = body;
+  void _unsupported;
+  return compatible;
+}

--- a/apps/web/lib/providers/server/adapters/deepseek.ts
+++ b/apps/web/lib/providers/server/adapters/deepseek.ts
@@ -1,0 +1,4 @@
+import "server-only";
+import { createOpenAICompatibleAdapter } from "@/lib/providers/server/adapters/openai-compatible";
+
+export const deepSeekAdapter = createOpenAICompatibleAdapter("deepseek");

--- a/apps/web/lib/providers/server/model-catalog.json
+++ b/apps/web/lib/providers/server/model-catalog.json
@@ -2324,6 +2324,89 @@
       "temperature": false
     }
   },
+  "deepseek": {
+    "deepseek-chat": {
+      "context": 1000000,
+      "output": 384000,
+      "cost": {
+        "cache_read": 0.0028,
+        "input": 0.14,
+        "output": 0.28
+      },
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "attachment": true,
+      "tool_call": true,
+      "reasoning": false,
+      "temperature": true
+    },
+    "deepseek-reasoner": {
+      "context": 1000000,
+      "output": 384000,
+      "cost": {
+        "cache_read": 0.0028,
+        "input": 0.14,
+        "output": 0.28,
+        "reasoning": 0.28
+      },
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "attachment": true,
+      "tool_call": true,
+      "reasoning": true,
+      "temperature": true
+    },
+    "deepseek-v4-flash": {
+      "context": 1000000,
+      "output": 384000,
+      "cost": {
+        "cache_read": 0.0028,
+        "input": 0.14,
+        "output": 0.28,
+        "reasoning": 0.28
+      },
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "attachment": false,
+      "tool_call": true,
+      "reasoning": true,
+      "structured_output": true,
+      "temperature": true
+    },
+    "deepseek-v4-pro": {
+      "context": 1000000,
+      "output": 384000,
+      "cost": {
+        "cache_read": 0.003625,
+        "input": 0.435,
+        "output": 0.87,
+        "reasoning": 0.87
+      },
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "attachment": false,
+      "tool_call": true,
+      "reasoning": true,
+      "structured_output": true,
+      "temperature": true
+    }
+  },
   "bedrock": {
     "amazon.nova-2-lite-v1:0": {
       "context": 128000,
@@ -4024,13 +4107,32 @@
       "temperature": false
     },
     "openai.gpt-5.6-luna": {
-      "context": 272000,
+      "context": 1050000,
+      "input": 922000,
       "output": 128000,
       "cost": {
         "cache_read": 0.022,
         "cache_write": 0.275,
+        "context_over_200k": {
+          "cache_read": 0.044,
+          "cache_write": 0.55,
+          "input": 0.44,
+          "output": 1.98
+        },
         "input": 0.22,
-        "output": 1.32
+        "output": 1.32,
+        "tiers": [
+          {
+            "cache_read": 0.044,
+            "cache_write": 0.55,
+            "input": 0.44,
+            "output": 1.98,
+            "tier": {
+              "size": 272000,
+              "type": "context"
+            }
+          }
+        ]
       },
       "input_modalities": [
         "text",
@@ -4047,13 +4149,32 @@
       "temperature": false
     },
     "openai.gpt-5.6-sol": {
-      "context": 272000,
+      "context": 1050000,
+      "input": 922000,
       "output": 128000,
       "cost": {
         "cache_read": 0.55,
-        "cache_write": 6.88,
+        "cache_write": 6.875,
+        "context_over_200k": {
+          "cache_read": 1.1,
+          "cache_write": 13.75,
+          "input": 11,
+          "output": 49.5
+        },
         "input": 5.5,
-        "output": 33
+        "output": 33,
+        "tiers": [
+          {
+            "cache_read": 1.1,
+            "cache_write": 13.75,
+            "input": 11,
+            "output": 49.5,
+            "tier": {
+              "size": 272000,
+              "type": "context"
+            }
+          }
+        ]
       },
       "input_modalities": [
         "text",
@@ -4070,13 +4191,32 @@
       "temperature": false
     },
     "openai.gpt-5.6-terra": {
-      "context": 272000,
+      "context": 1050000,
+      "input": 922000,
       "output": 128000,
       "cost": {
         "cache_read": 0.22,
         "cache_write": 2.75,
+        "context_over_200k": {
+          "cache_read": 0.44,
+          "cache_write": 5.5,
+          "input": 4.4,
+          "output": 19.8
+        },
         "input": 2.2,
-        "output": 13.2
+        "output": 13.2,
+        "tiers": [
+          {
+            "cache_read": 0.44,
+            "cache_write": 5.5,
+            "input": 4.4,
+            "output": 19.8,
+            "tier": {
+              "size": 272000,
+              "type": "context"
+            }
+          }
+        ]
       },
       "input_modalities": [
         "text",

--- a/apps/web/lib/providers/server/model-catalog.manifest.json
+++ b/apps/web/lib/providers/server/model-catalog.manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-10T13:42:10.028Z",
+  "generatedAt": "2026-08-12T22:16:30.873Z",
   "sourceUrl": "https://models.dev/api.json",
-  "sourceSha256": "c91f5e14219faf156738a4da2b3cf81b22927e93acd797542c39ab8b2a568ca9",
-  "catalogSha256": "094a949df92c7b3dd09ea0d6475db67cce151a41efd0026fda77d0ad5082b24d",
-  "modelCount": 214
+  "sourceSha256": "cede069e634b86fd0a0440d1fd891220bbf9dd11d8d50e2e4c1ae86ad7f49528",
+  "catalogSha256": "0c7ecfeccf8e33b2a6d878d884f5d253b836ab9e785853ee82521962e8bfcfd3",
+  "modelCount": 218
 }

--- a/apps/web/lib/providers/server/model-catalog.test.ts
+++ b/apps/web/lib/providers/server/model-catalog.test.ts
@@ -21,6 +21,9 @@ describe("vendored model catalog", () => {
       1_048_576,
     );
     expect(
+      catalogContextWindowFor("deepseek", "deepseek-v4-flash"),
+    ).toBe(1_000_000);
+    expect(
       catalogContextWindowFor(
         "bedrock",
         "us.anthropic.claude-sonnet-5",
@@ -80,6 +83,13 @@ describe("vendored model catalog", () => {
       cacheRead: 0.25,
       cacheWrite: 2.5,
       tiered: true,
+    });
+    expect(catalogPricingFor("deepseek", "deepseek-v4-flash")).toEqual({
+      input: 0.14,
+      output: 0.28,
+      cacheRead: 0.0028,
+      cacheWrite: 0.14,
+      tiered: false,
     });
     expect(
       catalogPricingFor("custom", "private-model"),

--- a/apps/web/lib/providers/server/registry.test.ts
+++ b/apps/web/lib/providers/server/registry.test.ts
@@ -261,6 +261,18 @@ describe("provider registry", () => {
     },
   );
 
+  it("uses the shared OpenAI-compatible transport for DeepSeek", () => {
+    const configured = createConfiguredLanguageModel({
+      ...baseConfig,
+      providerId: "deepseek",
+      baseUrl: "https://api.deepseek.com",
+      model: "deepseek-v4-flash",
+    });
+
+    expect(configured.providerOptionsKey).toBe("deepseek");
+    expect(configured.promptCacheStrategy).toBeUndefined();
+  });
+
   it("rejects malformed endpoints and missing registered-provider credentials", () => {
     expect(() =>
       validateProviderConnection({
@@ -276,6 +288,13 @@ describe("provider registry", () => {
         apiKey: "",
       }),
     ).toThrow("requires an API key");
+    expect(() =>
+      validateProviderConnection({
+        ...baseConfig,
+        providerId: "deepseek",
+        apiKey: "",
+      }),
+    ).toThrow("DeepSeek requires an API key");
   });
 
   it("runs Bedrock endpoint and model-family validation before construction", () => {

--- a/apps/web/lib/providers/server/registry.ts
+++ b/apps/web/lib/providers/server/registry.ts
@@ -10,6 +10,7 @@ import {
 import { anthropicAdapter } from "@/lib/providers/server/adapters/anthropic";
 import { bedrockAdapter } from "@/lib/providers/server/adapters/bedrock";
 import { customAdapter } from "@/lib/providers/server/adapters/custom";
+import { deepSeekAdapter } from "@/lib/providers/server/adapters/deepseek";
 import { googleAdapter } from "@/lib/providers/server/adapters/google";
 import { llamaCppAdapter } from "@/lib/providers/server/adapters/llamacpp";
 import { openAIAdapter } from "@/lib/providers/server/adapters/openai";
@@ -29,6 +30,7 @@ const PROVIDER_REGISTRY: Record<ProviderId, ProviderAdapter> = {
   openai: openAIAdapter,
   anthropic: anthropicAdapter,
   google: googleAdapter,
+  deepseek: deepSeekAdapter,
   bedrock: bedrockAdapter,
   vllm: vllmAdapter,
   llamacpp: llamaCppAdapter,

--- a/apps/web/lib/providers/server/transports.ts
+++ b/apps/web/lib/providers/server/transports.ts
@@ -15,6 +15,9 @@ interface TransportConfig {
   baseUrl: string;
   apiKey: string | null | undefined;
   model: string;
+  transformRequestBody?: (
+    body: Record<string, unknown>,
+  ) => Record<string, unknown>;
 }
 
 export function createOpenAIResponsesModel(
@@ -40,6 +43,9 @@ export function createOpenAICompatibleChatModel(
     // numerator.
     includeUsage: true,
     convertUsage: convertOpenAICompatibleUsage,
+    ...(config.transformRequestBody
+      ? { transformRequestBody: config.transformRequestBody }
+      : {}),
   }).chatModel(config.model);
 }
 

--- a/apps/web/scripts/README.md
+++ b/apps/web/scripts/README.md
@@ -25,15 +25,23 @@ npx tsx --env-file=../../.env scripts/provider-cache-smoke.ts
 
 The full baseline run requires `GEMINI_API_KEY`, `AWS_BEARER_TOKEN`, and
 llama.cpp on `127.0.0.1:9876`. Native OpenAI and Anthropic targets are also
-included when `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are present. Select a
-comma-separated subset with `CACHE_SMOKE_TARGETS`; unrelated credentials and
-servers are then optional. `CACHE_SMOKE_CORPUS_WORDS` reduces or enlarges the
-stable synthetic prefix. The llama.cpp target sends `id_slot: 0` by default so
-multi-slot servers still produce an unambiguous cache signal; override it with
+included when `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are present. DeepSeek is
+included when `DEEPSEEK_API_KEY` is present. Select a comma-separated subset
+with `CACHE_SMOKE_TARGETS`; unrelated credentials and servers are then
+optional. `CACHE_SMOKE_CORPUS_WORDS` reduces or enlarges the stable synthetic
+prefix. The llama.cpp target sends `id_slot: 0` by default so multi-slot
+servers still produce an unambiguous cache signal; override it with
 `CACHE_SMOKE_LLAMA_SLOT`.
 
 ```bash
 CACHE_SMOKE_TARGETS='llama.cpp/local' \
 CACHE_SMOKE_CORPUS_WORDS=120 \
+npx tsx --env-file=../../.env scripts/provider-cache-smoke.ts
+```
+
+For a live DeepSeek-only run:
+
+```bash
+CACHE_SMOKE_TARGETS='deepseek/deepseek-v4-flash' \
 npx tsx --env-file=../../.env scripts/provider-cache-smoke.ts
 ```

--- a/apps/web/scripts/generate-model-catalog.ts
+++ b/apps/web/scripts/generate-model-catalog.ts
@@ -24,6 +24,7 @@ const PROVIDERS = [
   ["openai", "openai"],
   ["anthropic", "anthropic"],
   ["google", "google"],
+  ["deepseek", "deepseek"],
   ["bedrock", "amazon-bedrock"],
 ] as const;
 

--- a/apps/web/scripts/provider-cache-smoke.ts
+++ b/apps/web/scripts/provider-cache-smoke.ts
@@ -99,6 +99,7 @@ interface Target {
   cacheExpectations?: CacheExpectations;
   expectedSlotId?: number;
   providerOptions?: ProviderOptions;
+  forcedToolChoice?: NormalizedToolChoice;
 }
 
 class WireRecorder {
@@ -444,6 +445,31 @@ async function createTargets(
     }
   }
 
+  {
+    const label = "deepseek/deepseek-v4-flash";
+    if (selectedWhenConfigured(label, "DEEPSEEK_API_KEY")) {
+      const recorder = new WireRecorder("openai-chat");
+      targets.push({
+        label,
+        model: createOpenAICompatible({
+          name: "deepseek",
+          baseURL: "https://api.deepseek.com",
+          apiKey: requiredEnv("DEEPSEEK_API_KEY"),
+          includeUsage: true,
+          fetch: recorder.fetch,
+          transformRequestBody: (body) => {
+            if (body.tool_choice !== "required") return body;
+            const { tool_choice: _unsupported, ...compatible } = body;
+            void _unsupported;
+            return compatible;
+          },
+        }).chatModel("deepseek-v4-flash"),
+        recorder,
+        forcedToolChoice: "unspecified",
+      });
+    }
+  }
+
   const llamaLabel = "llama.cpp/local";
   if (selected(llamaLabel)) {
     const llamaHealth = await fetch("http://127.0.0.1:9876/health");
@@ -597,9 +623,12 @@ function assertTarget(target: Target, results: RunResult[]) {
           `${target.label}/${run.name}: forced tool call had no automatic follow-up step`,
         );
       }
-      if (result.wireRequests[0]?.toolChoice !== "required") {
+      if (
+        result.wireRequests[0]?.toolChoice !==
+        (target.forcedToolChoice ?? "required")
+      ) {
         throw new Error(
-          `${target.label}/${run.name}: first step was not forced`,
+          `${target.label}/${run.name}: first step used an unexpected tool choice`,
         );
       }
       const laterNonAuto = result.wireRequests


### PR DESCRIPTION
## Summary

- add DeepSeek as a first-class provider preset with its official endpoint, branding, API-key validation, and model discovery
- route DeepSeek through the shared OpenAI-compatible Chat Completions transport so streamed usage, reasoning content, and tool calls use the existing provider architecture
- adapt forced Search requests for DeepSeek thinking mode, which rejects `tool_choice: required`, while preserving thinking and reasoning-content replay across tool-result turns
- vendor DeepSeek model context, capability, and pricing metadata from models.dev
- add DeepSeek to the opt-in live provider smoke suite
- cover catalog metadata, schema validation, authenticated discovery, serialized request compatibility, registry routing, and pricing/context lookup

## Test plan

- `npm run test -w apps/web --` (406 tests)
- `npm run lint -w apps/web --`
- `npm run typecheck -w apps/web --`
- `npm run catalog:check -w apps/web --`
- live authenticated model discovery against `https://api.deepseek.com/models`
- `CACHE_SMOKE_TARGETS=deepseek/deepseek-v4-flash CACHE_SMOKE_CORPUS_WORDS=120 npx tsx --env-file=../../.env scripts/provider-cache-smoke.ts`

## Live verification

The live smoke completed Cold Auto → Warm Auto → Forced Search → Forced Direct URL → Auto After Force. It verified streaming, both tool-result follow-ups, append-only conversation serialization, reasoning replay, and DeepSeek cache accounting (up to 3,712 cache-read tokens in the final turn).

The initial live run exposed DeepSeek V4 thinking-mode incompatibility with forced `tool_choice`. The provider adapter now omits that unsupported field only for forced thinking-mode steps; explicit non-thinking configurations retain strict required tool choice. Both forced prompts selected and executed the intended tool in the passing live run.

## Notes

The official DeepSeek API documents `https://api.deepseek.com` as the OpenAI-compatible base URL and exposes `GET /models` for discovery. The endpoint remains editable for compatible DeepSeek deployments.