### PR TITLE
chore: prepare v0.13.7 release

### DIFF
--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -136,7 +136,7 @@ describe.sequential("connector client compatibility", () => {
     expect(headers.get("x-overtchat-connector-version")).toBe(
       HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     );
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.1");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.2");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/site/lib/install-redirect.test.ts
+++ b/apps/site/lib/install-redirect.test.ts
@@ -296,7 +296,7 @@ describe("Host Connector installer redirect", () => {
     } = createUpgradeFixture("stable");
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Host Connector upgraded to 0.3.1");
+    expect(result.stdout).toContain("Host Connector upgraded to 0.3.2");
     expect(readFileSync(installPath, "utf8")).toBe(newConnector);
     expect(existsSync(`${installPath}.previous`)).toBe(false);
     expect(readFileSync(systemctlCalls, "utf8")).toContain(

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -5,6 +5,7 @@
 /install/connector/0.2.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.2.0/install-connector.sh 302
 /install/connector/0.3.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.0/install-connector.sh 302
 /install/connector/0.3.1 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.1/install-connector.sh 302
+/install/connector/0.3.2 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.2/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.3.1 302
+/install-connector.sh /install/connector/0.3.2 302

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,7 +80,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.1 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.2 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -108,9 +108,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.3.1",
+            version: "0.3.2",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.1 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.2 | sh -s -- --upgrade",
           },
         },
       ],
@@ -122,7 +122,7 @@ describe("Host Connectors route", () => {
       {
         id: "current",
         name: "Current",
-        version: "0.3.1",
+        version: "0.3.2",
         lastSeenAt: null,
       },
       {

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -86,7 +86,7 @@ async function startHostConnector(
   );
   await page.keyboard.press("Escape");
   const command = await page.getByLabel("Host Connector install command").textContent();
-  expect(command).toContain("https://overtchat.com/install/connector/0.3.1");
+  expect(command).toContain("https://overtchat.com/install/connector/0.3.2");
   expect(command).toContain("--server 'http://127.0.0.1:4718'");
   const pairCode = /--pair-code '([^']+)'/u.exec(command ?? "")?.[1];
   if (!pairCode) throw new Error("The Host Connector pairing code was missing.");
@@ -281,7 +281,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
   page,
 }) => {
   const upgradeCommand =
-    "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.1 | sh -s -- --upgrade";
+    "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.2 | sh -s -- --upgrade";
   await page.route("**/api/host-connectors", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -293,7 +293,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
             version: "0.2.0",
             lastSeenAt: Date.now(),
             online: true,
-            upgrade: { version: "0.3.1", command: upgradeCommand },
+            upgrade: { version: "0.3.2", command: upgradeCommand },
           },
         ],
       }),
@@ -309,7 +309,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
   await page.goto("/settings/connections");
 
   await expect(
-    page.getByText("Host Connector 0.3.1 is available", { exact: true }),
+    page.getByText("Host Connector 0.3.2 is available", { exact: true }),
   ).toBeVisible();
   await expect(page.getByLabel("Host Connector upgrade command")).toHaveText(
     upgradeCommand,

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.6}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.7}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -23,7 +23,7 @@ export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
  * wire shape and remains stable even when the connector build version changes.
  */
 export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.2.0";
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.1";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.2";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.3.1"
+connector_version="0.3.2"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

- prepare the app image default for v0.13.7
- bump the Host Connector to v0.3.2 for the Codex usage/compaction fixes in #160
- add the immutable v0.3.2 installer route and update generated install/upgrade expectations
- include first-class DeepSeek support from #161

## Validation

- npm test
- npm run typecheck
- npm run lint
- npm run deps:check
- npm run catalog:check
- npm run build
- E2E_PORT=4743 npm run test:e2e (11 passed, 4 skipped)
- sh -n scripts/install-connector.sh
- APP_VERSION= docker compose config --images