### PR TITLE
chore: prepare v0.13.9 release

### DIFF
--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -136,7 +136,7 @@ describe.sequential("connector client compatibility", () => {
     expect(headers.get("x-overtchat-connector-version")).toBe(
       HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     );
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.3");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.4");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/site/lib/install-redirect.test.ts
+++ b/apps/site/lib/install-redirect.test.ts
@@ -296,7 +296,7 @@ describe("Host Connector installer redirect", () => {
     } = createUpgradeFixture("stable");
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Host Connector upgraded to 0.3.3");
+    expect(result.stdout).toContain("Host Connector upgraded to 0.3.4");
     expect(readFileSync(installPath, "utf8")).toBe(newConnector);
     expect(existsSync(`${installPath}.previous`)).toBe(false);
     expect(readFileSync(systemctlCalls, "utf8")).toContain(

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -7,6 +7,7 @@
 /install/connector/0.3.1 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.1/install-connector.sh 302
 /install/connector/0.3.2 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.2/install-connector.sh 302
 /install/connector/0.3.3 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.3/install-connector.sh 302
+/install/connector/0.3.4 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.4/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.3.3 302
+/install-connector.sh /install/connector/0.3.4 302

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,7 +80,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.3 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.4 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -108,9 +108,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.3.3",
+            version: "0.3.4",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.3 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.4 | sh -s -- --upgrade",
           },
         },
       ],
@@ -122,7 +122,7 @@ describe("Host Connectors route", () => {
       {
         id: "current",
         name: "Current",
-        version: "0.3.3",
+        version: "0.3.4",
         lastSeenAt: null,
       },
       {

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -86,7 +86,7 @@ async function startHostConnector(
   );
   await page.keyboard.press("Escape");
   const command = await page.getByLabel("Host Connector install command").textContent();
-  expect(command).toContain("https://overtchat.com/install/connector/0.3.3");
+  expect(command).toContain("https://overtchat.com/install/connector/0.3.4");
   expect(command).toContain("--server 'http://127.0.0.1:4718'");
   const pairCode = /--pair-code '([^']+)'/u.exec(command ?? "")?.[1];
   if (!pairCode) throw new Error("The Host Connector pairing code was missing.");
@@ -281,7 +281,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
   page,
 }) => {
   const upgradeCommand =
-    "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.3 | sh -s -- --upgrade";
+    "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.4 | sh -s -- --upgrade";
   await page.route("**/api/host-connectors", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -293,7 +293,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
             version: "0.2.0",
             lastSeenAt: Date.now(),
             online: true,
-            upgrade: { version: "0.3.3", command: upgradeCommand },
+            upgrade: { version: "0.3.4", command: upgradeCommand },
           },
         ],
       }),
@@ -309,7 +309,7 @@ test("shows the no-re-pair upgrade command for an older connector", async ({
   await page.goto("/settings/connections");
 
   await expect(
-    page.getByText("Host Connector 0.3.3 is available", { exact: true }),
+    page.getByText("Host Connector 0.3.4 is available", { exact: true }),
   ).toBeVisible();
   await expect(page.getByLabel("Host Connector upgrade command")).toHaveText(
     upgradeCommand,

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.8}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.9}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -23,7 +23,7 @@ export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
  * wire shape and remains stable even when the connector build version changes.
  */
 export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.2.0";
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.3";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.4";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.3.3"
+connector_version="0.3.4"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

- include the in-place Codex edit fix from #165 and the dedicated task model from #166
- prepare the default app image for v0.13.9
- bump the Host Connector to v0.3.4 for the matching Codex runtime lifecycle
- add the immutable v0.3.4 installer route while retaining all previous connector routes

## Release order

Publish `connector-v0.3.4` before `v0.13.9` so the server's installer and upgrade flow resolve to a public, verified connector artifact.

## Validation

- `npm test` (427 web tests; all repository test tasks passed)
- `npm run typecheck`
- `npm run lint`
- `npm run deps:check`
- `npm run catalog:check`
- `npm run build`
- `E2E_PORT=4748 npm run test:e2e -w apps/web --` (12 passed, 4 provider-dependent tests skipped)
- `sh -n scripts/install-connector.sh`
- `APP_VERSION= docker compose config --images`
- `git diff --check`
