### PR TITLE
feat(models): add dedicated task model

### DIFF
--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -6,6 +6,14 @@ import { AlertDialog } from "@base-ui/react/alert-dialog";
 import { Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/toast";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
@@ -15,19 +23,25 @@ import { getProvider, modelIconForModel } from "@/lib/providers/catalog";
 import {
   useAdminModelConfigs,
   useDeleteModelConfig,
+  useSetTaskModel,
   useUpdateModelConfig,
 } from "@/lib/queries/modelConfigs";
 import { cn } from "@/lib/utils";
 import {
   SettingsNotice,
   SettingsPageHeader,
+  SettingsRow,
+  SettingsSection,
 } from "../_components/SettingsRows";
 import { HealthBadge } from "./HealthBadge";
 import { motionClasses } from "@/lib/motion";
 
+const ACTIVE_CHAT_MODEL = "__active-chat-model__";
+
 export function ModelsPanel() {
   const { data: models = [] } = useAdminModelConfigs();
   const deleteMut = useDeleteModelConfig();
+  const taskModelMut = useSetTaskModel();
   const updateMut = useUpdateModelConfig();
 
   const [query, setQuery] = useState("");
@@ -36,6 +50,7 @@ export function ModelsPanel() {
   );
   const [deleteError, setDeleteError] = useState("");
   const [togglingId, setTogglingId] = useState<string | null>(null);
+  const taskModel = models.find((model) => model.taskModel) ?? null;
 
   const filteredModels = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -50,6 +65,7 @@ export function ModelsPanel() {
         host,
         provider.label,
         m.enabled ? "enabled" : "disabled",
+        m.taskModel ? "task" : "",
       ]
         .join(" ")
         .toLowerCase()
@@ -107,11 +123,25 @@ export function ModelsPanel() {
     }
   }
 
+  async function selectTaskModel(value: string | null) {
+    if (!value) return;
+    const modelConfigId = value === ACTIVE_CHAT_MODEL ? null : value;
+    if (modelConfigId === (taskModel?.id ?? null)) return;
+    try {
+      await taskModelMut.mutateAsync(modelConfigId);
+    } catch (err) {
+      toast.error({
+        title: "Failed to update task model",
+        description: getErrorMessage(err, "The task model was not changed."),
+      });
+    }
+  }
+
   return (
     <div className="@container max-w-4xl space-y-6">
       <SettingsPageHeader
         title="Models"
-        description="Manage the models available in chat."
+        description="Manage models used in chat and background tasks."
         action={
           models.length > 0 ? (
             <Button render={<Link href="/settings/models/new" />} size="sm">
@@ -120,6 +150,57 @@ export function ModelsPanel() {
           ) : undefined
         }
       />
+
+      {models.length > 0 && (
+        <SettingsSection
+          title="Background tasks"
+          description="Choose how lightweight model work is handled across this server."
+        >
+          <SettingsRow
+            title="Task model"
+            description="Used to generate chat titles. A fast, inexpensive, non-reasoning model works best."
+            align="center"
+            controlAlign="end"
+          >
+            <Select
+              value={taskModel?.id ?? ACTIVE_CHAT_MODEL}
+              onValueChange={(value) => void selectTaskModel(value)}
+              disabled={taskModelMut.isPending}
+            >
+              <SelectTrigger
+                aria-label="Task model"
+                className="w-full @2xl:w-72"
+              >
+                <SelectValue>
+                  {taskModel ? taskModel.label : "Same as chat model"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ACTIVE_CHAT_MODEL}>
+                  Same as chat model
+                </SelectItem>
+                <SelectSeparator />
+                {models.map((model) => {
+                  const provider = getProvider(model.providerId);
+                  const iconId =
+                    modelIconForModel(model.model) ?? provider.iconId;
+                  return (
+                    <SelectItem key={model.id} value={model.id}>
+                      <ModelBrandIcon iconId={iconId} className="size-4" />
+                      <span>{model.label}</span>
+                      {!model.enabled && (
+                        <span className="text-xs text-muted-foreground">
+                          Not in chat
+                        </span>
+                      )}
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </SettingsRow>
+        </SettingsSection>
+      )}
 
       {models.length > 0 && (
         <div className="flex flex-col gap-3 @2xl:flex-row @2xl:items-center @2xl:justify-between">
@@ -180,7 +261,15 @@ export function ModelsPanel() {
                       <span className="min-w-0 truncate text-sm font-medium text-foreground">
                         {m.label}
                       </span>
-                      <HealthBadge id={m.id} enabled={m.enabled} />
+                      {m.taskModel && (
+                        <span className="rounded-full border bg-accent/50 px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                          Task
+                        </span>
+                      )}
+                      <HealthBadge
+                        id={m.id}
+                        enabled={m.enabled || m.taskModel}
+                      />
                     </div>
                     <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
                       <span>{provider.label}</span>
@@ -275,6 +364,8 @@ export function ModelsPanel() {
                 {pendingDelete?.label}
               </span>{" "}
               will be removed from chat. Existing chats keep their messages.
+              {pendingDelete?.taskModel &&
+                " Background tasks will return to using the active chat model."}
             </AlertDialog.Description>
             {deleteError && (
               <SettingsNotice tone="error" className="mt-3 text-xs">

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => {
     getChatMessage: vi.fn(),
     inlineUploads: vi.fn(),
     getModelConfig: vi.fn(),
+    getTaskModelConfig: vi.fn(),
     getProject: vi.fn(),
     generateChatTitle: vi.fn(),
     getProvider: vi.fn(),
@@ -103,6 +104,7 @@ vi.mock("@/lib/db/chatTurns", () => ({
 vi.mock("@/lib/db/uploads", () => ({ inlineUploads: mocks.inlineUploads }));
 vi.mock("@/lib/db/modelConfigs", () => ({
   getModelConfig: mocks.getModelConfig,
+  getTaskModelConfig: mocks.getTaskModelConfig,
 }));
 vi.mock("@/lib/db/projects", () => ({ getProject: mocks.getProject }));
 vi.mock("@/lib/title", () => ({
@@ -204,6 +206,7 @@ describe("chat route setup boundary", () => {
     mocks.getSession.mockResolvedValue({ user: { id: "user" } });
     mocks.parseChatRequest.mockResolvedValue({ ...parsedRequest });
     mocks.getModelConfig.mockResolvedValue({ ...modelConfig });
+    mocks.getTaskModelConfig.mockReturnValue(null);
     mocks.getChat.mockResolvedValue(null);
     mocks.getProject.mockResolvedValue(null);
     mocks.getChatMessage.mockResolvedValue(null);
@@ -759,11 +762,31 @@ describe("chat route setup boundary", () => {
     expect(mocks.generateChatTitle).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user",
+        modelConfig,
         userParts: messages[0].parts,
       }),
     );
     expect(messages).toEqual(originalMessages);
     expect(mocks.agentSettings[0]).not.toHaveProperty("runtimeContext");
+  });
+
+  it("uses a dedicated task model for title generation even when hidden from chat", async () => {
+    const taskModelConfig = {
+      ...modelConfig,
+      id: "task-model",
+      label: "Fast task model",
+      model: "fast-model",
+      enabled: false,
+      taskModel: true,
+    };
+    mocks.getTaskModelConfig.mockReturnValue(taskModelConfig);
+
+    await POST(request());
+
+    expect(mocks.getTaskModelConfig).toHaveBeenCalledOnce();
+    expect(mocks.generateChatTitle).toHaveBeenCalledWith(
+      expect.objectContaining({ modelConfig: taskModelConfig }),
+    );
   });
 
   it("emits provider cache token details in finish metadata", async () => {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -33,7 +33,10 @@ import {
   type CompletedGenerationUsage,
 } from "@/lib/db/chatTurns";
 import { inlineUploads } from "@/lib/db/uploads";
-import { getModelConfig } from "@/lib/db/modelConfigs";
+import {
+  getModelConfig,
+  getTaskModelConfig,
+} from "@/lib/db/modelConfigs";
 import { getProject } from "@/lib/db/projects";
 import { generateChatTitle } from "@/lib/title";
 import { getProvider, modelIconForModel } from "@/lib/providers/catalog";
@@ -293,10 +296,11 @@ async function handlePost(req: Request): Promise<Response> {
       messageId === undefined &&
       userMessageCount === 1
     ) {
+      const titleModelConfig = getTaskModelConfig() ?? modelConfig;
       titlePromise = generateChatTitle({
         chatId,
         userId,
-        modelConfig,
+        modelConfig: titleModelConfig,
         userParts: last.parts,
       });
     }

--- a/apps/web/app/api/model-configs/task-model/route.test.ts
+++ b/apps/web/app/api/model-configs/task-model/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  setTaskModelConfig: vi.fn(),
+  toAdminModelConfig: vi.fn((row) => row),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/modelConfigs", () => ({
+  setTaskModelConfig: mocks.setTaskModelConfig,
+  toAdminModelConfig: mocks.toAdminModelConfig,
+}));
+
+import { PUT } from "./route";
+
+function request(modelConfigId: unknown = "task-model"): Request {
+  return new Request("http://server.test/api/model-configs/task-model", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ modelConfigId }),
+  });
+}
+
+describe("task model selection", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "admin", role: "admin" },
+    });
+    mocks.setTaskModelConfig.mockReturnValue({
+      status: "updated",
+      modelConfig: {
+        id: "task-model",
+        label: "Fast model",
+        enabled: false,
+        taskModel: true,
+      },
+    });
+  });
+
+  it("allows an administrator to select a model hidden from chat", async () => {
+    const response = await PUT(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.setTaskModelConfig).toHaveBeenCalledWith("task-model");
+    await expect(response.json()).resolves.toMatchObject({
+      taskModel: {
+        id: "task-model",
+        enabled: false,
+        taskModel: true,
+      },
+    });
+  });
+
+  it("clears the dedicated task model", async () => {
+    mocks.setTaskModelConfig.mockReturnValue({
+      status: "updated",
+      modelConfig: null,
+    });
+
+    const response = await PUT(request(null));
+
+    expect(response.status).toBe(200);
+    expect(mocks.setTaskModelConfig).toHaveBeenCalledWith(null);
+    await expect(response.json()).resolves.toEqual({ taskModel: null });
+  });
+
+  it("rejects an unknown model", async () => {
+    mocks.setTaskModelConfig.mockReturnValue({ status: "not_found" });
+
+    const response = await PUT(request("missing"));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Model config not found",
+    });
+  });
+
+  it("requires an administrator", async () => {
+    mocks.getSession.mockResolvedValue({
+      user: { id: "user", role: "user" },
+    });
+
+    const response = await PUT(request());
+
+    expect(response.status).toBe(403);
+    expect(mocks.setTaskModelConfig).not.toHaveBeenCalled();
+  });
+
+  it("validates the request body", async () => {
+    const response = await PUT(request(42));
+
+    expect(response.status).toBe(400);
+    expect(mocks.setTaskModelConfig).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/model-configs/task-model/route.ts
+++ b/apps/web/app/api/model-configs/task-model/route.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { auth } from "@/lib/auth/server";
+import {
+  setTaskModelConfig,
+  toAdminModelConfig,
+} from "@/lib/db/modelConfigs";
+
+const TaskModelSelectionSchema = z.object({
+  modelConfigId: z.string().trim().min(1).nullable(),
+});
+
+export async function PUT(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = TaskModelSelectionSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input" },
+      { status: 400 },
+    );
+  }
+
+  const result = setTaskModelConfig(parsed.data.modelConfigId);
+  if (result.status === "not_found") {
+    return Response.json({ error: "Model config not found" }, { status: 404 });
+  }
+
+  return Response.json({
+    taskModel: result.modelConfig
+      ? toAdminModelConfig(result.modelConfig)
+      : null,
+  });
+}

--- a/apps/web/drizzle/0009_common_human_torch.sql
+++ b/apps/web/drizzle/0009_common_human_torch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `model_configs` ADD `task_model` integer DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `model_configs_taskModel_idx` ON `model_configs` (`task_model`) WHERE "model_configs"."task_model" = true;

--- a/apps/web/drizzle/meta/0009_snapshot.json
+++ b/apps/web/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1742 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a5f75aee-5d9b-4f6d-a3ce-aa8a202e57d3",
+  "prevId": "b9b6ade3-5f32-4b13-a5d9-c6ed31b42858",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connections": {
+      "name": "agent_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shell_mode": {
+          "name": "shell_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "detected_version": {
+          "name": "detected_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_connections_hostId_provider_idx": {
+          "name": "agent_connections_hostId_provider_idx",
+          "columns": [
+            "host_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connections_host_id_agent_hosts_id_fk": {
+          "name": "agent_connections_host_id_agent_hosts_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "agent_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_hosts": {
+      "name": "agent_hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_alias": {
+          "name": "ssh_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_hosts_userId_updatedAt_idx": {
+          "name": "agent_hosts_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "agent_hosts_connectorId_idx": {
+          "name": "agent_hosts_connectorId_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_hosts_user_id_user_id_fk": {
+          "name": "agent_hosts_user_id_user_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_hosts_connector_id_host_connectors_id_fk": {
+          "name": "agent_hosts_connector_id_host_connectors_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "host_connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_sessions": {
+      "name": "agent_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_path": {
+          "name": "provider_session_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_modified_at": {
+          "name": "provider_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_sessions_workspaceId_providerSessionPath_idx": {
+          "name": "agent_sessions_workspaceId_providerSessionPath_idx",
+          "columns": [
+            "workspace_id",
+            "provider_session_path"
+          ],
+          "isUnique": true
+        },
+        "agent_sessions_workspaceId_providerModifiedAt_idx": {
+          "name": "agent_sessions_workspaceId_providerModifiedAt_idx",
+          "columns": [
+            "workspace_id",
+            "provider_modified_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_workspace_id_agent_workspaces_id_fk": {
+          "name": "agent_sessions_workspace_id_agent_workspaces_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_workspaces": {
+      "name": "agent_workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_workspaces_connectionId_path_idx": {
+          "name": "agent_workspaces_connectionId_path_idx",
+          "columns": [
+            "connection_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_connection_id_agent_connections_id_fk": {
+          "name": "agent_workspaces_connection_id_agent_connections_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "agent_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "chats_userId_updatedAt_idx": {
+          "name": "chats_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "chats_userId_projectId_updatedAt_idx": {
+          "name": "chats_userId_projectId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_user_id_fk": {
+          "name": "chats_user_id_user_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_usage": {
+      "name": "generation_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_cost_nano_usd": {
+          "name": "input_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_cost_nano_usd": {
+          "name": "output_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_cost_nano_usd": {
+          "name": "cache_read_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_nano_usd": {
+          "name": "cache_write_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_nano_usd": {
+          "name": "total_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generation_usage_userId_occurredAt_idx": {
+          "name": "generation_usage_userId_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_userId_providerId_model_occurredAt_idx": {
+          "name": "generation_usage_userId_providerId_model_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "provider_id",
+            "model",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_context_occurredAt_idx": {
+          "name": "generation_usage_context_occurredAt_idx",
+          "columns": [
+            "context",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_chatId_idx": {
+          "name": "generation_usage_chatId_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_messageId_idx": {
+          "name": "generation_usage_messageId_idx",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "generation_usage_user_id_user_id_fk": {
+          "name": "generation_usage_user_id_user_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_usage_chat_id_chats_id_fk": {
+          "name": "generation_usage_chat_id_chats_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_usage_message_id_messages_id_fk": {
+          "name": "generation_usage_message_id_messages_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connector_pairings": {
+      "name": "host_connector_pairings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connector_pairings_userId_idx": {
+          "name": "host_connector_pairings_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connector_pairings_user_id_user_id_fk": {
+          "name": "host_connector_pairings_user_id_user_id_fk",
+          "tableFrom": "host_connector_pairings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connectors": {
+      "name": "host_connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connectors_userId_idx": {
+          "name": "host_connectors_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connectors_user_id_user_id_fk": {
+          "name": "host_connectors_user_id_user_id_fk",
+          "tableFrom": "host_connectors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "messages_chatId_createdAt_idx": {
+          "name": "messages_chatId_createdAt_idx",
+          "columns": [
+            "chat_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "api_format": {
+          "name": "api_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai-chat'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_context_window": {
+          "name": "discovered_context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_capabilities": {
+          "name": "discovered_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calling_enabled": {
+          "name": "tool_calling_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "task_model": {
+          "name": "task_model",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "model_configs_taskModel_idx": {
+          "name": "model_configs_taskModel_idx",
+          "columns": [
+            "task_model"
+          ],
+          "isUnique": true,
+          "where": "\"model_configs\".\"task_model\" = true"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "projects_userId_updatedAt_idx": {
+          "name": "projects_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_user_id_fk": {
+          "name": "projects_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploads": {
+      "name": "uploads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "uploads_user_id_user_id_fk": {
+          "name": "uploads_user_id_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1786171471895,
       "tag": "0008_tense_plazm",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1786653947672,
+      "tag": "0009_common_human_torch",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/e2e/task-model.spec.ts
+++ b/apps/web/e2e/task-model.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+import { openE2eDatabase, resetE2eDatabase } from "./helpers/database";
+
+test.beforeEach(resetE2eDatabase);
+
+function seedModels() {
+  const db = openE2eDatabase();
+  const now = Date.now();
+  try {
+    const insert = db.prepare(`
+      INSERT INTO model_configs (
+        id, label, provider_id, api_format, base_url, model,
+        tool_calling_enabled, enabled, sort_order, created_at, updated_at
+      ) VALUES (?, ?, 'custom', 'openai-chat', 'http://127.0.0.1:9999/v1', ?, 1, ?, ?, ?, ?)
+    `);
+    insert.run(
+      "chat-model",
+      "Chat Model",
+      "chat-model",
+      1,
+      0,
+      now,
+      now,
+    );
+    insert.run(
+      "hidden-task-model",
+      "Hidden Task Model",
+      "hidden-task-model",
+      0,
+      1,
+      now,
+      now,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+test("assign and clear a task model hidden from chat", async ({ page }) => {
+  await page.goto("/signup");
+  await page.locator("#name").fill("Task Model Admin");
+  await page.locator("#email").fill("task-model@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+
+  seedModels();
+  await page.goto("/settings/models");
+
+  const taskModel = page.getByRole("combobox", {
+    name: "Task model",
+    exact: true,
+  });
+  await expect(taskModel).toContainText("Same as chat model");
+  await taskModel.click();
+  await page
+    .getByRole("option", { name: /Hidden Task Model.*Not in chat/u })
+    .click();
+
+  await expect(taskModel).toContainText("Hidden Task Model");
+  await expect(page.getByText("Task", { exact: true })).toBeVisible();
+
+  let db = openE2eDatabase();
+  try {
+    expect(
+      db
+        .prepare("SELECT id FROM model_configs WHERE task_model = true")
+        .get(),
+    ).toEqual({ id: "hidden-task-model" });
+  } finally {
+    db.close();
+  }
+
+  await page.reload();
+  await expect(
+    page.getByRole("combobox", { name: "Task model", exact: true }),
+  ).toContainText("Hidden Task Model");
+
+  await page
+    .getByRole("combobox", { name: "Task model", exact: true })
+    .click();
+  await page.getByRole("option", { name: "Same as chat model" }).click();
+  await expect(
+    page.getByRole("combobox", { name: "Task model", exact: true }),
+  ).toContainText("Same as chat model");
+
+  db = openE2eDatabase();
+  try {
+    expect(
+      db
+        .prepare("SELECT id FROM model_configs WHERE task_model = true")
+        .get(),
+    ).toBeUndefined();
+  } finally {
+    db.close();
+  }
+});

--- a/apps/web/lib/db/modelConfigs.test.ts
+++ b/apps/web/lib/db/modelConfigs.test.ts
@@ -1,0 +1,125 @@
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const databasePath = path.join(
+  os.tmpdir(),
+  `overtchat-model-configs-${process.pid}-${Date.now()}.db`,
+);
+process.env.DATABASE_URL = databasePath;
+
+const raw = new Database(databasePath);
+raw.exec(`
+  CREATE TABLE model_configs (
+    id TEXT PRIMARY KEY NOT NULL,
+    label TEXT NOT NULL,
+    provider_id TEXT DEFAULT 'custom' NOT NULL,
+    api_format TEXT DEFAULT 'openai-chat' NOT NULL,
+    base_url TEXT NOT NULL,
+    api_key TEXT,
+    model TEXT NOT NULL,
+    pricing TEXT,
+    context_window INTEGER,
+    discovered_context_window INTEGER,
+    discovered_capabilities TEXT,
+    system_prompt TEXT,
+    provider_options TEXT,
+    tool_calling_enabled INTEGER DEFAULT true NOT NULL,
+    enabled INTEGER DEFAULT true NOT NULL,
+    task_model INTEGER DEFAULT false NOT NULL,
+    sort_order INTEGER DEFAULT 0 NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+    updated_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer))
+  );
+  CREATE UNIQUE INDEX model_configs_taskModel_idx
+    ON model_configs (task_model)
+    WHERE task_model = true;
+`);
+
+let modelConfigDb: typeof import("./modelConfigs");
+
+beforeAll(async () => {
+  modelConfigDb = await import("./modelConfigs");
+});
+
+beforeEach(() => {
+  raw.exec(`
+    DELETE FROM model_configs;
+    INSERT INTO model_configs (id, label, base_url, model, enabled)
+    VALUES
+      ('chat-model', 'Chat model', 'https://example.test/v1', 'chat', true),
+      ('hidden-model', 'Hidden model', 'https://example.test/v1', 'hidden', false);
+  `);
+});
+
+afterAll(() => {
+  raw.close();
+  fs.rmSync(databasePath, { force: true });
+});
+
+describe("task model assignment", () => {
+  it("assigns a model that is hidden from chat", () => {
+    const result = modelConfigDb.setTaskModelConfig("hidden-model");
+
+    expect(result).toMatchObject({
+      status: "updated",
+      modelConfig: {
+        id: "hidden-model",
+        enabled: false,
+        taskModel: true,
+      },
+    });
+    expect(modelConfigDb.getTaskModelConfig()?.id).toBe("hidden-model");
+  });
+
+  it("atomically replaces the previous assignment", () => {
+    modelConfigDb.setTaskModelConfig("chat-model");
+    modelConfigDb.setTaskModelConfig("hidden-model");
+
+    expect(modelConfigDb.getTaskModelConfig()?.id).toBe("hidden-model");
+    expect(
+      raw
+        .prepare("SELECT count(*) AS count FROM model_configs WHERE task_model = true")
+        .get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("keeps the current assignment when the requested model is missing", () => {
+    modelConfigDb.setTaskModelConfig("chat-model");
+
+    expect(modelConfigDb.setTaskModelConfig("missing")).toEqual({
+      status: "not_found",
+    });
+    expect(modelConfigDb.getTaskModelConfig()?.id).toBe("chat-model");
+  });
+
+  it("clears back to the active chat model fallback", () => {
+    modelConfigDb.setTaskModelConfig("chat-model");
+
+    expect(modelConfigDb.setTaskModelConfig(null)).toEqual({
+      status: "updated",
+      modelConfig: null,
+    });
+    expect(modelConfigDb.getTaskModelConfig()).toBeNull();
+  });
+
+  it("returns to fallback when the assigned model is deleted", async () => {
+    modelConfigDb.setTaskModelConfig("hidden-model");
+
+    await modelConfigDb.deleteModelConfig("hidden-model");
+
+    expect(modelConfigDb.getTaskModelConfig()).toBeNull();
+  });
+});

--- a/apps/web/lib/db/modelConfigs.ts
+++ b/apps/web/lib/db/modelConfigs.ts
@@ -44,6 +44,7 @@ export function toAdminModelConfig(row: ModelConfigRow): AdminModelConfig {
     providerOptions: row.providerOptions,
     toolCallingEnabled: row.toolCallingEnabled,
     enabled: row.enabled,
+    taskModel: row.taskModel,
     sortOrder: row.sortOrder,
   };
 }
@@ -64,6 +65,54 @@ export async function getModelConfig(
     .where(eq(modelConfigs.id, id))
     .limit(1);
   return row ?? null;
+}
+
+export function getTaskModelConfig(): ModelConfigRow | null {
+  return (
+    db
+      .select()
+      .from(modelConfigs)
+      .where(eq(modelConfigs.taskModel, true))
+      .limit(1)
+      .get() ?? null
+  );
+}
+
+export type SetTaskModelResult =
+  | { status: "updated"; modelConfig: ModelConfigRow | null }
+  | { status: "not_found" };
+
+export function setTaskModelConfig(
+  id: string | null,
+): SetTaskModelResult {
+  return db.transaction((tx) => {
+    const target = id
+      ? tx
+          .select()
+          .from(modelConfigs)
+          .where(eq(modelConfigs.id, id))
+          .limit(1)
+          .get()
+      : null;
+    if (id && !target) return { status: "not_found" };
+
+    tx.update(modelConfigs)
+      .set({ taskModel: false, updatedAt: new Date() })
+      .where(eq(modelConfigs.taskModel, true))
+      .run();
+
+    if (!target) return { status: "updated", modelConfig: null };
+
+    const updated = tx
+      .update(modelConfigs)
+      .set({ taskModel: true, updatedAt: new Date() })
+      .where(eq(modelConfigs.id, target.id))
+      .returning()
+      .get();
+    return updated
+      ? { status: "updated", modelConfig: updated }
+      : { status: "not_found" };
+  });
 }
 
 export async function createModelConfig(

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -574,38 +574,49 @@ export const uploadsRelations = relations(uploads, ({ one }) => ({
   }),
 }));
 
-export const modelConfigs = sqliteTable("model_configs", {
-  id: text("id").primaryKey(),
-  label: text("label").notNull(),
-  providerId: text("provider_id", { enum: PROVIDER_IDS })
-    .default("custom")
-    .notNull(),
-  apiFormat: text("api_format", { enum: API_FORMAT_IDS })
-    .default("openai-chat")
-    .notNull(),
-  baseUrl: text("base_url").notNull(),
-  apiKey: text("api_key"),
-  model: text("model").notNull(),
-  pricing: text("pricing", { mode: "json" }).$type<ModelPricing>(),
-  contextWindow: integer("context_window"),
-  discoveredContextWindow: integer("discovered_context_window"),
-  discoveredCapabilities: text("discovered_capabilities", {
-    mode: "json",
-  }).$type<ModelCapabilities>(),
-  systemPrompt: text("system_prompt"),
-  providerOptions: text("provider_options", { mode: "json" }).$type<
-    Record<string, unknown>
-  >(),
-  toolCallingEnabled: integer("tool_calling_enabled", { mode: "boolean" })
-    .default(true)
-    .notNull(),
-  enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
-  sortOrder: integer("sort_order").default(0).notNull(),
-  createdAt: integer("created_at", { mode: "timestamp_ms" })
-    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
-    .notNull(),
-  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
-    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
-    .$onUpdate(() => new Date())
-    .notNull(),
-});
+export const modelConfigs = sqliteTable(
+  "model_configs",
+  {
+    id: text("id").primaryKey(),
+    label: text("label").notNull(),
+    providerId: text("provider_id", { enum: PROVIDER_IDS })
+      .default("custom")
+      .notNull(),
+    apiFormat: text("api_format", { enum: API_FORMAT_IDS })
+      .default("openai-chat")
+      .notNull(),
+    baseUrl: text("base_url").notNull(),
+    apiKey: text("api_key"),
+    model: text("model").notNull(),
+    pricing: text("pricing", { mode: "json" }).$type<ModelPricing>(),
+    contextWindow: integer("context_window"),
+    discoveredContextWindow: integer("discovered_context_window"),
+    discoveredCapabilities: text("discovered_capabilities", {
+      mode: "json",
+    }).$type<ModelCapabilities>(),
+    systemPrompt: text("system_prompt"),
+    providerOptions: text("provider_options", { mode: "json" }).$type<
+      Record<string, unknown>
+    >(),
+    toolCallingEnabled: integer("tool_calling_enabled", { mode: "boolean" })
+      .default(true)
+      .notNull(),
+    enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+    taskModel: integer("task_model", { mode: "boolean" })
+      .default(false)
+      .notNull(),
+    sortOrder: integer("sort_order").default(0).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("model_configs_taskModel_idx")
+      .on(table.taskModel)
+      .where(sql`${table.taskModel} = true`),
+  ],
+);

--- a/apps/web/lib/model-config/schema.ts
+++ b/apps/web/lib/model-config/schema.ts
@@ -47,6 +47,7 @@ export interface AdminModelConfig {
   providerOptions: Record<string, unknown> | null;
   toolCallingEnabled: boolean;
   enabled: boolean;
+  taskModel: boolean;
   sortOrder: number;
 }
 

--- a/apps/web/lib/queries/modelConfigs.ts
+++ b/apps/web/lib/queries/modelConfigs.ts
@@ -89,6 +89,34 @@ export function useDeleteModelConfig() {
   });
 }
 
+export function useSetTaskModel() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (modelConfigId: string | null) => {
+      const r = await fetch("/api/model-configs/task-model", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ modelConfigId }),
+      });
+      if (!r.ok) {
+        const j = (await r.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `HTTP ${r.status}`);
+      }
+    },
+    onSuccess: (_data, modelConfigId) => {
+      qc.setQueryData<AdminModelConfig[]>(
+        modelConfigKeys.adminList(),
+        (current) =>
+          current?.map((model) => ({
+            ...model,
+            taskModel: model.id === modelConfigId,
+          })),
+      );
+      invalidateAll(qc);
+    },
+  });
+}
+
 export type ModelHealth =
   | { ok: true; elapsedMs: number }
   | { ok: false; error: string; elapsedMs: number };


### PR DESCRIPTION
## Summary

- add a server-wide task-model selector under Settings → Models, defaulting to the active chat model
- allow chat-hidden models to handle background work and identify the selected model with a Task badge
- route first-turn title generation through the task model without changing title races, usage attribution, or failure isolation
- enforce a single task-model assignment atomically and return to the fallback when the assignment is cleared or its model is deleted

## Behavior

Existing installations keep their current behavior because no task model is selected by default. Administrators can choose a fast, inexpensive model for lightweight background work without exposing it in the chat model picker.

The migration adds a `task_model` flag to model configurations and a partial unique index that permits at most one selected model.

## Validation

- `npm test` (web: 424 tests; all repository test tasks passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build -w apps/web --`
- applied all migrations to a fresh temporary SQLite database and inspected the generated `task_model` column and index
- `E2E_PORT=4747 npm run test:e2e -w apps/web -- --grep "assign and clear a task model hidden from chat"`

The Playwright flow signs up an administrator, selects a model hidden from chat, verifies the persisted assignment and Task badge, reloads the page, and clears back to the active-chat fallback.
