### PR TITLE
feat(agents): add Codex session controls

### DIFF
--- a/apps/web/components/agents/AgentComposerControls.tsx
+++ b/apps/web/components/agents/AgentComposerControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Menu } from "@base-ui/react/menu";
 import {
   ArrowLeft,
@@ -9,12 +10,16 @@ import {
   ChevronDown,
   ChevronRight,
   ListTodo,
+  Shield,
+  ShieldAlert,
+  ShieldCheck,
   X,
   Zap,
 } from "lucide-react";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import { Button } from "@/components/ui/button";
 import type {
+  AgentAccessMode,
   AgentCollaborationMode,
   AgentModel,
   AgentThinkingLevel,
@@ -33,11 +38,14 @@ export interface AgentComposerControlsProps {
   collaborationModes: AgentCollaborationMode[];
   fastModeEnabled: boolean;
   fastModeAvailable: boolean;
+  accessMode: AgentAccessMode;
+  accessModes: AgentAccessMode[];
   disabled: boolean;
   onSelectModel: (model: AgentModel) => void;
   onSelectThinking: (level: AgentThinkingLevel) => void;
   onSelectCollaborationMode: (mode: AgentCollaborationMode) => void;
   onToggleFastMode: (enabled: boolean) => void;
+  onSelectAccessMode: (mode: AgentAccessMode) => void;
   onMenuOpenChange?: (open: boolean) => void;
 }
 
@@ -53,8 +61,9 @@ export function AgentComposerControls(props: AgentComposerControlsProps) {
     (props.thinkingLevels.length > 1 && props.thinkingLevel !== null);
   const hasControls =
     hasModelOrEffort ||
+    props.accessModes.length > 0 ||
     props.collaborationMode === "plan" ||
-    props.fastModeAvailable;
+    props.fastModeEnabled;
 
   if (!hasControls) return null;
 
@@ -64,6 +73,7 @@ export function AgentComposerControls(props: AgentComposerControlsProps) {
       className="flex min-w-0 items-center gap-0.5"
     >
       {hasModelOrEffort && <ModelEffortControl {...props} />}
+      {props.accessModes.length > 0 && <AccessModeControl {...props} />}
       {props.collaborationMode === "plan" && (
         <PlanModeControl
           disabled={props.disabled}
@@ -71,23 +81,178 @@ export function AgentComposerControls(props: AgentComposerControlsProps) {
           onOpenChange={props.onMenuOpenChange}
         />
       )}
-      {props.fastModeAvailable && (
+      {props.fastModeEnabled && props.fastModeAvailable && (
         <Button
           type="button"
-          variant={props.fastModeEnabled ? "secondary" : "ghost"}
+          variant="secondary"
           size="sm"
           className="h-7 px-2"
           aria-pressed={props.fastModeEnabled}
           aria-label="Fast"
           title="Fast mode uses priority inference at higher usage"
           disabled={props.disabled}
-          onClick={() => props.onToggleFastMode(!props.fastModeEnabled)}
+          onClick={() => props.onToggleFastMode(false)}
         >
           <Zap className="size-3.5" />
           <span className="hidden @xl:inline">Fast</span>
         </Button>
       )}
     </div>
+  );
+}
+
+const accessModeMetadata: Record<
+  AgentAccessMode,
+  { label: string; description: string }
+> = {
+  inherit: {
+    label: "Codex default",
+    description: "Use the permissions from your Codex configuration",
+  },
+  default: {
+    label: "Default permissions",
+    description: "Workspace writes; ask before broader access",
+  },
+  "auto-review": {
+    label: "Auto-review",
+    description: "Codex reviews approval requests automatically",
+  },
+  "full-access": {
+    label: "Full access",
+    description: "No sandbox or approval prompts",
+  },
+};
+
+function AccessModeControl(props: AgentComposerControlsProps) {
+  const [fullAccessOpen, setFullAccessOpen] = useState(false);
+  const selected = accessModeMetadata[props.accessMode];
+  const dangerous = props.accessMode === "full-access";
+
+  function select(mode: AgentAccessMode) {
+    if (mode === props.accessMode) return;
+    if (mode === "full-access") {
+      setFullAccessOpen(true);
+      return;
+    }
+    props.onSelectAccessMode(mode);
+  }
+
+  return (
+    <>
+      <Menu.Root onOpenChange={props.onMenuOpenChange}>
+        <Menu.Trigger
+          render={
+            <Button
+              type="button"
+              variant={dangerous ? "destructive" : "ghost"}
+              size="sm"
+              className="h-7 min-w-0 max-w-40 gap-1.5 px-2"
+              aria-label={`Permissions: ${selected.label}`}
+              data-testid="agent-access-mode-trigger"
+              disabled={props.disabled}
+            />
+          }
+        >
+          {dangerous ? (
+            <ShieldAlert className="size-3.5" />
+          ) : props.accessMode === "inherit" ? (
+            <Shield className="size-3.5" />
+          ) : (
+            <ShieldCheck className="size-3.5" />
+          )}
+          <span className="hidden truncate @xl:inline">{selected.label}</span>
+          <ChevronDown className="hidden @xl:block" />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner side="top" align="start" sideOffset={6}>
+            <Menu.Popup
+              aria-label="Permissions"
+              className={cn(
+                "z-50 w-80 max-w-[calc(100vw-1rem)] rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+                motionClasses.popup,
+              )}
+            >
+              {props.accessModes.map((mode) => {
+                const metadata = accessModeMetadata[mode];
+                const isDangerous = mode === "full-access";
+                return (
+                  <Menu.Item
+                    key={mode}
+                    onClick={() => select(mode)}
+                    className={cn(
+                      choiceItemClassName,
+                      isDangerous &&
+                        "text-destructive data-[highlighted]:text-destructive",
+                    )}
+                  >
+                    {isDangerous ? (
+                      <ShieldAlert className="size-4 shrink-0" />
+                    ) : mode === "inherit" ? (
+                      <Shield className="size-4 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <ShieldCheck className="size-4 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-medium">{metadata.label}</span>
+                      <span className="block text-xs text-muted-foreground">
+                        {metadata.description}
+                      </span>
+                    </span>
+                    <span className="flex size-4 shrink-0 items-center justify-center">
+                      {mode === props.accessMode && (
+                        <Check className="size-3.5" />
+                      )}
+                    </span>
+                  </Menu.Item>
+                );
+              })}
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+
+      <AlertDialog.Root open={fullAccessOpen} onOpenChange={setFullAccessOpen}>
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop
+            className={cn(
+              "fixed inset-0 z-50 bg-black/40",
+              motionClasses.overlay,
+            )}
+          />
+          <AlertDialog.Popup
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-5 text-card-foreground shadow-lg outline-none",
+              motionClasses.dialog,
+            )}
+          >
+            <AlertDialog.Title className="text-base font-semibold tracking-tight">
+              Enable Full access?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">
+              Codex will be able to run commands and modify files without
+              sandbox restrictions or approval prompts.
+            </AlertDialog.Description>
+            <div className="mt-5 flex justify-end gap-2">
+              <AlertDialog.Close
+                render={<Button variant="ghost" size="sm" />}
+              >
+                Cancel
+              </AlertDialog.Close>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => {
+                  setFullAccessOpen(false);
+                  props.onSelectAccessMode("full-access");
+                }}
+              >
+                Enable Full access
+              </Button>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+    </>
   );
 }
 

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -17,6 +17,7 @@ import { SidebarToggle } from "@/components/SidebarToggle";
 import { toast } from "@/components/ui/toast";
 import { AGENT_GOAL_STATUSES } from "@overtchat/agent-bridge";
 import type {
+  AgentAccessMode,
   AgentCollaborationMode,
   AgentGoal,
   AgentPromptImage,
@@ -95,6 +96,27 @@ function currentCollaborationMode(
   snapshot: AgentRuntimeSnapshot,
 ): AgentCollaborationMode {
   return snapshot.state.collaborationMode === "plan" ? "plan" : "default";
+}
+
+function accessModes(snapshot: AgentRuntimeSnapshot): AgentAccessMode[] {
+  const value = snapshot.state.accessModes;
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (mode): mode is AgentAccessMode =>
+      mode === "inherit" ||
+      mode === "default" ||
+      mode === "auto-review" ||
+      mode === "full-access",
+  );
+}
+
+function currentAccessMode(snapshot: AgentRuntimeSnapshot): AgentAccessMode {
+  const mode = snapshot.state.accessMode;
+  return mode === "default" ||
+    mode === "auto-review" ||
+    mode === "full-access"
+    ? mode
+    : "inherit";
 }
 
 function currentGoal(snapshot: AgentRuntimeSnapshot): AgentGoal | null {
@@ -304,6 +326,8 @@ export function AgentSessionView({
   const collaborationMode = currentCollaborationMode(snapshot);
   const fastModeEnabled = snapshot.state.fastModeEnabled === true;
   const fastModeAvailable = snapshot.state.fastModeAvailable === true;
+  const availableAccessModes = accessModes(snapshot);
+  const accessMode = currentAccessMode(snapshot);
   const goal = currentGoal(snapshot);
   const runtimeError =
     snapshot.error ??
@@ -328,8 +352,7 @@ export function AgentSessionView({
         : null;
   const composerDisabled =
     exited || Boolean(readOnly) || Boolean(snapshot.pendingInteraction);
-  const controlsDisabled =
-    composerDisabled || running || command.isPending;
+  const controlsDisabled = composerDisabled || command.isPending;
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -461,6 +484,8 @@ export function AgentSessionView({
               collaborationModes: availableCollaborationModes,
               fastModeEnabled,
               fastModeAvailable,
+              accessMode,
+              accessModes: availableAccessModes,
               disabled: controlsDisabled,
               onSelectModel: (selected) =>
                 void run({
@@ -474,6 +499,8 @@ export function AgentSessionView({
                 void run({ type: "set_collaboration_mode", mode }),
               onToggleFastMode: (enabled) =>
                 void run({ type: "set_fast_mode", enabled }),
+              onSelectAccessMode: (mode) =>
+                void run({ type: "set_access_mode", mode }),
               onMenuOpenChange: setComposerMenuOpen,
             }}
             contextUsage={snapshot.stats.contextUsage}

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -102,6 +102,8 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
       collaborationModes: ["default", "plan"],
       fastModeEnabled: false,
       fastModeAvailable: true,
+      accessMode: "inherit",
+      accessModes: ["inherit", "default", "auto-review", "full-access"],
       goalsSupported: true,
       goal: {
         objective: "Finish Codex parity",
@@ -274,7 +276,12 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
     commands: [
       {
         name: "plan",
-        description: "Toggle Plan mode",
+        description: "Enable Plan mode",
+        source: "builtin",
+      },
+      {
+        name: "fast",
+        description: "Enable Fast mode",
         source: "builtin",
       },
     ],
@@ -477,6 +484,9 @@ test("shows durable turn activity without changing completed tool status", async
         }
         if (command.type === "set_fast_mode") {
           snapshot.state.fastModeEnabled = command.enabled;
+        }
+        if (command.type === "set_access_mode") {
+          snapshot.state.accessMode = command.mode;
         }
         if (command.type === "update_goal") {
           if (command.action === "clear") {
@@ -715,11 +725,42 @@ test("shows durable turn activity without changing completed tool status", async
     agentComposer.getByRole("button", {
       name: "Model and effort: GPT-5.6, High",
     }),
-  ).toBeDisabled();
+  ).toBeEnabled();
   await expect(agentComposer.getByRole("button", { name: "Plan mode" })).toHaveCount(0);
   await expect(
     agentComposer.getByRole("button", { name: "Fast", exact: true }),
-  ).toBeDisabled();
+  ).toHaveCount(0);
+  const permissionsControl = agentComposer.getByRole("button", {
+    name: "Permissions: Codex default",
+  });
+  await expect(permissionsControl).toBeEnabled();
+  await permissionsControl.click();
+  await page
+    .getByRole("menu", { name: "Permissions" })
+    .getByRole("menuitem", { name: /Default permissions/u })
+    .click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "set_access_mode",
+    mode: "default",
+  });
+  const defaultPermissionsControl = agentComposer.getByRole("button", {
+    name: "Permissions: Default permissions",
+  });
+  await defaultPermissionsControl.click();
+  await page
+    .getByRole("menu", { name: "Permissions" })
+    .getByRole("menuitem", { name: /Full access/u })
+    .click();
+  const fullAccessDialog = page.getByRole("alertdialog", {
+    name: "Enable Full access?",
+  });
+  await fullAccessDialog
+    .getByRole("button", { name: "Enable Full access" })
+    .click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "set_access_mode",
+    mode: "full-access",
+  });
   await expect(
     agentComposer.getByRole("button", {
       name: /Usage: 42% context used/u,
@@ -1148,8 +1189,8 @@ test("shows durable turn activity without changing completed tool status", async
   ).toBeVisible();
   await page.keyboard.press("Enter");
   await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
-    type: "prompt",
-    message: "/plan",
+    type: "set_collaboration_mode",
+    mode: "plan",
   });
   await page.evaluate((model) => {
     const controls = (
@@ -1171,6 +1212,8 @@ test("shows durable turn activity without changing completed tool status", async
         collaborationModes: ["default", "plan"],
         fastModeEnabled: false,
         fastModeAvailable: true,
+        accessMode: "default",
+        accessModes: ["inherit", "default", "auto-review", "full-access"],
       },
     });
   }, imageModel);
@@ -1222,13 +1265,31 @@ test("shows durable turn activity without changing completed tool status", async
     provider: "codex",
     modelId: "gpt-5.6-mini",
   });
-  await agentComposer
-    .getByRole("button", { name: "Fast", exact: true })
-    .click();
+  await expect(
+    agentComposer.getByRole("button", { name: "Fast", exact: true }),
+  ).toHaveCount(0);
+  await composer.fill("/fast");
+  await expect(
+    page
+      .getByRole("listbox", { name: "Codex commands" })
+      .getByRole("option", { name: /Enable Fast mode/u }),
+  ).toBeVisible();
+  await page.keyboard.press("Enter");
   await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
     type: "set_fast_mode",
     enabled: true,
   });
+  const fastModeControl = agentComposer.getByRole("button", {
+    name: "Fast",
+    exact: true,
+  });
+  await expect(fastModeControl).toBeVisible();
+  await fastModeControl.click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "set_fast_mode",
+    enabled: false,
+  });
+  await expect(fastModeControl).toHaveCount(0);
   await page.getByRole("button", { name: "Pause goal" }).click();
   await expect(page.getByRole("button", { name: "Resume goal" })).toBeVisible();
   await page.getByRole("button", { name: "Resume goal" }).click();

--- a/apps/web/lib/agents/sessionCommands.test.ts
+++ b/apps/web/lib/agents/sessionCommands.test.ts
@@ -59,6 +59,26 @@ describe("commandForAgentSessionSubmit", () => {
     ).toEqual({ type: "queue", message: "Continue with the tests" });
   });
 
+  it("keeps Plan and Fast toggles out of the queue while Codex is working", () => {
+    const working = snapshot({
+      status: "running",
+      state: {
+        collaborationMode: "default",
+        collaborationModes: ["default", "plan"],
+        fastModeAvailable: true,
+        fastModeEnabled: false,
+      },
+    });
+    expect(commandForAgentSessionSubmit(working, "/plan", [])).toEqual({
+      type: "set_collaboration_mode",
+      mode: "plan",
+    });
+    expect(commandForAgentSessionSubmit(working, "/fast", [])).toEqual({
+      type: "set_fast_mode",
+      enabled: true,
+    });
+  });
+
   it("does not intercept usage for providers that do not advertise it", () => {
     expect(
       commandForAgentSessionSubmit(

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -414,6 +414,7 @@ export function useAgentSessionCommand(id: string) {
         command.type === "set_thinking_level" ||
         command.type === "set_collaboration_mode" ||
         command.type === "set_fast_mode" ||
+        command.type === "set_access_mode" ||
         command.type === "update_goal" ||
         command.type === "implement_plan" ||
         command.type === "compact" ||

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -270,6 +270,14 @@ export const AGENT_COLLABORATION_MODES = ["default", "plan"] as const;
 export type AgentCollaborationMode =
   (typeof AGENT_COLLABORATION_MODES)[number];
 
+export const AGENT_ACCESS_MODES = [
+  "inherit",
+  "default",
+  "auto-review",
+  "full-access",
+] as const;
+export type AgentAccessMode = (typeof AGENT_ACCESS_MODES)[number];
+
 export const AGENT_GOAL_STATUSES = [
   "active",
   "paused",
@@ -354,6 +362,10 @@ export const agentSessionCommandSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("set_fast_mode"),
     enabled: z.boolean(),
+  }),
+  z.object({
+    type: z.literal("set_access_mode"),
+    mode: z.enum(AGENT_ACCESS_MODES),
   }),
   z.object({
     type: z.literal("update_goal"),

--- a/packages/agent-bridge/src/commands.test.ts
+++ b/packages/agent-bridge/src/commands.test.ts
@@ -129,6 +129,28 @@ describe("agent slash commands", () => {
       type: "set_auto_compaction",
       enabled: false,
     });
+    expect(
+      normalizeAgentSessionCommand(
+        { type: "prompt", message: "/plan" },
+        {
+          collaborationMode: "default",
+          collaborationModes: ["default", "plan"],
+        },
+      ),
+    ).toEqual({ type: "set_collaboration_mode", mode: "plan" });
+    expect(
+      normalizeAgentSessionCommand(
+        { type: "prompt", message: "/fast" },
+        { fastModeAvailable: true, fastModeEnabled: false },
+      ),
+    ).toEqual({ type: "set_fast_mode", enabled: true });
+  });
+
+  it("only intercepts provider modes when the runtime advertises them", () => {
+    const plan = { type: "prompt" as const, message: "/plan" };
+    const fast = { type: "prompt" as const, message: "/fast" };
+    expect(normalizeAgentSessionCommand(plan, {})).toBe(plan);
+    expect(normalizeAgentSessionCommand(fast, {})).toBe(fast);
   });
 
   it("leaves Pi-discovered commands on the prompt path", () => {

--- a/packages/agent-bridge/src/commands.ts
+++ b/packages/agent-bridge/src/commands.ts
@@ -104,6 +104,24 @@ export function normalizeAgentSessionCommand(
   if (!invocation) return command;
 
   switch (invocation.name) {
+    case "plan": {
+      const modes = Array.isArray(state.collaborationModes)
+        ? state.collaborationModes
+        : [];
+      if (!modes.includes("default") || !modes.includes("plan")) return command;
+      if (invocation.arguments) throw new Error("Usage: /plan");
+      return {
+        type: "set_collaboration_mode",
+        mode: state.collaborationMode === "plan" ? "default" : "plan",
+      };
+    }
+    case "fast":
+      if (state.fastModeAvailable !== true) return command;
+      if (invocation.arguments) throw new Error("Usage: /fast");
+      return {
+        type: "set_fast_mode",
+        enabled: state.fastModeEnabled !== true,
+      };
     case "compact":
       return compactCommand(invocation.arguments);
     case "autocompact":

--- a/packages/agent-bridge/src/state.ts
+++ b/packages/agent-bridge/src/state.ts
@@ -525,6 +525,12 @@ export function applyAgentRuntimeEnvelope(
         ...(typeof event.fastModeAvailable === "boolean"
           ? { fastModeAvailable: event.fastModeAvailable }
           : {}),
+        ...(typeof event.accessMode === "string"
+          ? { accessMode: event.accessMode }
+          : {}),
+        ...(Array.isArray(event.accessModes)
+          ? { accessModes: event.accessModes }
+          : {}),
         ...(typeof event.goalsSupported === "boolean"
           ? { goalsSupported: event.goalsSupported }
           : {}),

--- a/packages/agent-runtime/src/codex/client.test.ts
+++ b/packages/agent-runtime/src/codex/client.test.ts
@@ -47,6 +47,8 @@ class FakeCodexServer {
   collaborationModes: unknown[] = [];
   goalSupported = false;
   goal: Record<string, unknown> | null = null;
+  threadAccess: Record<string, unknown> = {};
+  config: Record<string, unknown> | null = null;
   readonly threadReads = new Map<string, Record<string, unknown>>();
   private notification: Listener<{ method: string; params?: unknown }> =
     () => {};
@@ -91,6 +93,9 @@ class FakeCodexServer {
     }
     if (method === "collaborationMode/list") {
       return { data: this.collaborationModes };
+    }
+    if (method === "config/read") {
+      return this.config ? { config: this.config } : {};
     }
     if (method === "thread/goal/get") {
       if (!this.goalSupported) throw new Error("Method not found");
@@ -195,6 +200,7 @@ class FakeCodexServer {
         },
         model: "gpt-5.6",
         reasoningEffort: "high",
+        ...this.threadAccess,
       };
     }
     if (method === "thread/fork") {
@@ -373,6 +379,8 @@ describe("CodexRuntimeClient", () => {
     server.collaborationModes = [];
     server.goalSupported = false;
     server.goal = null;
+    server.threadAccess = {};
+    server.config = null;
     server.threadReads.clear();
     server.respondError.mockClear();
     mocks.startCodexAppServer.mockResolvedValue(server);
@@ -395,6 +403,11 @@ describe("CodexRuntimeClient", () => {
     );
 
     await expect(client.getCommands()).resolves.toEqual([
+      {
+        name: "fast",
+        description: "Enable Fast mode",
+        source: "builtin",
+      },
       {
         name: "prompts:review",
         description: "Review a path",
@@ -426,6 +439,13 @@ describe("CodexRuntimeClient", () => {
         ],
       },
     });
+    const inheritedTurn = server.requests.at(-1)?.params as Record<
+      string,
+      unknown
+    >;
+    expect(inheritedTurn).not.toHaveProperty("approvalPolicy");
+    expect(inheritedTurn).not.toHaveProperty("sandboxPolicy");
+    expect(inheritedTurn).not.toHaveProperty("approvalsReviewer");
 
     await client.prompt('/prompts:review "src/a b.ts"');
     expect(server.requests.at(-1)).toMatchObject({
@@ -517,8 +537,13 @@ describe("CodexRuntimeClient", () => {
     });
   });
 
-  it("supports native goals, Code/Plan modes, and Fast turns", async () => {
+  it("supports native goals, Code/Plan modes, Fast turns, and access modes", async () => {
     server.goalSupported = true;
+    server.threadAccess = {
+      approvalPolicy: "untrusted",
+      approvalsReviewer: "user",
+      sandbox: { type: "readOnly", networkAccess: false },
+    };
     server.collaborationModes = [
       {
         name: "Code",
@@ -547,6 +572,8 @@ describe("CodexRuntimeClient", () => {
       collaborationModes: ["default", "plan"],
       fastModeEnabled: false,
       fastModeAvailable: true,
+      accessMode: "inherit",
+      accessModes: ["inherit", "default", "auto-review", "full-access"],
       goalsSupported: true,
       goal: null,
     });
@@ -564,17 +591,44 @@ describe("CodexRuntimeClient", () => {
     });
     await expect(client.getCommands()).resolves.toContainEqual({
       name: "plan",
-      description: "Toggle Plan mode",
+      description: "Enable Plan mode",
+      source: "builtin",
+    });
+    await expect(client.getCommands()).resolves.toContainEqual({
+      name: "fast",
+      description: "Enable Fast mode",
       source: "builtin",
     });
 
     await client.setCollaborationMode("plan");
     await client.setFastMode(true);
+    await client.setAccessMode("auto-review");
+    await expect(client.getCommands()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "plan",
+          description: "Disable Plan mode",
+        }),
+        expect.objectContaining({
+          name: "fast",
+          description: "Disable Fast mode",
+        }),
+      ]),
+    );
     await client.prompt("Design the change");
     expect(server.requests.at(-1)).toMatchObject({
       method: "turn/start",
       params: {
         serviceTier: "fast",
+        approvalPolicy: "on-request",
+        approvalsReviewer: "auto_review",
+        sandboxPolicy: {
+          type: "workspaceWrite",
+          writableRoots: [],
+          networkAccess: false,
+          excludeTmpdirEnvVar: false,
+          excludeSlashTmp: false,
+        },
         collaborationMode: {
           mode: "plan",
           settings: {
@@ -583,6 +637,28 @@ describe("CodexRuntimeClient", () => {
             developer_instructions: null,
           },
         },
+      },
+    });
+
+    await client.setAccessMode("full-access");
+    await client.prompt("Apply the approved change");
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: {
+        approvalPolicy: "never",
+        approvalsReviewer: "user",
+        sandboxPolicy: { type: "dangerFullAccess" },
+      },
+    });
+
+    await client.setAccessMode("inherit");
+    await client.prompt("Use my Codex defaults again");
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: {
+        approvalPolicy: "untrusted",
+        approvalsReviewer: "user",
+        sandboxPolicy: { type: "readOnly", networkAccess: false },
       },
     });
 
@@ -609,6 +685,91 @@ describe("CodexRuntimeClient", () => {
     });
     await client.updateGoal("clear");
     await expect(client.getState()).resolves.toMatchObject({ goal: null });
+  });
+
+  it("only advertises Auto-review on supported Codex versions", async () => {
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        detectedVersion: "0.114.0",
+      },
+    );
+
+    await expect(client.getState()).resolves.toMatchObject({
+      accessModes: ["inherit", "default", "full-access"],
+    });
+    await expect(client.setAccessMode("auto-review")).rejects.toThrow(
+      "does not provide Auto-review",
+    );
+  });
+
+  it("restores the effective access mode reported by Codex", async () => {
+    server.threadAccess = {
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      sandbox: { type: "dangerFullAccess" },
+    };
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        detectedVersion: "0.147.0",
+      },
+    );
+
+    await expect(client.getState()).resolves.toMatchObject({
+      accessMode: "full-access",
+    });
+  });
+
+  it("restores Codex configuration when leaving an explicit access mode", async () => {
+    server.config = {
+      approval_policy: "on-request",
+      approvals_reviewer: "user",
+      sandbox_mode: "workspace-write",
+      sandbox_workspace_write: {
+        writable_roots: [],
+        network_access: false,
+        exclude_tmpdir_env_var: false,
+        exclude_slash_tmp: false,
+      },
+    };
+    server.threadAccess = {
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      sandbox: { type: "dangerFullAccess" },
+    };
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      {
+        executable: "codex",
+        cwd: "/workspace",
+        detectedVersion: "0.147.0",
+      },
+    );
+
+    await expect(client.getState()).resolves.toMatchObject({
+      accessMode: "full-access",
+    });
+    await client.setAccessMode("inherit");
+    await client.prompt("Use my configured permissions");
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: {
+        approvalPolicy: "on-request",
+        approvalsReviewer: "user",
+        sandboxPolicy: {
+          type: "workspaceWrite",
+          writableRoots: [],
+          networkAccess: false,
+          excludeTmpdirEnvVar: false,
+          excludeSlashTmp: false,
+        },
+      },
+    });
   });
 
   it("keeps plans, terminal input, and child activity after sparse completion", async () => {

--- a/packages/agent-runtime/src/codex/client.ts
+++ b/packages/agent-runtime/src/codex/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentAccessMode,
   AgentCollaborationMode,
   AgentGoal,
   AgentGoalStatus,
@@ -67,6 +68,7 @@ const MAX_SUBAGENT_HISTORY_THREADS = 100;
 const MAX_PENDING_SUBAGENT_THREADS = 32;
 const MAX_PENDING_SUBAGENT_NOTIFICATIONS = 50;
 const CODEX_GOALS_MIN_VERSION = [0, 128, 0] as const;
+const CODEX_AUTO_REVIEW_MIN_VERSION = [0, 115, 0] as const;
 
 type CodexCollaborationPreset = {
   name: string;
@@ -298,14 +300,70 @@ function codexModelSupportsFastMode(modelId: string): boolean {
 }
 
 function codexVersionSupportsGoals(version: string | null | undefined): boolean {
+  return codexVersionAtLeast(version, CODEX_GOALS_MIN_VERSION);
+}
+
+function codexVersionAtLeast(
+  version: string | null | undefined,
+  minimum: readonly [number, number, number],
+): boolean {
   const match = version?.match(/(\d+)\.(\d+)\.(\d+)/u);
   if (!match) return false;
   const parsed = [Number(match[1]), Number(match[2]), Number(match[3])];
-  for (let index = 0; index < CODEX_GOALS_MIN_VERSION.length; index += 1) {
-    if (parsed[index] > CODEX_GOALS_MIN_VERSION[index]) return true;
-    if (parsed[index] < CODEX_GOALS_MIN_VERSION[index]) return false;
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (parsed[index] > minimum[index]) return true;
+    if (parsed[index] < minimum[index]) return false;
   }
   return true;
+}
+
+function accessModeFromThreadConfiguration(
+  threadResponse: UnknownRecord,
+): AgentAccessMode {
+  const approvalPolicy = stringOf(threadResponse, "approvalPolicy");
+  const approvalsReviewer = stringOf(threadResponse, "approvalsReviewer");
+  const sandbox = recordOf(threadResponse.sandbox);
+  const sandboxType = stringOf(sandbox, "type");
+  if (approvalPolicy === "never" && sandboxType === "dangerFullAccess") {
+    return "full-access";
+  }
+  if (approvalPolicy === "on-request" && sandboxType === "workspaceWrite") {
+    return approvalsReviewer === "auto_review" ? "auto-review" : "default";
+  }
+  return "inherit";
+}
+
+function accessOverridesFromConfig(value: unknown): Record<string, unknown> | null {
+  const config = recordOf(recordOf(value)?.config);
+  if (!config) return null;
+  const approvalPolicy = config.approval_policy;
+  const approvalsReviewer = stringOf(config, "approvals_reviewer");
+  const sandboxMode = stringOf(config, "sandbox_mode");
+  const workspaceWrite = recordOf(config.sandbox_workspace_write);
+  const sandboxPolicy =
+    sandboxMode === "danger-full-access"
+      ? { type: "dangerFullAccess" }
+      : sandboxMode === "read-only"
+        ? { type: "readOnly", networkAccess: false }
+        : sandboxMode === "workspace-write"
+          ? {
+              type: "workspaceWrite",
+              writableRoots: Array.isArray(workspaceWrite?.writable_roots)
+                ? workspaceWrite.writable_roots
+                : [],
+              networkAccess: workspaceWrite?.network_access === true,
+              excludeTmpdirEnvVar:
+                workspaceWrite?.exclude_tmpdir_env_var === true,
+              excludeSlashTmp: workspaceWrite?.exclude_slash_tmp === true,
+            }
+          : null;
+  return {
+    ...(approvalPolicy !== undefined
+      ? { approvalPolicy }
+      : {}),
+    ...(approvalsReviewer ? { approvalsReviewer } : {}),
+    ...(sandboxPolicy ? { sandboxPolicy } : {}),
+  };
 }
 
 function parseGoal(value: unknown): AgentGoal | null {
@@ -863,6 +921,9 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private collaborationModes: CodexCollaborationPreset[] = [];
   private selectedCollaborationMode: AgentCollaborationMode = "default";
   private fastModeEnabled = false;
+  private selectedAccessMode: AgentAccessMode = "inherit";
+  private inheritedAccessOverrides: Record<string, unknown> = {};
+  private configuredAccessOverrides: Record<string, unknown> | null = null;
   private goalsSupported = false;
   private goal: AgentGoal | null = null;
   private modelResponse: unknown = { data: [] };
@@ -915,6 +976,8 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       collaborationModes: this.availableCollaborationModes(),
       fastModeEnabled: this.fastModeEnabled,
       fastModeAvailable: codexModelSupportsFastMode(this.selectedModel),
+      accessMode: this.selectedAccessMode,
+      accessModes: this.availableAccessModes(),
       goalsSupported: this.goalsSupported,
       goal: this.goal,
       ...(this.readOnly
@@ -984,6 +1047,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         ...(this.resolvedCollaborationMode()
           ? { collaborationMode: this.resolvedCollaborationMode() }
           : {}),
+        ...this.accessOverrides(),
       });
       const turn = parseCodexTurn(response.turn);
       this.rememberUserInput(turn.id, input);
@@ -1104,6 +1168,21 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     this.fastModeEnabled = enabled;
     this.emitConfig();
     return { fastModeEnabled: enabled };
+  }
+
+  async setAccessMode(mode: AgentAccessMode): Promise<unknown> {
+    await this.readyPromise;
+    this.assertInteractive();
+    if (!this.availableAccessModes().includes(mode)) {
+      throw new Error(
+        mode === "auto-review"
+          ? "This Codex installation does not provide Auto-review."
+          : `Codex access mode ${mode} is not available.`,
+      );
+    }
+    this.selectedAccessMode = mode;
+    this.emitConfig();
+    return { accessMode: mode };
   }
 
   async updateGoal(
@@ -1408,6 +1487,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private async openThread(): Promise<void> {
     await this.server.ready();
     const modelPromise = this.server.request("model/list", { limit: 200 });
+    const configPromise = this.server.request("config/read", {}).catch(() => null);
     const collaborationModePromise = this.server
       .request("collaborationMode/list", {})
       .catch(() => null);
@@ -1444,6 +1524,9 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       hydratedThread = threadResponse;
     }
     this.modelResponse = await modelPromise;
+    this.configuredAccessOverrides = accessOverridesFromConfig(
+      await configPromise,
+    );
     this.loadCollaborationModes(await collaborationModePromise);
     this.hydrateThread(hydratedThread);
     this.applyThreadConfiguration(threadResponse);
@@ -1467,6 +1550,28 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   }
 
   private applyThreadConfiguration(threadResponse: UnknownRecord): void {
+    const inheritedSandbox = recordOf(threadResponse.sandbox);
+    const effectiveAccessOverrides = {
+      ...(threadResponse.approvalPolicy !== undefined
+        ? { approvalPolicy: threadResponse.approvalPolicy }
+        : {}),
+      ...(typeof threadResponse.approvalsReviewer === "string"
+        ? { approvalsReviewer: threadResponse.approvalsReviewer }
+        : {}),
+      ...(inheritedSandbox ? { sandboxPolicy: inheritedSandbox } : {}),
+    };
+    this.inheritedAccessOverrides =
+      this.configuredAccessOverrides ?? effectiveAccessOverrides;
+    const inheritedAccessMode = accessModeFromThreadConfiguration(threadResponse);
+    const effectiveMatchesConfigured =
+      this.configuredAccessOverrides !== null &&
+      JSON.stringify(effectiveAccessOverrides) ===
+        JSON.stringify(this.configuredAccessOverrides);
+    this.selectedAccessMode = effectiveMatchesConfigured
+      ? "inherit"
+      : this.availableAccessModes().includes(inheritedAccessMode)
+      ? inheritedAccessMode
+      : "inherit";
     this.selectedModel =
       stringOf(threadResponse, "model") ??
       parseCodexModels(this.modelResponse)[0]?.id ??
@@ -2493,7 +2598,21 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         ? [
             {
               name: "plan",
-              description: "Toggle Plan mode",
+              description:
+                this.selectedCollaborationMode === "plan"
+                  ? "Disable Plan mode"
+                  : "Enable Plan mode",
+              source: "builtin" as const,
+            },
+          ]
+        : []),
+      ...(codexModelSupportsFastMode(this.selectedModel)
+        ? [
+            {
+              name: "fast",
+              description: this.fastModeEnabled
+                ? "Disable Fast mode"
+                : "Enable Fast mode",
               source: "builtin" as const,
             },
           ]
@@ -2747,12 +2866,53 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       collaborationModes: this.availableCollaborationModes(),
       fastModeEnabled: this.fastModeEnabled,
       fastModeAvailable: codexModelSupportsFastMode(this.selectedModel),
+      accessMode: this.selectedAccessMode,
+      accessModes: this.availableAccessModes(),
       goalsSupported: this.goalsSupported,
       goal: this.goal,
       ...(this.selectedThinking
         ? { thinkingLevel: this.selectedThinking }
         : {}),
     });
+  }
+
+  private availableAccessModes(): AgentAccessMode[] {
+    return [
+      "inherit",
+      "default",
+      ...(codexVersionAtLeast(
+        this.launch.detectedVersion,
+        CODEX_AUTO_REVIEW_MIN_VERSION,
+      )
+        ? (["auto-review"] as const)
+        : []),
+      "full-access",
+    ];
+  }
+
+  private accessOverrides(): Record<string, unknown> {
+    if (this.selectedAccessMode === "inherit") {
+      return this.inheritedAccessOverrides;
+    }
+    if (this.selectedAccessMode === "full-access") {
+      return {
+        approvalPolicy: "never",
+        approvalsReviewer: "user",
+        sandboxPolicy: { type: "dangerFullAccess" },
+      };
+    }
+    return {
+      approvalPolicy: "on-request",
+      approvalsReviewer:
+        this.selectedAccessMode === "auto-review" ? "auto_review" : "user",
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        writableRoots: [],
+        networkAccess: false,
+        excludeTmpdirEnvVar: false,
+        excludeSlashTmp: false,
+      },
+    };
   }
 
   private emit(event: AgentRuntimeEvent): void {

--- a/packages/agent-runtime/src/providers/codex.test.ts
+++ b/packages/agent-runtime/src/providers/codex.test.ts
@@ -108,4 +108,28 @@ describe("codexProviderAdapter", () => {
       ),
     ).toThrow("does not provide Plan mode");
   });
+
+  it("toggles supported Fast mode out of band", () => {
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/fast" },
+        { fastModeAvailable: true, fastModeEnabled: false },
+      ),
+    ).toEqual({ type: "set_fast_mode", enabled: true });
+    expect(
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/fast" },
+        { fastModeAvailable: true, fastModeEnabled: true },
+      ),
+    ).toEqual({ type: "set_fast_mode", enabled: false });
+  });
+
+  it("rejects /fast when Fast mode is unavailable", () => {
+    expect(() =>
+      codexProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/fast" },
+        { fastModeAvailable: false },
+      ),
+    ).toThrow("does not provide Fast mode");
+  });
 });

--- a/packages/agent-runtime/src/providers/codex.ts
+++ b/packages/agent-runtime/src/providers/codex.ts
@@ -102,6 +102,23 @@ function normalizeCommand(
   if (
     command.type === "prompt" &&
     !command.images?.length &&
+    /^\/fast(?:[^\S\n]+([^\n]*))?$/iu.test(command.message.trim())
+  ) {
+    const argumentsText =
+      /^\/fast(?:[^\S\n]+([^\n]*))?$/iu.exec(command.message.trim())?.[1]?.trim() ??
+      "";
+    if (argumentsText) throw new Error("Usage: /fast");
+    if (state.fastModeAvailable !== true) {
+      throw new Error("This Codex model does not provide Fast mode.");
+    }
+    return {
+      type: "set_fast_mode",
+      enabled: state.fastModeEnabled !== true,
+    };
+  }
+  if (
+    command.type === "prompt" &&
+    !command.images?.length &&
     /^\/usage(?:\s*)$/iu.test(command.message)
   ) {
     return { type: "show_usage" };

--- a/packages/agent-runtime/src/providers/types.ts
+++ b/packages/agent-runtime/src/providers/types.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentAccessMode,
   AgentCollaborationMode,
   AgentConnectionDraft,
   AgentGoal,
@@ -83,6 +84,7 @@ export interface AgentRuntimeClient {
   setThinkingLevel(level: string): Promise<unknown>;
   setCollaborationMode?(mode: AgentCollaborationMode): Promise<unknown>;
   setFastMode?(enabled: boolean): Promise<unknown>;
+  setAccessMode?(mode: AgentAccessMode): Promise<unknown>;
   updateGoal?(
     action: "set" | "pause" | "resume" | "clear",
     objective?: string,

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -484,6 +484,12 @@ export class AgentSessionRuntime {
           ...(typeof event.fastModeAvailable === "boolean"
             ? { fastModeAvailable: event.fastModeAvailable }
             : {}),
+          ...(typeof event.accessMode === "string"
+            ? { accessMode: event.accessMode }
+            : {}),
+          ...(Array.isArray(event.accessModes)
+            ? { accessModes: event.accessModes }
+            : {}),
           ...(typeof event.goalsSupported === "boolean"
             ? { goalsSupported: event.goalsSupported }
             : {}),
@@ -710,6 +716,18 @@ export class AgentSessionRuntime {
           );
         }
         return this.client.setFastMode(command.enabled).then(async (value) => {
+          await this.refresh();
+          return value;
+        });
+      case "set_access_mode":
+        if (!this.client.setAccessMode) {
+          return Promise.reject(
+            new Error(
+              `${agentProviderMetadata(this.provider).label} does not provide access modes.`,
+            ),
+          );
+        }
+        return this.client.setAccessMode(command.mode).then(async (value) => {
           await this.refresh();
           return value;
         });


### PR DESCRIPTION
## Summary

- add a composer permissions selector matching the Paseo-style Default permissions, Auto-review, and Full access modes while preserving Codex configuration as the inherited default
- make /plan and /fast out-of-band next-turn controls, including while a turn or compaction is active
- show /fast in slash autocomplete with state-aware enable/disable copy and only show the Fast toolbar chip while enabled
- keep the effective permission state synchronized across connector events and Codex thread resumes, with explicit confirmation before Full access

## Validation

- npm run test
- npm run typecheck
- npm run lint
- npm run deps:check
- npm run build
- focused Playwright agent runtime flow on an isolated port