### PR TITLE
Fix installer fallback without a controlling terminal

### DIFF
--- a/apps/site/lib/managed-installer.test.ts
+++ b/apps/site/lib/managed-installer.test.ts
@@ -1,0 +1,111 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function writeExecutable(filePath: string, contents: string) {
+  writeFileSync(filePath, contents);
+  chmodSync(filePath, 0o755);
+}
+
+describe("Managed installer", () => {
+  it("falls back cleanly when the process has no controlling terminal", () => {
+    const fixtureDirectory = mkdtempSync(
+      path.join(os.tmpdir(), "overtchat-managed-installer-test-"),
+    );
+    temporaryDirectories.push(fixtureDirectory);
+
+    const homeDirectory = path.join(fixtureDirectory, "home");
+    const mockBinDirectory = path.join(fixtureDirectory, "bin");
+    mkdirSync(homeDirectory);
+    mkdirSync(mockBinDirectory);
+
+    const mockCli = `#!/bin/sh
+if [ "\${1:-}" = "setup" ]; then
+  echo "setup must not run without a controlling terminal" >&2
+  exit 42
+fi
+exit 0
+`;
+    const checksum = createHash("sha256").update(mockCli).digest("hex");
+
+    writeExecutable(
+      path.join(mockBinDirectory, "uname"),
+      `#!/bin/sh
+if [ "\${1:-}" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+`,
+    );
+    writeExecutable(
+      path.join(mockBinDirectory, "curl"),
+      `#!/bin/sh
+set -eu
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -fsSLo)
+      output=$2
+      shift 2
+      ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+case "$url" in
+  */overtchat-checksums.txt)
+    printf '%s  overtchat-linux-amd64\\n' "$MOCK_ASSET_SHA256" > "$output"
+    ;;
+  *)
+    cat > "$output" <<'MOCK_CLI'
+${mockCli}MOCK_CLI
+    ;;
+esac
+`,
+    );
+
+    const installer = path.join(process.cwd(), "public/install");
+    const result = spawnSync("/bin/sh", [installer], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: homeDirectory,
+        MOCK_ASSET_SHA256: checksum,
+        PATH: `${mockBinDirectory}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+      },
+      timeout: 5_000,
+    });
+    const installPath = path.join(homeDirectory, ".local/bin/overtchat");
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("/dev/tty");
+    expect(result.stdout).toContain(
+      `Run ${installPath} setup in an interactive terminal to finish.`,
+    );
+    expect(existsSync(installPath)).toBe(true);
+    expect(readFileSync(installPath, "utf8")).toBe(mockCli);
+  });
+});

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -57,7 +57,7 @@ case ":$PATH:" in
     ;;
 esac
 
-if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+if ( : </dev/tty >/dev/tty ) 2>/dev/null; then
   exec "$install_path" setup </dev/tty >/dev/tty
 fi
 


### PR DESCRIPTION
## Summary

- probe `/dev/tty` by opening it in a contained subshell
- fall back to the explicit `overtchat setup` instruction in CI, cron, and other no-TTY environments
- add a regression test that installs a checksum-verified mock CLI without a controlling terminal

## Validation

- `sh -n apps/site/public/install`
- `npm run test -w apps/site --`
- `npm run lint -w apps/site --`
- `npm run build -w apps/site --`