### PR TITLE
Add guided managed server setup

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,176 @@
+name: Build and publish OvertChat CLI
+
+on:
+  push:
+    tags: ["cli-v*"]
+  pull_request:
+    paths:
+      - ".github/workflows/cli-release.yml"
+      - "apps/cli/**"
+      - "apps/site/public/install"
+      - "apps/site/public/install-manifest.json"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing cli-v* release tag to publish into
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: cli-release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Use pinned npm
+        run: npm install --global npm@10.9.8
+
+      - run: npm ci
+
+      - name: Validate CLI release version
+        id: version
+        run: |
+          version=$(node -p "require('./apps/cli/package.json').version")
+          grep -F "cli_version=\"$version\"" apps/site/public/install
+          test "$(node -p "require('./apps/site/public/install-manifest.json').cliVersion")" = "$version"
+          test "$(node -p "require('./apps/site/public/install-manifest.json').connectorVersion")" = \
+            "$(node -p "require('./apps/connector/package.json').version")"
+          app_version=$(node -p "require('./apps/site/public/install-manifest.json').appVersion")
+          test "$(sed -n 's/.*${APP_VERSION:-\([^}]*\)}.*/\1/p' compose.yml)" = "$app_version"
+          stt_version=$(node -p "require('./apps/site/public/install-manifest.json').sttVersion")
+          grep -F "export const STT_VERSION = \"$stt_version\"" apps/cli/src/constants.ts
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Build Linux binaries
+        run: |
+          mkdir -p dist/cli-release
+          bun build apps/cli/src/cli.ts \
+            --compile \
+            --target=bun-linux-x64-baseline \
+            --outfile dist/cli-release/overtchat-linux-amd64
+          bun build apps/cli/src/cli.ts \
+            --compile \
+            --target=bun-linux-arm64 \
+            --outfile dist/cli-release/overtchat-linux-arm64
+          (
+            cd dist/cli-release
+            sha256sum overtchat-linux-amd64 overtchat-linux-arm64 \
+              > overtchat-checksums.txt
+          )
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: overtchat-cli-release
+          path: dist/cli-release/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: overtchat-cli-release
+          path: release
+
+      - name: Validate release tag
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: test "$TAG" = "cli-v$VERSION"
+
+      - name: Create or resume draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if gh release view "$TAG" --json isDraft --jq '.isDraft' > release-draft; then
+            test "$(cat release-draft)" = "true" || {
+              echo "Release $TAG is already published and immutable." >&2
+              exit 1
+            }
+          else
+            gh release create "$TAG" \
+              --draft \
+              --title "OvertChat CLI v$VERSION" \
+              --generate-notes \
+              --latest=false \
+              --verify-tag
+          fi
+
+      - name: Upload assets to draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          test "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true"
+          gh release upload "$TAG" release/* --clobber
+
+      - name: Verify and publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          expected_assets=$(printf '%s\n' \
+            overtchat-checksums.txt \
+            overtchat-linux-amd64 \
+            overtchat-linux-arm64)
+          actual_assets=$(gh release view "$TAG" --json assets --jq '.assets[].name' | LC_ALL=C sort)
+          test "$actual_assets" = "$expected_assets"
+
+          verification_directory=$(mktemp -d)
+          trap 'rm -rf "$verification_directory"' EXIT HUP INT TERM
+          gh release download "$TAG" --dir "$verification_directory" \
+            --pattern overtchat-checksums.txt \
+            --pattern overtchat-linux-amd64 \
+            --pattern overtchat-linux-arm64
+          for asset in overtchat-checksums.txt overtchat-linux-amd64 overtchat-linux-arm64; do
+            cmp "release/$asset" "$verification_directory/$asset"
+          done
+          (cd "$verification_directory" && sha256sum --check overtchat-checksums.txt)
+          gh release edit "$TAG" --draft=false --latest=false
+
+  deploy-site:
+    if: github.event_name != 'pull_request'
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Deploy installer after the CLI is public
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh workflow run site.yml --ref main

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -92,10 +92,46 @@ jobs:
           cmp scripts/install-connector.sh "$verification_directory/install-connector.sh"
           echo "ready=true" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve public managed installer
+        id: managed-installer
+        if: github.event_name != 'pull_request'
+        run: |
+          cli_version=$(node -p "require('./apps/site/public/install-manifest.json').cliVersion")
+          app_version=$(node -p "require('./apps/site/public/install-manifest.json').appVersion")
+          grep -F "cli_version=\"$cli_version\"" apps/site/public/install
+
+          release_url="https://github.com/yoloyash/overtchat/releases/download/cli-v$cli_version"
+          verification_directory=$(mktemp -d)
+          trap 'rm -rf "$verification_directory"' EXIT HUP INT TERM
+          ready=true
+          for asset in overtchat-checksums.txt overtchat-linux-amd64 overtchat-linux-arm64; do
+            curl --proto '=https' --tlsv1.2 \
+              --fail --silent --show-error --location \
+              --retry 10 --retry-delay 3 --retry-all-errors --retry-max-time 120 \
+              --output "$verification_directory/$asset" \
+              "$release_url/$asset" || ready=false
+          done
+          if [ "$ready" = "true" ]; then
+            (cd "$verification_directory" && sha256sum --check overtchat-checksums.txt) || ready=false
+          fi
+          docker manifest inspect \
+            "ghcr.io/yoloyash/overtchat-app:$app_version" >/dev/null || ready=false
+
+          if [ "$ready" != "true" ]; then
+            if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+              echo "The managed OvertChat release is not public yet; deferring site deployment."
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
       - name: Deploy site to Cloudflare
         if: >-
           github.event_name != 'pull_request' &&
-          steps.connector-installer.outputs.ready == 'true'
+          steps.connector-installer.outputs.ready == 'true' &&
+          steps.managed-installer.outputs.ready == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ playwright/.cache/
 /build
 /dist
 /apps/connector/dist/
+/apps/cli/dist/
 
 # data (dev SQLite DB only; anchored so it can't match source dirs like settings/data/)
 /apps/web/data/

--- a/README.md
+++ b/README.md
@@ -36,28 +36,31 @@ If you want every feature in the world — image generation, a code interpreter,
 ## Quick start
 
 ```bash
-git clone https://github.com/yoloyash/overtchat
-cd overtchat
-cp .env.example .env
-echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)" >> .env
-echo "SEARXNG_SECRET=$(openssl rand -hex 32)" >> .env
-docker compose up -d --build
+curl -fsSL https://overtchat.com/install | sh
 ```
 
-Open [http://localhost:4718](http://localhost:4718), sign up, the setup wizard takes you the rest of the way.
+The guided terminal setup detects Docker, offers to install it when missing,
+and lets you choose web search, text-to-speech, speech-to-text (including a
+specific NVIDIA GPU), and Agent Connections. It generates the secrets and
+Compose configuration itself. Open the URL it prints; the first signup becomes
+the admin, then the existing model setup gets you chatting.
 
-- **LAN access:** set `BETTER_AUTH_URL=http://<your-lan-ip>:4718` in `.env`, then `docker compose up -d`.
-- **Internet access:** uncomment the `cloudflared` block in `compose.yml` and paste a tunnel token.
+- Re-run `overtchat setup` to add an optional local service later.
+- Run `overtchat update` to update the manager, app, selected sidecars, database
+  migrations, and the managed Agent Connector together.
+- Existing standard Docker Compose installations are adopted in place; the
+  current data volume or bind mount is preserved.
 
-Already run SearXNG or Kokoro elsewhere? You can point overtchat at them; see [deploy docs](docs/deploy.md#reusing-sidecars).
+Prefer to manage Compose by hand or deploy from source? The legacy/manual flow
+remains supported in the [deploy docs](docs/deploy.md#manual-compose-installation).
 
 ## Agent Connections (Beta)
 
 Run Codex, Pi, and Oh My Pi from the browser on local or SSH-connected machines.
-Setup is one generated command under **Settings → Connections** and does not
-upload SSH keys or config. Server updates leave the connector alone; if the
-connector itself needs an update, the same page shows a one-line command that
-keeps its pairing.
+Choose **Agent Connections → Yes** during `overtchat setup`. The installer
+provisions the connector internally and prints the normal OvertChat sign-in URL;
+there is no pairing code to copy. `overtchat update` keeps the connector in sync.
+Existing manually paired connectors continue to work.
 
 ## Mobile
 
@@ -83,14 +86,11 @@ Native chat with streaming replies, the model picker, projects, full-text search
 
 ## Speech-to-text (optional)
 
-Off by default — the mic button in the composer is greyed out until you bring up the Parakeet sidecar:
-
-```bash
-docker compose --profile stt up -d        # CPU (~670 MB model, ~2 GB RAM)
-docker compose --profile stt-gpu up -d    # NVIDIA GPU (requires NVIDIA Container Toolkit)
-```
-
-Multilingual (25 languages, auto-detected). All processing stays on your machine. Model downloads on first start (~10 s) and is cached in a Docker volume.
+Choose bundled Parakeet during `overtchat setup`, then select Auto, a specific
+NVIDIA GPU, or CPU. If you skip it initially, run `overtchat setup` later; the
+admin settings will show that the local provider is not installed until then.
+Multilingual audio processing stays on your machine and the model is cached in
+a Docker volume.
 
 ## Privacy
 
@@ -100,7 +100,8 @@ The Android client can send crash diagnostics to Sentry. These may include techn
 
 ## Requirements
 
-- Docker + Docker Compose v2
+- Linux on x86-64 or arm64 for the managed installer
+- Docker + Docker Compose v2 (the installer can install Docker on supported systems)
 - ~1 GB RAM free for the app stack (Kokoro TTS pulls ~100 MB on first boot)
 - An LLM endpoint (API key or self-hosted)
 

--- a/apps/cli/eslint.config.mjs
+++ b/apps/cli/eslint.config.mjs
@@ -1,0 +1,10 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["dist/**"],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+);

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@overtchat/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "overtchat": "./dist/overtchat.mjs"
+  },
+  "scripts": {
+    "dev": "tsx src/cli.ts",
+    "build": "esbuild src/cli.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/overtchat.mjs",
+    "build:binary": "bun build src/cli.ts --compile --outfile dist/overtchat",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.11.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9",
+    "@types/node": "^22",
+    "esbuild": "^0.25.0",
+    "eslint": "^9",
+    "tsx": "^4.23.1",
+    "typescript": "^5",
+    "typescript-eslint": "^8",
+    "vitest": "^4.1.6"
+  }
+}

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { CLI_VERSION } from "./constants.js";
+import { setup } from "./setup.js";
+import { status } from "./status.js";
+import { update } from "./update.js";
+
+function usage(): string {
+  return `OvertChat management CLI
+
+Usage:
+  overtchat setup [--dry-run] [--defaults] [--development]
+  overtchat update
+  overtchat status
+  overtchat version
+`;
+}
+
+async function main(): Promise<void> {
+  const [command = "setup", ...args] = process.argv.slice(2);
+  switch (command) {
+    case "setup": {
+      const supported = new Set(["--dry-run", "--defaults", "--development"]);
+      const unexpected = args.find((argument) => !supported.has(argument));
+      if (unexpected) throw new Error(`Unknown setup option: ${unexpected}`);
+      await setup({
+        dryRun: args.includes("--dry-run"),
+        defaults: args.includes("--defaults"),
+        development: args.includes("--development"),
+      });
+      return;
+    }
+    case "update":
+      if (args.length > 0) throw new Error("overtchat update takes no options.");
+      await update();
+      return;
+    case "status":
+      if (args.length > 0) throw new Error("overtchat status takes no options.");
+      await status();
+      return;
+    case "version":
+    case "--version":
+    case "-v":
+      console.log(CLI_VERSION);
+      return;
+    case "help":
+    case "--help":
+    case "-h":
+      console.log(usage());
+      return;
+    default:
+      throw new Error(`Unknown command: ${command}\n\n${usage()}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/cli/src/compose.test.ts
+++ b/apps/cli/src/compose.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { renderComposeFile, renderStackEnvironment } from "./compose.js";
+import type { InstallationConfig, RuntimePaths } from "./types.js";
+
+const paths: RuntimePaths = {
+  configDirectory: "/home/test/.config/overtchat",
+  stateFile: "/home/test/.config/overtchat/installation.json",
+  secretsFile: "/home/test/.config/overtchat/stack.env",
+  stackDirectory: "/home/test/.local/share/overtchat",
+  composeFile: "/home/test/.local/share/overtchat/compose.yml",
+  searxngDirectory: "/home/test/.local/share/overtchat/searxng",
+  searxngSettingsFile:
+    "/home/test/.local/share/overtchat/searxng/settings.yml",
+};
+
+function config(): InstallationConfig {
+  return {
+    format: 1,
+    appVersion: "1.2.3",
+    appImage: "ghcr.io/example/overtchat:1.2.3",
+    connectorVersion: "2.0.0",
+    sttVersion: "3.0.0",
+    appPort: 4718,
+    bindAddress: "0.0.0.0",
+    publicUrl: "http://192.168.1.10:4718",
+    extraTrustedOrigins: ["https://chat.example.com"],
+    connectorServerUrl: "http://192.168.1.10:4718",
+    composeProject: "overtchat",
+    dataMountType: "volume",
+    dataVolume: "existing_overtchat-data",
+    search: {
+      provider: "brave",
+      bundledInstalled: false,
+      apiKey: "brave-secret",
+    },
+    tts: {
+      provider: "bundled",
+      bundledInstalled: true,
+      apiKey: "tts-secret",
+    },
+    stt: {
+      provider: "disabled",
+      bundledInstalled: true,
+      accelerator: "gpu",
+      gpuUuid: "GPU-abc",
+      apiKey: "stt-secret",
+    },
+    agents: { installed: true },
+  };
+}
+
+describe("managed Compose configuration", () => {
+  it("starts installed local services independently from the active provider", () => {
+    const environment = renderStackEnvironment(
+      config(),
+      {
+        betterAuthSecret: "auth",
+        managementSecret: "management",
+        searxngSecret: "search",
+      },
+      paths,
+    );
+
+    expect(environment).toContain(
+      'COMPOSE_PROFILES="tts-bundled,stt-gpu"',
+    );
+    expect(environment).toContain(
+      'OVERTCHAT_INSTALLED_CAPABILITIES="tts,stt,agents"',
+    );
+    expect(environment).toContain('WEB_SEARCH_PROVIDER="brave"');
+    expect(environment).toContain(
+      'EXTRA_TRUSTED_ORIGINS="http://192.168.1.10:4718,http://localhost:4718,http://127.0.0.1:4718,https://chat.example.com"',
+    );
+    expect(environment).toContain(
+      'HOST_CONNECTOR_URL="http://192.168.1.10:4718"',
+    );
+    expect(environment).toContain('STT_GPU_DEVICE_ID="GPU-abc"');
+    expect(environment).toContain(
+      'OVERTCHAT_DATA_SOURCE="existing_overtchat-data"',
+    );
+    expect(environment).not.toContain("BRAVE_SEARCH_API_KEY");
+    expect(environment).not.toContain("TTS_API_KEY");
+    expect(environment).not.toContain("STT_API_KEY");
+    expect(environment).not.toContain("brave-secret");
+    expect(environment).not.toContain("tts-secret");
+    expect(environment).not.toContain("stt-secret");
+  });
+
+  it("keeps optional services behind Compose profiles", () => {
+    const compose = renderComposeFile(config());
+    expect(compose).toContain("profiles: [search-bundled]");
+    expect(compose).toContain("profiles: [tts-bundled]");
+    expect(compose).toContain("profiles: [stt-cpu]");
+    expect(compose).toContain("profiles: [stt-gpu]");
+    expect(compose).toContain('device_ids: ["${STT_GPU_DEVICE_ID}"]');
+    expect(compose).toContain("external: true");
+    expect(compose).not.toContain("BRAVE_SEARCH_API_KEY");
+    expect(compose).not.toContain("TTS_API_KEY");
+    expect(compose).not.toContain("STT_API_KEY");
+  });
+
+  it("preserves an adopted bind-mounted data directory", () => {
+    const bindConfig = {
+      ...config(),
+      dataMountType: "bind" as const,
+      dataVolume: "/srv/overtchat/data",
+    };
+    const compose = renderComposeFile(bindConfig);
+
+    expect(compose).toContain("type: bind");
+    expect(compose).toContain("source: ${OVERTCHAT_DATA_SOURCE}");
+    expect(compose).not.toContain("external: true");
+  });
+});

--- a/apps/cli/src/compose.ts
+++ b/apps/cli/src/compose.ts
@@ -1,0 +1,269 @@
+import type { InstallationConfig, RuntimePaths } from "./types.js";
+import type { InstallationSecrets } from "./config.js";
+
+function envValue(value: string): string {
+  if (/[\r\n\0]/u.test(value)) {
+    throw new Error("Configuration values cannot contain line breaks.");
+  }
+  return JSON.stringify(value.replaceAll("$", "$$"));
+}
+
+function composeBindAddress(value: string): string {
+  return value.includes(":") && !value.startsWith("[") ? `[${value}]` : value;
+}
+
+function profileList(config: InstallationConfig): string[] {
+  const profiles: string[] = [];
+  if (config.search.bundledInstalled) profiles.push("search-bundled");
+  if (config.tts.bundledInstalled) profiles.push("tts-bundled");
+  if (config.stt.bundledInstalled) {
+    profiles.push(config.stt.accelerator === "cpu" ? "stt-cpu" : "stt-gpu");
+  }
+  return profiles;
+}
+
+function capabilityUrl(
+  provider: string,
+  bundledUrl: string,
+  configuredUrl?: string,
+): string {
+  if (provider === "bundled") return bundledUrl;
+  if (provider === "disabled") return "";
+  return configuredUrl ?? "";
+}
+
+export function renderStackEnvironment(
+  config: InstallationConfig,
+  secrets: InstallationSecrets,
+  paths: RuntimePaths,
+): string {
+  const trustedOrigins = [
+    config.publicUrl,
+    `http://localhost:${config.appPort}`,
+    `http://127.0.0.1:${config.appPort}`,
+    ...config.extraTrustedOrigins,
+  ].filter((value, index, values) => values.indexOf(value) === index);
+  const values: Array<[string, string | number]> = [
+    ["APP_VERSION", config.appVersion],
+    ["OVERTCHAT_APP_IMAGE", config.appImage],
+    ["STT_VERSION", config.sttVersion],
+    ["APP_PORT", config.appPort],
+    ["APP_BIND_ADDRESS", composeBindAddress(config.bindAddress)],
+    ["BETTER_AUTH_URL", config.publicUrl],
+    ["EXTRA_TRUSTED_ORIGINS", trustedOrigins.join(",")],
+    ["HOST_CONNECTOR_URL", config.connectorServerUrl],
+    ["BETTER_AUTH_SECRET", secrets.betterAuthSecret],
+    ["OVERTCHAT_MANAGEMENT_SECRET", secrets.managementSecret],
+    ["SEARXNG_SECRET", secrets.searxngSecret],
+    ["COMPOSE_PROJECT_NAME", config.composeProject],
+    ["OVERTCHAT_CONTAINER_PREFIX", "overtchat"],
+    ["COMPOSE_PROFILES", profileList(config).join(",")],
+    ["OVERTCHAT_DATA_SOURCE", config.dataVolume],
+    ["SEARXNG_CONFIG_DIR", paths.searxngDirectory],
+    [
+      "OVERTCHAT_INSTALLED_CAPABILITIES",
+      [
+        ...(config.search.bundledInstalled ? ["search"] : []),
+        ...(config.tts.bundledInstalled ? ["tts"] : []),
+        ...(config.stt.bundledInstalled ? ["stt"] : []),
+        ...(config.agents.installed ? ["agents"] : []),
+      ].join(","),
+    ],
+    ["WEB_SEARCH_PROVIDER", config.search.provider],
+    [
+      "OVERTCHAT_SEARXNG_URL",
+      capabilityUrl(
+        config.search.provider,
+        "http://searxng:8080",
+        config.search.baseUrl,
+      ),
+    ],
+    ["TTS_PROVIDER", config.tts.provider],
+    [
+      "OVERTCHAT_TTS_URL",
+      capabilityUrl(
+        config.tts.provider,
+        "http://kokoro:8880",
+        config.tts.baseUrl,
+      ),
+    ],
+    ["TTS_MODEL", config.tts.model ?? "kokoro"],
+    ["TTS_VOICE", config.tts.voice ?? "af_heart"],
+    ["STT_PROVIDER", config.stt.provider],
+    [
+      "OVERTCHAT_STT_URL",
+      capabilityUrl(
+        config.stt.provider,
+        "http://stt:5092",
+        config.stt.baseUrl,
+      ),
+    ],
+    ["STT_MODEL", config.stt.model ?? "parakeet-tdt-0.6b-v3"],
+    ["STT_GPU_DEVICE_ID", config.stt.gpuUuid ?? "0"],
+  ];
+  return `${values
+    .map(([key, value]) => `${key}=${envValue(String(value))}`)
+    .join("\n")}\n`;
+}
+
+export function renderComposeFile(config: InstallationConfig): string {
+  const appDataMount =
+    config.dataMountType === "bind"
+      ? `      - type: bind
+        source: \${OVERTCHAT_DATA_SOURCE}
+        target: /app/data`
+      : `      - overtchat-data:/app/data`;
+  const appDataVolume =
+    config.dataMountType === "bind"
+      ? ""
+      : `  overtchat-data:
+    name: \${OVERTCHAT_DATA_SOURCE}
+    external: true
+`;
+  return `name: \${COMPOSE_PROJECT_NAME:-overtchat}
+
+services:
+  app:
+    image: \${OVERTCHAT_APP_IMAGE}
+    container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-app
+    restart: unless-stopped
+    ports:
+      - "\${APP_BIND_ADDRESS}:\${APP_PORT}:4717"
+    environment:
+      BETTER_AUTH_SECRET: \${BETTER_AUTH_SECRET}
+      BETTER_AUTH_URL: \${BETTER_AUTH_URL}
+      EXTRA_TRUSTED_ORIGINS: \${EXTRA_TRUSTED_ORIGINS:-}
+      HOST_CONNECTOR_URL: \${HOST_CONNECTOR_URL}
+      OVERTCHAT_MANAGEMENT_SECRET: \${OVERTCHAT_MANAGEMENT_SECRET}
+      OVERTCHAT_INSTALLED_CAPABILITIES: \${OVERTCHAT_INSTALLED_CAPABILITIES:-}
+      WEB_SEARCH_PROVIDER: \${WEB_SEARCH_PROVIDER}
+      SEARXNG_URL: \${OVERTCHAT_SEARXNG_URL:-}
+      TTS_PROVIDER: \${TTS_PROVIDER}
+      KOKORO_URL: \${OVERTCHAT_TTS_URL:-}
+      TTS_MODEL: \${TTS_MODEL:-kokoro}
+      TTS_VOICE: \${TTS_VOICE:-af_heart}
+      STT_PROVIDER: \${STT_PROVIDER}
+      STT_URL: \${OVERTCHAT_STT_URL:-}
+      STT_MODEL: \${STT_MODEL:-parakeet-tdt-0.6b-v3}
+      DATABASE_URL: /app/data/chat.db
+      REDIS_URL: redis://redis:6379
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+${appDataMount}
+    depends_on:
+      redis:
+        condition: service_healthy
+      searxng:
+        condition: service_healthy
+        required: false
+      kokoro:
+        condition: service_healthy
+        required: false
+
+  redis:
+    image: redis:8-alpine@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2
+    container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-redis
+    restart: unless-stopped
+    command: [redis-server, --save, "", --appendonly, "no", --maxmemory, 64mb, --maxmemory-policy, allkeys-lru]
+    healthcheck:
+      test: [CMD, redis-cli, ping]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  searxng:
+    image: docker.io/searxng/searxng:latest
+    container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-searxng
+    restart: unless-stopped
+    profiles: [search-bundled]
+    environment:
+      FORCE_OWNERSHIP: "false"
+      SEARXNG_SECRET: \${SEARXNG_SECRET}
+    volumes:
+      - \${SEARXNG_CONFIG_DIR}:/etc/searxng:rw
+    healthcheck:
+      test: [CMD-SHELL, "wget -q --spider http://localhost:8080/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+  kokoro:
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4
+    container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-kokoro
+    restart: unless-stopped
+    profiles: [tts-bundled]
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)"
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+
+  stt-cpu:
+    image: ghcr.io/yoloyash/overtchat-stt-cpu:\${STT_VERSION}
+    container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-stt-cpu
+    restart: unless-stopped
+    profiles: [stt-cpu]
+    networks:
+      default:
+        aliases: [stt]
+    volumes:
+      - overtchat-stt-models:/models
+
+  stt-gpu:
+    image: ghcr.io/yoloyash/overtchat-stt-gpu:\${STT_VERSION}
+    container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-stt-gpu
+    restart: unless-stopped
+    profiles: [stt-gpu]
+    networks:
+      default:
+        aliases: [stt]
+    volumes:
+      - overtchat-stt-models:/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["\${STT_GPU_DEVICE_ID}"]
+              capabilities: [gpu]
+
+volumes:
+${appDataVolume}  overtchat-stt-models:
+    name: overtchat-stt-models
+`;
+}
+
+export const SEARXNG_SETTINGS = `use_default_settings: true
+
+server:
+  bind_address: 0.0.0.0
+  port: 8080
+  secret_key: "\${SEARXNG_SECRET}"
+  limiter: false
+  public_instance: false
+  image_proxy: true
+
+search:
+  safe_search: 0
+  formats:
+    - html
+    - json
+
+ui:
+  static_use_hash: true
+
+outgoing:
+  request_timeout: 4.0
+  max_request_timeout: 10.0
+  pool_connections: 100
+  pool_maxsize: 20
+
+engines:
+  - name: brave
+    disabled: true
+`;

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  defaultInstallationConfig,
+  initialSecrets,
+  readInstallationConfig,
+  writeInstallationConfig,
+} from "./config.js";
+import type { ExistingInstallation, RuntimePaths } from "./types.js";
+
+function existing(
+  overrides: Partial<ExistingInstallation> = {},
+): ExistingInstallation {
+  return {
+    containerName: "overtchat-app",
+    composeProject: "homechat",
+    composeWorkingDir: "/srv/overtchat",
+    dataMountType: "bind",
+    dataVolume: "/srv/overtchat/data",
+    appPort: 9000,
+    bindAddress: "127.0.0.1",
+    publicUrl: "https://chat.example.com",
+    environment: new Map([
+      ["BETTER_AUTH_SECRET", "existing-auth-secret"],
+      ["EXTRA_TRUSTED_ORIGINS", "https://mobile.example.com"],
+      ["HOST_CONNECTOR_URL", "https://chat.example.com"],
+      ["SEARXNG_URL", "http://search.internal:8080"],
+      ["KOKORO_URL", "http://speech.internal:8880"],
+    ]),
+    ...overrides,
+  };
+}
+
+describe("existing installation adoption", () => {
+  it("preserves network, storage, secrets, and external providers", () => {
+    const detected = existing();
+    const config = defaultInstallationConfig(detected);
+
+    expect(config).toMatchObject({
+      composeProject: "homechat",
+      adoptedFrom: "/srv/overtchat",
+      dataMountType: "bind",
+      dataVolume: "/srv/overtchat/data",
+      appPort: 9000,
+      bindAddress: "127.0.0.1",
+      publicUrl: "https://chat.example.com",
+      extraTrustedOrigins: ["https://mobile.example.com"],
+      connectorServerUrl: "https://chat.example.com",
+      search: {
+        provider: "searxng",
+        baseUrl: "http://search.internal:8080",
+      },
+      tts: {
+        provider: "openai-compatible",
+        baseUrl: "http://speech.internal:8880",
+      },
+    });
+    expect(initialSecrets(detected).betterAuthSecret).toBe(
+      "existing-auth-secret",
+    );
+  });
+
+  it("never downgrades an already newer official app image", () => {
+    const config = defaultInstallationConfig(
+      existing({
+        appVersion: "9.1.0",
+        appImage: "ghcr.io/yoloyash/overtchat-app:9.1.0",
+      }),
+    );
+
+    expect(config.appVersion).toBe("9.1.0");
+    expect(config.appImage).toBe("ghcr.io/yoloyash/overtchat-app:9.1.0");
+  });
+});
+
+describe("managed installation state", () => {
+  it("never persists provider API keys", async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "overtchat-installation-state-"),
+    );
+    const paths: RuntimePaths = {
+      configDirectory: directory,
+      stateFile: path.join(directory, "installation.json"),
+      secretsFile: path.join(directory, "stack.env"),
+      stackDirectory: path.join(directory, "stack"),
+      composeFile: path.join(directory, "stack", "compose.yml"),
+      searxngDirectory: path.join(directory, "stack", "searxng"),
+      searxngSettingsFile: path.join(
+        directory,
+        "stack",
+        "searxng",
+        "settings.yml",
+      ),
+    };
+    try {
+      const config = defaultInstallationConfig(null);
+      config.search.apiKey = "brave-secret";
+      config.tts.apiKey = "tts-secret";
+      config.stt.apiKey = "stt-secret";
+
+      await writeInstallationConfig(paths, config);
+
+      const contents = await readFile(paths.stateFile, "utf8");
+      expect(contents).not.toContain("brave-secret");
+      expect(contents).not.toContain("tts-secret");
+      expect(contents).not.toContain("stt-secret");
+      expect(contents).not.toContain("apiKey");
+      const loaded = await readInstallationConfig(paths);
+      expect(loaded?.search.apiKey).toBeUndefined();
+      expect(loaded?.tts.apiKey).toBeUndefined();
+      expect(loaded?.stt.apiKey).toBeUndefined();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -22,6 +22,7 @@ function existing(
     appPort: 9000,
     bindAddress: "127.0.0.1",
     publicUrl: "https://chat.example.com",
+    bundledServices: { search: false, tts: false, stt: false },
     environment: new Map([
       ["BETTER_AUTH_SECRET", "existing-auth-secret"],
       ["EXTRA_TRUSTED_ORIGINS", "https://mobile.example.com"],

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,0 +1,233 @@
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  ExistingInstallation,
+  InstallationConfig,
+  RuntimePaths,
+} from "./types.js";
+import {
+  APP_VERSION,
+  APP_IMAGE,
+  CONNECTOR_VERSION,
+  DEFAULT_APP_PORT,
+  DEFAULT_COMPOSE_PROJECT,
+  DEFAULT_DATA_VOLUME,
+  STT_VERSION,
+} from "./constants.js";
+
+export type InstallationSecrets = {
+  betterAuthSecret: string;
+  managementSecret: string;
+  searxngSecret: string;
+};
+
+function generatedSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function newerVersion(left: string | undefined, right: string): boolean {
+  if (!left || !/^\d+\.\d+\.\d+$/u.test(left)) return false;
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  return leftParts.some((value, index) => {
+    const previousEqual = leftParts
+      .slice(0, index)
+      .every((part, partIndex) => part === rightParts[partIndex]);
+    return previousEqual && value > (rightParts[index] ?? 0);
+  });
+}
+
+export function defaultInstallationConfig(
+  existing: ExistingInstallation | null,
+): InstallationConfig {
+  const environment = existing?.environment;
+  const searchUrl = environment?.get("SEARXNG_URL");
+  const ttsUrl = environment?.get("KOKORO_URL");
+  const sttUrl = environment?.get("STT_URL");
+  const preserveNewerApp = newerVersion(existing?.appVersion, APP_VERSION);
+  const appVersion = preserveNewerApp ? existing!.appVersion! : APP_VERSION;
+  const appImage = preserveNewerApp
+    ? existing!.appImage!
+    : `${APP_IMAGE}:${APP_VERSION}`;
+  return {
+    format: 1,
+    appVersion,
+    appImage,
+    connectorVersion: CONNECTOR_VERSION,
+    sttVersion: STT_VERSION,
+    appPort: existing?.appPort ?? DEFAULT_APP_PORT,
+    bindAddress: existing?.bindAddress ?? "0.0.0.0",
+    publicUrl:
+      existing?.publicUrl ?? `http://localhost:${DEFAULT_APP_PORT}`,
+    extraTrustedOrigins:
+      existing?.environment
+        .get("EXTRA_TRUSTED_ORIGINS")
+        ?.split(",")
+        .map((value) => value.trim())
+        .filter(Boolean) ?? [],
+    connectorServerUrl:
+      existing?.environment.get("HOST_CONNECTOR_URL") ??
+      `http://127.0.0.1:${existing?.appPort ?? DEFAULT_APP_PORT}`,
+    composeProject: existing?.composeProject ?? DEFAULT_COMPOSE_PROJECT,
+    dataMountType: existing?.dataMountType ?? "volume",
+    dataVolume: existing?.dataVolume ?? DEFAULT_DATA_VOLUME,
+    search: searchUrl && searchUrl !== "http://searxng:8080"
+      ? { provider: "searxng", bundledInstalled: false, baseUrl: searchUrl }
+      : { provider: "bundled", bundledInstalled: true },
+    tts: ttsUrl && ttsUrl !== "http://kokoro:8880"
+      ? {
+          provider: "openai-compatible",
+          bundledInstalled: false,
+          baseUrl: ttsUrl,
+        }
+      : { provider: "bundled", bundledInstalled: true },
+    stt:
+      sttUrl && sttUrl !== "http://stt:5092"
+        ? {
+            provider: "openai-compatible",
+            bundledInstalled: false,
+            baseUrl: sttUrl,
+          }
+        : existing?.sttAccelerator
+          ? {
+              provider: "bundled",
+              bundledInstalled: true,
+              accelerator: existing.sttAccelerator,
+              gpuUuid: existing.sttGpuUuid,
+            }
+          : { provider: "disabled", bundledInstalled: false },
+    agents: { installed: false },
+    ...(existing?.composeWorkingDir
+      ? { adoptedFrom: existing.composeWorkingDir }
+      : {}),
+  };
+}
+
+export async function readInstallationConfig(
+  paths: RuntimePaths,
+): Promise<InstallationConfig | null> {
+  try {
+    const parsed = JSON.parse(await readFile(paths.stateFile, "utf8")) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Reflect.get(parsed, "format") !== 1
+    ) {
+      throw new Error(`Unsupported installation state at ${paths.stateFile}.`);
+    }
+    const config = parsed as InstallationConfig;
+    return withoutProviderKeys({
+      ...config,
+      // State written by the first installer draft only supported volumes.
+      dataMountType: config.dataMountType ?? "volume",
+      bindAddress: config.bindAddress ?? "0.0.0.0",
+      extraTrustedOrigins: config.extraTrustedOrigins ?? [],
+      connectorServerUrl:
+        config.connectorServerUrl ?? `http://127.0.0.1:${config.appPort}`,
+    });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function withoutApiKey<T extends { apiKey?: string }>(
+  capability: T,
+): Omit<T, "apiKey"> {
+  const persisted = { ...capability };
+  delete persisted.apiKey;
+  return persisted;
+}
+
+export function withoutProviderKeys(
+  config: InstallationConfig,
+): InstallationConfig {
+  return {
+    ...config,
+    search: withoutApiKey(config.search),
+    tts: withoutApiKey(config.tts),
+    stt: withoutApiKey(config.stt),
+  };
+}
+
+export function initialSecrets(
+  existing: ExistingInstallation | null,
+  previous: Partial<InstallationSecrets> = {},
+): InstallationSecrets {
+  return {
+    betterAuthSecret:
+      previous.betterAuthSecret ||
+      existing?.environment.get("BETTER_AUTH_SECRET") ||
+      generatedSecret(),
+    managementSecret: previous.managementSecret || generatedSecret(),
+    searxngSecret:
+      previous.searxngSecret ||
+      existing?.environment.get("SEARXNG_SECRET") ||
+      generatedSecret(),
+  };
+}
+
+function parseEnv(contents: string): Map<string, string> {
+  const values = new Map<string, string>();
+  for (const line of contents.split(/\r?\n/u)) {
+    const match = /^([A-Z][A-Z0-9_]*)=(.*)$/u.exec(line);
+    if (!match?.[1]) continue;
+    let value = match[2] ?? "";
+    if (value.startsWith('"') && value.endsWith('"')) {
+      try {
+        value = JSON.parse(value) as string;
+      } catch {
+        // Preserve the raw value; the next write will normalize it.
+      }
+    }
+    values.set(match[1], value);
+  }
+  return values;
+}
+
+export async function readInstallationSecrets(
+  paths: RuntimePaths,
+): Promise<Partial<InstallationSecrets>> {
+  try {
+    const values = parseEnv(await readFile(paths.secretsFile, "utf8"));
+    return {
+      betterAuthSecret: values.get("BETTER_AUTH_SECRET"),
+      managementSecret: values.get("OVERTCHAT_MANAGEMENT_SECRET"),
+      searxngSecret: values.get("SEARXNG_SECRET"),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+async function writeAtomic(
+  destination: string,
+  contents: string,
+  mode: number,
+): Promise<void> {
+  await mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+  const temporary = `${destination}.new-${process.pid}`;
+  await writeFile(temporary, contents, { encoding: "utf8", mode });
+  await chmod(temporary, mode);
+  await rename(temporary, destination);
+}
+
+export async function writeInstallationConfig(
+  paths: RuntimePaths,
+  config: InstallationConfig,
+): Promise<void> {
+  await writeAtomic(
+    paths.stateFile,
+    `${JSON.stringify(withoutProviderKeys(config), null, 2)}\n`,
+    0o600,
+  );
+}
+
+export async function writeSecretsFile(
+  paths: RuntimePaths,
+  contents: string,
+): Promise<void> {
+  await writeAtomic(paths.secretsFile, contents, 0o600);
+}

--- a/apps/cli/src/connector.ts
+++ b/apps/cli/src/connector.ts
@@ -1,0 +1,223 @@
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { CONNECTOR_REPOSITORY } from "./constants.js";
+import {
+  commandExists,
+  requireSuccessful,
+  runCommand,
+} from "./process.js";
+import type { InstallationConfig } from "./types.js";
+
+function connectorAsset(): string {
+  if (process.platform !== "linux") {
+    throw new Error("Agent Connections currently require Linux.");
+  }
+  if (process.arch === "x64") return "overtchat-connector-linux-amd64";
+  if (process.arch === "arm64") return "overtchat-connector-linux-arm64";
+  throw new Error(`Agent Connections do not support ${process.arch}.`);
+}
+
+async function download(url: string): Promise<Uint8Array> {
+  const response = await fetch(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Could not download ${url} (HTTP ${response.status}).`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function expectedChecksum(contents: string, asset: string): string {
+  for (const line of contents.split(/\r?\n/u)) {
+    const [checksum, filename] = line.trim().split(/\s+/u);
+    if (filename?.replace(/^\*/u, "") === asset && checksum) return checksum;
+  }
+  throw new Error(`The connector checksum for ${asset} is missing.`);
+}
+
+async function stageConnectorBinary(
+  version: string,
+): Promise<{ temporaryDirectory: string; binary: string }> {
+  const override = process.env.OVERTCHAT_CONNECTOR_BINARY?.trim();
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "overtchat-connector-"),
+  );
+  const staged = path.join(temporaryDirectory, "overtchat-connector");
+  if (override) {
+    await copyFile(override, staged);
+    await chmod(staged, 0o755);
+    return { temporaryDirectory, binary: staged };
+  }
+  const asset = connectorAsset();
+  const releaseBase = `https://github.com/${CONNECTOR_REPOSITORY}/releases/download/connector-v${version}`;
+  const [binary, checksums] = await Promise.all([
+    download(`${releaseBase}/${asset}`),
+    download(`${releaseBase}/connector-checksums.txt`),
+  ]);
+  const expected = expectedChecksum(new TextDecoder().decode(checksums), asset);
+  const actual = createHash("sha256").update(binary).digest("hex");
+  if (actual !== expected) {
+    throw new Error("The downloaded Agent Connector failed checksum verification.");
+  }
+  await writeFile(staged, binary, { mode: 0o755 });
+  await chmod(staged, 0o755);
+  return { temporaryDirectory, binary: staged };
+}
+
+async function provisionConnector(
+  config: InstallationConfig,
+  managementSecret: string,
+): Promise<{ connectorId: string; token: string }> {
+  const response = await fetch(
+    `http://127.0.0.1:${config.appPort}/api/internal/management/connector`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${managementSecret}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: os.hostname(),
+        version: config.connectorVersion,
+      }),
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+  const body = (await response.json().catch(() => null)) as {
+    connectorId?: string;
+    token?: string;
+    error?: string;
+  } | null;
+  if (!response.ok || !body?.connectorId || !body.token) {
+    throw new Error(
+      body?.error ??
+        `OvertChat could not provision Agent Connections (HTTP ${response.status}).`,
+    );
+  }
+  return { connectorId: body.connectorId, token: body.token };
+}
+
+async function waitForConnector(
+  config: InstallationConfig,
+  managementSecret: string,
+): Promise<void> {
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    const response = await fetch(
+      `http://127.0.0.1:${config.appPort}/api/internal/management/connector`,
+      {
+        headers: { Authorization: `Bearer ${managementSecret}` },
+        signal: AbortSignal.timeout(5_000),
+      },
+    ).catch(() => null);
+    if (response?.ok) {
+      const body = (await response.json()) as {
+        connector?: { online?: boolean } | null;
+      };
+      if (body.connector?.online) return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+  }
+  throw new Error("The Agent Connector service started but did not come online.");
+}
+
+async function ensureUserLinger(): Promise<void> {
+  if (!(await commandExists("loginctl"))) return;
+  const username = os.userInfo().username;
+  const current = await runCommand("loginctl", [
+    "show-user",
+    username,
+    "--property=Linger",
+    "--value",
+  ]);
+  if (current.exitCode === 0 && current.stdout.trim() === "yes") return;
+  const direct = await runCommand("loginctl", ["enable-linger", username]);
+  if (direct.exitCode === 0) return;
+  if (!(await commandExists("sudo"))) {
+    throw new Error(
+      "Agent Connections need user lingering enabled so they stay online after logout.",
+    );
+  }
+  await requireSuccessful(
+    "sudo",
+    ["loginctl", "enable-linger", username],
+    { inherit: true },
+  );
+}
+
+export async function installManagedConnector(
+  config: InstallationConfig,
+  managementSecret: string,
+): Promise<void> {
+  if (process.getuid?.() === 0 && process.env.SUDO_USER) {
+    throw new Error(
+      "Run overtchat setup as your normal user. It will request sudo only when Docker needs it.",
+    );
+  }
+  const systemd = await runCommand("systemctl", ["--user", "show-environment"]);
+  if (systemd.exitCode !== 0) {
+    throw new Error(
+      "Agent Connections require a running systemd user session on this machine.",
+    );
+  }
+  await ensureUserLinger();
+  const staged = await stageConnectorBinary(config.connectorVersion);
+  const installDirectory = path.join(os.homedir(), ".local", "bin");
+  const installPath = path.join(installDirectory, "overtchat-connector");
+  const backupPath = `${installPath}.previous`;
+  let hadPrevious = false;
+  try {
+    const preflight = await requireSuccessful(staged.binary, ["version"]);
+    if (preflight.stdout.trim() !== config.connectorVersion) {
+      throw new Error(
+        "The downloaded Agent Connector failed its version check.",
+      );
+    }
+    await mkdir(installDirectory, { recursive: true, mode: 0o700 });
+    try {
+      await readFile(installPath);
+      hadPrevious = true;
+      await rm(backupPath, { force: true });
+      await rename(installPath, backupPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    await copyFile(staged.binary, installPath);
+    await chmod(installPath, 0o755);
+    const provisioned = await provisionConnector(config, managementSecret);
+    await requireSuccessful(installPath, ["install-managed"], {
+      input: `${JSON.stringify({
+        serverUrl: `http://127.0.0.1:${config.appPort}`,
+        connectorId: provisioned.connectorId,
+        token: provisioned.token,
+      })}\n`,
+    });
+    await waitForConnector(config, managementSecret);
+    await rm(backupPath, { force: true });
+  } catch (error) {
+    await rm(installPath, { force: true });
+    if (hadPrevious) {
+      await rename(backupPath, installPath).catch(() => {});
+      await runCommand("systemctl", [
+        "--user",
+        "restart",
+        "overtchat-connector.service",
+      ]).catch(() => null);
+    }
+    throw error;
+  } finally {
+    await rm(staged.temporaryDirectory, { recursive: true, force: true });
+  }
+}

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,0 +1,13 @@
+export const CLI_VERSION = "0.1.0";
+export const APP_VERSION = "0.14.0";
+export const CONNECTOR_VERSION = "0.4.0";
+export const STT_VERSION = "0.1.0";
+
+export const APP_IMAGE = "ghcr.io/yoloyash/overtchat-app";
+export const CONNECTOR_REPOSITORY = "yoloyash/overtchat";
+export const RELEASE_MANIFEST_URL =
+  "https://overtchat.com/install-manifest.json";
+
+export const DEFAULT_APP_PORT = 4718;
+export const DEFAULT_COMPOSE_PROJECT = "overtchat";
+export const DEFAULT_DATA_VOLUME = "overtchat-data";

--- a/apps/cli/src/docker.test.ts
+++ b/apps/cli/src/docker.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseNvidiaSmi } from "./docker.js";
+
+describe("NVIDIA GPU discovery", () => {
+  it("keeps stable UUIDs alongside the friendly index and memory", () => {
+    expect(
+      parseNvidiaSmi(
+        "0, GPU-4090, NVIDIA GeForce RTX 4090, 24564\n1, GPU-A4000, NVIDIA RTX A4000, 16376\n",
+      ),
+    ).toEqual([
+      {
+        index: 0,
+        uuid: "GPU-4090",
+        name: "NVIDIA GeForce RTX 4090",
+        memoryMiB: 24_564,
+      },
+      {
+        index: 1,
+        uuid: "GPU-A4000",
+        name: "NVIDIA RTX A4000",
+        memoryMiB: 16_376,
+      },
+    ]);
+  });
+
+  it("ignores malformed rows rather than offering broken devices", () => {
+    expect(parseNvidiaSmi("not,a,gpu,row\n2, GPU-ok, RTX 6000, 49140"))
+      .toEqual([
+        {
+          index: 2,
+          uuid: "GPU-ok",
+          name: "RTX 6000",
+          memoryMiB: 49_140,
+        },
+      ]);
+  });
+});

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -327,6 +327,7 @@ async function stoppedComposeInstallation(
   const project = volume?.Labels?.["com.docker.compose.project"] || "overtchat";
   const redis = await inspectContainer(docker, "overtchat-redis");
   const searxng = await inspectContainer(docker, "overtchat-searxng");
+  const kokoro = await inspectContainer(docker, "overtchat-kokoro");
   const sttGpu = await inspectContainer(docker, "overtchat-stt-gpu");
   const sttCpu = sttGpu
     ? null
@@ -345,6 +346,11 @@ async function stoppedComposeInstallation(
     searxngConfigPath: searxng?.Mounts?.find(
       (mount) => mount.Destination === "/etc/searxng",
     )?.Source,
+    bundledServices: {
+      search: Boolean(searxng),
+      tts: Boolean(kokoro),
+      stt: Boolean(sttGpu ?? sttCpu),
+    },
     sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
     sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
   };
@@ -380,6 +386,7 @@ export async function detectExistingInstallation(
   }
 
   const searxng = await inspectContainer(docker, "overtchat-searxng");
+  const kokoro = await inspectContainer(docker, "overtchat-kokoro");
   const searxngConfigPath = searxng?.Mounts?.find(
     (mount) => mount.Destination === "/etc/searxng",
   )?.Source;
@@ -402,6 +409,11 @@ export async function detectExistingInstallation(
       environment.get("BETTER_AUTH_URL") || `http://localhost:${appPort}`,
     environment,
     searxngConfigPath,
+    bundledServices: {
+      search: Boolean(searxng),
+      tts: Boolean(kokoro),
+      stt: Boolean(sttGpu ?? sttCpu),
+    },
     sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
     sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
   };

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -1,0 +1,457 @@
+import type { ExistingInstallation, Gpu } from "./types.js";
+import { APP_IMAGE } from "./constants.js";
+import { commandExists, requireSuccessful, runCommand } from "./process.js";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+type DockerInspect = {
+  Name?: string;
+  Config?: {
+    Env?: string[];
+    Image?: string;
+    Labels?: Record<string, string>;
+  };
+  Mounts?: Array<{
+    Destination?: string;
+    Name?: string;
+    Source?: string;
+    Type?: string;
+  }>;
+  NetworkSettings?: {
+    Ports?: Record<
+      string,
+      Array<{ HostIp?: string; HostPort?: string }> | null
+    >;
+  };
+  HostConfig?: {
+    DeviceRequests?: Array<{ DeviceIDs?: string[] }>;
+  };
+};
+
+type DockerVolumeInspect = {
+  Name?: string;
+  Labels?: Record<string, string>;
+};
+
+export type DockerCommand = {
+  command: string;
+  prefix: string[];
+};
+
+export async function detectDockerCommand(): Promise<DockerCommand | null> {
+  if (!(await commandExists("docker"))) return null;
+  const direct = await runCommand("docker", ["info"]);
+  if (direct.exitCode === 0) return { command: "docker", prefix: [] };
+  if (await commandExists("sudo")) {
+    const elevated = await runCommand("sudo", ["-n", "docker", "info"]);
+    if (elevated.exitCode === 0) {
+      return { command: "sudo", prefix: ["docker"] };
+    }
+    return { command: "sudo", prefix: ["docker"] };
+  }
+  return { command: "docker", prefix: [] };
+}
+
+export async function installDockerEngine(): Promise<void> {
+  const response = await fetch("https://get.docker.com", {
+    redirect: "follow",
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Docker's installer returned HTTP ${response.status}.`);
+  }
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "overtchat-docker-"),
+  );
+  const installer = path.join(temporaryDirectory, "get-docker.sh");
+  try {
+    await writeFile(installer, new Uint8Array(await response.arrayBuffer()), {
+      mode: 0o700,
+    });
+    await chmod(installer, 0o700);
+    const elevated = process.getuid?.() === 0 ? [] : ["sudo"];
+    await requireSuccessful(elevated[0] ?? "sh", [
+      ...(elevated.length > 0 ? ["sh"] : []),
+      installer,
+    ], { inherit: true });
+    const serviceCommand = elevated[0] ?? "systemctl";
+    const serviceArgs = [
+      ...(elevated.length > 0 ? ["systemctl"] : []),
+      "enable",
+      "--now",
+      "docker",
+    ];
+    await requireSuccessful(serviceCommand, serviceArgs, { inherit: true });
+    const user = process.env.SUDO_USER || os.userInfo().username;
+    if (process.getuid?.() !== 0 && user && user !== "root") {
+      await requireSuccessful("sudo", ["usermod", "-aG", "docker", user], {
+        inherit: true,
+      });
+    }
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function runElevated(
+  command: string,
+  args: string[],
+  options: Parameters<typeof requireSuccessful>[2] = {},
+) {
+  if (process.getuid?.() === 0) {
+    return await requireSuccessful(command, args, options);
+  }
+  if (!(await commandExists("sudo"))) {
+    throw new Error(`Installing ${command} requires root access or sudo.`);
+  }
+  return await requireSuccessful("sudo", [command, ...args], options);
+}
+
+async function downloadText(url: string): Promise<string> {
+  const response = await fetch(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}.`);
+  return await response.text();
+}
+
+function linuxDistribution(contents: string): "apt" | "dnf" | null {
+  const values = new Map<string, string>();
+  for (const line of contents.split(/\r?\n/u)) {
+    const match = /^([A-Z_]+)=(.*)$/u.exec(line);
+    if (!match?.[1]) continue;
+    values.set(match[1], (match[2] ?? "").replace(/^['"]|['"]$/gu, ""));
+  }
+  const names = `${values.get("ID") ?? ""} ${values.get("ID_LIKE") ?? ""}`;
+  if (/\b(?:debian|ubuntu)\b/u.test(names)) return "apt";
+  if (/\b(?:fedora|rhel|centos)\b/u.test(names)) return "dnf";
+  return null;
+}
+
+export async function installNvidiaContainerToolkit(): Promise<void> {
+  if (await commandExists("nvidia-ctk")) {
+    await runElevated("nvidia-ctk", ["runtime", "configure", "--runtime=docker"], {
+      inherit: true,
+    });
+    await runElevated("systemctl", ["restart", "docker"], { inherit: true });
+    return;
+  }
+  const distribution = linuxDistribution(
+    await readFile("/etc/os-release", "utf8").catch(() => ""),
+  );
+  if (!distribution) {
+    throw new Error(
+      "Automatic NVIDIA Container Toolkit installation supports Debian, Ubuntu, Fedora, RHEL, and CentOS.",
+    );
+  }
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "overtchat-nvidia-"),
+  );
+  try {
+    if (distribution === "apt") {
+      await runElevated(
+        "apt-get",
+        [
+          "update",
+        ],
+        { inherit: true, environment: { ...process.env, DEBIAN_FRONTEND: "noninteractive" } },
+      );
+      await runElevated(
+        "apt-get",
+        [
+          "install",
+          "-y",
+          "--no-install-recommends",
+          "ca-certificates",
+          "curl",
+          "gnupg2",
+        ],
+        { inherit: true, environment: { ...process.env, DEBIAN_FRONTEND: "noninteractive" } },
+      );
+      const key = await downloadText(
+        "https://nvidia.github.io/libnvidia-container/gpgkey",
+      );
+      const keyPath = path.join(temporaryDirectory, "nvidia-keyring.gpg");
+      await requireSuccessful(
+        "gpg",
+        ["--dearmor", "--yes", "--output", keyPath],
+        { input: key },
+      );
+      await runElevated("install", [
+        "-m",
+        "0644",
+        keyPath,
+        "/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg",
+      ]);
+      const repository = (
+        await downloadText(
+          "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list",
+        )
+      ).replaceAll(
+        "deb https://",
+        "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://",
+      );
+      const repositoryPath = path.join(
+        temporaryDirectory,
+        "nvidia-container-toolkit.list",
+      );
+      await writeFile(repositoryPath, repository, { mode: 0o644 });
+      await runElevated("install", [
+        "-m",
+        "0644",
+        repositoryPath,
+        "/etc/apt/sources.list.d/nvidia-container-toolkit.list",
+      ]);
+      await runElevated("apt-get", ["update"], {
+        inherit: true,
+        environment: { ...process.env, DEBIAN_FRONTEND: "noninteractive" },
+      });
+      await runElevated("apt-get", ["install", "-y", "nvidia-container-toolkit"], {
+        inherit: true,
+        environment: { ...process.env, DEBIAN_FRONTEND: "noninteractive" },
+      });
+    } else {
+      const repositoryPath = path.join(
+        temporaryDirectory,
+        "nvidia-container-toolkit.repo",
+      );
+      await writeFile(
+        repositoryPath,
+        await downloadText(
+          "https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo",
+        ),
+        { mode: 0o644 },
+      );
+      await runElevated("install", [
+        "-m",
+        "0644",
+        repositoryPath,
+        "/etc/yum.repos.d/nvidia-container-toolkit.repo",
+      ]);
+      await runElevated("dnf", ["install", "-y", "nvidia-container-toolkit"], {
+        inherit: true,
+      });
+    }
+    await runElevated("nvidia-ctk", ["runtime", "configure", "--runtime=docker"], {
+      inherit: true,
+    });
+    await runElevated("systemctl", ["restart", "docker"], { inherit: true });
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+export async function dockerComposeAvailable(
+  docker: DockerCommand,
+): Promise<boolean> {
+  const result = await runDocker(docker, ["compose", "version"]);
+  return result.exitCode === 0;
+}
+
+export async function runDocker(
+  docker: DockerCommand,
+  args: string[],
+  options: Parameters<typeof runCommand>[2] = {},
+) {
+  return await runCommand(docker.command, [...docker.prefix, ...args], options);
+}
+
+export async function requireDocker(
+  docker: DockerCommand,
+  args: string[],
+  options: Parameters<typeof requireSuccessful>[2] = {},
+) {
+  return await requireSuccessful(
+    docker.command,
+    [...docker.prefix, ...args],
+    options,
+  );
+}
+
+function environmentMap(values: string[] | undefined): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const value of values ?? []) {
+    const separator = value.indexOf("=");
+    if (separator < 1) continue;
+    result.set(value.slice(0, separator), value.slice(separator + 1));
+  }
+  return result;
+}
+
+async function inspectContainer(
+  docker: DockerCommand,
+  name: string,
+): Promise<DockerInspect | null> {
+  const result = await runDocker(docker, ["inspect", name]);
+  if (result.exitCode !== 0) return null;
+  try {
+    const parsed = JSON.parse(result.stdout) as DockerInspect[];
+    return parsed[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function stoppedComposeInstallation(
+  docker: DockerCommand,
+): Promise<ExistingInstallation | null> {
+  const volumes = await runDocker(docker, [
+    "volume",
+    "ls",
+    "--filter",
+    "label=com.docker.compose.volume=overtchat-data",
+    "--format",
+    "{{.Name}}",
+  ]);
+  if (volumes.exitCode !== 0) return null;
+  const candidates = volumes.stdout
+    .split(/\r?\n/u)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (candidates.length === 0) return null;
+  if (candidates.length > 1) {
+    throw new Error(
+      "More than one stopped OvertChat data volume was found. Start the installation you want to adopt, then run overtchat setup again.",
+    );
+  }
+  const inspected = await runDocker(docker, ["volume", "inspect", candidates[0]!]);
+  if (inspected.exitCode !== 0) return null;
+  let volume: DockerVolumeInspect | undefined;
+  try {
+    volume = (JSON.parse(inspected.stdout) as DockerVolumeInspect[])[0];
+  } catch {
+    return null;
+  }
+  const project = volume?.Labels?.["com.docker.compose.project"] || "overtchat";
+  const redis = await inspectContainer(docker, "overtchat-redis");
+  const searxng = await inspectContainer(docker, "overtchat-searxng");
+  const sttGpu = await inspectContainer(docker, "overtchat-stt-gpu");
+  const sttCpu = sttGpu
+    ? null
+    : await inspectContainer(docker, "overtchat-stt-cpu");
+  const labels = redis?.Config?.Labels ?? searxng?.Config?.Labels ?? {};
+  return {
+    containerName: "overtchat-app",
+    composeProject: project,
+    composeWorkingDir: labels["com.docker.compose.project.working_dir"],
+    dataMountType: "volume",
+    dataVolume: candidates[0]!,
+    appPort: 4718,
+    bindAddress: "0.0.0.0",
+    publicUrl: "http://localhost:4718",
+    environment: new Map(),
+    searxngConfigPath: searxng?.Mounts?.find(
+      (mount) => mount.Destination === "/etc/searxng",
+    )?.Source,
+    sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
+    sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
+  };
+}
+
+export async function detectExistingInstallation(
+  docker: DockerCommand,
+): Promise<ExistingInstallation | null> {
+  const app = await inspectContainer(docker, "overtchat-app");
+  if (!app) return await stoppedComposeInstallation(docker);
+  const environment = environmentMap(app.Config?.Env);
+  const imageMatch = new RegExp(
+    `^${APP_IMAGE.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}:(\\d+\\.\\d+\\.\\d+)$`,
+    "u",
+  ).exec(app.Config?.Image ?? "");
+  const dataMount = app.Mounts?.find(
+    (mount) => mount.Destination === "/app/data",
+  );
+  const dataVolume = dataMount?.Name ?? dataMount?.Source;
+  if (!dataVolume) {
+    throw new Error(
+      "The existing overtchat-app container has no recognizable /app/data mount.",
+    );
+  }
+  const labels = app.Config?.Labels ?? {};
+  const portValue =
+    app.NetworkSettings?.Ports?.["4717/tcp"]?.[0]?.HostPort ?? "4718";
+  const bindAddress =
+    app.NetworkSettings?.Ports?.["4717/tcp"]?.[0]?.HostIp || "0.0.0.0";
+  const appPort = Number(portValue);
+  if (!Number.isInteger(appPort) || appPort < 1 || appPort > 65_535) {
+    throw new Error(`The existing OvertChat port is invalid: ${portValue}`);
+  }
+
+  const searxng = await inspectContainer(docker, "overtchat-searxng");
+  const searxngConfigPath = searxng?.Mounts?.find(
+    (mount) => mount.Destination === "/etc/searxng",
+  )?.Source;
+  const sttGpu = await inspectContainer(docker, "overtchat-stt-gpu");
+  const sttCpu = sttGpu
+    ? null
+    : await inspectContainer(docker, "overtchat-stt-cpu");
+
+  return {
+    containerName: (app.Name ?? "/overtchat-app").replace(/^\//u, ""),
+    appVersion: imageMatch?.[1],
+    appImage: imageMatch?.[0],
+    composeProject: labels["com.docker.compose.project"] || "overtchat",
+    composeWorkingDir: labels["com.docker.compose.project.working_dir"],
+    dataMountType: dataMount?.Type === "bind" ? "bind" : "volume",
+    dataVolume,
+    appPort,
+    bindAddress,
+    publicUrl:
+      environment.get("BETTER_AUTH_URL") || `http://localhost:${appPort}`,
+    environment,
+    searxngConfigPath,
+    sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
+    sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
+  };
+}
+
+export async function detectNvidiaGpus(): Promise<Gpu[]> {
+  if (!(await commandExists("nvidia-smi"))) return [];
+  const result = await runCommand("nvidia-smi", [
+    "--query-gpu=index,uuid,name,memory.total",
+    "--format=csv,noheader,nounits",
+  ]);
+  if (result.exitCode !== 0) return [];
+  return parseNvidiaSmi(result.stdout);
+}
+
+export function parseNvidiaSmi(output: string): Gpu[] {
+  const gpus: Gpu[] = [];
+  for (const line of output.split(/\r?\n/u)) {
+    if (!line.trim()) continue;
+    const [rawIndex, rawUuid, rawName, rawMemory] = line
+      .split(",")
+      .map((value) => value.trim());
+    const index = Number(rawIndex);
+    const memoryMiB = Number(rawMemory);
+    if (
+      !Number.isInteger(index) ||
+      !rawUuid ||
+      !rawName ||
+      !Number.isFinite(memoryMiB)
+    ) {
+      continue;
+    }
+    gpus.push({ index, uuid: rawUuid, name: rawName, memoryMiB });
+  }
+  return gpus;
+}
+
+export async function nvidiaContainerRuntimeAvailable(
+  docker: DockerCommand,
+): Promise<boolean> {
+  const result = await runDocker(docker, [
+    "info",
+    "--format",
+    "{{json .Runtimes}}",
+  ]);
+  if (result.exitCode !== 0) return false;
+  try {
+    const runtimes = JSON.parse(result.stdout) as Record<string, unknown>;
+    return Object.hasOwn(runtimes, "nvidia");
+  } catch {
+    return false;
+  }
+}

--- a/apps/cli/src/network.ts
+++ b/apps/cli/src/network.ts
@@ -1,0 +1,21 @@
+import os from "node:os";
+
+export function primaryLanAddress(): string | null {
+  const candidates = Object.values(os.networkInterfaces())
+    .flatMap((addresses) => addresses ?? [])
+    .filter(
+      (address) =>
+        address.family === "IPv4" &&
+        !address.internal &&
+        address.address !== "0.0.0.0",
+    );
+  const privateAddress = candidates.find((address) => {
+    const value = address.address;
+    return (
+      value.startsWith("10.") ||
+      value.startsWith("192.168.") ||
+      /^172\.(?:1[6-9]|2\d|3[01])\./u.test(value)
+    );
+  });
+  return privateAddress?.address ?? candidates[0]?.address ?? null;
+}

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -1,0 +1,23 @@
+import os from "node:os";
+import path from "node:path";
+import type { RuntimePaths } from "./types.js";
+
+export function runtimePaths(environment = process.env): RuntimePaths {
+  const home = environment.OVERTCHAT_HOME?.trim() || os.homedir();
+  const configDirectory =
+    environment.OVERTCHAT_CONFIG_DIR?.trim() ||
+    path.join(home, ".config", "overtchat");
+  const stackDirectory =
+    environment.OVERTCHAT_STACK_DIR?.trim() ||
+    path.join(home, ".local", "share", "overtchat");
+  const searxngDirectory = path.join(stackDirectory, "searxng");
+  return {
+    configDirectory,
+    stateFile: path.join(configDirectory, "installation.json"),
+    secretsFile: path.join(configDirectory, "stack.env"),
+    stackDirectory,
+    composeFile: path.join(stackDirectory, "compose.yml"),
+    searxngDirectory,
+    searxngSettingsFile: path.join(searxngDirectory, "settings.yml"),
+  };
+}

--- a/apps/cli/src/process.ts
+++ b/apps/cli/src/process.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+
+export type CommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+export type RunOptions = {
+  cwd?: string;
+  environment?: NodeJS.ProcessEnv;
+  input?: string;
+  inherit?: boolean;
+};
+
+export async function runCommand(
+  command: string,
+  args: string[],
+  options: RunOptions = {},
+): Promise<CommandResult> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.environment ?? process.env,
+      stdio: options.inherit ? ["pipe", "inherit", "inherit"] : "pipe",
+    });
+    let stdout = "";
+    let stderr = "";
+    if (!options.inherit) {
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+    }
+    child.once("error", reject);
+    child.once("close", (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+    if (options.input !== undefined) child.stdin?.end(options.input);
+    else child.stdin?.end();
+  });
+}
+
+export async function commandExists(command: string): Promise<boolean> {
+  const result = await runCommand("sh", ["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", command]);
+  return result.exitCode === 0;
+}
+
+export async function requireSuccessful(
+  command: string,
+  args: string[],
+  options: RunOptions = {},
+): Promise<CommandResult> {
+  const result = await runCommand(command, args, options);
+  if (result.exitCode !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    throw new Error(
+      `${[command, ...args].join(" ")} failed${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  return result;
+}

--- a/apps/cli/src/prompts.test.ts
+++ b/apps/cli/src/prompts.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { existingInstallationSummary } from "./prompts.js";
+import type { ExistingInstallation } from "./types.js";
+
+function installation(
+  overrides: Partial<ExistingInstallation> = {},
+): ExistingInstallation {
+  return {
+    containerName: "overtchat-app",
+    appVersion: "0.13.9",
+    appImage: "ghcr.io/yoloyash/overtchat-app:0.13.9",
+    composeProject: "overtchat",
+    composeWorkingDir: "/home/yash/dev/overtchat",
+    dataMountType: "volume",
+    dataVolume: "overtchat_overtchat-data",
+    appPort: 49317,
+    bindAddress: "127.0.0.1",
+    publicUrl: "https://chat.example.com",
+    environment: new Map(),
+    bundledServices: { search: true, tts: true, stt: true },
+    sttAccelerator: "cpu",
+    ...overrides,
+  };
+}
+
+describe("existing installation summary", () => {
+  it("makes the reused production resources and safety behavior explicit", () => {
+    expect(existingInstallationSummary(installation())).toBe(
+      [
+        "Version: 0.13.9",
+        "Address: https://chat.example.com",
+        "Published port: 127.0.0.1:49317",
+        "Data: Docker volume overtchat_overtchat-data",
+        "Compose directory: /home/yash/dev/overtchat",
+        "Bundled services: SearXNG, Kokoro, Parakeet (CPU)",
+        "",
+        "This storage will be reused. A verified SQLite snapshot will be created before the app is replaced or migrations run.",
+      ].join("\n"),
+    );
+  });
+
+  it("describes bind mounts and unavailable metadata honestly", () => {
+    const summary = existingInstallationSummary(
+      installation({
+        appVersion: undefined,
+        composeWorkingDir: undefined,
+        dataMountType: "bind",
+        dataVolume: "/srv/overtchat/data",
+        bundledServices: { search: false, tts: false, stt: false },
+      }),
+    );
+
+    expect(summary).toContain("Version: unknown");
+    expect(summary).toContain("Data: Bind mount /srv/overtchat/data");
+    expect(summary).toContain("Bundled services: none detected");
+  });
+});

--- a/apps/cli/src/prompts.ts
+++ b/apps/cli/src/prompts.ts
@@ -10,6 +10,7 @@ import {
 } from "@clack/prompts";
 import { commandExists } from "./process.js";
 import type {
+  ExistingInstallation,
   Gpu,
   InstallationConfig,
   SearchProvider,
@@ -167,6 +168,38 @@ function gpuLabel(gpu: Gpu): string {
   return `GPU ${gpu.index} — ${gpu.name}, ${memoryGiB} GB`;
 }
 
+export function existingInstallationSummary(
+  existing: ExistingInstallation,
+): string {
+  const storage =
+    existing.dataMountType === "volume"
+      ? `Docker volume ${existing.dataVolume}`
+      : `Bind mount ${existing.dataVolume}`;
+  const services = [
+    ...(existing.bundledServices.search ? ["SearXNG"] : []),
+    ...(existing.bundledServices.tts ? ["Kokoro"] : []),
+    ...(existing.bundledServices.stt
+      ? [
+          existing.sttAccelerator === "gpu"
+            ? "Parakeet (NVIDIA)"
+            : "Parakeet (CPU)",
+        ]
+      : []),
+  ];
+  return [
+    `Version: ${existing.appVersion ?? "unknown"}`,
+    `Address: ${existing.publicUrl}`,
+    `Published port: ${existing.bindAddress}:${existing.appPort}`,
+    `Data: ${storage}`,
+    ...(existing.composeWorkingDir
+      ? [`Compose directory: ${existing.composeWorkingDir}`]
+      : []),
+    `Bundled services: ${services.length > 0 ? services.join(", ") : "none detected"}`,
+    "",
+    "This storage will be reused. A verified SQLite snapshot will be created before the app is replaced or migrations run.",
+  ].join("\n");
+}
+
 async function promptStt(
   current: InstallationConfig["stt"],
   gpus: Gpu[],
@@ -288,8 +321,24 @@ async function detectedAgents(): Promise<string[]> {
 export async function promptInstallationConfig(
   initial: InstallationConfig,
   gpus: Gpu[],
+  existing?: ExistingInstallation,
 ): Promise<InstallationConfig> {
   intro("OvertChat setup");
+  if (existing) {
+    note(existingInstallationSummary(existing), "Existing installation found");
+    const adopt = chosen(
+      await confirm({
+        message: "Adopt this installation and preserve its data?",
+        initialValue: true,
+        active: "Continue",
+        inactive: "Cancel",
+      }),
+    );
+    if (!adopt) {
+      cancel("Setup cancelled. Nothing was changed.");
+      process.exit(0);
+    }
+  }
   const search = await promptSearch(initial.search);
   const tts = await promptTts(initial.tts);
   const stt = await promptStt(initial.stt, gpus);

--- a/apps/cli/src/prompts.ts
+++ b/apps/cli/src/prompts.ts
@@ -1,0 +1,321 @@
+import {
+  cancel,
+  confirm,
+  intro,
+  isCancel,
+  note,
+  password,
+  select,
+  text,
+} from "@clack/prompts";
+import { commandExists } from "./process.js";
+import type {
+  Gpu,
+  InstallationConfig,
+  SearchProvider,
+  SttProvider,
+  TtsProvider,
+} from "./types.js";
+
+function chosen<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel("Setup cancelled. Nothing was changed.");
+    process.exit(130);
+  }
+  return value;
+}
+
+function urlValidation(value: string | undefined): string | undefined {
+  if (!value?.trim()) return "Enter the API base URL.";
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return "Use an http:// or https:// URL.";
+    }
+  } catch {
+    return "Enter a valid URL.";
+  }
+  return undefined;
+}
+
+async function promptSearch(
+  current: InstallationConfig["search"],
+): Promise<InstallationConfig["search"]> {
+  const provider = chosen(
+    await select<SearchProvider>({
+      message: "Web search",
+      initialValue: current.provider,
+      options: [
+        {
+          value: "bundled",
+          label: "Bundled SearXNG",
+          hint: "private and runs on this server",
+        },
+        { value: "brave", label: "Brave Search API" },
+        { value: "searxng", label: "Existing SearXNG" },
+        { value: "disabled", label: "Disabled" },
+      ],
+    }),
+  );
+  if (provider === "brave") {
+    const hasCurrentKey = Boolean(current.apiKey);
+    const apiKey = chosen(
+      await password({
+        message: hasCurrentKey
+          ? "Brave Search API key (leave blank to keep current)"
+          : "Brave Search API key",
+        mask: "•",
+        validate: (value) =>
+          value?.trim() || hasCurrentKey
+            ? undefined
+            : "Enter your Brave Search API key.",
+      }),
+    );
+    return {
+      provider,
+      bundledInstalled: current.bundledInstalled,
+      apiKey: apiKey.trim() || current.apiKey,
+    };
+  }
+  if (provider === "searxng") {
+    const baseUrl = chosen(
+      await text({
+        message: "Existing SearXNG URL",
+        placeholder: "http://host.docker.internal:8088",
+        initialValue: current.baseUrl,
+        validate: urlValidation,
+      }),
+    );
+    return {
+      provider,
+      bundledInstalled: current.bundledInstalled,
+      baseUrl: baseUrl.trim().replace(/\/$/u, ""),
+    };
+  }
+  return {
+    provider,
+    bundledInstalled: current.bundledInstalled || provider === "bundled",
+  };
+}
+
+async function promptTts(
+  current: InstallationConfig["tts"],
+): Promise<InstallationConfig["tts"]> {
+  const provider = chosen(
+    await select<TtsProvider>({
+      message: "Text-to-speech",
+      initialValue: current.provider,
+      options: [
+        {
+          value: "bundled",
+          label: "Bundled Kokoro",
+          hint: "local CPU service",
+        },
+        { value: "openai-compatible", label: "OpenAI-compatible API" },
+        { value: "disabled", label: "Disabled" },
+      ],
+    }),
+  );
+  if (provider !== "openai-compatible") {
+    return {
+      provider,
+      bundledInstalled: current.bundledInstalled || provider === "bundled",
+    };
+  }
+  const baseUrl = chosen(
+    await text({
+      message: "TTS API base URL",
+      placeholder: "https://api.openai.com/v1",
+      initialValue: current.baseUrl,
+      validate: urlValidation,
+    }),
+  );
+  const apiKey = chosen(
+    await password({
+      message: current.apiKey
+        ? "TTS API key (leave blank to keep current)"
+        : "TTS API key (leave blank when not required)",
+      mask: "•",
+    }),
+  );
+  const model = chosen(
+    await text({
+      message: "TTS model",
+      initialValue: current.model ?? "tts-1",
+      validate: (value) => (value?.trim() ? undefined : "Enter a model name."),
+    }),
+  );
+  const voice = chosen(
+    await text({
+      message: "Default voice",
+      initialValue: current.voice ?? "alloy",
+      validate: (value) => (value?.trim() ? undefined : "Enter a voice."),
+    }),
+  );
+  return {
+    provider,
+    bundledInstalled: current.bundledInstalled,
+    baseUrl: baseUrl.trim().replace(/\/$/u, ""),
+    apiKey: apiKey.trim() || current.apiKey || "",
+    model: model.trim(),
+    voice: voice.trim(),
+  };
+}
+
+function gpuLabel(gpu: Gpu): string {
+  const memoryGiB = Math.round((gpu.memoryMiB / 1024) * 10) / 10;
+  return `GPU ${gpu.index} — ${gpu.name}, ${memoryGiB} GB`;
+}
+
+async function promptStt(
+  current: InstallationConfig["stt"],
+  gpus: Gpu[],
+): Promise<InstallationConfig["stt"]> {
+  const provider = chosen(
+    await select<SttProvider>({
+      message: "Speech-to-text",
+      initialValue: current.provider,
+      options: [
+        {
+          value: "bundled",
+          label:
+            gpus.length > 0
+              ? "Bundled Parakeet — NVIDIA accelerated"
+              : "Bundled Parakeet — CPU",
+          hint: gpus.length > 0 ? `${gpus.length} NVIDIA GPU${gpus.length === 1 ? "" : "s"} detected` : "CPU",
+        },
+        { value: "openai-compatible", label: "OpenAI-compatible API" },
+        { value: "disabled", label: "Disabled" },
+      ],
+    }),
+  );
+  if (provider === "openai-compatible") {
+    const baseUrl = chosen(
+      await text({
+        message: "STT API base URL",
+        placeholder: "https://api.openai.com/v1",
+        initialValue: current.baseUrl,
+        validate: urlValidation,
+      }),
+    );
+    const apiKey = chosen(
+      await password({
+        message: current.apiKey
+          ? "STT API key (leave blank to keep current)"
+          : "STT API key (leave blank when not required)",
+        mask: "•",
+      }),
+    );
+    const model = chosen(
+      await text({
+        message: "STT model",
+        initialValue: current.model ?? "whisper-1",
+        validate: (value) => (value?.trim() ? undefined : "Enter a model name."),
+      }),
+    );
+    return {
+      provider,
+      bundledInstalled: current.bundledInstalled,
+      baseUrl: baseUrl.trim().replace(/\/$/u, ""),
+      apiKey: apiKey.trim() || current.apiKey || "",
+      model: model.trim(),
+    };
+  }
+  if (provider === "disabled") {
+    return { provider, bundledInstalled: current.bundledInstalled };
+  }
+  if (gpus.length === 0) {
+    note("No NVIDIA GPU was detected. Parakeet will use the CPU image.", "Local STT accelerator");
+    return { provider, bundledInstalled: true, accelerator: "cpu" };
+  }
+  const autoGpu = [...gpus].sort((left, right) => right.memoryMiB - left.memoryMiB)[0];
+  const currentSelection =
+    current.accelerator === "cpu"
+      ? "cpu"
+      : current.accelerator === "gpu" && current.gpuUuid
+        ? `gpu:${current.gpuUuid}`
+        : "auto";
+  const accelerator = chosen(
+    await select<string>({
+      message: "Local STT accelerator",
+      initialValue: currentSelection,
+      options: [
+        {
+          value: "auto",
+          label: `Auto — ${autoGpu?.name ?? gpus[0]?.name}`,
+          hint: "recommended",
+        },
+        ...gpus.map((gpu) => ({
+          value: `gpu:${gpu.uuid}`,
+          label: gpuLabel(gpu),
+        })),
+        { value: "cpu", label: "CPU" },
+      ],
+    }),
+  );
+  if (accelerator === "cpu") {
+    return { provider, bundledInstalled: true, accelerator: "cpu" };
+  }
+  if (accelerator === "auto") {
+    return {
+      provider,
+      bundledInstalled: true,
+      accelerator: "auto",
+      gpuUuid: autoGpu?.uuid ?? gpus[0]?.uuid,
+    };
+  }
+  return {
+    provider,
+    bundledInstalled: true,
+    accelerator: "gpu",
+    gpuUuid: accelerator.slice("gpu:".length),
+  };
+}
+
+async function detectedAgents(): Promise<string[]> {
+  const agents = [
+    ["codex", "Codex"],
+    ["pi", "Pi"],
+    ["omp", "Oh My Pi"],
+  ] as const;
+  const detected: string[] = [];
+  for (const [command, label] of agents) {
+    if (await commandExists(command)) detected.push(label);
+  }
+  return detected;
+}
+
+export async function promptInstallationConfig(
+  initial: InstallationConfig,
+  gpus: Gpu[],
+): Promise<InstallationConfig> {
+  intro("OvertChat setup");
+  const search = await promptSearch(initial.search);
+  const tts = await promptTts(initial.tts);
+  const stt = await promptStt(initial.stt, gpus);
+  const agents = await detectedAgents();
+  note(
+    [
+      "Use OvertChat as a client for coding agents such as Codex, Pi, and Oh My Pi.",
+      ...(agents.length > 0
+        ? [`Detected on this machine: ${agents.join(", ")}`]
+        : []),
+    ].join("\n"),
+    "Agent Connections",
+  );
+  const installAgents = chosen(
+    await confirm({
+      message: "Install Agent Connections?",
+      initialValue: initial.agents.installed || agents.length > 0,
+      active: "Yes",
+      inactive: "No",
+    }),
+  );
+  return {
+    ...initial,
+    search,
+    tts,
+    stt,
+    agents: { installed: installAgents },
+  };
+}

--- a/apps/cli/src/release.test.ts
+++ b/apps/cli/src/release.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { compareVersions, parseReleaseManifest } from "./release.js";
+
+describe("release manifest", () => {
+  it("accepts one coordinated set of component versions", () => {
+    expect(
+      parseReleaseManifest({
+        format: 1,
+        cliVersion: "1.2.3",
+        appVersion: "4.5.6",
+        connectorVersion: "7.8.9",
+        sttVersion: "0.1.0",
+      }),
+    ).toEqual({
+      format: 1,
+      cliVersion: "1.2.3",
+      appVersion: "4.5.6",
+      connectorVersion: "7.8.9",
+      sttVersion: "0.1.0",
+    });
+  });
+
+  it("rejects malformed or unpinned versions", () => {
+    expect(() =>
+      parseReleaseManifest({
+        format: 1,
+        cliVersion: "latest",
+        appVersion: "4.5.6",
+        connectorVersion: "7.8.9",
+        sttVersion: "0.1.0",
+      }),
+    ).toThrow("invalid CLI version");
+  });
+
+  it("orders stable component versions without downgrading", () => {
+    expect(compareVersions("1.10.0", "1.9.9")).toBeGreaterThan(0);
+    expect(compareVersions("2.0.0", "2.0.0")).toBe(0);
+    expect(compareVersions("0.4.0", "1.0.0")).toBeLessThan(0);
+  });
+});

--- a/apps/cli/src/release.ts
+++ b/apps/cli/src/release.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import {
+  CLI_VERSION,
+  CONNECTOR_REPOSITORY,
+  RELEASE_MANIFEST_URL,
+} from "./constants.js";
+import { runCommand } from "./process.js";
+
+export type ReleaseManifest = {
+  format: 1;
+  cliVersion: string;
+  appVersion: string;
+  connectorVersion: string;
+  sttVersion: string;
+};
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/u;
+
+export function compareVersions(left: string, right: string): number {
+  if (!VERSION_PATTERN.test(left) || !VERSION_PATTERN.test(right)) {
+    throw new Error("Cannot compare an invalid OvertChat component version.");
+  }
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function assertVersion(value: unknown, field: string): asserts value is string {
+  if (typeof value !== "string" || !VERSION_PATTERN.test(value)) {
+    throw new Error(`The release manifest has an invalid ${field}.`);
+  }
+}
+
+export function parseReleaseManifest(value: unknown): ReleaseManifest {
+  if (!value || typeof value !== "object" || Reflect.get(value, "format") !== 1) {
+    throw new Error("The OvertChat release manifest is invalid.");
+  }
+  const cliVersion = Reflect.get(value, "cliVersion");
+  const appVersion = Reflect.get(value, "appVersion");
+  const connectorVersion = Reflect.get(value, "connectorVersion");
+  const sttVersion = Reflect.get(value, "sttVersion");
+  assertVersion(cliVersion, "CLI version");
+  assertVersion(appVersion, "app version");
+  assertVersion(connectorVersion, "connector version");
+  assertVersion(sttVersion, "STT version");
+  return {
+    format: 1,
+    cliVersion,
+    appVersion,
+    connectorVersion,
+    sttVersion,
+  };
+}
+
+export async function latestReleaseManifest(): Promise<ReleaseManifest> {
+  const url =
+    process.env.OVERTCHAT_RELEASE_MANIFEST_URL?.trim() || RELEASE_MANIFEST_URL;
+  const response = await fetch(url, {
+    redirect: "follow",
+    headers: { "Cache-Control": "no-cache" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Could not check for OvertChat updates (HTTP ${response.status}).`);
+  }
+  return parseReleaseManifest(await response.json());
+}
+
+function cliAsset(): string {
+  if (process.platform !== "linux") {
+    throw new Error("The managed OvertChat CLI currently supports Linux.");
+  }
+  if (process.arch === "x64") return "overtchat-linux-amd64";
+  if (process.arch === "arm64") return "overtchat-linux-arm64";
+  throw new Error(`The OvertChat CLI does not support ${process.arch}.`);
+}
+
+function checksumFor(contents: string, asset: string): string {
+  for (const line of contents.split(/\r?\n/u)) {
+    const [checksum, filename] = line.trim().split(/\s+/u);
+    if (filename?.replace(/^\*/u, "") === asset && checksum) return checksum;
+  }
+  throw new Error(`The CLI checksum for ${asset} is missing.`);
+}
+
+async function download(url: string): Promise<Uint8Array> {
+  const response = await fetch(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Could not download ${url} (HTTP ${response.status}).`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function currentExecutable(): string | null {
+  const executable = process.execPath;
+  const basename = path.basename(executable);
+  return basename === "overtchat" || basename.startsWith("overtchat-linux-")
+    ? executable
+    : null;
+}
+
+export async function updateCliIfNeeded(
+  manifest: ReleaseManifest,
+): Promise<string | null> {
+  if (compareVersions(manifest.cliVersion, CLI_VERSION) <= 0) return null;
+  const executable = currentExecutable();
+  // Source/development runs use node, tsx, or bun. Never overwrite those.
+  if (!executable) return null;
+
+  const asset = cliAsset();
+  const releaseBase = `https://github.com/${CONNECTOR_REPOSITORY}/releases/download/cli-v${manifest.cliVersion}`;
+  const temporaryDirectory = await mkdtemp(
+    path.join(path.dirname(executable), ".overtchat-update-"),
+  );
+  const replacement = path.join(temporaryDirectory, "overtchat");
+  const backup = `${executable}.previous`;
+  try {
+    const [binary, checksums] = await Promise.all([
+      download(`${releaseBase}/${asset}`),
+      download(`${releaseBase}/overtchat-checksums.txt`),
+    ]);
+    const expected = checksumFor(new TextDecoder().decode(checksums), asset);
+    const actual = createHash("sha256").update(binary).digest("hex");
+    if (actual !== expected) {
+      throw new Error("The downloaded OvertChat CLI failed checksum verification.");
+    }
+    await writeFile(replacement, binary, { mode: 0o755 });
+    await chmod(replacement, 0o755);
+    const preflight = await runCommand(replacement, ["version"]);
+    if (
+      preflight.exitCode !== 0 ||
+      preflight.stdout.trim() !== manifest.cliVersion
+    ) {
+      throw new Error("The downloaded OvertChat CLI failed its startup check.");
+    }
+    await rm(backup, { force: true });
+    await copyFile(executable, backup);
+    await rename(replacement, executable);
+    return executable;
+  } catch (error) {
+    if (await readFile(backup).catch(() => null)) {
+      await copyFile(backup, executable).catch(() => {});
+    }
+    throw error;
+  } finally {
+    await rm(backup, { force: true });
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}

--- a/apps/cli/src/setup.test.ts
+++ b/apps/cli/src/setup.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { syncCapabilities } from "./setup.js";
+import { installationNeedsAdoption, syncCapabilities } from "./setup.js";
+import type { ExistingInstallation } from "./types.js";
 import type { InstallationConfig } from "./types.js";
 
 function config(): InstallationConfig {
@@ -42,6 +43,55 @@ function config(): InstallationConfig {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+function existingInstallation(
+  composeWorkingDir: string | undefined,
+): ExistingInstallation {
+  return {
+    containerName: "overtchat-app",
+    appVersion: "0.13.9",
+    appImage: "ghcr.io/yoloyash/overtchat-app:0.13.9",
+    composeProject: "overtchat",
+    composeWorkingDir,
+    dataMountType: "volume",
+    dataVolume: "overtchat_overtchat-data",
+    appPort: 4718,
+    bindAddress: "0.0.0.0",
+    publicUrl: "http://localhost:4718",
+    environment: new Map(),
+    bundledServices: { search: true, tts: true, stt: true },
+    sttAccelerator: "cpu",
+  };
+}
+
+describe("installation adoption", () => {
+  it("adopts stacks outside the managed directory", () => {
+    expect(
+      installationNeedsAdoption(
+        existingInstallation("/home/yash/dev/overtchat"),
+        "/home/yash/.local/share/overtchat",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not re-adopt a stack already owned by the manager", () => {
+    expect(
+      installationNeedsAdoption(
+        existingInstallation("/home/yash/.local/share/overtchat"),
+        "/home/yash/.local/share/overtchat",
+      ),
+    ).toBe(false);
+  });
+
+  it("fails safe when the prior Compose directory is unknown", () => {
+    expect(
+      installationNeedsAdoption(
+        existingInstallation(undefined),
+        "/home/yash/.local/share/overtchat",
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("capability synchronization", () => {

--- a/apps/cli/src/setup.test.ts
+++ b/apps/cli/src/setup.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { syncCapabilities } from "./setup.js";
+import type { InstallationConfig } from "./types.js";
+
+function config(): InstallationConfig {
+  return {
+    format: 1,
+    appVersion: "1.2.3",
+    appImage: "ghcr.io/example/overtchat:1.2.3",
+    connectorVersion: "2.0.0",
+    sttVersion: "3.0.0",
+    appPort: 4718,
+    bindAddress: "0.0.0.0",
+    publicUrl: "http://localhost:4718",
+    extraTrustedOrigins: [],
+    connectorServerUrl: "http://127.0.0.1:4718",
+    composeProject: "overtchat",
+    dataMountType: "volume",
+    dataVolume: "overtchat-data",
+    search: {
+      provider: "brave",
+      bundledInstalled: false,
+      apiKey: "replacement-search-key",
+    },
+    tts: {
+      provider: "openai-compatible",
+      bundledInstalled: false,
+      baseUrl: "https://speech.example.com/v1",
+      apiKey: "",
+      model: "tts-1",
+      voice: "alloy",
+    },
+    stt: {
+      provider: "openai-compatible",
+      bundledInstalled: false,
+      baseUrl: "https://speech.example.com/v1",
+      model: "whisper-1",
+    },
+    agents: { installed: false },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("capability synchronization", () => {
+  it("replaces explicit keys, clears explicit blanks, and preserves omitted keys", async () => {
+    let submitted: unknown;
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        submitted = JSON.parse(String(init.body));
+        return Response.json({ capabilities: [] });
+      }
+      return Response.json({
+        capabilities: [
+          {
+            id: "search",
+            provider: "brave",
+            bundledInstalled: false,
+            baseUrl: null,
+            apiKey: "stored-search-key",
+            model: null,
+            voice: null,
+          },
+          {
+            id: "tts",
+            provider: "openai-compatible",
+            bundledInstalled: false,
+            baseUrl: "https://speech.example.com/v1",
+            apiKey: "stored-tts-key",
+            model: "tts-1",
+            voice: "alloy",
+          },
+          {
+            id: "stt",
+            provider: "openai-compatible",
+            bundledInstalled: false,
+            baseUrl: "https://speech.example.com/v1",
+            apiKey: "stored-stt-key",
+            model: "whisper-1",
+            voice: null,
+          },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncCapabilities(config(), "management-secret");
+
+    expect(submitted).toMatchObject({
+      capabilities: [
+        { id: "search", apiKey: "replacement-search-key" },
+        { id: "tts", apiKey: null },
+        { id: "stt", apiKey: "stored-stt-key" },
+      ],
+    });
+  });
+});

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -1,6 +1,6 @@
 import { cp, mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { confirm, isCancel, outro, spinner } from "@clack/prompts";
+import { confirm, isCancel, note, outro, spinner } from "@clack/prompts";
 import {
   defaultInstallationConfig,
   initialSecrets,
@@ -30,7 +30,8 @@ import { primaryLanAddress } from "./network.js";
 import { runtimePaths } from "./paths.js";
 import { requireSuccessful } from "./process.js";
 import { promptInstallationConfig } from "./prompts.js";
-import type { InstallationConfig } from "./types.js";
+import { createPreMigrationSnapshot } from "./snapshot.js";
+import type { ExistingInstallation, InstallationConfig } from "./types.js";
 
 export type SetupOptions = {
   dryRun: boolean;
@@ -235,6 +236,18 @@ export async function syncCapabilities(
   }
 }
 
+export function installationNeedsAdoption(
+  existing: ExistingInstallation | null,
+  managedStackDirectory: string,
+): existing is ExistingInstallation {
+  if (!existing) return false;
+  if (!existing.composeWorkingDir) return true;
+  return (
+    path.resolve(existing.composeWorkingDir) !==
+    path.resolve(managedStackDirectory)
+  );
+}
+
 export async function setup(options: SetupOptions): Promise<void> {
   if (process.platform !== "linux") {
     throw new Error("The managed OvertChat installer currently supports Linux.");
@@ -267,6 +280,7 @@ export async function setup(options: SetupOptions): Promise<void> {
   const paths = runtimePaths();
   const existing = await detectExistingInstallation(docker);
   const saved = await readInstallationConfig(paths);
+  const adopting = installationNeedsAdoption(existing, paths.stackDirectory);
   const previousSecrets = await readInstallationSecrets(paths);
   let config = saved ?? defaultInstallationConfig(existing);
   if (saved) {
@@ -297,7 +311,11 @@ export async function setup(options: SetupOptions): Promise<void> {
         "Interactive setup needs a terminal. Re-run with --defaults for an unattended test install.",
       );
     }
-    config = await promptInstallationConfig(config, gpus);
+    config = await promptInstallationConfig(
+      config,
+      gpus,
+      adopting ? existing ?? undefined : undefined,
+    );
   } else if (gpus.length > 0 && config.stt.provider === "bundled") {
     const gpu = [...gpus].sort((left, right) => right.memoryMiB - left.memoryMiB)[0];
     config.stt = {
@@ -366,8 +384,12 @@ export async function setup(options: SetupOptions): Promise<void> {
     return;
   }
 
-  const progress = spinner();
-  progress.start(existing ? "Adopting the existing OvertChat installation" : "Preparing OvertChat data");
+  const preparation = spinner();
+  preparation.start(
+    adopting
+      ? "Preparing the existing OvertChat installation"
+      : "Preparing OvertChat data",
+  );
   if (config.dataMountType === "volume") {
     const volume = await runDocker(docker, ["volume", "inspect", config.dataVolume]);
     if (volume.exitCode !== 0) {
@@ -375,14 +397,14 @@ export async function setup(options: SetupOptions): Promise<void> {
     }
   }
   if (options.development) {
-    progress.message("Building the OvertChat app from this worktree");
+    preparation.message("Building the OvertChat app from this worktree");
     await requireDocker(
       docker,
       ["build", "--tag", config.appImage, sourceDirectory],
       { inherit: true },
     );
     if (config.agents.installed) {
-      progress.message("Building Agent Connections from this worktree");
+      preparation.message("Building Agent Connections from this worktree");
       await requireSuccessful(
         "npm",
         ["run", "build", "-w", "apps/connector", "--"],
@@ -396,17 +418,31 @@ export async function setup(options: SetupOptions): Promise<void> {
         "overtchat-connector.mjs",
       );
     }
-    progress.message("Downloading the selected service images");
+    preparation.message("Downloading the selected service images");
     await requireDocker(
       docker,
       [...composeArgs, "pull", "--ignore-pull-failures"],
       { inherit: true },
     );
   } else {
-    progress.message("Downloading the selected OvertChat components");
+    preparation.message("Downloading the selected OvertChat components");
     await requireDocker(docker, [...composeArgs, "pull"], { inherit: true });
   }
-  progress.message("Starting OvertChat");
+  const snapshot = adopting && existing
+    ? await (async () => {
+        preparation.message("Creating and verifying a SQLite safety snapshot");
+        return await createPreMigrationSnapshot(docker, existing, config);
+      })()
+    : null;
+  preparation.stop(
+    snapshot ? "Existing data snapshot created" : "OvertChat components ready",
+  );
+  if (snapshot) {
+    note(snapshot.displayPath, "Pre-migration snapshot");
+  }
+
+  const progress = spinner();
+  progress.start("Starting OvertChat");
   await requireDocker(docker, [...composeArgs, "up", "-d"], { inherit: true });
   progress.message("Waiting for OvertChat to become ready");
   await waitForApp(`http://127.0.0.1:${config.appPort}`);

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -1,0 +1,423 @@
+import { cp, mkdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { confirm, isCancel, outro, spinner } from "@clack/prompts";
+import {
+  defaultInstallationConfig,
+  initialSecrets,
+  readInstallationConfig,
+  readInstallationSecrets,
+  writeInstallationConfig,
+  writeSecretsFile,
+} from "./config.js";
+import { installManagedConnector } from "./connector.js";
+import {
+  renderComposeFile,
+  renderStackEnvironment,
+  SEARXNG_SETTINGS,
+} from "./compose.js";
+import {
+  detectDockerCommand,
+  detectExistingInstallation,
+  detectNvidiaGpus,
+  dockerComposeAvailable,
+  installDockerEngine,
+  installNvidiaContainerToolkit,
+  nvidiaContainerRuntimeAvailable,
+  requireDocker,
+  runDocker,
+} from "./docker.js";
+import { primaryLanAddress } from "./network.js";
+import { runtimePaths } from "./paths.js";
+import { requireSuccessful } from "./process.js";
+import { promptInstallationConfig } from "./prompts.js";
+import type { InstallationConfig } from "./types.js";
+
+export type SetupOptions = {
+  dryRun: boolean;
+  defaults: boolean;
+  development: boolean;
+};
+
+type RunningCapability = {
+  id: "search" | "tts" | "stt";
+  provider: string;
+  bundledInstalled: boolean;
+  baseUrl: string | null;
+  apiKey: string | null;
+  model: string | null;
+  voice: string | null;
+};
+
+type CapabilityPayload = Omit<RunningCapability, "apiKey"> & {
+  apiKey: string | null;
+};
+
+async function runningCapabilities(
+  config: InstallationConfig,
+  managementSecret: string | undefined,
+): Promise<RunningCapability[] | null> {
+  if (!managementSecret) return null;
+  const response = await fetch(
+    `http://127.0.0.1:${config.appPort}/api/internal/management/capabilities`,
+    {
+      headers: { Authorization: `Bearer ${managementSecret}` },
+      signal: AbortSignal.timeout(3_000),
+    },
+  ).catch(() => null);
+  if (!response?.ok) return null;
+  const body = (await response.json().catch(() => null)) as {
+    capabilities?: RunningCapability[];
+  } | null;
+  return Array.isArray(body?.capabilities) ? body.capabilities : null;
+}
+
+function mergeRunningCapabilities(
+  config: InstallationConfig,
+  capabilities: RunningCapability[] | null,
+): InstallationConfig {
+  if (!capabilities) return config;
+  const search = capabilities.find((capability) => capability.id === "search");
+  const tts = capabilities.find((capability) => capability.id === "tts");
+  const stt = capabilities.find((capability) => capability.id === "stt");
+  return {
+    ...config,
+    search: search
+      ? {
+          provider: search.provider as InstallationConfig["search"]["provider"],
+          bundledInstalled: search.bundledInstalled,
+          baseUrl: search.baseUrl ?? undefined,
+          apiKey: search.apiKey ?? undefined,
+        }
+      : config.search,
+    tts: tts
+      ? {
+          provider: tts.provider as InstallationConfig["tts"]["provider"],
+          bundledInstalled: tts.bundledInstalled,
+          baseUrl: tts.baseUrl ?? undefined,
+          apiKey: tts.apiKey ?? undefined,
+          model: tts.model ?? undefined,
+          voice: tts.voice ?? undefined,
+        }
+      : config.tts,
+    stt: stt
+      ? {
+          ...config.stt,
+          provider: stt.provider as InstallationConfig["stt"]["provider"],
+          bundledInstalled: stt.bundledInstalled,
+          baseUrl: stt.baseUrl ?? undefined,
+          apiKey: stt.apiKey ?? undefined,
+          model: stt.model ?? undefined,
+        }
+      : config.stt,
+  };
+}
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await stat(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function prepareFiles(
+  config: InstallationConfig,
+  existingSearxngConfigPath: string | undefined,
+): Promise<void> {
+  const paths = runtimePaths();
+  await mkdir(paths.stackDirectory, { recursive: true, mode: 0o700 });
+  await mkdir(paths.searxngDirectory, { recursive: true, mode: 0o700 });
+  if (
+    config.search.provider === "bundled" &&
+    existingSearxngConfigPath &&
+    existingSearxngConfigPath !== paths.searxngDirectory &&
+    !(await exists(paths.searxngSettingsFile))
+  ) {
+    await cp(existingSearxngConfigPath, paths.searxngDirectory, {
+      recursive: true,
+      force: false,
+    });
+  }
+  if (!(await exists(paths.searxngSettingsFile))) {
+    await writeFile(paths.searxngSettingsFile, SEARXNG_SETTINGS, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+  }
+  await writeFile(paths.composeFile, renderComposeFile(config), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+export async function waitForApp(url: string): Promise<void> {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    const response = await fetch(url, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(5_000),
+    }).catch(() => null);
+    if (response && response.status >= 200 && response.status < 500) return;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error("OvertChat did not become ready within three minutes.");
+}
+
+export async function syncCapabilities(
+  config: InstallationConfig,
+  managementSecret: string,
+): Promise<void> {
+  const running = await runningCapabilities(config, managementSecret);
+  const existingApiKey = (id: RunningCapability["id"]): string | null =>
+    running?.find((capability) => capability.id === id)?.apiKey ?? null;
+  const apiKey = (
+    configured: string | undefined,
+    id: RunningCapability["id"],
+  ): string | null =>
+    configured === undefined ? existingApiKey(id) : configured.trim() || null;
+  const capabilities: CapabilityPayload[] = [
+    {
+      id: "search",
+      provider: config.search.provider,
+      bundledInstalled: config.search.bundledInstalled,
+      baseUrl: config.search.baseUrl ?? null,
+      apiKey: apiKey(config.search.apiKey, "search"),
+      model: null,
+      voice: null,
+    },
+    {
+      id: "tts",
+      provider: config.tts.provider,
+      bundledInstalled: config.tts.bundledInstalled,
+      baseUrl: config.tts.baseUrl ?? null,
+      apiKey: apiKey(config.tts.apiKey, "tts"),
+      model:
+        config.tts.model ??
+        (config.tts.provider === "bundled" ? "kokoro" : null),
+      voice:
+        config.tts.voice ??
+        (config.tts.provider === "bundled" ? "af_heart" : null),
+    },
+    {
+      id: "stt",
+      provider: config.stt.provider,
+      bundledInstalled: config.stt.bundledInstalled,
+      baseUrl: config.stt.baseUrl ?? null,
+      apiKey: apiKey(config.stt.apiKey, "stt"),
+      model:
+        config.stt.model ??
+        (config.stt.provider === "bundled"
+          ? "parakeet-tdt-0.6b-v3"
+          : null),
+      voice: null,
+    },
+  ];
+  const response = await fetch(
+    `http://127.0.0.1:${config.appPort}/api/internal/management/capabilities`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${managementSecret}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ capabilities }),
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `OvertChat rejected its capability configuration (${response.status})${
+        detail ? `: ${detail}` : ""
+      }`,
+    );
+  }
+}
+
+export async function setup(options: SetupOptions): Promise<void> {
+  if (process.platform !== "linux") {
+    throw new Error("The managed OvertChat installer currently supports Linux.");
+  }
+  let docker = await detectDockerCommand();
+  if (!docker) {
+    if (options.defaults) {
+      throw new Error("Docker Engine was not found.");
+    }
+    const installDocker = await confirm({
+      message: "Docker Engine is not installed. Install it now?",
+      initialValue: true,
+      active: "Yes",
+      inactive: "No",
+    });
+    if (isCancel(installDocker) || !installDocker) {
+      throw new Error("Docker Engine is required to install OvertChat.");
+    }
+    const dockerProgress = spinner();
+    dockerProgress.start("Installing Docker Engine");
+    await installDockerEngine();
+    dockerProgress.stop("Docker Engine installed");
+    docker = await detectDockerCommand();
+    if (!docker) throw new Error("Docker was installed but could not be started.");
+  }
+  if (!(await dockerComposeAvailable(docker))) {
+    throw new Error("Docker Compose v2 was not found.");
+  }
+
+  const paths = runtimePaths();
+  const existing = await detectExistingInstallation(docker);
+  const saved = await readInstallationConfig(paths);
+  const previousSecrets = await readInstallationSecrets(paths);
+  let config = saved ?? defaultInstallationConfig(existing);
+  if (saved) {
+    config = mergeRunningCapabilities(
+      config,
+      await runningCapabilities(config, previousSecrets.managementSecret),
+    );
+  }
+  const sourceDirectory = path.resolve(
+    process.env.OVERTCHAT_SOURCE_DIR || process.env.INIT_CWD || process.cwd(),
+  );
+  if (options.development) {
+    if (!(await exists(path.join(sourceDirectory, "Dockerfile")))) {
+      throw new Error(
+        `No OvertChat Dockerfile was found in ${sourceDirectory}. Set OVERTCHAT_SOURCE_DIR to the repository root.`,
+      );
+    }
+    config = { ...config, appImage: "overtchat-app:setup-dev" };
+  }
+  if (!saved && !existing) {
+    const lanAddress = primaryLanAddress();
+    if (lanAddress) config.publicUrl = `http://${lanAddress}:${config.appPort}`;
+  }
+  const gpus = await detectNvidiaGpus();
+  if (!options.defaults) {
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      throw new Error(
+        "Interactive setup needs a terminal. Re-run with --defaults for an unattended test install.",
+      );
+    }
+    config = await promptInstallationConfig(config, gpus);
+  } else if (gpus.length > 0 && config.stt.provider === "bundled") {
+    const gpu = [...gpus].sort((left, right) => right.memoryMiB - left.memoryMiB)[0];
+    config.stt = {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "auto",
+      gpuUuid: gpu?.uuid,
+    };
+  }
+
+  if (
+    config.stt.provider === "bundled" &&
+    config.stt.accelerator !== "cpu" &&
+    !(await nvidiaContainerRuntimeAvailable(docker))
+  ) {
+    if (options.defaults) {
+      config.stt = { ...config.stt, accelerator: "cpu", gpuUuid: undefined };
+    } else {
+      const installToolkit = await confirm({
+        message:
+          "The NVIDIA Container Toolkit is missing. Install and configure it now?",
+        initialValue: true,
+        active: "Yes",
+        inactive: "Use CPU",
+      });
+      if (isCancel(installToolkit)) {
+        throw new Error("NVIDIA Container Toolkit installation was cancelled.");
+      }
+      if (installToolkit) {
+        const toolkitProgress = spinner();
+        toolkitProgress.start("Installing NVIDIA Container Toolkit");
+        await installNvidiaContainerToolkit();
+        toolkitProgress.stop("NVIDIA Container Toolkit installed");
+        if (!(await nvidiaContainerRuntimeAvailable(docker))) {
+          throw new Error(
+            "The NVIDIA Container Toolkit was installed, but Docker does not report the NVIDIA runtime.",
+          );
+        }
+      } else {
+        config.stt = { ...config.stt, accelerator: "cpu", gpuUuid: undefined };
+      }
+    }
+  }
+
+  const secrets = initialSecrets(
+    existing,
+    previousSecrets,
+  );
+  await prepareFiles(config, existing?.searxngConfigPath);
+  await writeSecretsFile(
+    paths,
+    renderStackEnvironment(config, secrets, paths),
+  );
+
+  const composeArgs = [
+    "compose",
+    "--env-file",
+    paths.secretsFile,
+    "-f",
+    paths.composeFile,
+  ];
+  await requireDocker(docker, [...composeArgs, "config"]);
+  if (options.dryRun) {
+    await writeInstallationConfig(paths, config);
+    outro(`Configuration written to ${paths.stackDirectory}`);
+    return;
+  }
+
+  const progress = spinner();
+  progress.start(existing ? "Adopting the existing OvertChat installation" : "Preparing OvertChat data");
+  if (config.dataMountType === "volume") {
+    const volume = await runDocker(docker, ["volume", "inspect", config.dataVolume]);
+    if (volume.exitCode !== 0) {
+      await requireDocker(docker, ["volume", "create", config.dataVolume]);
+    }
+  }
+  if (options.development) {
+    progress.message("Building the OvertChat app from this worktree");
+    await requireDocker(
+      docker,
+      ["build", "--tag", config.appImage, sourceDirectory],
+      { inherit: true },
+    );
+    if (config.agents.installed) {
+      progress.message("Building Agent Connections from this worktree");
+      await requireSuccessful(
+        "npm",
+        ["run", "build", "-w", "apps/connector", "--"],
+        { cwd: sourceDirectory, inherit: true },
+      );
+      process.env.OVERTCHAT_CONNECTOR_BINARY = path.join(
+        sourceDirectory,
+        "apps",
+        "connector",
+        "dist",
+        "overtchat-connector.mjs",
+      );
+    }
+    progress.message("Downloading the selected service images");
+    await requireDocker(
+      docker,
+      [...composeArgs, "pull", "--ignore-pull-failures"],
+      { inherit: true },
+    );
+  } else {
+    progress.message("Downloading the selected OvertChat components");
+    await requireDocker(docker, [...composeArgs, "pull"], { inherit: true });
+  }
+  progress.message("Starting OvertChat");
+  await requireDocker(docker, [...composeArgs, "up", "-d"], { inherit: true });
+  progress.message("Waiting for OvertChat to become ready");
+  await waitForApp(`http://127.0.0.1:${config.appPort}`);
+  progress.message("Applying provider configuration");
+  await syncCapabilities(config, secrets.managementSecret);
+  if (config.agents.installed) {
+    progress.message("Installing Agent Connections");
+    await installManagedConnector(config, secrets.managementSecret);
+  }
+  await writeInstallationConfig(paths, config);
+  progress.stop("OvertChat is ready");
+
+  outro(`Open: ${config.publicUrl}`);
+}

--- a/apps/cli/src/snapshot.test.ts
+++ b/apps/cli/src/snapshot.test.ts
@@ -73,6 +73,7 @@ describe("pre-migration snapshots", () => {
     expect(args).toContain("no-new-privileges:true");
     expect(args).toContain("ghcr.io/yoloyash/overtchat-app:0.14.0");
     expect(args.at(-1)).toContain("sourceDatabase.backup(destination)");
+    expect(args.at(-1)).toContain('snapshot.pragma("journal_mode = DELETE"');
     expect(args.at(-1)).toContain('snapshot.pragma("integrity_check")');
   });
 

--- a/apps/cli/src/snapshot.test.ts
+++ b/apps/cli/src/snapshot.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { databaseSnapshot, snapshotDockerArgs } from "./snapshot.js";
+import type { ExistingInstallation, InstallationConfig } from "./types.js";
+
+function existing(
+  overrides: Partial<ExistingInstallation> = {},
+): ExistingInstallation {
+  return {
+    containerName: "overtchat-app",
+    appVersion: "0.13.9",
+    appImage: "ghcr.io/yoloyash/overtchat-app:0.13.9",
+    composeProject: "overtchat",
+    composeWorkingDir: "/srv/overtchat",
+    dataMountType: "volume",
+    dataVolume: "overtchat_overtchat-data",
+    appPort: 4718,
+    bindAddress: "127.0.0.1",
+    publicUrl: "https://chat.example.com",
+    environment: new Map(),
+    bundledServices: { search: true, tts: true, stt: true },
+    sttAccelerator: "cpu",
+    ...overrides,
+  };
+}
+
+function config(): InstallationConfig {
+  return {
+    format: 1,
+    appVersion: "0.14.0",
+    appImage: "ghcr.io/yoloyash/overtchat-app:0.14.0",
+    connectorVersion: "0.5.0",
+    sttVersion: "0.1.0",
+    appPort: 4718,
+    bindAddress: "127.0.0.1",
+    publicUrl: "https://chat.example.com",
+    extraTrustedOrigins: [],
+    connectorServerUrl: "http://127.0.0.1:4718",
+    composeProject: "overtchat",
+    dataMountType: "volume",
+    dataVolume: "overtchat_overtchat-data",
+    search: { provider: "bundled", bundledInstalled: true },
+    tts: { provider: "bundled", bundledInstalled: true },
+    stt: {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "cpu",
+    },
+    agents: { installed: false },
+  };
+}
+
+describe("pre-migration snapshots", () => {
+  it("creates a stable volume path and a locked-down helper container", () => {
+    const installation = existing();
+    const snapshot = databaseSnapshot(
+      installation,
+      new Date("2026-08-14T05:30:12.345Z"),
+    );
+    const args = snapshotDockerArgs(installation, config(), snapshot);
+
+    expect(snapshot).toEqual({
+      fileName: "pre-managed-2026-08-14T05-30-12-345Z.db",
+      containerPath:
+        "/app/data/backups/pre-managed-2026-08-14T05-30-12-345Z.db",
+      displayPath:
+        "overtchat_overtchat-data:/backups/pre-managed-2026-08-14T05-30-12-345Z.db",
+    });
+    expect(args).toContain(
+      "type=volume,source=overtchat_overtchat-data,target=/app/data",
+    );
+    expect(args).toContain("none");
+    expect(args).toContain("--read-only");
+    expect(args).toContain("no-new-privileges:true");
+    expect(args).toContain("ghcr.io/yoloyash/overtchat-app:0.14.0");
+    expect(args.at(-1)).toContain("sourceDatabase.backup(destination)");
+    expect(args.at(-1)).toContain('snapshot.pragma("integrity_check")');
+  });
+
+  it("shows the host path for bind-mounted installations", () => {
+    const installation = existing({
+      dataMountType: "bind",
+      dataVolume: "/srv/overtchat/data",
+    });
+    const snapshot = databaseSnapshot(
+      installation,
+      new Date("2026-08-14T05:30:12.345Z"),
+    );
+
+    expect(snapshot.displayPath).toBe(
+      "/srv/overtchat/data/backups/pre-managed-2026-08-14T05-30-12-345Z.db",
+    );
+    expect(snapshotDockerArgs(installation, config(), snapshot)).toContain(
+      "type=bind,source=/srv/overtchat/data,target=/app/data",
+    );
+  });
+});

--- a/apps/cli/src/snapshot.ts
+++ b/apps/cli/src/snapshot.ts
@@ -1,0 +1,126 @@
+import path from "node:path";
+import { requireDocker, type DockerCommand } from "./docker.js";
+import type { ExistingInstallation, InstallationConfig } from "./types.js";
+
+const SNAPSHOT_SCRIPT = String.raw`
+const fs = require("node:fs");
+const Database = require("better-sqlite3");
+
+(async () => {
+  const source = "/app/data/chat.db";
+  const destination = process.env.OVERTCHAT_SNAPSHOT_PATH;
+  if (!destination) throw new Error("Snapshot destination was not provided.");
+  const snapshotDirectory = require("node:path").dirname(destination);
+  fs.mkdirSync(snapshotDirectory, {
+    recursive: true,
+    mode: 0o700,
+  });
+  fs.chmodSync(snapshotDirectory, 0o700);
+  try {
+    const sourceDatabase = new Database(source, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    try {
+      await sourceDatabase.backup(destination);
+    } finally {
+      sourceDatabase.close();
+    }
+    fs.chmodSync(destination, 0o600);
+    const snapshot = new Database(destination, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    try {
+      const integrity = snapshot.pragma("integrity_check");
+      if (
+        !Array.isArray(integrity) ||
+        integrity.length !== 1 ||
+        integrity[0]?.integrity_check !== "ok"
+      ) {
+        throw new Error("Snapshot failed SQLite integrity_check.");
+      }
+    } finally {
+      snapshot.close();
+    }
+  } catch (error) {
+    fs.rmSync(destination, { force: true });
+    throw error;
+  }
+})().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+`;
+
+export type DatabaseSnapshot = {
+  fileName: string;
+  containerPath: string;
+  displayPath: string;
+};
+
+function timestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/gu, "-");
+}
+
+export function databaseSnapshot(
+  existing: ExistingInstallation,
+  date = new Date(),
+): DatabaseSnapshot {
+  const fileName = `pre-managed-${timestamp(date)}.db`;
+  const containerPath = `/app/data/backups/${fileName}`;
+  return {
+    fileName,
+    containerPath,
+    displayPath:
+      existing.dataMountType === "bind"
+        ? path.join(existing.dataVolume, "backups", fileName)
+        : `${existing.dataVolume}:/backups/${fileName}`,
+  };
+}
+
+export function snapshotDockerArgs(
+  existing: ExistingInstallation,
+  config: InstallationConfig,
+  snapshot: DatabaseSnapshot,
+): string[] {
+  const mount = [
+    `type=${existing.dataMountType}`,
+    `source=${existing.dataVolume}`,
+    "target=/app/data",
+  ].join(",");
+  return [
+    "run",
+    "--rm",
+    "--network",
+    "none",
+    "--read-only",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges:true",
+    "--mount",
+    mount,
+    "--env",
+    `OVERTCHAT_SNAPSHOT_PATH=${snapshot.containerPath}`,
+    "--entrypoint",
+    "node",
+    config.appImage,
+    "-e",
+    SNAPSHOT_SCRIPT,
+  ];
+}
+
+export async function createPreMigrationSnapshot(
+  docker: DockerCommand,
+  existing: ExistingInstallation,
+  config: InstallationConfig,
+  date = new Date(),
+): Promise<DatabaseSnapshot> {
+  const snapshot = databaseSnapshot(existing, date);
+  await requireDocker(
+    docker,
+    snapshotDockerArgs(existing, config, snapshot),
+  );
+  return snapshot;
+}

--- a/apps/cli/src/snapshot.ts
+++ b/apps/cli/src/snapshot.ts
@@ -26,12 +26,16 @@ const Database = require("better-sqlite3");
     } finally {
       sourceDatabase.close();
     }
-    fs.chmodSync(destination, 0o600);
     const snapshot = new Database(destination, {
-      readonly: true,
       fileMustExist: true,
     });
     try {
+      const journalMode = snapshot.pragma("journal_mode = DELETE", {
+        simple: true,
+      });
+      if (journalMode !== "delete") {
+        throw new Error("Snapshot could not be made self-contained.");
+      }
       const integrity = snapshot.pragma("integrity_check");
       if (
         !Array.isArray(integrity) ||
@@ -43,8 +47,13 @@ const Database = require("better-sqlite3");
     } finally {
       snapshot.close();
     }
+    fs.rmSync(destination + "-wal", { force: true });
+    fs.rmSync(destination + "-shm", { force: true });
+    fs.chmodSync(destination, 0o600);
   } catch (error) {
     fs.rmSync(destination, { force: true });
+    fs.rmSync(destination + "-wal", { force: true });
+    fs.rmSync(destination + "-shm", { force: true });
     throw error;
   }
 })().catch((error) => {

--- a/apps/cli/src/status.ts
+++ b/apps/cli/src/status.ts
@@ -1,0 +1,28 @@
+import { readInstallationConfig } from "./config.js";
+import { detectDockerCommand, runDocker } from "./docker.js";
+import { runtimePaths } from "./paths.js";
+
+export async function status(): Promise<void> {
+  const paths = runtimePaths();
+  const config = await readInstallationConfig(paths);
+  if (!config) {
+    console.log("OvertChat is not managed on this machine. Run: overtchat setup");
+    return;
+  }
+  const docker = await detectDockerCommand();
+  const app = docker
+    ? await runDocker(docker, [
+        "inspect",
+        "--format",
+        "{{.State.Status}}",
+        "overtchat-app",
+      ])
+    : null;
+  console.log(`OvertChat ${config.appVersion}`);
+  console.log(`Status: ${app?.exitCode === 0 ? app.stdout.trim() : "unavailable"}`);
+  console.log(`URL: ${config.publicUrl}`);
+  console.log(`Web search: ${config.search.provider}`);
+  console.log(`Text-to-speech: ${config.tts.provider}`);
+  console.log(`Speech-to-text: ${config.stt.provider}`);
+  console.log(`Agent Connections: ${config.agents.installed ? "installed" : "not installed"}`);
+}

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -1,0 +1,89 @@
+export type SearchProvider = "bundled" | "brave" | "searxng" | "disabled";
+export type TtsProvider = "bundled" | "openai-compatible" | "disabled";
+export type SttProvider = "bundled" | "openai-compatible" | "disabled";
+export type SttAccelerator = "auto" | "cpu" | "gpu";
+
+export type Gpu = {
+  index: number;
+  uuid: string;
+  name: string;
+  memoryMiB: number;
+};
+
+export type SearchConfig = {
+  provider: SearchProvider;
+  bundledInstalled: boolean;
+  baseUrl?: string;
+  apiKey?: string;
+};
+
+export type TtsConfig = {
+  provider: TtsProvider;
+  bundledInstalled: boolean;
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+  voice?: string;
+};
+
+export type SttConfig = {
+  provider: SttProvider;
+  bundledInstalled: boolean;
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+  accelerator?: SttAccelerator;
+  gpuUuid?: string;
+};
+
+export type AgentConfig = {
+  installed: boolean;
+};
+
+export type InstallationConfig = {
+  format: 1;
+  appVersion: string;
+  appImage: string;
+  connectorVersion: string;
+  sttVersion: string;
+  appPort: number;
+  bindAddress: string;
+  publicUrl: string;
+  extraTrustedOrigins: string[];
+  connectorServerUrl: string;
+  composeProject: string;
+  dataMountType: "volume" | "bind";
+  dataVolume: string;
+  search: SearchConfig;
+  tts: TtsConfig;
+  stt: SttConfig;
+  agents: AgentConfig;
+  adoptedFrom?: string;
+};
+
+export type ExistingInstallation = {
+  containerName: string;
+  appVersion?: string;
+  appImage?: string;
+  composeProject: string;
+  composeWorkingDir?: string;
+  dataMountType: "volume" | "bind";
+  dataVolume: string;
+  appPort: number;
+  bindAddress: string;
+  publicUrl: string;
+  environment: Map<string, string>;
+  searxngConfigPath?: string;
+  sttAccelerator?: "cpu" | "gpu";
+  sttGpuUuid?: string;
+};
+
+export type RuntimePaths = {
+  configDirectory: string;
+  stateFile: string;
+  secretsFile: string;
+  stackDirectory: string;
+  composeFile: string;
+  searxngDirectory: string;
+  searxngSettingsFile: string;
+};

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -74,6 +74,11 @@ export type ExistingInstallation = {
   publicUrl: string;
   environment: Map<string, string>;
   searxngConfigPath?: string;
+  bundledServices: {
+    search: boolean;
+    tts: boolean;
+    stt: boolean;
+  };
   sttAccelerator?: "cpu" | "gpu";
   sttGpuUuid?: string;
 };

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InstallationSecrets } from "./config.js";
+import type { InstallationConfig, RuntimePaths } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  detectDockerCommand: vi.fn(),
+  dockerComposeAvailable: vi.fn(),
+  installManagedConnector: vi.fn(),
+  latestReleaseManifest: vi.fn(),
+  outro: vi.fn(),
+  prepareFiles: vi.fn(),
+  readInstallationConfig: vi.fn(),
+  readInstallationSecrets: vi.fn(),
+  renderStackEnvironment: vi.fn(),
+  requireDocker: vi.fn(),
+  requireSuccessful: vi.fn(),
+  spinnerMessage: vi.fn(),
+  spinnerStart: vi.fn(),
+  spinnerStop: vi.fn(),
+  updateCliIfNeeded: vi.fn(),
+  waitForApp: vi.fn(),
+  writeInstallationConfig: vi.fn(),
+  writeSecretsFile: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  outro: mocks.outro,
+  spinner: () => ({
+    message: mocks.spinnerMessage,
+    start: mocks.spinnerStart,
+    stop: mocks.spinnerStop,
+  }),
+}));
+
+vi.mock("./config.js", () => ({
+  readInstallationConfig: mocks.readInstallationConfig,
+  readInstallationSecrets: mocks.readInstallationSecrets,
+  writeInstallationConfig: mocks.writeInstallationConfig,
+  writeSecretsFile: mocks.writeSecretsFile,
+}));
+
+vi.mock("./connector.js", () => ({
+  installManagedConnector: mocks.installManagedConnector,
+}));
+
+vi.mock("./compose.js", () => ({
+  renderStackEnvironment: mocks.renderStackEnvironment,
+}));
+
+vi.mock("./docker.js", () => ({
+  detectDockerCommand: mocks.detectDockerCommand,
+  dockerComposeAvailable: mocks.dockerComposeAvailable,
+  requireDocker: mocks.requireDocker,
+}));
+
+const paths: RuntimePaths = {
+  configDirectory: "/home/test/.config/overtchat",
+  stateFile: "/home/test/.config/overtchat/config.json",
+  secretsFile: "/home/test/.config/overtchat/secrets.env",
+  stackDirectory: "/home/test/.local/share/overtchat",
+  composeFile: "/home/test/.local/share/overtchat/compose.yml",
+  searxngDirectory: "/home/test/.local/share/overtchat/searxng",
+  searxngSettingsFile:
+    "/home/test/.local/share/overtchat/searxng/settings.yml",
+};
+
+vi.mock("./paths.js", () => ({ runtimePaths: () => paths }));
+
+vi.mock("./process.js", () => ({
+  requireSuccessful: mocks.requireSuccessful,
+}));
+
+vi.mock("./release.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./release.js")>();
+  return {
+    ...original,
+    latestReleaseManifest: mocks.latestReleaseManifest,
+    updateCliIfNeeded: mocks.updateCliIfNeeded,
+  };
+});
+
+vi.mock("./setup.js", () => ({
+  prepareFiles: mocks.prepareFiles,
+  waitForApp: mocks.waitForApp,
+}));
+
+import { update } from "./update.js";
+
+function config(
+  overrides: Partial<InstallationConfig> = {},
+): InstallationConfig {
+  return {
+    format: 1,
+    appVersion: "0.14.0",
+    appImage: "ghcr.io/yoloyash/overtchat-app:0.14.0",
+    connectorVersion: "0.4.0",
+    sttVersion: "0.1.0",
+    appPort: 4718,
+    bindAddress: "127.0.0.1",
+    publicUrl: "https://chat.example.com",
+    extraTrustedOrigins: [],
+    connectorServerUrl: "http://127.0.0.1:4718",
+    composeProject: "overtchat",
+    dataMountType: "volume",
+    dataVolume: "overtchat-data",
+    search: { provider: "bundled", bundledInstalled: true },
+    tts: { provider: "bundled", bundledInstalled: true },
+    stt: { provider: "disabled", bundledInstalled: false },
+    agents: { installed: false },
+    ...overrides,
+  };
+}
+
+const secrets: InstallationSecrets = {
+  betterAuthSecret: "better-auth-secret",
+  managementSecret: "management-secret",
+  searxngSecret: "searxng-secret",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.readInstallationConfig.mockResolvedValue(config());
+  mocks.detectDockerCommand.mockResolvedValue("docker");
+  mocks.dockerComposeAvailable.mockResolvedValue(true);
+  mocks.readInstallationSecrets.mockResolvedValue(secrets);
+  mocks.latestReleaseManifest.mockResolvedValue({
+    format: 1,
+    cliVersion: "0.1.0",
+    appVersion: "0.14.0",
+    connectorVersion: "0.4.0",
+    sttVersion: "0.1.0",
+  });
+  mocks.updateCliIfNeeded.mockResolvedValue(null);
+  mocks.renderStackEnvironment.mockReturnValue("rendered environment\n");
+  mocks.requireDocker.mockResolvedValue({
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+  });
+  mocks.requireSuccessful.mockResolvedValue({
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+describe("managed updates", () => {
+  it("rejects installations that have not been managed by setup", async () => {
+    mocks.readInstallationConfig.mockResolvedValue(null);
+
+    await expect(update()).rejects.toThrow(
+      "OvertChat is not managed yet. Run overtchat setup first.",
+    );
+    expect(mocks.detectDockerCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects incomplete managed secrets before changing files", async () => {
+    mocks.readInstallationSecrets.mockResolvedValue({
+      betterAuthSecret: "better-auth-secret",
+    });
+
+    await expect(update()).rejects.toThrow(
+      "The managed installation secrets are incomplete",
+    );
+    expect(mocks.prepareFiles).not.toHaveBeenCalled();
+    expect(mocks.requireDocker).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a current installation without changing its versions", async () => {
+    const current = config();
+    mocks.readInstallationConfig.mockResolvedValue(current);
+
+    await update();
+
+    expect(mocks.prepareFiles).toHaveBeenCalledWith(current, undefined);
+    expect(mocks.writeSecretsFile).toHaveBeenCalledWith(
+      paths,
+      "rendered environment\n",
+    );
+    expect(mocks.requireDocker).toHaveBeenNthCalledWith(
+      1,
+      "docker",
+      [
+        "compose",
+        "--env-file",
+        paths.secretsFile,
+        "-f",
+        paths.composeFile,
+        "pull",
+      ],
+      { inherit: true },
+    );
+    expect(mocks.requireDocker).toHaveBeenNthCalledWith(
+      2,
+      "docker",
+      [
+        "compose",
+        "--env-file",
+        paths.secretsFile,
+        "-f",
+        paths.composeFile,
+        "up",
+        "-d",
+      ],
+      { inherit: true },
+    );
+    expect(mocks.waitForApp).toHaveBeenCalledWith("http://127.0.0.1:4718");
+    expect(mocks.installManagedConnector).not.toHaveBeenCalled();
+    expect(mocks.writeInstallationConfig).toHaveBeenCalledWith(paths, current);
+    expect(mocks.outro).toHaveBeenCalledWith("Open: https://chat.example.com");
+  });
+
+  it("updates every component without downgrading newer local versions", async () => {
+    const current = config({
+      appVersion: "0.13.9",
+      appImage: "ghcr.io/yoloyash/overtchat-app:0.13.9",
+      connectorVersion: "0.5.0",
+      sttVersion: "0.0.9",
+      agents: { installed: true },
+    });
+    mocks.readInstallationConfig.mockResolvedValue(current);
+    mocks.latestReleaseManifest.mockResolvedValue({
+      format: 1,
+      cliVersion: "0.1.0",
+      appVersion: "0.14.0",
+      connectorVersion: "0.4.0",
+      sttVersion: "0.1.0",
+    });
+
+    await update();
+
+    const expected = {
+      ...current,
+      appVersion: "0.14.0",
+      appImage: "ghcr.io/yoloyash/overtchat-app:0.14.0",
+      connectorVersion: "0.5.0",
+      sttVersion: "0.1.0",
+    };
+    expect(mocks.prepareFiles).toHaveBeenCalledWith(expected, undefined);
+    expect(mocks.installManagedConnector).toHaveBeenCalledWith(
+      expected,
+      "management-secret",
+    );
+    expect(mocks.writeInstallationConfig).toHaveBeenCalledWith(paths, expected);
+    expect(
+      mocks.waitForApp.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.installManagedConnector.mock.invocationCallOrder[0]!);
+    expect(
+      mocks.installManagedConnector.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.writeInstallationConfig.mock.invocationCallOrder[0]!);
+  });
+
+  it("hands control to an updated CLI before touching the stack", async () => {
+    mocks.updateCliIfNeeded.mockResolvedValue("/home/test/.local/bin/overtchat");
+
+    await update();
+
+    expect(mocks.requireSuccessful).toHaveBeenCalledWith(
+      "/home/test/.local/bin/overtchat",
+      ["update"],
+      { inherit: true },
+    );
+    expect(mocks.prepareFiles).not.toHaveBeenCalled();
+    expect(mocks.requireDocker).not.toHaveBeenCalled();
+    expect(mocks.writeInstallationConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not commit state or replace the connector when pulling fails", async () => {
+    mocks.readInstallationConfig.mockResolvedValue(
+      config({
+        appVersion: "0.13.9",
+        appImage: "ghcr.io/yoloyash/overtchat-app:0.13.9",
+        agents: { installed: true },
+      }),
+    );
+    mocks.latestReleaseManifest.mockResolvedValue({
+      format: 1,
+      cliVersion: "0.1.0",
+      appVersion: "0.14.0",
+      connectorVersion: "0.4.0",
+      sttVersion: "0.1.0",
+    });
+    mocks.requireDocker.mockRejectedValueOnce(new Error("pull failed"));
+
+    await expect(update()).rejects.toThrow("pull failed");
+
+    expect(mocks.requireDocker).toHaveBeenCalledTimes(1);
+    expect(mocks.waitForApp).not.toHaveBeenCalled();
+    expect(mocks.installManagedConnector).not.toHaveBeenCalled();
+    expect(mocks.writeInstallationConfig).not.toHaveBeenCalled();
+    expect(mocks.spinnerStop).toHaveBeenCalledWith(
+      "OvertChat update failed",
+      1,
+    );
+  });
+});

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -43,75 +43,83 @@ export async function update(): Promise<void> {
     );
   }
   const progress = spinner();
+  let progressActive = true;
   progress.start("Checking for OvertChat updates");
-  const manifest = await latestReleaseManifest();
-  const updatedExecutable = await updateCliIfNeeded(manifest);
-  if (updatedExecutable) {
-    progress.stop("OvertChat manager updated");
-    await requireSuccessful(updatedExecutable, ["update"], { inherit: true });
-    return;
-  }
+  try {
+    const manifest = await latestReleaseManifest();
+    const updatedExecutable = await updateCliIfNeeded(manifest);
+    if (updatedExecutable) {
+      progress.stop("OvertChat manager updated");
+      progressActive = false;
+      await requireSuccessful(updatedExecutable, ["update"], { inherit: true });
+      return;
+    }
 
-  const appVersion =
-    compareVersions(manifest.appVersion, config.appVersion) > 0
-      ? manifest.appVersion
-      : config.appVersion;
-  const connectorVersion =
-    compareVersions(manifest.connectorVersion, config.connectorVersion) > 0
-      ? manifest.connectorVersion
-      : config.connectorVersion;
-  const sttVersion =
-    compareVersions(manifest.sttVersion, config.sttVersion) > 0
-      ? manifest.sttVersion
-      : config.sttVersion;
-  const nextConfig = {
-    ...config,
-    appVersion,
-    appImage: config.appImage === "overtchat-app:setup-dev"
-      ? config.appImage
-      : `${APP_IMAGE}:${appVersion}`,
-    connectorVersion,
-    sttVersion,
-  };
-  await prepareFiles(nextConfig, undefined);
-  await writeSecretsFile(
-    paths,
-    renderStackEnvironment(nextConfig, {
-      betterAuthSecret: secrets.betterAuthSecret,
-      managementSecret: secrets.managementSecret,
-      searxngSecret: secrets.searxngSecret,
-    }, paths),
-  );
-  const composeArgs = [
-    "compose",
-    "--env-file",
-    paths.secretsFile,
-    "-f",
-    paths.composeFile,
-  ];
-  progress.message("Downloading installed components");
-  await requireDocker(
-    docker,
-    [
-      ...composeArgs,
-      "pull",
-      ...(nextConfig.appImage === "overtchat-app:setup-dev"
-        ? ["--ignore-pull-failures"]
-        : []),
-    ],
-    { inherit: true },
-  );
-  progress.message("Applying updates and database migrations");
-  await requireDocker(docker, [...composeArgs, "up", "-d"], {
-    inherit: true,
-  });
-  progress.message("Waiting for OvertChat and database migrations");
-  await waitForApp(`http://127.0.0.1:${nextConfig.appPort}`);
-  if (nextConfig.agents.installed) {
-    progress.message("Updating Agent Connections");
-    await installManagedConnector(nextConfig, secrets.managementSecret);
+    const appVersion =
+      compareVersions(manifest.appVersion, config.appVersion) > 0
+        ? manifest.appVersion
+        : config.appVersion;
+    const connectorVersion =
+      compareVersions(manifest.connectorVersion, config.connectorVersion) > 0
+        ? manifest.connectorVersion
+        : config.connectorVersion;
+    const sttVersion =
+      compareVersions(manifest.sttVersion, config.sttVersion) > 0
+        ? manifest.sttVersion
+        : config.sttVersion;
+    const nextConfig = {
+      ...config,
+      appVersion,
+      appImage: config.appImage === "overtchat-app:setup-dev"
+        ? config.appImage
+        : `${APP_IMAGE}:${appVersion}`,
+      connectorVersion,
+      sttVersion,
+    };
+    await prepareFiles(nextConfig, undefined);
+    await writeSecretsFile(
+      paths,
+      renderStackEnvironment(nextConfig, {
+        betterAuthSecret: secrets.betterAuthSecret,
+        managementSecret: secrets.managementSecret,
+        searxngSecret: secrets.searxngSecret,
+      }, paths),
+    );
+    const composeArgs = [
+      "compose",
+      "--env-file",
+      paths.secretsFile,
+      "-f",
+      paths.composeFile,
+    ];
+    progress.message("Downloading installed components");
+    await requireDocker(
+      docker,
+      [
+        ...composeArgs,
+        "pull",
+        ...(nextConfig.appImage === "overtchat-app:setup-dev"
+          ? ["--ignore-pull-failures"]
+          : []),
+      ],
+      { inherit: true },
+    );
+    progress.message("Applying updates and database migrations");
+    await requireDocker(docker, [...composeArgs, "up", "-d"], {
+      inherit: true,
+    });
+    progress.message("Waiting for OvertChat and database migrations");
+    await waitForApp(`http://127.0.0.1:${nextConfig.appPort}`);
+    if (nextConfig.agents.installed) {
+      progress.message("Updating Agent Connections");
+      await installManagedConnector(nextConfig, secrets.managementSecret);
+    }
+    await writeInstallationConfig(paths, nextConfig);
+    progress.stop("OvertChat is up to date");
+    progressActive = false;
+    outro(`Open: ${nextConfig.publicUrl}`);
+  } catch (error) {
+    if (progressActive) progress.stop("OvertChat update failed", 1);
+    throw error;
   }
-  await writeInstallationConfig(paths, nextConfig);
-  progress.stop("OvertChat is up to date");
-  outro(`Open: ${nextConfig.publicUrl}`);
 }

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -1,0 +1,117 @@
+import { outro, spinner } from "@clack/prompts";
+import {
+  readInstallationConfig,
+  readInstallationSecrets,
+  writeInstallationConfig,
+  writeSecretsFile,
+} from "./config.js";
+import { installManagedConnector } from "./connector.js";
+import { APP_IMAGE } from "./constants.js";
+import { renderStackEnvironment } from "./compose.js";
+import {
+  detectDockerCommand,
+  dockerComposeAvailable,
+  requireDocker,
+} from "./docker.js";
+import { runtimePaths } from "./paths.js";
+import { requireSuccessful } from "./process.js";
+import {
+  compareVersions,
+  latestReleaseManifest,
+  updateCliIfNeeded,
+} from "./release.js";
+import { prepareFiles, waitForApp } from "./setup.js";
+
+export async function update(): Promise<void> {
+  const paths = runtimePaths();
+  const config = await readInstallationConfig(paths);
+  if (!config) {
+    throw new Error("OvertChat is not managed yet. Run overtchat setup first.");
+  }
+  const docker = await detectDockerCommand();
+  if (!docker || !(await dockerComposeAvailable(docker))) {
+    throw new Error("Docker Engine and Docker Compose v2 are required.");
+  }
+  const secrets = await readInstallationSecrets(paths);
+  if (
+    !secrets.betterAuthSecret ||
+    !secrets.managementSecret ||
+    !secrets.searxngSecret
+  ) {
+    throw new Error(
+      "The managed installation secrets are incomplete. Run overtchat setup to repair them.",
+    );
+  }
+  const progress = spinner();
+  progress.start("Checking for OvertChat updates");
+  const manifest = await latestReleaseManifest();
+  const updatedExecutable = await updateCliIfNeeded(manifest);
+  if (updatedExecutable) {
+    progress.stop("OvertChat manager updated");
+    await requireSuccessful(updatedExecutable, ["update"], { inherit: true });
+    return;
+  }
+
+  const appVersion =
+    compareVersions(manifest.appVersion, config.appVersion) > 0
+      ? manifest.appVersion
+      : config.appVersion;
+  const connectorVersion =
+    compareVersions(manifest.connectorVersion, config.connectorVersion) > 0
+      ? manifest.connectorVersion
+      : config.connectorVersion;
+  const sttVersion =
+    compareVersions(manifest.sttVersion, config.sttVersion) > 0
+      ? manifest.sttVersion
+      : config.sttVersion;
+  const nextConfig = {
+    ...config,
+    appVersion,
+    appImage: config.appImage === "overtchat-app:setup-dev"
+      ? config.appImage
+      : `${APP_IMAGE}:${appVersion}`,
+    connectorVersion,
+    sttVersion,
+  };
+  await prepareFiles(nextConfig, undefined);
+  await writeSecretsFile(
+    paths,
+    renderStackEnvironment(nextConfig, {
+      betterAuthSecret: secrets.betterAuthSecret,
+      managementSecret: secrets.managementSecret,
+      searxngSecret: secrets.searxngSecret,
+    }, paths),
+  );
+  const composeArgs = [
+    "compose",
+    "--env-file",
+    paths.secretsFile,
+    "-f",
+    paths.composeFile,
+  ];
+  progress.message("Downloading installed components");
+  await requireDocker(
+    docker,
+    [
+      ...composeArgs,
+      "pull",
+      ...(nextConfig.appImage === "overtchat-app:setup-dev"
+        ? ["--ignore-pull-failures"]
+        : []),
+    ],
+    { inherit: true },
+  );
+  progress.message("Applying updates and database migrations");
+  await requireDocker(docker, [...composeArgs, "up", "-d"], {
+    inherit: true,
+  });
+  progress.message("Waiting for OvertChat and database migrations");
+  await waitForApp(`http://127.0.0.1:${nextConfig.appPort}`);
+  if (nextConfig.agents.installed) {
+    progress.message("Updating Agent Connections");
+    await installManagedConnector(nextConfig, secrets.managementSecret);
+  }
+  await writeInstallationConfig(paths, nextConfig);
+  progress.stop("OvertChat is up to date");
+  outro(`Open: ${nextConfig.publicUrl}`);
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/cli.ts
+++ b/apps/connector/src/cli.ts
@@ -17,8 +17,66 @@ type ParsedArgs = {
   values: Map<string, string>;
 };
 
+async function readStdinJson(): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of process.stdin) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += bytes.length;
+    if (total > 16 * 1024) {
+      throw new Error("Managed connector configuration is too large.");
+    }
+    chunks.push(bytes);
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    throw new Error("Managed connector configuration must be valid JSON.");
+  }
+}
+
+function managedConfig(value: unknown): {
+  serverUrl: string;
+  connectorId: string;
+  token: string;
+} {
+  if (!value || typeof value !== "object") {
+    throw new Error("Managed connector configuration is invalid.");
+  }
+  const server = Reflect.get(value, "serverUrl");
+  const connectorId = Reflect.get(value, "connectorId");
+  const token = Reflect.get(value, "token");
+  if (
+    typeof server !== "string" ||
+    typeof connectorId !== "string" ||
+    !/^[A-Za-z0-9_-]{1,128}$/u.test(connectorId) ||
+    typeof token !== "string" ||
+    !token.startsWith(`oct_${connectorId}.`)
+  ) {
+    throw new Error("Managed connector configuration is invalid.");
+  }
+  return {
+    serverUrl: normalizeServerUrl(server),
+    connectorId,
+    token,
+  };
+}
+
+async function installManaged(): Promise<void> {
+  await assertUserServiceAvailable();
+  const config = managedConfig(await readStdinJson());
+  await writeConnectorConfig(config);
+  const unitPath = await installUserService();
+  console.log(`Managed service installed at ${unitPath}`);
+}
+
 function parseArgs(argv: string[]): ParsedArgs {
-  const command = argv[0] && !argv[0].startsWith("-") ? argv[0] : "run";
+  const command =
+    argv[0] === "--version" || argv[0] === "-v"
+      ? "version"
+      : argv[0] && !argv[0].startsWith("-")
+        ? argv[0]
+        : "run";
   const rest = command === "run" && argv[0]?.startsWith("-") ? argv : argv.slice(1);
   const values = new Map<string, string>();
   for (let index = 0; index < rest.length; index++) {
@@ -103,6 +161,12 @@ async function main(): Promise<void> {
       console.log(`Service installed at ${unitPath}`);
       return;
     }
+    case "install-managed":
+      if (parsed.values.size > 0) {
+        throw new Error("The install-managed command reads configuration from stdin.");
+      }
+      await installManaged();
+      return;
     case "run":
       await run();
       return;
@@ -112,9 +176,15 @@ async function main(): Promise<void> {
       }
       await preflight();
       return;
+    case "version":
+      if (parsed.values.size > 0) {
+        throw new Error("The version command does not accept arguments.");
+      }
+      console.log(CONNECTOR_VERSION);
+      return;
     default:
       throw new Error(
-        "Usage: overtchat-connector <install|pair|run> --server URL --pair-code CODE",
+        "Usage: overtchat-connector <install|install-managed|pair|preflight|run|version>",
       );
   }
 }

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -136,7 +136,7 @@ describe.sequential("connector client compatibility", () => {
     expect(headers.get("x-overtchat-connector-version")).toBe(
       HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     );
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.3.4");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.4.0");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/connector/src/config.ts
+++ b/apps/connector/src/config.ts
@@ -53,7 +53,7 @@ export async function readConnectorConfig(): Promise<ConnectorConfig> {
     parsed = JSON.parse(await readFile(file, "utf8"));
   } catch {
     throw new Error(
-      `OvertChat Connector is not paired. Run overtchat-connector install --server <url> --pair-code <code>.`,
+      "OvertChat Connector is not configured. Run overtchat setup.",
     );
   }
   if (

--- a/apps/mobile/src/lib/chat/message.ts
+++ b/apps/mobile/src/lib/chat/message.ts
@@ -11,7 +11,7 @@ export function dictationErrorMessage(
       return "Audio recording isn't supported on this device.";
     case "stt_unavailable":
       return isAdmin || err.role === "admin"
-        ? "Speech-to-text isn't running. Start it with: docker compose --profile stt up -d (or --profile stt-gpu for NVIDIA GPU)."
+        ? "Speech-to-text isn't configured on this server. Run: overtchat setup"
         : "Speech-to-text isn't enabled. Ask the admin to enable it.";
     case "empty":
       return "No speech detected. Try again.";

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -38,12 +38,7 @@ export const metadata: Metadata = createPageMetadata({
   absoluteTitle: true,
 });
 
-const quickStart = `git clone https://github.com/yoloyash/overtchat
-cd overtchat
-cp .env.example .env
-echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)" >> .env
-echo "SEARXNG_SECRET=$(openssl rand -hex 32)" >> .env
-docker compose up -d --build`;
+const quickStart = "curl -fsSL https://overtchat.com/install | sh";
 
 const steps: Array<{
   number: string;
@@ -53,12 +48,12 @@ const steps: Array<{
   {
     number: "01",
     title: "Start your server",
-    body: "Run one Docker Compose command. OvertChat brings the app, SQLite database, resume buffer, web search, and text-to-speech.",
+    body: "Run one install command. The guided setup detects Docker and lets you choose local or API-backed search, speech, and coding-agent connections.",
   },
   {
     number: "02",
     title: "Connect your models",
-    body: "Add a hosted provider or an OpenAI-compatible local endpoint. The setup wizard checks the connection before you begin.",
+    body: "Create the first admin account, then add a hosted provider or an OpenAI-compatible local endpoint. OvertChat checks the connection before you begin.",
   },
   {
     number: "03",

--- a/apps/site/lib/install-redirect.test.ts
+++ b/apps/site/lib/install-redirect.test.ts
@@ -285,6 +285,12 @@ describe("Host Connector installer redirect", () => {
   });
 
   it("atomically upgrades and preserves the previous executable", () => {
+    const packageMetadata = JSON.parse(
+      readFileSync(
+        path.resolve(process.cwd(), "../connector/package.json"),
+        "utf8",
+      ),
+    ) as { version: string };
     const {
       configContents,
       configPath,
@@ -296,7 +302,9 @@ describe("Host Connector installer redirect", () => {
     } = createUpgradeFixture("stable");
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Host Connector upgraded to 0.3.4");
+    expect(result.stdout).toContain(
+      `Host Connector upgraded to ${packageMetadata.version}`,
+    );
     expect(readFileSync(installPath, "utf8")).toBe(newConnector);
     expect(existsSync(`${installPath}.previous`)).toBe(false);
     expect(readFileSync(systemctlCalls, "utf8")).toContain(

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -8,6 +8,7 @@
 /install/connector/0.3.2 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.2/install-connector.sh 302
 /install/connector/0.3.3 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.3/install-connector.sh 302
 /install/connector/0.3.4 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.4/install-connector.sh 302
+/install/connector/0.4.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.4.0/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.3.4 302
+/install-connector.sh /install/connector/0.4.0 302

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+
+repository="yoloyash/overtchat"
+cli_version="0.1.0"
+
+say() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'OvertChat install failed: %s\n' "$*" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = "Linux" ] || fail "the managed installer currently supports Linux"
+
+case "$(uname -m)" in
+  x86_64|amd64) architecture="amd64" ;;
+  aarch64|arm64) architecture="arm64" ;;
+  *) fail "unsupported CPU architecture: $(uname -m)" ;;
+esac
+
+for command in curl sha256sum awk install mktemp; do
+  command -v "$command" >/dev/null 2>&1 || fail "required command not found: $command"
+done
+
+asset="overtchat-linux-$architecture"
+release_url="https://github.com/$repository/releases/download/cli-v$cli_version"
+temporary_directory=$(mktemp -d)
+trap 'rm -rf "$temporary_directory"' EXIT HUP INT TERM
+
+say "Downloading OvertChat $cli_version..."
+curl --proto '=https' --tlsv1.2 -fsSLo "$temporary_directory/$asset" \
+  "$release_url/$asset"
+curl --proto '=https' --tlsv1.2 -fsSLo "$temporary_directory/checksums.txt" \
+  "$release_url/overtchat-checksums.txt"
+
+expected=$(
+  awk -v asset="$asset" '$2 == asset || $2 == "*" asset { print $1; exit }' \
+    "$temporary_directory/checksums.txt"
+)
+[ -n "$expected" ] || fail "the release checksum for $asset is missing"
+actual=$(sha256sum "$temporary_directory/$asset" | awk '{ print $1 }')
+[ "$actual" = "$expected" ] || fail "the downloaded binary failed checksum verification"
+
+install_directory="${HOME:?}/.local/bin"
+install_path="$install_directory/overtchat"
+mkdir -p "$install_directory"
+install -m 0755 "$temporary_directory/$asset" "$install_path"
+
+say "Installed the overtchat command at $install_path"
+case ":$PATH:" in
+  *":$install_directory:"*) ;;
+  *)
+    say "Add $install_directory to PATH to run overtchat from any shell."
+    ;;
+esac
+
+if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+  exec "$install_path" setup </dev/tty >/dev/tty
+fi
+
+say "Run $install_path setup in an interactive terminal to finish."

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,0 +1,7 @@
+{
+  "format": 1,
+  "cliVersion": "0.1.0",
+  "appVersion": "0.14.0",
+  "connectorVersion": "0.4.0",
+  "sttVersion": "0.1.0"
+}

--- a/apps/web/app/(app)/settings/SettingsNav.tsx
+++ b/apps/web/app/(app)/settings/SettingsNav.tsx
@@ -7,6 +7,7 @@ import {
   Cpu,
   Database,
   KeyRound,
+  ServerCog,
   Settings2,
   UserRound,
   Users,
@@ -33,6 +34,11 @@ const USER_ITEMS: Item[] = [
 ];
 
 const ADMIN_ITEMS: Item[] = [
+  {
+    href: "/settings/services",
+    label: "Services",
+    icon: ServerCog,
+  },
   {
     href: "/settings/connections",
     label: "Connections",

--- a/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
+++ b/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
@@ -294,7 +294,7 @@ export function ConnectionsPanel({
                   : "Host Connector"}
               </p>
             </div>
-            {!connector.online && (
+            {!connector.online && !connector.managed && (
               <Button
                 variant="outline"
                 size="sm"
@@ -309,22 +309,24 @@ export function ConnectionsPanel({
                 Pair again
               </Button>
             )}
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              disabled={deleteConnectorMutation.isPending}
-              onClick={() => {
-                setDetachError("");
-                setPendingDetach({ type: "connector", connector });
-              }}
-              aria-label="Remove Host Connector"
-              title="Remove Host Connector"
-            >
-              <Trash2 />
-            </Button>
+            {!connector.managed && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                disabled={deleteConnectorMutation.isPending}
+                onClick={() => {
+                  setDetachError("");
+                  setPendingDetach({ type: "connector", connector });
+                }}
+                aria-label="Remove Host Connector"
+                title="Remove Host Connector"
+              >
+                <Trash2 />
+              </Button>
+            )}
           </div>
         ) : (
-          <div className="flex items-center justify-between gap-3 px-4 py-4">
+          <div className="flex items-center gap-3 px-4 py-4">
             <div className="flex min-w-0 items-center gap-3">
               <span className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/30">
                 <Server className="size-4" />
@@ -334,23 +336,10 @@ export function ConnectionsPanel({
                   OvertChat host
                 </span>
                 <span className="block text-xs text-muted-foreground">
-                  Local agents and SSH
+                  Not installed on this server. Run: overtchat setup
                 </span>
               </span>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={pairingMutation.isPending}
-              onClick={() => void createPairing()}
-            >
-              {pairingMutation.isPending ? (
-                <Loader2 className="animate-spin motion-reduce:animate-none" />
-              ) : (
-                <Link2 />
-              )}
-              Set up
-            </Button>
           </div>
         )}
         {connector?.upgrade && (

--- a/apps/web/app/(app)/settings/services/ServicesPanel.tsx
+++ b/apps/web/app/(app)/settings/services/ServicesPanel.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import type {
+  AdminServerCapability,
+  ServerCapabilityInput,
+} from "@/lib/capabilities/schema";
+import { getErrorMessage } from "@/lib/errors";
+import {
+  useServerCapabilities,
+  useUpdateServerCapability,
+} from "@/lib/queries/serverCapabilities";
+import {
+  SettingsActions,
+  SettingsNotice,
+  SettingsPageHeader,
+  SettingsRow,
+  SettingsSection,
+} from "../_components/SettingsRows";
+
+type ProviderOption = {
+  value: string;
+  label: string;
+  bundled?: boolean;
+};
+
+type CapabilityDraft = {
+  id: AdminServerCapability["id"];
+  provider: string;
+  bundledInstalled: boolean;
+  baseUrl: string | null;
+  apiKey: string | null;
+  apiKeySet: boolean;
+  model: string | null;
+  voice: string | null;
+  configured: boolean;
+};
+
+const PROVIDERS: Record<AdminServerCapability["id"], ProviderOption[]> = {
+  search: [
+    { value: "bundled", label: "Bundled SearXNG", bundled: true },
+    { value: "brave", label: "Brave Search API" },
+    { value: "searxng", label: "Existing SearXNG" },
+    { value: "disabled", label: "Disabled" },
+  ],
+  tts: [
+    { value: "bundled", label: "Bundled Kokoro", bundled: true },
+    { value: "openai-compatible", label: "OpenAI-compatible API" },
+    { value: "disabled", label: "Disabled" },
+  ],
+  stt: [
+    { value: "bundled", label: "Bundled Parakeet", bundled: true },
+    { value: "openai-compatible", label: "OpenAI-compatible API" },
+    { value: "disabled", label: "Disabled" },
+  ],
+};
+
+const TITLES: Record<AdminServerCapability["id"], string> = {
+  search: "Web search",
+  tts: "Text-to-speech",
+  stt: "Speech-to-text",
+};
+
+function needsBaseUrl(capability: CapabilityDraft): boolean {
+  return (
+    capability.provider === "searxng" ||
+    capability.provider === "openai-compatible"
+  );
+}
+
+function needsApiKey(capability: CapabilityDraft): boolean {
+  return (
+    capability.provider === "brave" ||
+    capability.provider === "openai-compatible"
+  );
+}
+
+function CapabilitySection({
+  capability,
+}: {
+  capability: AdminServerCapability;
+}) {
+  const [draft, setDraft] = useState<CapabilityDraft>(capability);
+  const updateCapability = useUpdateServerCapability();
+
+  async function save() {
+    try {
+      const updated = await updateCapability.mutateAsync(
+        draft as unknown as ServerCapabilityInput,
+      );
+      setDraft(updated);
+      toast.success({ title: `${TITLES[draft.id]} updated` });
+    } catch (error) {
+      toast.error({
+        title: `Could not update ${TITLES[draft.id].toLowerCase()}`,
+        description: getErrorMessage(error, "The provider was not changed."),
+      });
+    }
+  }
+
+  const bundledMissing = !draft.bundledInstalled;
+  return (
+    <SettingsSection
+      title={TITLES[draft.id]}
+      description="Choose the provider used by everyone on this server."
+    >
+      <SettingsRow
+        title="Provider"
+        description={
+          bundledMissing
+            ? `${PROVIDERS[draft.id].find((provider) => provider.bundled)?.label} is not installed on this server. Run: overtchat setup`
+            : undefined
+        }
+        align="center"
+      >
+        <Select
+          value={draft.provider}
+          onValueChange={(provider) => {
+            if (!provider) return;
+            setDraft((current) => {
+              if (current.id === "tts" && provider === "bundled") {
+                return {
+                  ...current,
+                  provider,
+                  model: "kokoro",
+                  voice: "af_heart",
+                };
+              }
+              if (current.id === "tts" && provider === "openai-compatible") {
+                return {
+                  ...current,
+                  provider,
+                  model:
+                    current.provider !== "openai-compatible"
+                      ? "tts-1"
+                      : current.model ?? "tts-1",
+                  voice:
+                    current.provider !== "openai-compatible"
+                      ? "alloy"
+                      : current.voice ?? "alloy",
+                };
+              }
+              if (current.id === "stt" && provider === "bundled") {
+                return {
+                  ...current,
+                  provider,
+                  model: "parakeet-tdt-0.6b-v3",
+                };
+              }
+              if (current.id === "stt" && provider === "openai-compatible") {
+                return {
+                  ...current,
+                  provider,
+                  model:
+                    current.provider !== "openai-compatible"
+                      ? "whisper-1"
+                      : current.model ?? "whisper-1",
+                };
+              }
+              return { ...current, provider };
+            });
+          }}
+        >
+          <SelectTrigger className="w-full" aria-label={`${TITLES[draft.id]} provider`}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PROVIDERS[draft.id].map((provider) => (
+              <SelectItem
+                key={provider.value}
+                value={provider.value}
+                disabled={provider.bundled && bundledMissing}
+              >
+                {provider.label}
+                {provider.bundled && bundledMissing ? " — Not installed" : ""}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingsRow>
+
+      {needsBaseUrl(draft) && (
+        <SettingsRow title="API base URL" htmlFor={`${draft.id}-base-url`}>
+          <Input
+            id={`${draft.id}-base-url`}
+            value={draft.baseUrl ?? ""}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                baseUrl: event.target.value,
+              }))
+            }
+            placeholder={
+              draft.id === "search"
+                ? "http://host.docker.internal:8088"
+                : "https://api.openai.com/v1"
+            }
+          />
+        </SettingsRow>
+      )}
+
+      {needsApiKey(draft) && (
+        <SettingsRow
+          title="API key"
+          description={
+            draft.apiKeySet
+              ? "A key is configured. Leave this blank to keep it."
+              : undefined
+          }
+          htmlFor={`${draft.id}-api-key`}
+        >
+          <PasswordInput
+            id={`${draft.id}-api-key`}
+            value={draft.apiKey ?? ""}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                apiKey: event.target.value,
+              }))
+            }
+            autoComplete="off"
+          />
+        </SettingsRow>
+      )}
+
+      {(draft.id === "tts" || draft.id === "stt") &&
+        draft.provider === "openai-compatible" && (
+          <SettingsRow title="Model" htmlFor={`${draft.id}-model`}>
+            <Input
+              id={`${draft.id}-model`}
+              value={draft.model ?? ""}
+              onChange={(event) =>
+                setDraft((current) => ({
+                  ...current,
+                  model: event.target.value,
+                }))
+              }
+              placeholder={draft.id === "tts" ? "tts-1" : "whisper-1"}
+            />
+          </SettingsRow>
+        )}
+
+      {draft.id === "tts" && draft.provider === "openai-compatible" && (
+        <SettingsRow title="Default voice" htmlFor="tts-voice">
+          <Input
+            id="tts-voice"
+            value={draft.voice ?? ""}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                voice: event.target.value,
+              }))
+            }
+            placeholder="alloy"
+          />
+        </SettingsRow>
+      )}
+
+      <SettingsActions className="py-4">
+        <Button
+          size="sm"
+          onClick={() => void save()}
+          disabled={updateCapability.isPending}
+        >
+          {updateCapability.isPending ? "Saving…" : "Save"}
+        </Button>
+      </SettingsActions>
+    </SettingsSection>
+  );
+}
+
+export function ServicesPanel() {
+  const { data: capabilities = [], isPending, error } =
+    useServerCapabilities();
+
+  return (
+    <div className="max-w-3xl space-y-8">
+      <SettingsPageHeader
+        title="Services"
+        description="Manage search and speech providers for this server. Local services are installed with overtchat setup."
+      />
+      {isPending && <SettingsNotice>Loading services…</SettingsNotice>}
+      {error && (
+        <SettingsNotice tone="error">
+          {getErrorMessage(error, "Could not load server services.")}
+        </SettingsNotice>
+      )}
+      {capabilities.map((capability) => (
+        <CapabilitySection key={capability.id} capability={capability} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/(app)/settings/services/page.tsx
+++ b/apps/web/app/(app)/settings/services/page.tsx
@@ -1,0 +1,30 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { auth } from "@/lib/auth/server";
+import {
+  listServerCapabilities,
+  toAdminServerCapability,
+} from "@/lib/db/serverCapabilities";
+import { getQueryClient } from "@/lib/queryClient";
+import { serverCapabilityKeys } from "@/lib/queries/keys";
+import { ServicesPanel } from "./ServicesPanel";
+
+export default async function Page() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+  if (session.user.role !== "admin") redirect("/settings/general");
+
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: serverCapabilityKeys.list(),
+    queryFn: async () =>
+      listServerCapabilities().map(toAdminServerCapability),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ServicesPanel />
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/app/api/capabilities/route.ts
+++ b/apps/web/app/api/capabilities/route.ts
@@ -1,0 +1,19 @@
+import { auth } from "@/lib/auth/server";
+import { listServerCapabilities } from "@/lib/db/serverCapabilities";
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  return Response.json({
+    capabilities: Object.fromEntries(
+      listServerCapabilities().map((capability) => [
+        capability.id,
+        {
+          provider: capability.provider,
+          available: capability.provider !== "disabled",
+          bundledInstalled: capability.bundledInstalled,
+        },
+      ]),
+    ),
+  });
+}

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
     inlineUploads: vi.fn(),
     getModelConfig: vi.fn(),
     getTaskModelConfig: vi.fn(),
+    getServerCapability: vi.fn(),
     getProject: vi.fn(),
     generateChatTitle: vi.fn(),
     getProvider: vi.fn(),
@@ -105,6 +106,9 @@ vi.mock("@/lib/db/uploads", () => ({ inlineUploads: mocks.inlineUploads }));
 vi.mock("@/lib/db/modelConfigs", () => ({
   getModelConfig: mocks.getModelConfig,
   getTaskModelConfig: mocks.getTaskModelConfig,
+}));
+vi.mock("@/lib/db/serverCapabilities", () => ({
+  getServerCapability: mocks.getServerCapability,
 }));
 vi.mock("@/lib/db/projects", () => ({ getProject: mocks.getProject }));
 vi.mock("@/lib/title", () => ({
@@ -207,6 +211,7 @@ describe("chat route setup boundary", () => {
     mocks.parseChatRequest.mockResolvedValue({ ...parsedRequest });
     mocks.getModelConfig.mockResolvedValue({ ...modelConfig });
     mocks.getTaskModelConfig.mockReturnValue(null);
+    mocks.getServerCapability.mockReturnValue({ provider: "bundled" });
     mocks.getChat.mockResolvedValue(null);
     mocks.getProject.mockResolvedValue(null);
     mocks.getChatMessage.mockResolvedValue(null);

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -25,6 +25,7 @@ import { corsHeaders, preflight, withCors } from "@/lib/cors";
 import { auth } from "@/lib/auth/server";
 import { ChatRequestError, parseChatRequest } from "@/lib/chat/request";
 import { getChat } from "@/lib/db/chats";
+import { getServerCapability } from "@/lib/db/serverCapabilities";
 import {
   clearActiveStreamId,
   commitChatTurn,
@@ -185,7 +186,10 @@ async function handlePost(req: Request): Promise<Response> {
       ? withOpenAIPromptCacheKey(providerOptions, promptCacheKeyForChat(chatId))
       : providerOptions;
   const toolCallingEnabled = modelConfig.toolCallingEnabled !== false;
-  const webToolsEnabled = toolCallingEnabled && webSearchEnabled;
+  const webSearchAvailable =
+    getServerCapability("search").provider !== "disabled";
+  const webToolsEnabled =
+    toolCallingEnabled && webSearchEnabled && webSearchAvailable;
   const systemParts = [
     modelConfig.systemPrompt,
     projectSystemPrompt(project),

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,9 +80,32 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.4 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.4.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
+  });
+
+  it("keeps managed connectors under overtchat setup", async () => {
+    const managed = {
+      id: "managed",
+      name: "Managed host",
+      managed: true,
+      version: "0.4.0",
+      lastSeenAt: null,
+    };
+    mocks.listConnectors.mockReturnValue([managed]);
+    mocks.getOwnedConnector.mockReturnValue(managed);
+
+    const pairResponse = await POST(request("POST"));
+    const deleteResponse = await DELETE(
+      request("DELETE", "?id=managed"),
+    );
+
+    expect(pairResponse.status).toBe(409);
+    expect(deleteResponse.status).toBe(409);
+    expect(mocks.createPairing).not.toHaveBeenCalled();
+    expect(mocks.daemonRequest).not.toHaveBeenCalled();
+    expect(mocks.deleteConnector).not.toHaveBeenCalled();
   });
 
   it("offers an in-place upgrade command for an older connector", async () => {
@@ -90,6 +113,7 @@ describe("Host Connectors route", () => {
       {
         id: "connector",
         name: "Home server",
+        managed: false,
         version: "0.2.0",
         lastSeenAt: new Date(12_000),
       },
@@ -104,13 +128,14 @@ describe("Host Connectors route", () => {
         {
           id: "connector",
           name: "Home server",
+          managed: false,
           version: "0.2.0",
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.3.4",
+            version: "0.4.0",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.3.4 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.4.0 | sh -s -- --upgrade",
           },
         },
       ],
@@ -122,13 +147,15 @@ describe("Host Connectors route", () => {
       {
         id: "current",
         name: "Current",
-        version: "0.3.4",
+        managed: false,
+        version: "0.4.0",
         lastSeenAt: null,
       },
       {
         id: "newer",
         name: "Newer",
-        version: "0.4.0",
+        managed: false,
+        version: "0.5.0",
         lastSeenAt: null,
       },
     ]);

--- a/apps/web/app/api/host-connectors/route.ts
+++ b/apps/web/app/api/host-connectors/route.ts
@@ -83,10 +83,11 @@ export async function GET(request: Request) {
     return {
       id: connector.id,
       name: connector.name,
+      managed: connector.managed,
       version: connector.version,
       lastSeenAt: connector.lastSeenAt?.getTime() ?? null,
       online: hostConnectorBroker.isOnline(connector.id),
-      upgrade: needsUpgrade
+      upgrade: needsUpgrade && !connector.managed
         ? {
             version: HOST_CONNECTOR_RELEASE_VERSION,
             command: upgradeCommand(),
@@ -100,6 +101,15 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const result = await adminUser(request);
   if (!result.ok) return result.error;
+  if (listHostConnectors(result.user.id).some((connector) => connector.managed)) {
+    return Response.json(
+      {
+        error: "Agent Connections are managed by overtchat setup.",
+        code: "managed_connector",
+      },
+      { status: 409 },
+    );
+  }
   const pairing = createHostConnectorPairing(result.user.id);
   return Response.json({
     pairCode: pairing.pairCode,
@@ -113,8 +123,18 @@ export async function DELETE(request: Request) {
   if (!result.ok) return result.error;
   const id = new URL(request.url).searchParams.get("id");
   if (!id) return new Response("Missing connector id", { status: 400 });
-  if (!getOwnedHostConnector(id, result.user.id)) {
+  const connector = getOwnedHostConnector(id, result.user.id);
+  if (!connector) {
     return new Response("Not found", { status: 404 });
+  }
+  if (connector.managed) {
+    return Response.json(
+      {
+        error: "Agent Connections are managed by overtchat setup.",
+        code: "managed_connector",
+      },
+      { status: 409 },
+    );
   }
   await hostConnectorBroker.request(id, { type: "stop_all" }).catch(() => {});
   return deleteHostConnector(id, result.user.id)

--- a/apps/web/app/api/host-connectors/uploads/[id]/route.ts
+++ b/apps/web/app/api/host-connectors/uploads/[id]/route.ts
@@ -8,6 +8,7 @@ export async function GET(
 ) {
   const connector = authenticateHostConnector(request);
   if (!connector) return new Response("Unauthorized", { status: 401 });
+  if (!connector.userId) return new Response("Connector not claimed", { status: 403 });
   const { id } = await params;
   const upload = await getUpload(id, connector.userId);
   if (!upload || upload.category !== "image") {

--- a/apps/web/app/api/internal/management/capabilities/route.ts
+++ b/apps/web/app/api/internal/management/capabilities/route.ts
@@ -1,0 +1,43 @@
+import { serverCapabilitiesInputSchema } from "@/lib/capabilities/schema";
+import {
+  listServerCapabilities,
+  replaceServerCapabilities,
+  toAdminServerCapability,
+} from "@/lib/db/serverCapabilities";
+import { managementRequestAuthorized } from "@/lib/management/auth";
+
+export async function GET(request: Request) {
+  if (!managementRequestAuthorized(request)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  return Response.json({
+    capabilities: listServerCapabilities().map((capability) => ({
+      id: capability.id,
+      provider: capability.provider,
+      bundledInstalled: capability.bundledInstalled,
+      baseUrl: capability.baseUrl,
+      apiKey: capability.apiKey,
+      model: capability.model,
+      voice: capability.voice,
+    })),
+  });
+}
+
+export async function PUT(request: Request) {
+  if (!managementRequestAuthorized(request)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const parsed = serverCapabilitiesInputSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid capabilities." },
+      { status: 400 },
+    );
+  }
+  const capabilities = replaceServerCapabilities(parsed.data.capabilities);
+  return Response.json({
+    capabilities: capabilities.map(toAdminServerCapability),
+  });
+}

--- a/apps/web/app/api/internal/management/connector/route.ts
+++ b/apps/web/app/api/internal/management/connector/route.ts
@@ -1,0 +1,50 @@
+import os from "node:os";
+import { z } from "zod";
+import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import {
+  getManagedHostConnector,
+  provisionManagedHostConnector,
+} from "@/lib/db/hostConnectors";
+import { managementRequestAuthorized } from "@/lib/management/auth";
+
+const inputSchema = z.object({
+  name: z.string().trim().min(1).max(120).default(os.hostname()),
+  version: z.string().trim().min(1).max(40).nullable(),
+});
+
+export async function GET(request: Request) {
+  if (!managementRequestAuthorized(request)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const connector = getManagedHostConnector();
+  return Response.json({
+    connector: connector
+      ? {
+          id: connector.id,
+          name: connector.name,
+          version: connector.version,
+          online: hostConnectorBroker.isOnline(connector.id),
+        }
+      : null,
+  });
+}
+
+export async function PUT(request: Request) {
+  if (!managementRequestAuthorized(request)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const parsed = inputSchema.safeParse(
+    await request.json().catch(() => ({})),
+  );
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid connector." },
+      { status: 400 },
+    );
+  }
+  const provisioned = provisionManagedHostConnector(parsed.data);
+  return Response.json({
+    connectorId: provisioned.connector.id,
+    token: provisioned.token,
+  });
+}

--- a/apps/web/app/api/server-capabilities/[id]/route.test.ts
+++ b/apps/web/app/api/server-capabilities/[id]/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getCapability: vi.fn(),
+  updateCapability: vi.fn(),
+  toAdmin: vi.fn((value) => value),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/serverCapabilities", () => ({
+  getServerCapability: mocks.getCapability,
+  updateServerCapability: mocks.updateCapability,
+  toAdminServerCapability: mocks.toAdmin,
+}));
+
+import { PUT } from "./route";
+
+function request(body: object): Request {
+  return new Request("http://server.test/api/server-capabilities/search", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const searchInput = {
+  provider: "brave",
+  bundledInstalled: false,
+  baseUrl: null,
+  apiKey: null,
+  model: null,
+  voice: null,
+};
+
+describe("server capability update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "admin", role: "admin" },
+    });
+    mocks.getCapability.mockReturnValue({
+      id: "search",
+      provider: "brave",
+      bundledInstalled: false,
+      apiKey: "stored-key",
+    });
+    mocks.updateCapability.mockImplementation((value) => value);
+  });
+
+  it("requires an administrator", async () => {
+    mocks.getSession.mockResolvedValue({ user: { role: "user" } });
+    expect(
+      (await PUT(request(searchInput), { params: Promise.resolve({ id: "search" }) })).status,
+    ).toBe(403);
+    expect(mocks.updateCapability).not.toHaveBeenCalled();
+  });
+
+  it("keeps a masked API key when the admin leaves the field blank", async () => {
+    const response = await PUT(request(searchInput), {
+      params: Promise.resolve({ id: "search" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateCapability).toHaveBeenCalledWith({
+      ...searchInput,
+      id: "search",
+      apiKey: "stored-key",
+    });
+  });
+
+  it("does not activate a bundled service absent from this server", async () => {
+    const response = await PUT(
+      request({ ...searchInput, provider: "bundled" }),
+      { params: Promise.resolve({ id: "search" }) },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "not_installed",
+    });
+    expect(mocks.updateCapability).not.toHaveBeenCalled();
+  });
+
+  it("requires a Brave API key when none is stored", async () => {
+    mocks.getCapability.mockReturnValue({
+      id: "search",
+      bundledInstalled: false,
+      apiKey: null,
+    });
+
+    const response = await PUT(request(searchInput), {
+      params: Promise.resolve({ id: "search" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Enter a Brave Search API key.",
+    });
+  });
+});

--- a/apps/web/app/api/server-capabilities/[id]/route.ts
+++ b/apps/web/app/api/server-capabilities/[id]/route.ts
@@ -1,0 +1,87 @@
+import { auth } from "@/lib/auth/server";
+import {
+  CAPABILITY_IDS,
+  serverCapabilityInputSchema,
+  type CapabilityId,
+} from "@/lib/capabilities/schema";
+import {
+  getServerCapability,
+  toAdminServerCapability,
+  updateServerCapability,
+} from "@/lib/db/serverCapabilities";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+  const { id } = await params;
+  if (!CAPABILITY_IDS.includes(id as CapabilityId)) {
+    return new Response("Not found", { status: 404 });
+  }
+  const parsed = serverCapabilityInputSchema.safeParse({
+    ...(await request.json().catch(() => null)),
+    id,
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid capability." },
+      { status: 400 },
+    );
+  }
+  const current = getServerCapability(id as CapabilityId);
+  if (parsed.data.provider === "bundled" && !current.bundledInstalled) {
+    return Response.json(
+      {
+        error: `${id} is not installed on this server. Run: overtchat setup`,
+        code: "not_installed",
+      },
+      { status: 409 },
+    );
+  }
+  const apiKey = parsed.data.apiKey ?? current.apiKey;
+  if (parsed.data.provider === "brave" && !apiKey) {
+    return Response.json(
+      { error: "Enter a Brave Search API key." },
+      { status: 400 },
+    );
+  }
+  if (
+    (parsed.data.provider === "searxng" ||
+      parsed.data.provider === "openai-compatible") &&
+    !parsed.data.baseUrl
+  ) {
+    return Response.json(
+      { error: "Enter the provider API base URL." },
+      { status: 400 },
+    );
+  }
+  if (
+    parsed.data.provider === "openai-compatible" &&
+    (parsed.data.id === "tts" || parsed.data.id === "stt") &&
+    !parsed.data.model?.trim()
+  ) {
+    return Response.json(
+      { error: "Enter the provider model name." },
+      { status: 400 },
+    );
+  }
+  if (
+    parsed.data.provider === "openai-compatible" &&
+    parsed.data.id === "tts" &&
+    !parsed.data.voice?.trim()
+  ) {
+    return Response.json(
+      { error: "Enter the default voice." },
+      { status: 400 },
+    );
+  }
+  const capability = updateServerCapability({ ...parsed.data, apiKey });
+  return Response.json({
+    capability: toAdminServerCapability(capability),
+  });
+}

--- a/apps/web/app/api/server-capabilities/route.ts
+++ b/apps/web/app/api/server-capabilities/route.ts
@@ -1,0 +1,16 @@
+import { auth } from "@/lib/auth/server";
+import {
+  listServerCapabilities,
+  toAdminServerCapability,
+} from "@/lib/db/serverCapabilities";
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+  return Response.json({
+    capabilities: listServerCapabilities().map(toAdminServerCapability),
+  });
+}

--- a/apps/web/app/api/transcribe/route.ts
+++ b/apps/web/app/api/transcribe/route.ts
@@ -1,7 +1,12 @@
 import { auth } from "@/lib/auth/server";
+import { getServerCapability } from "@/lib/db/serverCapabilities";
 
-const STT_URL = process.env.STT_URL ?? "http://localhost:5092";
 const MAX_BYTES = 25 * 1024 * 1024;
+
+function transcriptionEndpoint(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/$/u, "");
+  return `${normalized}${normalized.endsWith("/v1") ? "" : "/v1"}/audio/transcriptions`;
+}
 
 export async function POST(req: Request) {
   const session = await auth.api.getSession({ headers: req.headers });
@@ -12,14 +17,37 @@ export async function POST(req: Request) {
     return new Response("Audio too large", { status: 413 });
   }
 
-  const upstream = await fetch(`${STT_URL}/v1/audio/transcriptions`, {
+  const capability = getServerCapability("stt");
+  const baseUrl =
+    capability.provider === "bundled"
+      ? "http://stt:5092"
+      : capability.baseUrl || process.env.STT_URL;
+  if (capability.provider === "disabled" || !baseUrl) {
+    return Response.json(
+      { error: "stt_unavailable", role: session.user.role ?? "user" },
+      { status: 503 },
+    );
+  }
+  const incoming = await req.formData().catch(() => null);
+  const file = incoming?.get("file");
+  if (!(file instanceof File)) {
+    return new Response("Missing audio file", { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return new Response("Audio too large", { status: 413 });
+  }
+  const outgoing = new FormData();
+  outgoing.append("file", file, file.name);
+  outgoing.append("model", capability.model ?? "parakeet-tdt-0.6b-v3");
+  const headers: Record<string, string> = {};
+  if (capability.apiKey) {
+    headers.Authorization = `Bearer ${capability.apiKey}`;
+  }
+
+  const upstream = await fetch(transcriptionEndpoint(baseUrl), {
     method: "POST",
-    body: req.body,
-    // @ts-expect-error duplex is required by Node when streaming a body
-    duplex: "half",
-    headers: {
-      "Content-Type": req.headers.get("content-type") ?? "application/octet-stream",
-    },
+    body: outgoing,
+    headers,
     signal: req.signal,
   }).catch(() => null);
 
@@ -38,4 +66,3 @@ export async function POST(req: Request) {
     },
   });
 }
-

--- a/apps/web/app/api/tts/route.ts
+++ b/apps/web/app/api/tts/route.ts
@@ -1,7 +1,12 @@
 import { auth } from "@/lib/auth/server";
+import { getServerCapability } from "@/lib/db/serverCapabilities";
 
-const KOKORO_URL = process.env.KOKORO_URL ?? "http://localhost:8880";
 const MAX_CHARS = 5000;
+
+function speechEndpoint(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/$/u, "");
+  return `${normalized}${normalized.endsWith("/v1") ? "" : "/v1"}/audio/speech`;
+}
 
 export async function POST(req: Request) {
   const session = await auth.api.getSession({ headers: req.headers });
@@ -16,12 +21,36 @@ export async function POST(req: Request) {
     return new Response(`Text exceeds ${MAX_CHARS} chars`, { status: 413 });
   }
 
-  const upstream = await fetch(`${KOKORO_URL}/v1/audio/speech`, {
+  const capability = getServerCapability("tts");
+  if (capability.provider === "disabled") {
+    return Response.json(
+      { error: "tts_unavailable", role: session.user.role ?? "user" },
+      { status: 503 },
+    );
+  }
+  const baseUrl =
+    capability.provider === "bundled"
+      ? "http://kokoro:8880"
+      : capability.baseUrl || process.env.KOKORO_URL;
+  if (!baseUrl) {
+    return Response.json(
+      { error: "tts_unavailable", role: session.user.role ?? "user" },
+      { status: 503 },
+    );
+  }
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (capability.apiKey) {
+    headers.Authorization = `Bearer ${capability.apiKey}`;
+  }
+
+  const upstream = await fetch(speechEndpoint(baseUrl), {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({
-      model: "kokoro",
-      voice: body?.voice ?? "af_heart",
+      model: capability.model ?? "kokoro",
+      voice: body?.voice ?? capability.voice ?? "af_heart",
       input: text,
       response_format: "mp3",
       stream: true,
@@ -35,7 +64,7 @@ export async function POST(req: Request) {
 
   return new Response(upstream.body, {
     headers: {
-      "Content-Type": "audio/mpeg",
+      "Content-Type": upstream.headers.get("content-type") ?? "audio/mpeg",
       "Cache-Control": "no-store",
     },
   });

--- a/apps/web/drizzle/0010_deep_nico_minoru.sql
+++ b/apps/web/drizzle/0010_deep_nico_minoru.sql
@@ -10,7 +10,14 @@ CREATE TABLE `server_capabilities` (
 	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL
 );
 --> statement-breakpoint
-PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TEMP TABLE `__overtchat_0010_agent_hosts` AS SELECT * FROM `agent_hosts`;--> statement-breakpoint
+CREATE TEMP TABLE `__overtchat_0010_agent_connections` AS SELECT * FROM `agent_connections`;--> statement-breakpoint
+CREATE TEMP TABLE `__overtchat_0010_agent_workspaces` AS SELECT * FROM `agent_workspaces`;--> statement-breakpoint
+CREATE TEMP TABLE `__overtchat_0010_agent_sessions` AS SELECT * FROM `agent_sessions`;--> statement-breakpoint
+DELETE FROM `agent_sessions`;--> statement-breakpoint
+DELETE FROM `agent_workspaces`;--> statement-breakpoint
+DELETE FROM `agent_connections`;--> statement-breakpoint
+DELETE FROM `agent_hosts`;--> statement-breakpoint
 CREATE TABLE `__new_host_connectors` (
 	`id` text PRIMARY KEY NOT NULL,
 	`user_id` text,
@@ -27,5 +34,12 @@ CREATE TABLE `__new_host_connectors` (
 INSERT INTO `__new_host_connectors`("id", "user_id", "managed", "name", "token_hash", "version", "last_seen_at", "created_at", "updated_at") SELECT "id", "user_id", false, "name", "token_hash", "version", "last_seen_at", "created_at", "updated_at" FROM `host_connectors`;--> statement-breakpoint
 DROP TABLE `host_connectors`;--> statement-breakpoint
 ALTER TABLE `__new_host_connectors` RENAME TO `host_connectors`;--> statement-breakpoint
-PRAGMA foreign_keys=ON;--> statement-breakpoint
+INSERT INTO `agent_hosts` SELECT * FROM `__overtchat_0010_agent_hosts`;--> statement-breakpoint
+INSERT INTO `agent_connections` SELECT * FROM `__overtchat_0010_agent_connections`;--> statement-breakpoint
+INSERT INTO `agent_workspaces` SELECT * FROM `__overtchat_0010_agent_workspaces`;--> statement-breakpoint
+INSERT INTO `agent_sessions` SELECT * FROM `__overtchat_0010_agent_sessions`;--> statement-breakpoint
+DROP TABLE `__overtchat_0010_agent_sessions`;--> statement-breakpoint
+DROP TABLE `__overtchat_0010_agent_workspaces`;--> statement-breakpoint
+DROP TABLE `__overtchat_0010_agent_connections`;--> statement-breakpoint
+DROP TABLE `__overtchat_0010_agent_hosts`;--> statement-breakpoint
 CREATE UNIQUE INDEX `host_connectors_userId_idx` ON `host_connectors` (`user_id`);

--- a/apps/web/drizzle/0010_deep_nico_minoru.sql
+++ b/apps/web/drizzle/0010_deep_nico_minoru.sql
@@ -1,0 +1,31 @@
+CREATE TABLE `server_capabilities` (
+	`id` text PRIMARY KEY NOT NULL,
+	`provider` text NOT NULL,
+	`bundled_installed` integer DEFAULT false NOT NULL,
+	`base_url` text,
+	`api_key` text,
+	`model` text,
+	`voice` text,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_host_connectors` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text,
+	`managed` integer DEFAULT false NOT NULL,
+	`name` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`version` text,
+	`last_seen_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_host_connectors`("id", "user_id", "managed", "name", "token_hash", "version", "last_seen_at", "created_at", "updated_at") SELECT "id", "user_id", false, "name", "token_hash", "version", "last_seen_at", "created_at", "updated_at" FROM `host_connectors`;--> statement-breakpoint
+DROP TABLE `host_connectors`;--> statement-breakpoint
+ALTER TABLE `__new_host_connectors` RENAME TO `host_connectors`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `host_connectors_userId_idx` ON `host_connectors` (`user_id`);

--- a/apps/web/drizzle/meta/0010_snapshot.json
+++ b/apps/web/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1826 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7b2b61c5-f99e-4a95-9978-2af04bd5159a",
+  "prevId": "a5f75aee-5d9b-4f6d-a3ce-aa8a202e57d3",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connections": {
+      "name": "agent_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shell_mode": {
+          "name": "shell_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "detected_version": {
+          "name": "detected_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_connections_hostId_provider_idx": {
+          "name": "agent_connections_hostId_provider_idx",
+          "columns": [
+            "host_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connections_host_id_agent_hosts_id_fk": {
+          "name": "agent_connections_host_id_agent_hosts_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "agent_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_hosts": {
+      "name": "agent_hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_alias": {
+          "name": "ssh_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_hosts_userId_updatedAt_idx": {
+          "name": "agent_hosts_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "agent_hosts_connectorId_idx": {
+          "name": "agent_hosts_connectorId_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_hosts_user_id_user_id_fk": {
+          "name": "agent_hosts_user_id_user_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_hosts_connector_id_host_connectors_id_fk": {
+          "name": "agent_hosts_connector_id_host_connectors_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "host_connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_sessions": {
+      "name": "agent_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_path": {
+          "name": "provider_session_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_modified_at": {
+          "name": "provider_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_sessions_workspaceId_providerSessionPath_idx": {
+          "name": "agent_sessions_workspaceId_providerSessionPath_idx",
+          "columns": [
+            "workspace_id",
+            "provider_session_path"
+          ],
+          "isUnique": true
+        },
+        "agent_sessions_workspaceId_providerModifiedAt_idx": {
+          "name": "agent_sessions_workspaceId_providerModifiedAt_idx",
+          "columns": [
+            "workspace_id",
+            "provider_modified_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_workspace_id_agent_workspaces_id_fk": {
+          "name": "agent_sessions_workspace_id_agent_workspaces_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_workspaces": {
+      "name": "agent_workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_workspaces_connectionId_path_idx": {
+          "name": "agent_workspaces_connectionId_path_idx",
+          "columns": [
+            "connection_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_connection_id_agent_connections_id_fk": {
+          "name": "agent_workspaces_connection_id_agent_connections_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "agent_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "chats_userId_updatedAt_idx": {
+          "name": "chats_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "chats_userId_projectId_updatedAt_idx": {
+          "name": "chats_userId_projectId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_user_id_fk": {
+          "name": "chats_user_id_user_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_usage": {
+      "name": "generation_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_cost_nano_usd": {
+          "name": "input_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_cost_nano_usd": {
+          "name": "output_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_cost_nano_usd": {
+          "name": "cache_read_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_nano_usd": {
+          "name": "cache_write_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_nano_usd": {
+          "name": "total_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generation_usage_userId_occurredAt_idx": {
+          "name": "generation_usage_userId_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_userId_providerId_model_occurredAt_idx": {
+          "name": "generation_usage_userId_providerId_model_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "provider_id",
+            "model",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_context_occurredAt_idx": {
+          "name": "generation_usage_context_occurredAt_idx",
+          "columns": [
+            "context",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_chatId_idx": {
+          "name": "generation_usage_chatId_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_messageId_idx": {
+          "name": "generation_usage_messageId_idx",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "generation_usage_user_id_user_id_fk": {
+          "name": "generation_usage_user_id_user_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_usage_chat_id_chats_id_fk": {
+          "name": "generation_usage_chat_id_chats_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_usage_message_id_messages_id_fk": {
+          "name": "generation_usage_message_id_messages_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connector_pairings": {
+      "name": "host_connector_pairings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connector_pairings_userId_idx": {
+          "name": "host_connector_pairings_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connector_pairings_user_id_user_id_fk": {
+          "name": "host_connector_pairings_user_id_user_id_fk",
+          "tableFrom": "host_connector_pairings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connectors": {
+      "name": "host_connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connectors_userId_idx": {
+          "name": "host_connectors_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connectors_user_id_user_id_fk": {
+          "name": "host_connectors_user_id_user_id_fk",
+          "tableFrom": "host_connectors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "messages_chatId_createdAt_idx": {
+          "name": "messages_chatId_createdAt_idx",
+          "columns": [
+            "chat_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "api_format": {
+          "name": "api_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai-chat'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_context_window": {
+          "name": "discovered_context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_capabilities": {
+          "name": "discovered_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calling_enabled": {
+          "name": "tool_calling_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "task_model": {
+          "name": "task_model",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "model_configs_taskModel_idx": {
+          "name": "model_configs_taskModel_idx",
+          "columns": [
+            "task_model"
+          ],
+          "isUnique": true,
+          "where": "\"model_configs\".\"task_model\" = true"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "projects_userId_updatedAt_idx": {
+          "name": "projects_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_user_id_fk": {
+          "name": "projects_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "server_capabilities": {
+      "name": "server_capabilities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bundled_installed": {
+          "name": "bundled_installed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploads": {
+      "name": "uploads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "uploads_user_id_user_id_fk": {
+          "name": "uploads_user_id_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1786653947672,
       "tag": "0009_common_human_torch",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1786682215506,
+      "tag": "0010_deep_nico_minoru",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -59,37 +59,28 @@ async function startHostConnector(
   ).toBeVisible();
   await expect(page.getByText("Not set up", { exact: true })).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Agents" }),
-  ).toHaveCount(0);
-
-  await page.getByRole("button", { name: "Set up" }).click();
-  await expect(
-    page.getByText("Install Host Connector", { exact: true }),
-  ).toBeVisible();
-  await expect(
     page.getByText(
-      "Run this command in a terminal on the computer running OvertChat.",
+      "Not installed on this server. Run: overtchat setup",
       { exact: true },
     ),
   ).toBeVisible();
-  await page.getByRole("button", { name: "About Host Connector" }).click();
   await expect(
-    page.getByText(
-      /Lets OvertChat use agent binaries and SSH hosts available on this server/,
-    ),
-  ).toBeVisible();
+    page.getByRole("button", { name: "Set up" }),
+  ).toHaveCount(0);
   await expect(
-    page.getByRole("link", { name: "View installer source" }),
-  ).toHaveAttribute(
-    "href",
-    "https://github.com/yoloyash/overtchat/blob/main/scripts/install-connector.sh",
-  );
-  await page.keyboard.press("Escape");
-  const command = await page.getByLabel("Host Connector install command").textContent();
-  expect(command).toContain("https://overtchat.com/install/connector/0.3.4");
-  expect(command).toContain("--server 'http://127.0.0.1:4718'");
-  const pairCode = /--pair-code '([^']+)'/u.exec(command ?? "")?.[1];
-  if (!pairCode) throw new Error("The Host Connector pairing code was missing.");
+    page.getByRole("heading", { name: "Agents" }),
+  ).toHaveCount(0);
+
+  // Managed setup is the only user-facing installation path. Provision an
+  // unmanaged connector through the authenticated API solely as an E2E fixture
+  // so the connector transport and agent flows below remain covered.
+  const { pairCode } = await page.evaluate(async () => {
+    const response = await fetch("/api/host-connectors", { method: "POST" });
+    if (!response.ok) {
+      throw new Error(`Could not create connector fixture: ${response.status}`);
+    }
+    return (await response.json()) as { pairCode: string };
+  });
 
   const server = new URL(page.url()).origin;
   const configPath = testInfo.outputPath("host-connector.json");
@@ -233,39 +224,26 @@ test("explains agent access before setup", async ({ page }, testInfo) => {
   ).toBeVisible();
   await expect(page.getByText("Not set up", { exact: true })).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Agents" }),
-  ).toHaveCount(0);
-
-  await page.getByRole("button", { name: "Set up" }).click();
-  await expect(
-    page.getByText("Install Host Connector", { exact: true }),
-  ).toBeVisible();
-  await expect(
     page.getByText(
-      "Run this command in a terminal on the computer running OvertChat.",
+      "Not installed on this server. Run: overtchat setup",
       { exact: true },
     ),
   ).toBeVisible();
   await expect(
-    page.getByText("Waiting for connection…", { exact: true }),
-  ).toBeVisible();
-  await page.getByRole("button", { name: "About Host Connector" }).click();
+    page.getByRole("button", { name: "Set up" }),
+  ).toHaveCount(0);
   await expect(
-    page.getByText(
-      /Lets OvertChat use agent binaries and SSH hosts available on this server/,
-    ),
-  ).toBeVisible();
-  await expect(
-    page.getByRole("link", { name: "View installer source" }),
-  ).toBeVisible();
+    page.getByRole("heading", { name: "Agents" }),
+  ).toHaveCount(0);
+
   await page.screenshot({
-    path: testInfo.outputPath("agent-access-setup-desktop.png"),
+    path: testInfo.outputPath("agent-access-uninstalled-desktop.png"),
     fullPage: true,
   });
 
   await page.setViewportSize({ width: 390, height: 844 });
   await page.screenshot({
-    path: testInfo.outputPath("agent-access-setup-mobile.png"),
+    path: testInfo.outputPath("agent-access-uninstalled-mobile.png"),
     fullPage: true,
   });
   expect(

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -4,6 +4,11 @@ export async function register() {
   const { runMigrations } = await import("@/lib/db/migrate");
   runMigrations();
 
+  const { ensureServerCapabilityConfigs } = await import(
+    "@/lib/db/serverCapabilities"
+  );
+  ensureServerCapabilityConfigs();
+
   const { sweepOrphanedUploads } = await import("@/lib/db/uploads");
   sweepOrphanedUploads().catch((err) =>
     console.error("[sweep-orphan-uploads]", err),

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -7,6 +7,7 @@ import { APIError } from "better-auth/api";
 import { count } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import * as schema from "@/lib/db/schema";
+import { claimManagedHostConnector } from "@/lib/db/hostConnectors";
 
 const extraTrustedOrigins =
   process.env.EXTRA_TRUSTED_ORIGINS?.split(",").map((s) => s.trim()).filter(Boolean) ?? [];
@@ -37,6 +38,11 @@ export const auth = betterAuth({
           const sessionUser = ctx?.context?.session?.user;
           if (sessionUser?.role === "admin") return { data };
           throw new APIError("BAD_REQUEST", { message: "Signup is closed." });
+        },
+        after: async (createdUser) => {
+          if (createdUser.role === "admin") {
+            claimManagedHostConnector(createdUser.id);
+          }
         },
       },
     },

--- a/apps/web/lib/capabilities/schema.ts
+++ b/apps/web/lib/capabilities/schema.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+export const CAPABILITY_IDS = ["search", "tts", "stt"] as const;
+export type CapabilityId = (typeof CAPABILITY_IDS)[number];
+
+export const searchProviderSchema = z.enum([
+  "bundled",
+  "brave",
+  "searxng",
+  "disabled",
+]);
+export const ttsProviderSchema = z.enum([
+  "bundled",
+  "openai-compatible",
+  "disabled",
+]);
+export const sttProviderSchema = ttsProviderSchema;
+
+const commonFields = {
+  bundledInstalled: z.boolean(),
+  baseUrl: z.string().url().nullable(),
+  apiKey: z.string().nullable(),
+  model: z.string().nullable(),
+  voice: z.string().nullable(),
+};
+
+export const serverCapabilityInputSchema = z.discriminatedUnion("id", [
+  z.object({
+    id: z.literal("search"),
+    provider: searchProviderSchema,
+    ...commonFields,
+  }),
+  z.object({
+    id: z.literal("tts"),
+    provider: ttsProviderSchema,
+    ...commonFields,
+  }),
+  z.object({
+    id: z.literal("stt"),
+    provider: sttProviderSchema,
+    ...commonFields,
+  }),
+]);
+
+export const serverCapabilitiesInputSchema = z.object({
+  capabilities: z
+    .array(serverCapabilityInputSchema)
+    .length(CAPABILITY_IDS.length)
+    .refine(
+      (values) => new Set(values.map((value) => value.id)).size === CAPABILITY_IDS.length,
+      "Provide one configuration for each capability.",
+    ),
+});
+
+export type ServerCapabilityInput = z.infer<
+  typeof serverCapabilityInputSchema
+>;
+
+export type AdminServerCapability = ServerCapabilityInput & {
+  configured: boolean;
+  apiKeySet: boolean;
+};

--- a/apps/web/lib/chat/message.ts
+++ b/apps/web/lib/chat/message.ts
@@ -36,7 +36,7 @@ export function dictationErrorMessage(
       return "Your browser doesn't support audio recording.";
     case "stt_unavailable":
       return isAdmin || err.role === "admin"
-        ? "Speech-to-text isn't running. Start it with: docker compose --profile stt up -d (or --profile stt-gpu for NVIDIA GPU)."
+        ? "Speech-to-text isn't configured on this server. Run: overtchat setup"
         : "Speech-to-text isn't enabled. Ask the admin to enable it.";
     case "empty":
       return "No speech detected. Try again.";

--- a/apps/web/lib/db/hostConnectorMigration.test.ts
+++ b/apps/web/lib/db/hostConnectorMigration.test.ts
@@ -1,0 +1,71 @@
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+const databasePath = path.join(
+  os.tmpdir(),
+  `overtchat-connector-migration-${process.pid}-${Date.now()}.db`,
+);
+
+afterAll(() => {
+  fs.rmSync(databasePath, { force: true });
+});
+
+describe("managed connector migration", () => {
+  it("preserves a legacy connector and permits pre-admin provisioning", () => {
+    const database = new Database(databasePath);
+    database.exec(`
+      CREATE TABLE user (id TEXT PRIMARY KEY NOT NULL);
+      INSERT INTO user (id) VALUES ('existing-admin');
+      CREATE TABLE host_connectors (
+        id TEXT PRIMARY KEY NOT NULL,
+        user_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        token_hash TEXT NOT NULL,
+        version TEXT,
+        last_seen_at INTEGER,
+        created_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+        updated_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+        FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX host_connectors_userId_idx ON host_connectors (user_id);
+      INSERT INTO host_connectors (id, user_id, name, token_hash, version)
+      VALUES ('legacy', 'existing-admin', 'Existing host', 'hash', '0.3.4');
+    `);
+    const migration = fs.readFileSync(
+      path.resolve(process.cwd(), "drizzle/0010_deep_nico_minoru.sql"),
+      "utf8",
+    );
+    for (const statement of migration.split("--> statement-breakpoint")) {
+      if (statement.trim()) database.exec(statement);
+    }
+
+    expect(
+      database.prepare("SELECT id, user_id, managed, name FROM host_connectors").all(),
+    ).toEqual([
+      {
+        id: "legacy",
+        user_id: "existing-admin",
+        managed: 0,
+        name: "Existing host",
+      },
+    ]);
+    expect(
+      database
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'server_capabilities'",
+        )
+        .get(),
+    ).toEqual({ name: "server_capabilities" });
+    expect(() =>
+      database
+        .prepare(
+          "INSERT INTO host_connectors (id, user_id, managed, name, token_hash) VALUES (?, NULL, true, ?, ?)",
+        )
+        .run("pending", "Setup host", "new-hash"),
+    ).not.toThrow();
+    database.close();
+  });
+});

--- a/apps/web/lib/db/hostConnectorMigration.test.ts
+++ b/apps/web/lib/db/hostConnectorMigration.test.ts
@@ -16,6 +16,7 @@ afterAll(() => {
 describe("managed connector migration", () => {
   it("preserves a legacy connector and permits pre-admin provisioning", () => {
     const database = new Database(databasePath);
+    database.pragma("foreign_keys = ON");
     database.exec(`
       CREATE TABLE user (id TEXT PRIMARY KEY NOT NULL);
       INSERT INTO user (id) VALUES ('existing-admin');
@@ -33,13 +34,79 @@ describe("managed connector migration", () => {
       CREATE UNIQUE INDEX host_connectors_userId_idx ON host_connectors (user_id);
       INSERT INTO host_connectors (id, user_id, name, token_hash, version)
       VALUES ('legacy', 'existing-admin', 'Existing host', 'hash', '0.3.4');
+      CREATE TABLE agent_hosts (
+        id TEXT PRIMARY KEY NOT NULL,
+        user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+        connector_id TEXT NOT NULL REFERENCES host_connectors(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        transport TEXT NOT NULL,
+        ssh_alias TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE agent_connections (
+        id TEXT PRIMARY KEY NOT NULL,
+        host_id TEXT NOT NULL REFERENCES agent_hosts(id) ON DELETE CASCADE,
+        provider TEXT NOT NULL,
+        executable TEXT NOT NULL,
+        shell_mode TEXT NOT NULL,
+        detected_version TEXT,
+        last_validated_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE agent_workspaces (
+        id TEXT PRIMARY KEY NOT NULL,
+        connection_id TEXT NOT NULL REFERENCES agent_connections(id) ON DELETE CASCADE,
+        path TEXT NOT NULL,
+        name TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE agent_sessions (
+        id TEXT PRIMARY KEY NOT NULL,
+        workspace_id TEXT NOT NULL REFERENCES agent_workspaces(id) ON DELETE CASCADE,
+        provider_session_id TEXT NOT NULL,
+        provider_session_path TEXT NOT NULL,
+        name TEXT,
+        first_message TEXT,
+        message_count INTEGER NOT NULL,
+        provider_created_at INTEGER,
+        provider_modified_at INTEGER,
+        last_synced_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO agent_hosts
+        (id, user_id, connector_id, name, transport, created_at, updated_at)
+      VALUES
+        ('host', 'existing-admin', 'legacy', 'Local', 'local', 1, 2);
+      INSERT INTO agent_connections
+        (id, host_id, provider, executable, shell_mode, created_at, updated_at)
+      VALUES
+        ('connection', 'host', 'codex', 'codex', 'login', 3, 4);
+      INSERT INTO agent_workspaces
+        (id, connection_id, path, name, created_at, updated_at)
+      VALUES
+        ('workspace', 'connection', '/srv/project', 'Project', 5, 6);
+      INSERT INTO agent_sessions
+        (id, workspace_id, provider_session_id, provider_session_path, message_count, last_synced_at, created_at, updated_at)
+      VALUES
+        ('session', 'workspace', 'provider-session', '/tmp/session', 7, 8, 9, 10);
     `);
     const migration = fs.readFileSync(
       path.resolve(process.cwd(), "drizzle/0010_deep_nico_minoru.sql"),
       "utf8",
     );
-    for (const statement of migration.split("--> statement-breakpoint")) {
-      if (statement.trim()) database.exec(statement);
+    database.exec("BEGIN");
+    try {
+      for (const statement of migration.split("--> statement-breakpoint")) {
+        if (statement.trim()) database.exec(statement);
+      }
+      database.exec("COMMIT");
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
     }
 
     expect(
@@ -59,6 +126,58 @@ describe("managed connector migration", () => {
         )
         .get(),
     ).toEqual({ name: "server_capabilities" });
+    expect(database.prepare("SELECT * FROM agent_hosts").all()).toEqual([
+      {
+        id: "host",
+        user_id: "existing-admin",
+        connector_id: "legacy",
+        name: "Local",
+        transport: "local",
+        ssh_alias: null,
+        created_at: 1,
+        updated_at: 2,
+      },
+    ]);
+    expect(database.prepare("SELECT * FROM agent_connections").all()).toEqual([
+      {
+        id: "connection",
+        host_id: "host",
+        provider: "codex",
+        executable: "codex",
+        shell_mode: "login",
+        detected_version: null,
+        last_validated_at: null,
+        created_at: 3,
+        updated_at: 4,
+      },
+    ]);
+    expect(database.prepare("SELECT * FROM agent_workspaces").all()).toEqual([
+      {
+        id: "workspace",
+        connection_id: "connection",
+        path: "/srv/project",
+        name: "Project",
+        created_at: 5,
+        updated_at: 6,
+      },
+    ]);
+    expect(database.prepare("SELECT * FROM agent_sessions").all()).toEqual([
+      {
+        id: "session",
+        workspace_id: "workspace",
+        provider_session_id: "provider-session",
+        provider_session_path: "/tmp/session",
+        name: null,
+        first_message: null,
+        message_count: 7,
+        provider_created_at: null,
+        provider_modified_at: null,
+        last_synced_at: 8,
+        created_at: 9,
+        updated_at: 10,
+      },
+    ]);
+    expect(database.pragma("foreign_key_check")).toEqual([]);
     expect(() =>
       database
         .prepare(

--- a/apps/web/lib/db/hostConnectors.test.ts
+++ b/apps/web/lib/db/hostConnectors.test.ts
@@ -16,11 +16,22 @@ const raw = new Database(databasePath);
 raw.pragma("foreign_keys = ON");
 raw.exec(`
   CREATE TABLE user (
-    id TEXT PRIMARY KEY NOT NULL
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    email_verified INTEGER NOT NULL DEFAULT false,
+    image TEXT,
+    created_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+    updated_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+    role TEXT,
+    banned INTEGER DEFAULT false,
+    ban_reason TEXT,
+    ban_expires INTEGER
   );
   CREATE TABLE host_connectors (
     id TEXT PRIMARY KEY NOT NULL,
-    user_id TEXT NOT NULL,
+    user_id TEXT,
+    managed INTEGER NOT NULL DEFAULT false,
     name TEXT NOT NULL,
     token_hash TEXT NOT NULL,
     version TEXT,
@@ -54,7 +65,9 @@ beforeEach(() => {
     DELETE FROM host_connector_pairings;
     DELETE FROM host_connectors;
     DELETE FROM user;
-    INSERT INTO user (id) VALUES ('alice'), ('bob');
+    INSERT INTO user (id, name, email, role, created_at) VALUES
+      ('alice', 'Alice', 'alice@example.com', 'admin', 1),
+      ('bob', 'Bob', 'bob@example.com', 'user', 2);
   `);
 });
 
@@ -131,5 +144,58 @@ describe("Host Connector pairing", () => {
         version: null,
       }),
     ).toBeNull();
+  });
+});
+
+describe("managed Host Connector", () => {
+  it("can be provisioned before signup and claimed by the first admin", () => {
+    raw.exec("DELETE FROM user");
+    const provisioned = repository.provisionManagedHostConnector({
+      name: "Setup host",
+      version: "0.4.0",
+    });
+
+    expect(provisioned.connector).toMatchObject({
+      userId: null,
+      managed: true,
+      name: "Setup host",
+    });
+    raw.prepare(
+      "INSERT INTO user (id, name, email, role, created_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("owner", "Owner", "owner@example.com", "admin", 1);
+    repository.claimManagedHostConnector("owner");
+
+    expect(repository.getManagedHostConnector()).toMatchObject({
+      id: provisioned.connector.id,
+      userId: "owner",
+      managed: true,
+    });
+    expect(repository.authenticateHostConnectorToken(provisioned.token))
+      .toMatchObject({ id: provisioned.connector.id });
+  });
+
+  it("adopts an existing admin connector and rotates its credentials", () => {
+    const pairing = repository.createHostConnectorPairing("alice");
+    const legacy = repository.consumeHostConnectorPairing({
+      pairCode: pairing.pairCode,
+      name: "Legacy host",
+      version: "0.3.4",
+    })!;
+    const managed = repository.provisionManagedHostConnector({
+      name: "Managed host",
+      version: "0.4.0",
+    });
+
+    expect(managed.connector).toMatchObject({
+      id: legacy.connector.id,
+      userId: "alice",
+      managed: true,
+      name: "Managed host",
+      version: "0.4.0",
+    });
+    expect(repository.authenticateHostConnectorToken(legacy.token)).toBeNull();
+    expect(repository.authenticateHostConnectorToken(managed.token))
+      .toMatchObject({ id: legacy.connector.id });
+    expect(repository.listHostConnectors("alice")).toHaveLength(1);
   });
 });

--- a/apps/web/lib/db/hostConnectors.ts
+++ b/apps/web/lib/db/hostConnectors.ts
@@ -4,16 +4,29 @@ import {
   randomBytes,
   timingSafeEqual,
 } from "node:crypto";
-import { and, eq, gt, lt } from "drizzle-orm";
+import { and, asc, eq, gt, isNull, lt } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import {
   hostConnectorPairings,
   hostConnectors,
+  user,
 } from "@/lib/db/schema";
 
 const PAIRING_TTL_MS = 10 * 60_000;
 
 export type HostConnectorRow = typeof hostConnectors.$inferSelect;
+
+function installationOwnerUserId(): string | null {
+  return (
+    db
+      .select({ id: user.id })
+      .from(user)
+      .where(eq(user.role, "admin"))
+      .orderBy(asc(user.createdAt))
+      .limit(1)
+      .get()?.id ?? null
+  );
+}
 
 function hashSecret(value: string): string {
   return createHash("sha256").update(value).digest("base64url");
@@ -75,6 +88,83 @@ export function createHostConnectorPairing(userId: string): {
       .run();
   });
   return { pairCode: pair.value, expiresAt };
+}
+
+export function provisionManagedHostConnector(input: {
+  name: string;
+  version: string | null;
+}): { connector: HostConnectorRow; token: string } {
+  const token = credential("oct");
+  const installationOwner = installationOwnerUserId();
+  return db.transaction((tx) => {
+    const managed = tx
+      .select()
+      .from(hostConnectors)
+      .where(eq(hostConnectors.managed, true))
+      .limit(1)
+      .get();
+    const ownerConnector = installationOwner
+      ? tx
+          .select()
+          .from(hostConnectors)
+          .where(eq(hostConnectors.userId, installationOwner))
+          .limit(1)
+          .get()
+      : null;
+    const existing = managed ?? ownerConnector;
+    const ownerUserId = existing?.userId ?? installationOwner;
+    const connector = existing
+      ? tx
+          .update(hostConnectors)
+          .set({
+            userId: ownerUserId,
+            managed: true,
+            name: input.name,
+            tokenHash: token.secretHash,
+            version: input.version,
+            updatedAt: new Date(),
+          })
+          .where(eq(hostConnectors.id, existing.id))
+          .returning()
+          .get()
+      : tx
+          .insert(hostConnectors)
+          .values({
+            id: token.id,
+            userId: ownerUserId,
+            managed: true,
+            name: input.name,
+            tokenHash: token.secretHash,
+            version: input.version,
+          })
+          .returning()
+          .get();
+    if (!connector) throw new Error("Failed to provision the Host Connector.");
+    return {
+      connector,
+      token: existing
+        ? `oct_${existing.id}.${token.secret}`
+        : token.value,
+    };
+  });
+}
+
+export function claimManagedHostConnector(userId: string): void {
+  db.update(hostConnectors)
+    .set({ userId, updatedAt: new Date() })
+    .where(and(eq(hostConnectors.managed, true), isNull(hostConnectors.userId)))
+    .run();
+}
+
+export function getManagedHostConnector(): HostConnectorRow | null {
+  return (
+    db
+      .select()
+      .from(hostConnectors)
+      .where(eq(hostConnectors.managed, true))
+      .limit(1)
+      .get() ?? null
+  );
 }
 
 export function consumeHostConnectorPairing(input: {

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -132,8 +132,10 @@ export const hostConnectors = sqliteTable(
   {
     id: text("id").primaryKey(),
     userId: text("user_id")
-      .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    managed: integer("managed", { mode: "boolean" })
+      .default(false)
+      .notNull(),
     name: text("name").notNull(),
     tokenHash: text("token_hash").notNull(),
     version: text("version"),
@@ -620,3 +622,22 @@ export const modelConfigs = sqliteTable(
       .where(sql`${table.taskModel} = true`),
   ],
 );
+
+export const serverCapabilities = sqliteTable("server_capabilities", {
+  id: text("id", { enum: ["search", "tts", "stt"] }).primaryKey(),
+  provider: text("provider").notNull(),
+  bundledInstalled: integer("bundled_installed", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  baseUrl: text("base_url"),
+  apiKey: text("api_key"),
+  model: text("model"),
+  voice: text("voice"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .$onUpdate(() => new Date())
+    .notNull(),
+});

--- a/apps/web/lib/db/serverCapabilities.ts
+++ b/apps/web/lib/db/serverCapabilities.ts
@@ -1,0 +1,198 @@
+import "server-only";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { serverCapabilities } from "@/lib/db/schema";
+import {
+  CAPABILITY_IDS,
+  type AdminServerCapability,
+  type CapabilityId,
+  type ServerCapabilityInput,
+} from "@/lib/capabilities/schema";
+
+export type ServerCapabilityRow = typeof serverCapabilities.$inferSelect;
+
+function installedCapabilityDefaults(): Set<string> {
+  const configured = process.env.OVERTCHAT_INSTALLED_CAPABILITIES;
+  if (configured !== undefined) {
+    return new Set(
+      configured
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    );
+  }
+  // Compatibility with the original Compose stack, where these were bundled.
+  return new Set([
+    "search",
+    "tts",
+    ...(process.env.STT_URL ? ["stt"] : []),
+  ]);
+}
+
+function nullable(value: string | undefined): string | null {
+  return value?.trim() || null;
+}
+
+function environmentDefault(id: CapabilityId): ServerCapabilityInput {
+  const installed = installedCapabilityDefaults();
+  if (id === "search") {
+    const provider =
+      process.env.WEB_SEARCH_PROVIDER ??
+      (process.env.SEARXNG_URL &&
+      process.env.SEARXNG_URL !== "http://searxng:8080"
+        ? "searxng"
+        : "bundled");
+    return {
+      id,
+      provider:
+        provider === "brave" ||
+        provider === "searxng" ||
+        provider === "disabled"
+          ? provider
+          : "bundled",
+      bundledInstalled: installed.has("search"),
+      baseUrl: nullable(process.env.SEARXNG_URL),
+      apiKey: nullable(process.env.BRAVE_SEARCH_API_KEY),
+      model: null,
+      voice: null,
+    };
+  }
+  if (id === "tts") {
+    const provider =
+      process.env.TTS_PROVIDER ??
+      (process.env.KOKORO_URL &&
+      process.env.KOKORO_URL !== "http://kokoro:8880"
+        ? "openai-compatible"
+        : "bundled");
+    return {
+      id,
+      provider:
+        provider === "openai-compatible" || provider === "disabled"
+          ? provider
+          : "bundled",
+      bundledInstalled: installed.has("tts"),
+      baseUrl: nullable(process.env.KOKORO_URL),
+      apiKey: nullable(process.env.TTS_API_KEY),
+      model: nullable(process.env.TTS_MODEL) ?? "kokoro",
+      voice: nullable(process.env.TTS_VOICE) ?? "af_heart",
+    };
+  }
+  const provider = process.env.STT_PROVIDER ??
+    (process.env.STT_URL && process.env.STT_URL !== "http://stt:5092"
+      ? "openai-compatible"
+      : process.env.OVERTCHAT_INSTALLED_CAPABILITIES === undefined &&
+          process.env.STT_URL
+        ? "bundled"
+        : "disabled");
+  return {
+    id,
+    provider:
+      provider === "bundled" || provider === "openai-compatible"
+        ? provider
+        : "disabled",
+    bundledInstalled: installed.has("stt"),
+    baseUrl: nullable(process.env.STT_URL),
+    apiKey: nullable(process.env.STT_API_KEY),
+    model: nullable(process.env.STT_MODEL) ?? "parakeet-tdt-0.6b-v3",
+    voice: null,
+  };
+}
+
+export function ensureServerCapabilityConfigs(): void {
+  db.transaction((tx) => {
+    for (const id of CAPABILITY_IDS) {
+      const existing = tx
+        .select({ id: serverCapabilities.id })
+        .from(serverCapabilities)
+        .where(eq(serverCapabilities.id, id))
+        .get();
+      if (existing) continue;
+      tx.insert(serverCapabilities).values(environmentDefault(id)).run();
+    }
+  });
+}
+
+export function getServerCapability(
+  id: CapabilityId,
+): ServerCapabilityRow {
+  const row = db
+    .select()
+    .from(serverCapabilities)
+    .where(eq(serverCapabilities.id, id))
+    .get();
+  if (!row) {
+    const fallback = environmentDefault(id);
+    db.insert(serverCapabilities).values(fallback).run();
+    return db
+      .select()
+      .from(serverCapabilities)
+      .where(eq(serverCapabilities.id, id))
+      .get()!;
+  }
+  return row;
+}
+
+export function listServerCapabilities(): ServerCapabilityRow[] {
+  ensureServerCapabilityConfigs();
+  return CAPABILITY_IDS.map((id) => getServerCapability(id));
+}
+
+export function replaceServerCapabilities(
+  inputs: ServerCapabilityInput[],
+): ServerCapabilityRow[] {
+  db.transaction((tx) => {
+    for (const input of inputs) {
+      tx.insert(serverCapabilities)
+        .values(input)
+        .onConflictDoUpdate({
+          target: serverCapabilities.id,
+          set: {
+            provider: input.provider,
+            bundledInstalled: input.bundledInstalled,
+            baseUrl: input.baseUrl,
+            apiKey: input.apiKey,
+            model: input.model,
+            voice: input.voice,
+            updatedAt: new Date(),
+          },
+        })
+        .run();
+    }
+  });
+  return listServerCapabilities();
+}
+
+export function updateServerCapability(
+  input: ServerCapabilityInput,
+): ServerCapabilityRow {
+  const current = getServerCapability(input.id);
+  db.update(serverCapabilities)
+    .set({
+      provider: input.provider,
+      bundledInstalled: current.bundledInstalled,
+      baseUrl: input.baseUrl,
+      apiKey: input.apiKey,
+      model: input.model,
+      voice: input.voice,
+      updatedAt: new Date(),
+    })
+    .where(eq(serverCapabilities.id, input.id))
+    .run();
+  return getServerCapability(input.id);
+}
+
+export function toAdminServerCapability(
+  row: ServerCapabilityRow,
+): AdminServerCapability {
+  return {
+    id: row.id,
+    provider: row.provider as ServerCapabilityInput["provider"],
+    bundledInstalled: row.bundledInstalled,
+    baseUrl: row.baseUrl,
+    apiKey: null,
+    apiKeySet: Boolean(row.apiKey),
+    model: row.model,
+    voice: row.voice,
+    configured: row.provider !== "disabled",
+  } as AdminServerCapability;
+}

--- a/apps/web/lib/management/auth.ts
+++ b/apps/web/lib/management/auth.ts
@@ -1,0 +1,21 @@
+import "server-only";
+import { timingSafeEqual } from "node:crypto";
+
+function safeMatch(expected: string, actual: string): boolean {
+  const expectedBytes = Buffer.from(expected);
+  const actualBytes = Buffer.from(actual);
+  return (
+    expectedBytes.length === actualBytes.length &&
+    timingSafeEqual(expectedBytes, actualBytes)
+  );
+}
+
+export function managementRequestAuthorized(request: Request): boolean {
+  const expected = process.env.OVERTCHAT_MANAGEMENT_SECRET;
+  if (!expected || expected.length < 32) return false;
+  const authorization = request.headers.get("authorization") ?? "";
+  const actual = authorization.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length)
+    : "";
+  return safeMatch(expected, actual);
+}

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -52,6 +52,11 @@ export const modelConfigKeys = {
   health: (id: string) => [...modelConfigKeys.all(), "health", id] as const,
 };
 
+export const serverCapabilityKeys = {
+  all: () => ["serverCapabilities"] as const,
+  list: () => [...serverCapabilityKeys.all(), "list"] as const,
+};
+
 export const userKeys = {
   all: () => ["users"] as const,
   list: () => [...userKeys.all(), "list"] as const,

--- a/apps/web/lib/queries/serverCapabilities.ts
+++ b/apps/web/lib/queries/serverCapabilities.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  AdminServerCapability,
+  ServerCapabilityInput,
+} from "@/lib/capabilities/schema";
+import { serverCapabilityKeys } from "@/lib/queries/keys";
+
+export function useServerCapabilities() {
+  return useQuery({
+    queryKey: serverCapabilityKeys.list(),
+    queryFn: async (): Promise<AdminServerCapability[]> => {
+      const response = await fetch("/api/server-capabilities");
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const body = (await response.json()) as {
+        capabilities: AdminServerCapability[];
+      };
+      return body.capabilities;
+    },
+  });
+}
+
+export function useUpdateServerCapability() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: ServerCapabilityInput) => {
+      const response = await fetch(`/api/server-capabilities/${input.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      const body = (await response.json().catch(() => ({}))) as {
+        capability?: AdminServerCapability;
+        error?: string;
+      };
+      if (!response.ok || !body.capability) {
+        throw new Error(body.error ?? `HTTP ${response.status}`);
+      }
+      return body.capability;
+    },
+    onSuccess: (capability) => {
+      queryClient.setQueryData<AdminServerCapability[]>(
+        serverCapabilityKeys.list(),
+        (current) =>
+          current?.map((item) =>
+            item.id === capability.id ? capability : item,
+          ),
+      );
+    },
+  });
+}

--- a/apps/web/lib/tools.ts
+++ b/apps/web/lib/tools.ts
@@ -1,6 +1,5 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { searxngSearch, fetchReadable } from "./web";
 
 export const webTools = {
   web_search: tool({
@@ -10,7 +9,10 @@ export const webTools = {
       query: z.string(),
       limit: z.number().int().min(1).max(10).default(5),
     }),
-    execute: async ({ query, limit }) => searxngSearch(query, limit),
+    execute: async ({ query, limit }) => {
+      const { searxngSearch } = await import("./web");
+      return searxngSearch(query, limit);
+    },
   }),
 
   fetch_url: tool({
@@ -19,7 +21,10 @@ export const webTools = {
     inputSchema: z.object({
       url: z.string().url(),
     }),
-    execute: async ({ url }) => fetchReadable(url),
+    execute: async ({ url }) => {
+      const { fetchReadable } = await import("./web");
+      return fetchReadable(url);
+    },
   }),
 };
 

--- a/apps/web/lib/web-search.test.ts
+++ b/apps/web/lib/web-search.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCapability: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db/serverCapabilities", () => ({
+  getServerCapability: mocks.getCapability,
+}));
+
+import { searxngSearch } from "./web";
+
+describe("configured web search provider", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("keeps bundled search on the internal SearXNG service", async () => {
+    mocks.getCapability.mockReturnValue({ provider: "bundled" });
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        results: [
+          { url: "https://example.com", title: "Example", content: "Result" },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(searxngSearch("hello", 1)).resolves.toEqual([
+      { link: "https://example.com", title: "Example", snippet: "Result" },
+    ]);
+    const url = fetchMock.mock.calls[0]?.[0] as URL;
+    expect(url.origin).toBe("http://searxng:8080");
+    expect(url.searchParams.get("q")).toBe("hello");
+  });
+
+  it("uses Brave's API and subscription token", async () => {
+    mocks.getCapability.mockReturnValue({
+      provider: "brave",
+      apiKey: "brave-key",
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        web: {
+          results: [
+            {
+              url: "https://example.com/brave",
+              title: "Brave result",
+              description: "Description",
+            },
+          ],
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(searxngSearch("query", 3)).resolves.toEqual([
+      {
+        link: "https://example.com/brave",
+        title: "Brave result",
+        snippet: "Description",
+      },
+    ]);
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.hostname).toBe("api.search.brave.com");
+    expect(init.headers).toMatchObject({
+      "X-Subscription-Token": "brave-key",
+    });
+  });
+
+  it("fails closed when server search is disabled", async () => {
+    mocks.getCapability.mockReturnValue({ provider: "disabled" });
+    await expect(searxngSearch("query")).rejects.toThrow(
+      "Web search is disabled on this server.",
+    );
+  });
+});

--- a/apps/web/lib/web.ts
+++ b/apps/web/lib/web.ts
@@ -1,11 +1,12 @@
+import "server-only";
 import { lookup } from "node:dns/promises";
 import ipaddr from "ipaddr.js";
+import { getServerCapability } from "@/lib/db/serverCapabilities";
 import type { WebSearchResult, FetchedPage } from "./web-client";
 
 export type { WebSearchResult, FetchedPage } from "./web-client";
 export { cleanDomain, faviconUrl } from "./web-client";
 
-const SEARXNG_URL = process.env.SEARXNG_URL ?? "http://localhost:8088";
 const MAX_CONTENT_CHARS = 8_000;
 const MAX_FETCH_BYTES = 5 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
@@ -15,7 +16,19 @@ export async function searxngSearch(
   query: string,
   limit = 5,
 ): Promise<WebSearchResult[]> {
-  const u = new URL("/search", SEARXNG_URL);
+  const capability = getServerCapability("search");
+  if (capability.provider === "disabled") {
+    throw new Error("Web search is disabled on this server.");
+  }
+  if (capability.provider === "brave") {
+    return braveSearch(query, limit, capability.apiKey);
+  }
+  const baseUrl =
+    capability.provider === "bundled"
+      ? "http://searxng:8080"
+      : capability.baseUrl || process.env.SEARXNG_URL;
+  if (!baseUrl) throw new Error("SearXNG is not configured.");
+  const u = new URL("/search", baseUrl);
   u.searchParams.set("q", query);
   u.searchParams.set("format", "json");
   u.searchParams.set("safesearch", "1");
@@ -32,6 +45,36 @@ export async function searxngSearch(
     link: r.url,
     title: r.title ?? r.url,
     snippet: r.content ?? "",
+  }));
+}
+
+async function braveSearch(
+  query: string,
+  limit: number,
+  apiKey: string | null,
+): Promise<WebSearchResult[]> {
+  if (!apiKey) throw new Error("The Brave Search API key is not configured.");
+  const url = new URL("https://api.search.brave.com/res/v1/web/search");
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", String(limit));
+  url.searchParams.set("safesearch", "moderate");
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      "X-Subscription-Token": apiKey,
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`brave search: ${response.status}`);
+  const body = (await response.json()) as {
+    web?: {
+      results?: Array<{ url: string; title?: string; description?: string }>;
+    };
+  };
+  return (body.web?.results ?? []).slice(0, limit).map((result) => ({
+    link: result.url,
+    title: result.title ?? result.url,
+    snippet: result.description ?? "",
   }));
 }
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.13.9}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,30 +1,45 @@
 # Deploy
 
-Single-compose, self-hosted, LAN-only. Assumes Docker + Docker Compose v2 on the target machine.
+The managed installer runs OvertChat on the current Linux machine with Docker
+Compose. It supports x86-64 and arm64.
 
 ## One-time setup
 
 ```bash
-git clone <repo>
-cd overtchat
-cp .env.example .env
-echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)" >> .env
-echo "SEARXNG_SECRET=$(openssl rand -hex 32)" >> .env
+curl -fsSL https://overtchat.com/install | sh
 ```
 
-Edit `.env`:
+The terminal wizard configures web search, TTS, STT, and optional Agent
+Connections. Docker is detected automatically and can be installed when it is
+missing. For local STT, the wizard detects NVIDIA GPUs by stable UUID and lets
+you select Auto, a specific device, or CPU.
 
-- `BETTER_AUTH_URL` — the URL the browser will hit (scheme + host + port). For LAN access from other devices, set it to your host's LAN IP, e.g. `http://192.168.1.50:4718`.
+Open the printed URL. The first user to sign up becomes the admin. Model setup
+continues in the web app.
 
-Then:
+The managed files live under `~/.config/overtchat` and
+`~/.local/share/overtchat`. Re-run setup whenever you want to install an
+optional bundled service that was skipped initially:
 
 ```bash
-docker compose up -d --build
+overtchat setup
 ```
 
-First boot takes ~30s because the Kokoro TTS container downloads its model. Subsequent boots are fast.
+Provider selection can also be changed later in **Admin Settings → Services**.
+Bundled services must first be installed with `overtchat setup`.
 
-Open the URL. First user signs up → becomes admin. Add more users from `/settings/users`.
+## Existing Compose installations
+
+Running `overtchat setup` on a machine that already has the standard
+`overtchat-app` container adopts it in place. The installer preserves the
+current `/app/data` Docker volume or bind mount, public port, auth secret, and
+standard SearXNG configuration. If the containers were removed with
+`docker compose down`, it can recover a single standard Compose data volume by
+its Docker labels.
+
+The old Compose commands remain supported. If more than one candidate data
+volume exists or the installation uses unrelated container names, start the
+specific old stack first or continue managing that custom layout manually.
 
 ## Development
 
@@ -41,17 +56,32 @@ Open [http://localhost:4717](http://localhost:4717). Add `searxng` or `kokoro` t
 ## Deploying updates
 
 ```bash
-git pull
+overtchat update
+```
+
+This updates the management CLI, app image, selected local sidecars, and managed
+Agent Connector as one coordinated release. Database migrations run
+automatically when the app starts; the existing data mount is not replaced.
+
+Legacy manually paired connectors still update through the command shown in
+**Settings → Connections**.
+
+## Manual Compose installation
+
+For source development, custom orchestration, or non-Linux hosts, clone the
+repository and use the original Compose flow:
+
+```bash
+git clone https://github.com/yoloyash/overtchat
+cd overtchat
+cp .env.example .env
+echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)" >> .env
+echo "SEARXNG_SECRET=$(openssl rand -hex 32)" >> .env
 docker compose up -d --build
 ```
 
-Compose only recreates the container if the image changed. Migrations run automatically on boot. Data in the `overtchat-data` volume persists across rebuilds.
-
-The Host Connector updates independently from the Docker app and does not need
-to be reinstalled after routine server updates. If **Settings → Connections**
-offers a newer connector, run the displayed upgrade command on the connector
-host. It preserves the existing pairing and configuration, replaces the binary,
-and restarts the user service.
+Set `BETTER_AUTH_URL` in `.env` to the URL browsers will use. Manual installs
+update with `git pull && docker compose up -d --build`.
 
 ## Pointing at your LLM
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,53 @@
         "npm": "10.x"
       }
     },
+    "apps/cli": {
+      "name": "@overtchat/cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "@clack/prompts": "^0.11.0"
+      },
+      "bin": {
+        "overtchat": "dist/overtchat.mjs"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9",
+        "@types/node": "^22",
+        "esbuild": "^0.25.0",
+        "eslint": "^9",
+        "tsx": "^4.23.1",
+        "typescript": "^5",
+        "typescript-eslint": "^8",
+        "vitest": "^4.1.6"
+      }
+    },
+    "apps/cli/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "apps/cli/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"
@@ -3052,6 +3096,27 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@clack/core": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
+      "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.5.0",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.67.0",
@@ -7073,6 +7138,10 @@
     },
     "node_modules/@overtchat/agent-runtime": {
       "resolved": "packages/agent-runtime",
+      "link": true
+    },
+    "node_modules/@overtchat/cli": {
+      "resolved": "apps/cli",
       "link": true
     },
     "node_modules/@overtchat/connector": {

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -148,6 +148,7 @@ export type AgentConnectionListItem = {
 export type HostConnectorListItem = {
   id: string;
   name: string;
+  managed: boolean;
   version: string | null;
   lastSeenAt: number | null;
   online: boolean;

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -23,7 +23,7 @@ export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
  * wire shape and remains stable even when the connector build version changes.
  */
 export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.2.0";
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.3.4";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.4.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.3.4"
+connector_version="0.4.0"
 server=""
 pair_code=""
 connector_name=""

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,9 @@
     "@overtchat/connector#build": {
       "outputs": ["dist/**"]
     },
+    "@overtchat/cli#build": {
+      "outputs": ["dist/**"]
+    },
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
## Summary

This adds a guided, managed installation path for OvertChat:

```bash
curl -fsSL https://overtchat.com/install | sh
```

The installer handles Docker detection, secret generation, Compose configuration, optional services, and Agent Connections. The browser remains focused on account creation and model setup: the first signup becomes the admin, as before.

Manual/source-managed Compose deployments remain supported.

## Setup experience

The new `overtchat` CLI provides:

- `overtchat setup` — install or reconfigure the stack through a terminal wizard
- `overtchat update` — update the CLI, app, selected sidecars, migrations, and managed Agent Connector together
- `overtchat status` — show the managed installation state

The wizard configures:

- **Web search:** bundled SearXNG, Brave Search API, an existing SearXNG instance, or disabled
- **Text-to-speech:** bundled Kokoro, an OpenAI-compatible API, or disabled
- **Speech-to-text:** bundled Parakeet, an OpenAI-compatible API, or disabled
- **Local STT acceleration:** Auto, CPU, or a specific detected NVIDIA GPU selected by stable UUID
- **Agent Connections:** optional installer-managed connector with no pairing code or separate install command

Skipped bundled services are genuinely optional. Admin Settings → Services shows their installation state, lets admins switch providers later, and points back to `overtchat setup` when a local service must first be downloaded.

## Existing installation adoption

Standard existing Compose installations are adopted in place rather than duplicated:

- detects a running `overtchat-app` container or one unambiguous labeled Compose data volume
- displays the detected version, address, port, data mount, Compose directory, and bundled services
- requires explicit confirmation before changing anything
- preserves the existing data volume/bind mount, auth secret, published address, and supported service configuration
- creates an online SQLite snapshot before replacing the app or running migrations
- verifies snapshot integrity, stores it with mode `0600`, and normalizes it to `journal_mode=DELETE` without WAL sidecars
- does not create another pre-adoption snapshot on later managed setup runs

Ambiguous volumes and unrelated/custom container layouts are deliberately not guessed at; those installations can continue using the documented manual Compose flow.

## Server-managed capabilities and connector

Search, TTS, and STT provider configuration now has a server-level database model and admin API instead of being fixed entirely by environment variables. Existing environment configuration is imported as the compatibility default.

Agent Connections can now be provisioned internally before the first admin exists. The migration makes connector ownership nullable and records whether a connector is installer-managed; existing manually paired connectors remain supported.

The connector migration explicitly preserves and restores dependent agent hosts, connections, workspaces, and sessions while rebuilding `host_connectors`. This is necessary because SQLite cannot toggle foreign-key enforcement after Drizzle has opened the migration transaction.

## Distribution and documentation

- adds versioned CLI release artifacts and install manifest handling
- serves the bootstrap installer from `overtchat.com/install`
- updates the site, README, and deployment guide around the managed flow
- keeps the legacy connector installer and manual Compose instructions available

## Scope

- managed installation targets the current Linux machine only
- supported architectures are x86-64 and arm64
- remote/SSH installation, general backup/restore commands, and custom orchestration adoption are outside this PR
- an LLM endpoint is still configured in the existing web model setup

## Validation

- [x] CLI unit tests: 8 files / 25 tests, including updater orchestration, no-downgrade behavior, CLI handoff, connector ordering, and failed-pull safety
- [x] Web unit tests: 62 files / 438 tests
- [x] Full monorepo tests, lint, typecheck, and builds
- [x] Browser E2E, including the new uninstalled Agent Connections state and a live connector flow
- [x] Real Docker snapshot verification: integrity OK, mode `0600`, DELETE journal mode, no WAL/SHM sidecars
- [x] End-to-end adoption against an isolated clone of a real v0.13.9 installation
- [x] Literal `overtchat update` from v0.13.9 to v0.14.0 using the production-data clone and locally built release artifacts
- [x] Failed literal update exited nonzero while the same v0.13.9 container continued serving; state and all database fingerprints remained unchanged
- [x] Successful update advanced migrations 10 → 11, preserved all 15 application-table content fingerprints, retained the existing connector identity/owner and five agent hosts, converted it to managed v0.4.0, and brought it online
- [x] Same-version update rerun did not recreate the app, duplicate migrations/connectors, or lose any of the 174 agent sessions
- [x] Pre-adoption snapshot matched the original database
- [x] `PRAGMA integrity_check` passed and `PRAGMA foreign_key_check` returned no violations after every database scenario
- [x] All GitHub Actions checks pass
