### PR TITLE
fix(mobile): avoid popover anchor unmount race

### DIFF
--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -4,6 +4,7 @@ import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useMeasuredPopoverAnchor } from "@/components/ui/useMeasuredPopoverAnchor";
 import { buildSourceLookup } from "@/lib/chat/citations";
 import { groupMessageParts } from "@/lib/chat/parts";
 import { textOf } from "@/lib/chat/text";
@@ -38,8 +39,7 @@ export function MessageBubble({
 }) {
   const { colors, radii, fonts } = useTheme();
   const [copied, setCopied] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const anchorRef = useRef<View>(null);
+  const menu = useMeasuredPopoverAnchor();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -77,11 +77,11 @@ export function MessageBubble({
     function openUserMenu() {
       if (actions.length === 0) return;
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-      setMenuOpen(true);
+      menu.open();
     }
 
     return (
-      <View style={styles.userRow}>
+      <View ref={menu.anchorRef} collapsable={false} style={styles.userRow}>
         {fileParts.length > 0 && !editing ? (
           <View style={styles.attachmentsRow}>
             {fileParts.map((part, i) => (
@@ -93,7 +93,7 @@ export function MessageBubble({
             ))}
           </View>
         ) : null}
-        <View ref={anchorRef} collapsable={false}>
+        <View>
           {editing ? (
             <EditBubble
               initialText={text}
@@ -127,12 +127,12 @@ export function MessageBubble({
           ) : null}
         </View>
         <MessageMenu
-          from={anchorRef}
-          visible={menuOpen}
+          from={menu.anchorRect}
+          visible={menu.visible}
           actions={actions}
           placement="top"
           onSelect={onMenuSelect}
-          onClose={() => setMenuOpen(false)}
+          onClose={menu.close}
         />
       </View>
     );
@@ -152,11 +152,11 @@ export function MessageBubble({
   function openAssistantMenu() {
     if (assistantActions.length === 0) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-    setMenuOpen(true);
+    menu.open();
   }
 
   return (
-    <View ref={anchorRef} collapsable={false} style={styles.assistantRow}>
+    <View ref={menu.anchorRef} collapsable={false} style={styles.assistantRow}>
       <Pressable
         onLongPress={openAssistantMenu}
         delayLongPress={300}
@@ -208,12 +208,12 @@ export function MessageBubble({
         ) : null}
       </Pressable>
       <MessageMenu
-        from={anchorRef}
-        visible={menuOpen}
+        from={menu.anchorRect}
+        visible={menu.visible}
         actions={assistantActions}
         placement="bottom"
         onSelect={onAssistantMenuSelect}
-        onClose={() => setMenuOpen(false)}
+        onClose={menu.close}
       />
     </View>
   );

--- a/apps/mobile/src/components/chat/MessageMenu.tsx
+++ b/apps/mobile/src/components/chat/MessageMenu.tsx
@@ -1,8 +1,10 @@
 import { Feather } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
-import type { Component, RefObject } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import Popover, { PopoverPlacement } from "react-native-popover-view";
+import Popover, {
+  PopoverPlacement,
+  type Rect,
+} from "react-native-popover-view";
 import { useTheme } from "@/lib/theme";
 
 export type MessageAction = "copy" | "edit" | "regenerate";
@@ -24,7 +26,7 @@ export function MessageMenu({
   onSelect,
   onClose,
 }: {
-  from: RefObject<Component | null>;
+  from: Rect | null;
   visible: boolean;
   actions: MessageAction[];
   placement: "top" | "bottom";
@@ -35,7 +37,7 @@ export function MessageMenu({
 
   return (
     <Popover
-      from={from as RefObject<Component>}
+      from={from ?? undefined}
       isVisible={visible}
       onRequestClose={onClose}
       placement={

--- a/apps/mobile/src/components/drawer/AppDrawer.tsx
+++ b/apps/mobile/src/components/drawer/AppDrawer.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { ConfirmSheet } from "@/components/ui/ConfirmSheet";
+import { useMeasuredPopoverAnchor } from "@/components/ui/useMeasuredPopoverAnchor";
 import { getAuthClient } from "@/lib/auth/client";
 import { useChatSession } from "@/lib/chat/session";
 import { groupByDate, type DateBucket } from "@/lib/dateGroups";
@@ -668,16 +669,15 @@ function ChatRow({
   onDelete: (item: ChatListItem) => void;
 }) {
   const { colors, radii, fonts } = useTheme();
-  const anchorRef = useRef<View>(null);
-  const [menuOpen, setMenuOpen] = useState(false);
+  const menu = useMeasuredPopoverAnchor();
 
   return (
-    <View ref={anchorRef} collapsable={false}>
+    <View ref={menu.anchorRef} collapsable={false}>
       <Pressable
         onPress={() => onTap(item)}
         onLongPress={() => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-          setMenuOpen(true);
+          menu.open();
         }}
         delayLongPress={300}
         style={({ pressed }) => [
@@ -707,9 +707,9 @@ function ChatRow({
         </Text>
       </Pressable>
       <ChatRowMenu
-        from={anchorRef}
-        visible={menuOpen}
-        onClose={() => setMenuOpen(false)}
+        from={menu.anchorRect}
+        visible={menu.visible}
+        onClose={menu.close}
         onSelect={(action) => {
           if (action === "rename") onRename(item);
           else if (action === "move") onMove(item);

--- a/apps/mobile/src/components/drawer/ChatRowMenu.tsx
+++ b/apps/mobile/src/components/drawer/ChatRowMenu.tsx
@@ -1,8 +1,10 @@
 import { Feather } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
-import type { Component, RefObject } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import Popover, { PopoverPlacement } from "react-native-popover-view";
+import Popover, {
+  PopoverPlacement,
+  type Rect,
+} from "react-native-popover-view";
 import { useTheme } from "@/lib/theme";
 
 export type ChatRowAction = "rename" | "move" | "delete";
@@ -26,7 +28,7 @@ export function ChatRowMenu({
   onSelect,
   onClose,
 }: {
-  from: RefObject<Component | null>;
+  from: Rect | null;
   visible: boolean;
   onSelect: (action: ChatRowAction) => void;
   onClose: () => void;
@@ -35,7 +37,7 @@ export function ChatRowMenu({
 
   return (
     <Popover
-      from={from as RefObject<Component>}
+      from={from ?? undefined}
       isVisible={visible}
       onRequestClose={onClose}
       placement={PopoverPlacement.AUTO}

--- a/apps/mobile/src/components/ui/useMeasuredPopoverAnchor.ts
+++ b/apps/mobile/src/components/ui/useMeasuredPopoverAnchor.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { View } from "react-native";
+import { Rect } from "react-native-popover-view";
+
+export function useMeasuredPopoverAnchor() {
+  const anchorRef = useRef<View>(null);
+  const mountedRef = useRef(false);
+  const [anchorRect, setAnchorRect] = useState<Rect | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const open = useCallback(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+
+    // Popovers receive a geometry snapshot so a virtualized or replaced anchor
+    // can safely unmount while the menu is open.
+    anchor.measureInWindow((x, y, width, height) => {
+      if (!mountedRef.current || anchorRef.current !== anchor) return;
+      if (![x, y, width, height].every(Number.isFinite)) return;
+      if (width <= 0 || height <= 0) return;
+
+      setAnchorRect(new Rect(x, y, width, height));
+      setVisible(true);
+    });
+  }, []);
+
+  const close = useCallback(() => setVisible(false), []);
+
+  return { anchorRef, anchorRect, visible, open, close };
+}


### PR DESCRIPTION
## Summary

- measure menu anchors once before opening and pass stable geometry to the popover
- share the measurement and unmount guards between message and drawer menus
- anchor user-message menus to the complete row, including attachment-only messages

## Why

Sentry reported an unhandled Error: getRectForRef - current is not set from react-native-popover-view. The dependency polls a live source ref while positioning a popover. Drawer rows can be recycled by FlashList, and message rows can be replaced during chat actions or navigation, so the source can unmount between polling iterations.

Passing the dependency its supported Rect input avoids its asynchronous ref-polling path. The measurement callback also verifies that the component and the same anchor are still mounted before updating state.

Upstream context: https://github.com/SteffeyDev/react-native-popover-view/issues/153

## Testing

- npm run typecheck -w apps/mobile --