### PR TITLE
fix(agents): keep Codex edits in the active session

### DIFF
--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   getOrStart: vi.fn(),
   get: vi.fn(),
+  fork: vi.fn(),
   stopAll: vi.fn(),
   stopSession: vi.fn(),
   stopWorkspace: vi.fn(),
@@ -47,6 +48,7 @@ vi.mock("@overtchat/agent-runtime", async (importOriginal) => {
       create = mocks.create;
       getOrStart = mocks.getOrStart;
       get = mocks.get;
+      fork = mocks.fork;
       stopAll = mocks.stopAll;
       stopSession = mocks.stopSession;
       stopWorkspace = mocks.stopWorkspace;
@@ -192,6 +194,17 @@ beforeEach(() => {
   });
   mocks.getOrStart.mockResolvedValue(runtime());
   mocks.get.mockReturnValue(null);
+  mocks.fork.mockResolvedValue({
+    session: {
+      providerSessionId: "forked-provider-session",
+      providerSessionPath: "/sessions/forked-provider-session.jsonl",
+      name: null,
+      firstMessage: null,
+      messageCount: 0,
+      createdAt: new Date(1_000),
+      modifiedAt: new Date(2_000),
+    },
+  });
   mocks.stopAll.mockResolvedValue(undefined);
   mocks.stopSession.mockResolvedValue(undefined);
   mocks.stopWorkspace.mockResolvedValue(undefined);
@@ -322,6 +335,88 @@ describe("connector daemon command identity", () => {
         success: true,
       }),
     ]);
+    await timelines.close();
+    await journal.close();
+  });
+
+  it("journals an adopted provider thread and resets the existing timeline", async () => {
+    const { file, journal, timelines } = await openJournal();
+    const events: HostConnectorEventPayload[] = [];
+    const openTimeline = vi.spyOn(timelines, "openSession");
+    const activeRuntime = runtime();
+    mocks.getOrStart.mockResolvedValue(activeRuntime);
+    mocks.fork.mockResolvedValueOnce({
+      session: {
+        providerSessionId: "edited-provider-session",
+        providerSessionPath: "/sessions/edited-provider-session.jsonl",
+        name: null,
+        firstMessage: null,
+        messageCount: 0,
+        createdAt: new Date(1_000),
+        modifiedAt: new Date(2_000),
+      },
+      draft: "Rewrite this prompt",
+      replacesCurrentSession: true,
+    });
+    const daemon = new ConnectorDaemon(
+      (event) => events.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+
+    await daemon.handle({
+      type: "request",
+      requestId: "edit-request",
+      request: {
+        type: "session_command",
+        commandId: "edit-command",
+        session,
+        command: {
+          type: "edit_message",
+          messageId: "turn-1:user:0",
+        },
+      },
+    });
+
+    expect(mocks.fork).toHaveBeenCalledWith(activeRuntime, {
+      type: "edit_message",
+      messageId: "turn-1:user:0",
+    });
+    expect(openTimeline).toHaveBeenLastCalledWith(
+      "session",
+      "edited-provider-session",
+      mocks.snapshot(),
+    );
+    await daemon.handle({
+      type: "request",
+      requestId: "stale-open-request",
+      request: { type: "open_session", session },
+    });
+    expect(openTimeline).toHaveBeenCalledTimes(2);
+    const persisted = JSON.parse(await readFile(file, "utf8")) as {
+      sessions: Record<
+        string,
+        { descriptor: AgentDaemonSessionDescriptor }
+      >;
+    };
+    expect(persisted.sessions.session?.descriptor).toMatchObject({
+      sessionId: "session",
+      providerSessionId: "edited-provider-session",
+      providerSessionPath: "/sessions/edited-provider-session.jsonl",
+    });
+    expect(events).toContainEqual({
+      type: "response",
+      requestId: "edit-request",
+      success: true,
+      data: {
+        fork: expect.objectContaining({
+          replacesCurrentSession: true,
+          draft: "Rewrite this prompt",
+        }),
+      },
+    });
+    await daemon.stop();
     await timelines.close();
     await journal.close();
   });

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -35,6 +35,8 @@ type ResolveImages = (
 
 type TimelineCapture = {
   runtime: AgentSessionRuntime;
+  providerSessionId: string;
+  providerSessionPath: string;
   ready: Promise<void>;
   initialized: boolean;
   buffered: AgentRuntimeEnvelope[];
@@ -356,6 +358,7 @@ export class ConnectorDaemon {
           await this.attachTimeline(
             result.runtime,
             result.session.providerSessionId,
+            result.session.providerSessionPath,
           );
           await this.assertRuntimeAccepted(request.sessionId);
           return result;
@@ -491,10 +494,23 @@ export class ConnectorDaemon {
     const runtime = await this.registry.getOrStart(
       sessionDescriptor(descriptor),
     );
+    const capture = this.captures.get(descriptor.sessionId);
+    const attachedDescriptor =
+      capture?.runtime === runtime
+        ? {
+            ...descriptor,
+            providerSessionId: capture.providerSessionId,
+            providerSessionPath: capture.providerSessionPath,
+          }
+        : descriptor;
     await this.assertRuntimeAccepted(descriptor.sessionId);
-    await this.journal.recordSession(descriptor);
+    await this.journal.recordSession(attachedDescriptor);
     await this.assertRuntimeAccepted(descriptor.sessionId);
-    await this.attachTimeline(runtime, descriptor.providerSessionId);
+    await this.attachTimeline(
+      runtime,
+      attachedDescriptor.providerSessionId,
+      attachedDescriptor.providerSessionPath,
+    );
     await this.assertRuntimeAccepted(descriptor.sessionId);
     return runtime;
   }
@@ -537,6 +553,21 @@ export class ConnectorDaemon {
                   queuedMessages: runtime.snapshot().queuedMessages,
                 },
               }));
+        if ("fork" in data && data.fork.replacesCurrentSession) {
+          const descriptor = {
+            ...request.session,
+            providerSessionId: data.fork.session.providerSessionId,
+            providerSessionPath: data.fork.session.providerSessionPath,
+          };
+          this.assertStoresAvailable();
+          await this.journal.recordSession(descriptor);
+          this.assertStoresAvailable();
+          await this.attachTimeline(
+            runtime,
+            descriptor.providerSessionId,
+            descriptor.providerSessionPath,
+          );
+        }
         this.assertStoresAvailable();
         await this.flushCapture(request.session.sessionId);
         this.assertStoresAvailable();
@@ -623,17 +654,29 @@ export class ConnectorDaemon {
   private async attachTimeline(
     runtime: AgentSessionRuntime,
     providerSessionId: string,
+    providerSessionPath: string,
   ): Promise<void> {
     const sessionId = runtime.dbSessionId;
     const existing = this.captures.get(sessionId);
     if (existing?.runtime === runtime) {
       await this.flushCapture(sessionId);
+      if (existing.providerSessionId !== providerSessionId) {
+        await this.timelines.openSession(
+          sessionId,
+          providerSessionId,
+          runtime.snapshot(),
+        );
+        existing.providerSessionId = providerSessionId;
+        existing.providerSessionPath = providerSessionPath;
+      }
       return;
     }
     if (existing) await this.finishCapture(sessionId, false);
 
     const capture: TimelineCapture = {
       runtime,
+      providerSessionId,
+      providerSessionPath,
       ready: Promise.resolve(),
       initialized: false,
       buffered: [],

--- a/apps/web/app/api/agent-sessions/[id]/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   getOwnedAgentSession: vi.fn(),
+  replaceAgentSessionProviderSession: vi.fn(),
   updateAgentSessionMetadata: vi.fn(),
   upsertAgentSession: vi.fn(),
   daemonRequest: vi.fn(),
+  replaceBrokerSession: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -14,11 +16,15 @@ vi.mock("@/lib/auth/server", () => ({
 }));
 vi.mock("@/lib/db/agentConnections", () => ({
   getOwnedAgentSession: mocks.getOwnedAgentSession,
+  replaceAgentSessionProviderSession: mocks.replaceAgentSessionProviderSession,
   updateAgentSessionMetadata: mocks.updateAgentSessionMetadata,
   upsertAgentSession: mocks.upsertAgentSession,
 }));
 vi.mock("@/lib/agents/connector/broker", () => ({
-  hostConnectorBroker: { request: mocks.daemonRequest },
+  hostConnectorBroker: {
+    request: mocks.daemonRequest,
+    replaceSessionProviderSession: mocks.replaceBrokerSession,
+  },
 }));
 
 import { GET, POST } from "./route";
@@ -281,6 +287,85 @@ describe("agent session route", () => {
       command: { type: "show_usage" },
     });
     expect(mocks.updateAgentSessionMetadata).not.toHaveBeenCalled();
+  });
+
+  it("keeps the OvertChat session id when an edit replaces its provider thread", async () => {
+    const providerSession = {
+      providerSessionId: "edited-provider-session",
+      providerSessionPath: "/sessions/edited-provider-session.jsonl",
+      name: null,
+      firstMessage: null,
+      messageCount: 0,
+      createdAt: null,
+      modifiedAt: null,
+    };
+    mocks.daemonRequest.mockResolvedValue({
+      fork: {
+        session: providerSession,
+        draft: "Rewrite this prompt",
+        replacesCurrentSession: true,
+      },
+    });
+
+    const response = await POST(
+      request("POST", {
+        type: "edit_message",
+        messageId: "turn-1:user:0",
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      accepted: true,
+      sessionId: "session",
+      draft: "Rewrite this prompt",
+    });
+    expect(mocks.replaceAgentSessionProviderSession).toHaveBeenCalledWith(
+      "session",
+      providerSession,
+    );
+    expect(mocks.replaceBrokerSession).toHaveBeenCalledWith(
+      "connector",
+      "session",
+      providerSession,
+    );
+    expect(mocks.upsertAgentSession).not.toHaveBeenCalled();
+  });
+
+  it("creates a separate OvertChat session for an explicit conversation fork", async () => {
+    const providerSession = {
+      providerSessionId: "forked-provider-session",
+      providerSessionPath: "/sessions/forked-provider-session.jsonl",
+      name: null,
+      firstMessage: "Original prompt",
+      messageCount: 2,
+      createdAt: null,
+      modifiedAt: null,
+    };
+    mocks.daemonRequest.mockResolvedValue({
+      fork: { session: providerSession },
+    });
+    mocks.upsertAgentSession.mockResolvedValueOnce({ id: "forked-session" });
+
+    const response = await POST(
+      request("POST", {
+        type: "fork_message",
+        messageId: "turn-1:assistant",
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      accepted: true,
+      sessionId: "forked-session",
+    });
+    expect(mocks.upsertAgentSession).toHaveBeenCalledWith(
+      "workspace",
+      providerSession,
+    );
+    expect(mocks.replaceAgentSessionProviderSession).not.toHaveBeenCalled();
   });
 
   it("rejects delivery modes that bypass the connector-owned queue", async () => {

--- a/apps/web/app/api/agent-sessions/[id]/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/agents/connector/descriptors";
 import {
   getOwnedAgentSession,
+  replaceAgentSessionProviderSession,
   type OwnedAgentSession,
   updateAgentSessionMetadata,
   upsertAgentSession,
@@ -151,7 +152,11 @@ export async function POST(
     const result = await hostConnectorBroker.request<{
       commandResult?: unknown;
       snapshot?: { queuedMessages?: unknown[] };
-      fork?: { session: unknown; draft?: string };
+      fork?: {
+        session: unknown;
+        draft?: string;
+        replacesCurrentSession?: boolean;
+      };
     }>(authorized.owned.host.connectorId, {
       type: "session_command",
       commandId: clientMessageId ?? crypto.randomUUID(),
@@ -160,9 +165,27 @@ export async function POST(
       command,
     });
     if (result.fork) {
+      const providerSession = parseProviderSessionMetadata(
+        result.fork.session,
+      );
+      if (result.fork.replacesCurrentSession) {
+        hostConnectorBroker.replaceSessionProviderSession(
+          authorized.owned.host.connectorId,
+          id,
+          providerSession,
+        );
+        await replaceAgentSessionProviderSession(id, providerSession);
+        return Response.json({
+          accepted: true,
+          sessionId: id,
+          ...(result.fork.draft !== undefined
+            ? { draft: result.fork.draft }
+            : {}),
+        });
+      }
       const row = await upsertAgentSession(
         authorized.owned.workspace.id,
-        parseProviderSessionMetadata(result.fork.session),
+        providerSession,
       );
       return Response.json({
         accepted: true,

--- a/apps/web/components/agents/AgentComposer.tsx
+++ b/apps/web/components/agents/AgentComposer.tsx
@@ -79,6 +79,7 @@ export function AgentComposer({
   onDeleteQueued,
   onSteerQueued,
   restoreDraftKey,
+  restoredDraft,
 }: {
   providerLabel: string;
   commands: AgentSlashCommand[];
@@ -100,6 +101,7 @@ export function AgentComposer({
   onDeleteQueued: (id: string) => Promise<boolean>;
   onSteerQueued: (id: string) => Promise<boolean>;
   restoreDraftKey?: string;
+  restoredDraft?: { revision: number; text: string } | null;
 }) {
   const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -153,6 +155,23 @@ export function AgentComposer({
       if (focusFrame !== undefined) cancelAnimationFrame(focusFrame);
     };
   }, [restoreDraftKey]);
+
+  useEffect(() => {
+    if (!restoredDraft) return;
+    let focusFrame: number | undefined;
+    const restoreFrame = requestAnimationFrame(() => {
+      setInput((current) => current || restoredDraft.text);
+      focusFrame = requestAnimationFrame(() => {
+        const element = textareaRef.current;
+        element?.focus({ preventScroll: true });
+        element?.setSelectionRange(element.value.length, element.value.length);
+      });
+    });
+    return () => {
+      cancelAnimationFrame(restoreFrame);
+      if (focusFrame !== undefined) cancelAnimationFrame(focusFrame);
+    };
+  }, [restoredDraft]);
 
   const query = agentSlashCommandQuery(input);
   const filteredCommands = useMemo(() => {

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -110,7 +110,10 @@ export function AgentMessageList({
   );
 
   return (
-    <div className="relative min-h-0 flex-1 overflow-hidden">
+    <div
+      className="relative min-h-0 flex-1 overflow-hidden"
+      data-testid="agent-message-list"
+    >
       <div
         ref={scrollRef}
         className="h-full overflow-y-auto overscroll-contain"

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -172,6 +172,10 @@ export function AgentSessionView({
   const [usageError, setUsageError] = useState("");
   const [dialogError, setDialogError] = useState("");
   const [composerMenuOpen, setComposerMenuOpen] = useState(false);
+  const [restoredDraft, setRestoredDraft] = useState<{
+    revision: number;
+    text: string;
+  } | null>(null);
   const snapshot = session.data;
 
   useEffect(() => {
@@ -197,10 +201,18 @@ export function AgentSessionView({
         if (!result.sessionId) {
           throw new Error(`${providerLabel} did not return the forked session.`);
         }
-        if (result.draft !== undefined) {
+        const draft = result.draft;
+        if (draft !== undefined) {
+          if (result.sessionId === sessionId) {
+            setRestoredDraft((current) => ({
+              revision: (current?.revision ?? 0) + 1,
+              text: draft,
+            }));
+            return true;
+          }
           window.sessionStorage.setItem(
             forkDraftKey(result.sessionId),
-            result.draft,
+            draft,
           );
         }
         router.push(`/agents/${result.sessionId}`);
@@ -516,6 +528,7 @@ export function AgentSessionView({
               run({ type: "steer_queued_message", id })
             }
             restoreDraftKey={forkDraftKey(sessionId)}
+            restoredDraft={restoredDraft}
           />
         </div>
       </div>

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -117,6 +117,7 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
     },
     messages: [
       {
+        id: "turn-1:user:0",
         role: "user",
         content: "Inspect the runtime",
         timestamp: 1,
@@ -538,6 +539,12 @@ test("shows durable turn activity without changing completed tool status", async
           contentType: "application/json",
           body: JSON.stringify({
             accepted: true,
+            ...(command.type === "edit_message"
+              ? {
+                  sessionId: SESSION_ID,
+                  draft: "Inspect the runtime",
+                }
+              : {}),
             ...(command.type === "show_usage"
               ? { usage: { planType: "plus", windows: [] } }
               : {}),
@@ -1146,6 +1153,18 @@ test("shows durable turn activity without changing completed tool status", async
   snapshot.status = "idle";
   snapshot.activeTurn = null;
   snapshot.state.isStreaming = false;
+  const sessionUrl = page.url();
+  await page
+    .getByRole("button", { name: "Edit from this message" })
+    .click();
+  await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
+    type: "edit_message",
+    messageId: "turn-1:user:0",
+  });
+  await expect(composer).toHaveValue("Inspect the runtime");
+  await expect(page).toHaveURL(sessionUrl);
+  await expect(composer).toBeFocused();
+  await composer.fill("");
   const modelEffortControl = agentComposer.getByRole("button", {
     name: "Model and effort: GPT-5.6, High",
   });

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -773,7 +773,7 @@ test("connect local Oh My Pi and use its native commands", async ({
 test("connect local Codex and resume a native thread", async ({
   page,
 }, testInfo) => {
-  test.setTimeout(240_000);
+  test.setTimeout(360_000);
   test.skip(
     process.env.RUN_CODEX_E2E !== "1",
     "Set RUN_CODEX_E2E=1 on a machine with Codex installed and signed in.",
@@ -864,33 +864,6 @@ test("connect local Codex and resume a native thread", async ({
 
   const sourceUrl = page.url();
   await page
-    .getByRole("button", { name: "Edit from this message" })
-    .click();
-  await page.waitForURL(
-    (url) =>
-      url.pathname.startsWith("/agents/") && url.href !== sourceUrl,
-    { timeout: 30_000 },
-  );
-  await expect(composer).toHaveValue(prompt, { timeout: 30_000 });
-  await expect(composer).toBeFocused();
-  await expect
-    .poll(() =>
-      composer.evaluate((element) => {
-        const textarea = element as HTMLTextAreaElement;
-        return [textarea.selectionStart, textarea.selectionEnd];
-      }),
-    )
-    .toEqual([prompt.length, prompt.length]);
-
-  await page.goto(sourceUrl);
-  await expect(
-    page.locator("main").getByText(prompt, { exact: true }),
-  ).toBeVisible({ timeout: 60_000 });
-  await expect(
-    page.getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
-  ).toBeVisible({ timeout: 60_000 });
-
-  await page
     .getByRole("button", { name: "Fork from this response" })
     .click();
   await page.waitForURL(
@@ -930,6 +903,39 @@ test("connect local Codex and resume a native thread", async ({
     path: testInfo.outputPath("codex-forked-session-mobile.png"),
     fullPage: true,
   });
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(sourceUrl);
+  await page
+    .getByRole("button", { name: "Edit from this message" })
+    .click();
+  await expect(composer).toHaveValue(prompt, { timeout: 30_000 });
+  await expect(page).toHaveURL(sourceUrl);
+  await expect(composer).toBeFocused();
+  await expect
+    .poll(() =>
+      composer.evaluate((element) => {
+        const textarea = element as HTMLTextAreaElement;
+        return [textarea.selectionStart, textarea.selectionEnd];
+      }),
+    )
+    .toEqual([prompt.length, prompt.length]);
+  await expect(
+    page.getByRole("region", { name: "Read-only Codex session" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("agent-message-list").getByText(prompt, { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page
+      .getByTestId("agent-message-list")
+      .getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
+  ).toHaveCount(0);
+  await composer.press("Enter");
+  await expect(
+    page.getByText("OVERTCHAT_CODEX_E2E_OK", { exact: true }),
+  ).toBeVisible({ timeout: 150_000 });
+  await expect(composer).toBeEnabled({ timeout: 30_000 });
   expect(browserErrors).toEqual([]);
 });
 

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -645,6 +645,10 @@ describe("host connector daemon broker", () => {
     expect(subscription.sync).toEqual(initialSync);
     expect(subscription.authoritative).toBe(true);
     expect(broker.runtimeStatusForSession("session")).toBe("running");
+    broker.replaceSessionProviderSession("connector", "session", {
+      providerSessionId: "edited-thread",
+      providerSessionPath: "/edited-thread.jsonl",
+    });
     unregister();
 
     broker.register(
@@ -673,6 +677,10 @@ describe("host connector daemon broker", () => {
     if (reconnect.request.type !== "subscribe_session") {
       throw new Error("missing reconnect subscription");
     }
+    expect(reconnect.request.session).toMatchObject({
+      providerSessionId: "edited-thread",
+      providerSessionPath: "/edited-thread.jsonl",
+    });
     await broker.acceptBatch("connector", "transport", [
       {
         sequence: 2,

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -73,6 +73,28 @@ export class HostConnectorBroker {
     return this.sessionStatuses.get(sessionId) ?? "idle";
   }
 
+  replaceSessionProviderSession(
+    connectorId: string,
+    sessionId: string,
+    providerSession: Pick<
+      AgentDaemonSessionDescriptor,
+      "providerSessionId" | "providerSessionPath"
+    >,
+  ): void {
+    for (const subscription of this.subscriptions.values()) {
+      if (
+        subscription.connectorId !== connectorId ||
+        subscription.session.sessionId !== sessionId
+      ) {
+        continue;
+      }
+      subscription.session = {
+        ...subscription.session,
+        ...providerSession,
+      };
+    }
+  }
+
   register(
     connectorId: string,
     activeSessionIds: string[],

--- a/apps/web/lib/db/agentConnections.test.ts
+++ b/apps/web/lib/db/agentConnections.test.ts
@@ -233,6 +233,47 @@ describe("agent connection persistence", () => {
     });
   });
 
+  it("replaces a session's provider identity without changing its OvertChat id", async () => {
+    const owned = createAliceConnection();
+    const workspace = await repository.createAgentWorkspace(
+      owned.connection.id,
+      "alice",
+      { path: "/work/overtchat", name: "overtchat" },
+    );
+    const original = await repository.upsertAgentSession(workspace!.id, {
+      providerSessionId: "source-thread",
+      providerSessionPath: "/codex/source-thread.jsonl",
+      name: "Original thread",
+      firstMessage: "Original prompt",
+      messageCount: 4,
+      createdAt: new Date(1_000),
+      modifiedAt: new Date(2_000),
+    });
+
+    await repository.replaceAgentSessionProviderSession(original.id, {
+      providerSessionId: "edited-thread",
+      providerSessionPath: "/codex/edited-thread.jsonl",
+      name: null,
+      firstMessage: null,
+      messageCount: 0,
+      createdAt: new Date(3_000),
+      modifiedAt: new Date(4_000),
+    });
+
+    await expect(
+      repository.getOwnedAgentSession(original.id, "alice"),
+    ).resolves.toMatchObject({
+      agentSession: {
+        id: original.id,
+        providerSessionId: "edited-thread",
+        providerSessionPath: "/codex/edited-thread.jsonl",
+        name: null,
+        firstMessage: null,
+        messageCount: 0,
+      },
+    });
+  });
+
   it("enforces ownership through every level and cascades only local rows", async () => {
     const owned = createAliceConnection();
     const workspace = await repository.createAgentWorkspace(

--- a/apps/web/lib/db/agentConnections.ts
+++ b/apps/web/lib/db/agentConnections.ts
@@ -428,6 +428,27 @@ export async function upsertAgentSession(
   return row;
 }
 
+export async function replaceAgentSessionProviderSession(
+  id: string,
+  session: ProviderSessionMetadata,
+): Promise<void> {
+  const now = new Date();
+  await db
+    .update(agentSessions)
+    .set({
+      providerSessionId: session.providerSessionId,
+      providerSessionPath: session.providerSessionPath,
+      name: session.name,
+      firstMessage: session.firstMessage,
+      messageCount: session.messageCount,
+      providerCreatedAt: session.createdAt,
+      providerModifiedAt: session.modifiedAt,
+      lastSyncedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(agentSessions.id, id));
+}
+
 export async function updateAgentSessionMetadata(
   id: string,
   patch: {

--- a/packages/agent-runtime/src/codex/client.test.ts
+++ b/packages/agent-runtime/src/codex/client.test.ts
@@ -2265,6 +2265,7 @@ describe("CodexRuntimeClient", () => {
         modifiedAt: new Date(4_000),
       },
       draft: "Resume this thread",
+      replacesCurrentSession: true,
     });
     expect(server.requests).toContainEqual({
       method: "thread/fork",
@@ -2278,24 +2279,27 @@ describe("CodexRuntimeClient", () => {
     });
     expect(server.requests).toContainEqual({
       method: "thread/unsubscribe",
-      params: { threadId: "thread-fork" },
+      params: { threadId: "thread-1" },
     });
-    await expect(client.getMessages()).resolves.toMatchObject({
-      messages: expect.arrayContaining([
-        expect.objectContaining({ id: "turn-history:user:0", role: "user" }),
-        expect.objectContaining({
-          id: "commentary-history",
-          role: "assistant",
-        }),
-        expect.objectContaining({
-          id: "assistant-history",
-          role: "assistant",
-        }),
-        expect.objectContaining({
-          id: "turn-history:footer",
-          role: "turnFooter",
-        }),
-      ]),
+    await expect(client.getState()).resolves.toMatchObject({
+      sessionId: "thread-fork",
+      sessionFile: "/tmp/thread-fork.jsonl",
+    });
+    await expect(client.getMessages()).resolves.toEqual({ messages: [] });
+
+    await client.prompt("Replace the first message");
+    expect(server.requests).toContainEqual({
+      method: "turn/start",
+      params: expect.objectContaining({
+        threadId: "thread-fork",
+        input: [
+          {
+            type: "text",
+            text: "Replace the first message",
+            text_elements: [],
+          },
+        ],
+      }),
     });
   });
 

--- a/packages/agent-runtime/src/codex/client.ts
+++ b/packages/agent-runtime/src/codex/client.ts
@@ -1402,6 +1402,7 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       throw new Error("Wait for the current Codex turn to finish first.");
     }
 
+    const sourceThreadId = this.thread!.id;
     const turns = this.orderedTurns();
     let response: UnknownRecord;
     let draft: string | undefined;
@@ -1459,8 +1460,28 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     }
 
     const thread = parseCodexThread(response.thread);
-    if (thread.id === this.thread!.id) {
+    if (thread.id === sourceThreadId) {
       throw new Error("Codex did not create a new thread.");
+    }
+    if (mode === "edit") {
+      this.hydrateThread(response);
+      this.applyThreadConfiguration(response);
+      this.readOnly = false;
+      this.threadSubscribed = true;
+      await this.hydrateSubagentHistories();
+      await this.loadGoal();
+      await this.server
+        .request(
+          "thread/unsubscribe",
+          { threadId: sourceThreadId },
+          5_000,
+        )
+        .catch(() => {});
+      return {
+        session: codexSessionMetadata(thread),
+        draft,
+        replacesCurrentSession: true,
+      };
     }
     await this.server.request(
       "thread/unsubscribe",
@@ -1469,7 +1490,6 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     );
     return {
       session: codexSessionMetadata(thread),
-      ...(draft !== undefined ? { draft } : {}),
     };
   }
 

--- a/packages/agent-runtime/src/providers/types.ts
+++ b/packages/agent-runtime/src/providers/types.ts
@@ -51,6 +51,7 @@ export type AgentSessionLaunch = {
 export type AgentSessionForkResult = {
   session: AgentProviderSessionMetadata;
   draft?: string;
+  replacesCurrentSession?: boolean;
 };
 
 export type ResolvedAgentImage = AgentPromptImage & {

--- a/packages/agent-runtime/src/runtime/registry.test.ts
+++ b/packages/agent-runtime/src/runtime/registry.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   prompt: vi.fn(),
   steer: vi.fn(),
   abort: vi.fn(),
+  forkSession: vi.fn(),
   stop: vi.fn(),
   saveQueue: vi.fn(),
   getState: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock("@overtchat/agent-runtime/providers/registry", () => ({
       prompt: mocks.prompt,
       steer: mocks.steer,
       abort: mocks.abort,
+      forkSession: mocks.forkSession,
       stop: mocks.stop,
     }),
     sessionIdentity: () => ({
@@ -84,6 +86,17 @@ describe("agent runtime", () => {
     mocks.prompt.mockResolvedValue({ accepted: true });
     mocks.steer.mockResolvedValue({ accepted: true });
     mocks.abort.mockResolvedValue({ interrupted: true });
+    mocks.forkSession.mockResolvedValue({
+      session: {
+        providerSessionId: "forked-provider-session",
+        providerSessionPath: "/sessions/forked-provider-session.jsonl",
+        name: null,
+        firstMessage: null,
+        messageCount: 0,
+        createdAt: null,
+        modifiedAt: null,
+      },
+    });
     mocks.stop.mockResolvedValue(undefined);
     mocks.saveQueue.mockResolvedValue(undefined);
     mocks.getState.mockResolvedValue({
@@ -93,6 +106,72 @@ describe("agent runtime", () => {
     });
     mocks.getMessages.mockResolvedValue({ messages: [] });
     mocks.eventSubscriber = null;
+  });
+
+  it("refreshes the existing runtime after adopting an edited provider session", async () => {
+    mocks.getState
+      .mockResolvedValueOnce({
+        isStreaming: false,
+        sessionId: "provider-session",
+        sessionFile: "/sessions/provider-session.jsonl",
+      })
+      .mockResolvedValueOnce({
+        isStreaming: false,
+        sessionId: "edited-provider-session",
+        sessionFile: "/sessions/edited-provider-session.jsonl",
+      });
+    mocks.getMessages
+      .mockResolvedValueOnce({
+        messages: [{ id: "source-user", role: "user", content: "Original" }],
+      })
+      .mockResolvedValueOnce({ messages: [] });
+    mocks.forkSession.mockResolvedValueOnce({
+      session: {
+        providerSessionId: "edited-provider-session",
+        providerSessionPath: "/sessions/edited-provider-session.jsonl",
+        name: null,
+        firstMessage: null,
+        messageCount: 0,
+        createdAt: null,
+        modifiedAt: null,
+      },
+      draft: "Original",
+      replacesCurrentSession: true,
+    });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      saveQueuedMessages: mocks.saveQueue,
+    });
+    const runtime = await registry.getOrStart({
+      sessionId: "session",
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+    });
+
+    await expect(
+      registry.fork(runtime, {
+        type: "edit_message",
+        messageId: "source-user",
+      }),
+    ).resolves.toMatchObject({
+      replacesCurrentSession: true,
+      draft: "Original",
+    });
+
+    expect(runtime.snapshot()).toMatchObject({
+      sessionId: "session",
+      state: {
+        sessionId: "edited-provider-session",
+        sessionFile: "/sessions/edited-provider-session.jsonl",
+      },
+      messages: [],
+    });
   });
 
   it("removes a restored send already accepted by the provider", async () => {

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -845,7 +845,9 @@ export class AgentSessionRuntime {
         `${agentProviderMetadata(this.provider).label} does not support conversation forks.`,
       );
     }
-    return this.client.forkSession(messageId, mode);
+    const result = await this.client.forkSession(messageId, mode);
+    if (result.replacesCurrentSession) await this.refresh();
+    return result;
   }
 
   async discardForkedSession(


### PR DESCRIPTION
## Summary

- adopt an edited Codex thread inside the current app-server process while preserving the existing OvertChat session ID and URL
- reset the connector timeline and persisted provider identity, then restore the edited prompt in the composer
- keep explicit forks as separate sessions and prevent stale stream descriptors from reverting an adopted edit after reconnect

## Why

Editing previously forked the Codex thread, unsubscribed it, navigated to a new OvertChat session, and started another app-server process to resume it. Because Codex keeps an unsubscribed thread loaded for an inactivity grace period, the original process could still hold the writer lease and the replacement process could resume read-only.

The new lifecycle keeps the connected app-server, adopts the forked thread in place, refreshes the active runtime, and restores the edited user message in the composer. This follows the lifecycle described in the [OpenAI app-server documentation](https://learn.chatgpt.com/docs/app-server#api-overview).

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build -w apps/connector`
- `RUN_CODEX_E2E=1 E2E_PORT=4720 npm run test:e2e -w apps/web -- --grep "connect local Codex and resume a native thread"`

The live Codex flow verifies that editing stays on the same URL, removes the rolled-back transcript, restores and focuses the draft, avoids read-only mode, and successfully submits the replacement prompt.
