### PR TITLE
fix(cli): reconcile inactive bundled services

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = "0.1.0";
+export const CLI_VERSION = "0.1.1";
 export const APP_VERSION = "0.14.0";
 export const CONNECTOR_VERSION = "0.4.0";
 export const STT_VERSION = "0.1.0";

--- a/apps/cli/src/docker.test.ts
+++ b/apps/cli/src/docker.test.ts
@@ -1,5 +1,70 @@
-import { describe, expect, it } from "vitest";
-import { parseNvidiaSmi } from "./docker.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InstallationConfig } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  commandExists: vi.fn(),
+  requireSuccessful: vi.fn(),
+  runCommand: vi.fn(),
+}));
+
+vi.mock("./process.js", () => ({
+  commandExists: mocks.commandExists,
+  requireSuccessful: mocks.requireSuccessful,
+  runCommand: mocks.runCommand,
+}));
+
+import { parseNvidiaSmi, reconcileManagedSidecars } from "./docker.js";
+
+function config(
+  overrides: Partial<InstallationConfig> = {},
+): InstallationConfig {
+  return {
+    format: 1,
+    appVersion: "0.14.0",
+    appImage: "ghcr.io/yoloyash/overtchat-app:0.14.0",
+    connectorVersion: "0.4.0",
+    sttVersion: "0.1.0",
+    appPort: 4718,
+    bindAddress: "127.0.0.1",
+    publicUrl: "https://chat.example.com",
+    extraTrustedOrigins: [],
+    connectorServerUrl: "http://127.0.0.1:4718",
+    composeProject: "overtchat",
+    dataMountType: "volume",
+    dataVolume: "overtchat-data",
+    search: { provider: "bundled", bundledInstalled: true },
+    tts: { provider: "bundled", bundledInstalled: true },
+    stt: {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "cpu",
+    },
+    agents: { installed: false },
+    ...overrides,
+  };
+}
+
+function inspectedContainer(
+  name: string,
+  service: string,
+  project = "overtchat",
+): string {
+  return JSON.stringify([
+    {
+      Name: `/${name}`,
+      Config: {
+        Labels: {
+          "com.docker.compose.project": project,
+          "com.docker.compose.service": service,
+        },
+      },
+    },
+  ]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("NVIDIA GPU discovery", () => {
   it("keeps stable UUIDs alongside the friendly index and memory", () => {
@@ -33,5 +98,155 @@ describe("NVIDIA GPU discovery", () => {
           memoryMiB: 49_140,
         },
       ]);
+  });
+});
+
+describe("managed sidecar reconciliation", () => {
+  it("removes only inactive-profile containers owned by this Compose project", async () => {
+    mocks.runCommand.mockImplementation(
+      async (_command: string, args: string[]) => {
+        const name = args[1];
+        if (args[0] === "inspect" && name === "overtchat-searxng") {
+          return {
+            stdout: inspectedContainer(name, "searxng"),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (args[0] === "inspect") {
+          return { stdout: "", stderr: "No such container", exitCode: 1 };
+        }
+        return { stdout: name ?? "", stderr: "", exitCode: 0 };
+      },
+    );
+
+    const result = await reconcileManagedSidecars(
+      { command: "docker", prefix: [] },
+      config({
+        search: {
+          provider: "searxng",
+          bundledInstalled: false,
+          baseUrl: "http://host.docker.internal:8088",
+        },
+      }),
+    );
+
+    expect(result).toEqual({ removed: ["SearXNG"], warnings: [] });
+    expect(mocks.runCommand).toHaveBeenCalledWith(
+      "docker",
+      ["container", "rm", "--force", "overtchat-searxng"],
+      {},
+    );
+    expect(mocks.runCommand).not.toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["--volumes"]),
+      expect.anything(),
+    );
+    expect(mocks.runCommand).not.toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["overtchat-kokoro"]),
+      expect.anything(),
+    );
+    expect(mocks.runCommand).not.toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["overtchat-stt-cpu"]),
+      expect.anything(),
+    );
+  });
+
+  it("removes the old CPU container when managed STT moves to NVIDIA", async () => {
+    mocks.runCommand.mockImplementation(
+      async (_command: string, args: string[]) => {
+        const dockerArgs = args[0] === "docker" ? args.slice(1) : args;
+        return {
+          stdout:
+            dockerArgs[0] === "inspect"
+              ? inspectedContainer("overtchat-stt-cpu", "stt-cpu")
+              : "",
+          stderr: "",
+          exitCode: 0,
+        };
+      },
+    );
+
+    const result = await reconcileManagedSidecars(
+      { command: "sudo", prefix: ["docker"] },
+      config({
+        stt: {
+          provider: "bundled",
+          bundledInstalled: true,
+          accelerator: "gpu",
+          gpuUuid: "GPU-4090",
+        },
+      }),
+    );
+
+    expect(result.removed).toEqual(["Parakeet (CPU)"]);
+    expect(mocks.runCommand).toHaveBeenLastCalledWith(
+      "sudo",
+      [
+        "docker",
+        "container",
+        "rm",
+        "--force",
+        "overtchat-stt-cpu",
+      ],
+      {},
+    );
+  });
+
+  it("leaves a same-named container alone unless its Compose labels match", async () => {
+    mocks.runCommand.mockImplementation(
+      async (_command: string, args: string[]) => ({
+        stdout: inspectedContainer(
+          args[1] ?? "overtchat-searxng",
+          "searxng",
+          "someone-elses-project",
+        ),
+        stderr: "",
+        exitCode: 0,
+      }),
+    );
+
+    const result = await reconcileManagedSidecars(
+      { command: "docker", prefix: [] },
+      config({
+        search: { provider: "disabled", bundledInstalled: false },
+      }),
+    );
+
+    expect(result).toEqual({ removed: [], warnings: [] });
+    expect(
+      mocks.runCommand.mock.calls.some(
+        ([, args]) => (args as string[])[0] === "container",
+      ),
+    ).toBe(false);
+  });
+
+  it("reports cleanup failures without turning a healthy update into a failure", async () => {
+    mocks.runCommand.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === "inspect") {
+          return {
+            stdout: inspectedContainer("overtchat-kokoro", "kokoro"),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "container is busy", exitCode: 1 };
+      },
+    );
+
+    const result = await reconcileManagedSidecars(
+      { command: "docker", prefix: [] },
+      config({
+        tts: { provider: "disabled", bundledInstalled: false },
+      }),
+    );
+
+    expect(result).toEqual({
+      removed: [],
+      warnings: ["Could not remove Kokoro: container is busy"],
+    });
   });
 });

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -1,4 +1,8 @@
-import type { ExistingInstallation, Gpu } from "./types.js";
+import type {
+  ExistingInstallation,
+  Gpu,
+  InstallationConfig,
+} from "./types.js";
 import { APP_IMAGE } from "./constants.js";
 import { commandExists, requireSuccessful, runCommand } from "./process.js";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
@@ -268,6 +272,103 @@ export async function requireDocker(
     [...docker.prefix, ...args],
     options,
   );
+}
+
+type ManagedSidecar = {
+  containerName: string;
+  label: string;
+  selected: boolean;
+  service: string;
+};
+
+export type SidecarReconciliation = {
+  removed: string[];
+  warnings: string[];
+};
+
+/**
+ * Removes containers left behind when a managed Compose profile is no longer
+ * selected. Docker Compose intentionally leaves inactive-profile containers
+ * alone, so verify both Compose labels before touching an exact container name.
+ */
+export async function reconcileManagedSidecars(
+  docker: DockerCommand,
+  config: InstallationConfig,
+): Promise<SidecarReconciliation> {
+  const sidecars: ManagedSidecar[] = [
+    {
+      containerName: "overtchat-searxng",
+      label: "SearXNG",
+      selected: config.search.bundledInstalled,
+      service: "searxng",
+    },
+    {
+      containerName: "overtchat-kokoro",
+      label: "Kokoro",
+      selected: config.tts.bundledInstalled,
+      service: "kokoro",
+    },
+    {
+      containerName: "overtchat-stt-cpu",
+      label: "Parakeet (CPU)",
+      selected:
+        config.stt.bundledInstalled && config.stt.accelerator === "cpu",
+      service: "stt-cpu",
+    },
+    {
+      containerName: "overtchat-stt-gpu",
+      label: "Parakeet (NVIDIA)",
+      selected:
+        config.stt.bundledInstalled && config.stt.accelerator !== "cpu",
+      service: "stt-gpu",
+    },
+  ];
+  const result: SidecarReconciliation = { removed: [], warnings: [] };
+
+  for (const sidecar of sidecars) {
+    if (sidecar.selected) continue;
+    let container: DockerInspect | null;
+    try {
+      container = await inspectContainer(docker, sidecar.containerName);
+    } catch (error) {
+      result.warnings.push(
+        `Could not inspect ${sidecar.label}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    if (!container) continue;
+    const labels = container.Config?.Labels;
+    const inspectedName = (container.Name ?? "").replace(/^\//u, "");
+    if (
+      inspectedName !== sidecar.containerName ||
+      labels?.["com.docker.compose.project"] !== config.composeProject ||
+      labels?.["com.docker.compose.service"] !== sidecar.service
+    ) {
+      continue;
+    }
+    try {
+      const removal = await runDocker(docker, [
+        "container",
+        "rm",
+        "--force",
+        sidecar.containerName,
+      ]);
+      if (removal.exitCode === 0) {
+        result.removed.push(sidecar.label);
+      } else {
+        const detail = removal.stderr.trim() || removal.stdout.trim();
+        result.warnings.push(
+          `Could not remove ${sidecar.label}${detail ? `: ${detail}` : "."}`,
+        );
+      }
+    } catch (error) {
+      result.warnings.push(
+        `Could not remove ${sidecar.label}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return result;
 }
 
 function environmentMap(values: string[] | undefined): Map<string, string> {

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -23,8 +23,10 @@ import {
   installDockerEngine,
   installNvidiaContainerToolkit,
   nvidiaContainerRuntimeAvailable,
+  reconcileManagedSidecars,
   requireDocker,
   runDocker,
+  type SidecarReconciliation,
 } from "./docker.js";
 import { primaryLanAddress } from "./network.js";
 import { runtimePaths } from "./paths.js";
@@ -233,6 +235,20 @@ export async function syncCapabilities(
         detail ? `: ${detail}` : ""
       }`,
     );
+  }
+}
+
+export function showSidecarReconciliation(
+  reconciliation: SidecarReconciliation,
+): void {
+  if (reconciliation.removed.length > 0) {
+    note(
+      `Removed unused containers: ${reconciliation.removed.join(", ")}\nImages and service data were preserved.`,
+      "Bundled service cleanup",
+    );
+  }
+  if (reconciliation.warnings.length > 0) {
+    note(reconciliation.warnings.join("\n"), "Bundled service cleanup warning");
   }
 }
 
@@ -453,7 +469,11 @@ export async function setup(options: SetupOptions): Promise<void> {
     await installManagedConnector(config, secrets.managementSecret);
   }
   await writeInstallationConfig(paths, config);
+  progress.message("Reconciling bundled services");
+  const reconciliation = await reconcileManagedSidecars(docker, config);
   progress.stop("OvertChat is ready");
+
+  showSidecarReconciliation(reconciliation);
 
   outro(`Open: ${config.publicUrl}`);
 }

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -11,12 +11,14 @@ const mocks = vi.hoisted(() => ({
   prepareFiles: vi.fn(),
   readInstallationConfig: vi.fn(),
   readInstallationSecrets: vi.fn(),
+  reconcileManagedSidecars: vi.fn(),
   renderStackEnvironment: vi.fn(),
   requireDocker: vi.fn(),
   requireSuccessful: vi.fn(),
   spinnerMessage: vi.fn(),
   spinnerStart: vi.fn(),
   spinnerStop: vi.fn(),
+  showSidecarReconciliation: vi.fn(),
   updateCliIfNeeded: vi.fn(),
   waitForApp: vi.fn(),
   writeInstallationConfig: vi.fn(),
@@ -50,6 +52,7 @@ vi.mock("./compose.js", () => ({
 vi.mock("./docker.js", () => ({
   detectDockerCommand: mocks.detectDockerCommand,
   dockerComposeAvailable: mocks.dockerComposeAvailable,
+  reconcileManagedSidecars: mocks.reconcileManagedSidecars,
   requireDocker: mocks.requireDocker,
 }));
 
@@ -81,6 +84,7 @@ vi.mock("./release.js", async (importOriginal) => {
 
 vi.mock("./setup.js", () => ({
   prepareFiles: mocks.prepareFiles,
+  showSidecarReconciliation: mocks.showSidecarReconciliation,
   waitForApp: mocks.waitForApp,
 }));
 
@@ -125,13 +129,17 @@ beforeEach(() => {
   mocks.readInstallationSecrets.mockResolvedValue(secrets);
   mocks.latestReleaseManifest.mockResolvedValue({
     format: 1,
-    cliVersion: "0.1.0",
+    cliVersion: "0.1.1",
     appVersion: "0.14.0",
     connectorVersion: "0.4.0",
     sttVersion: "0.1.0",
   });
   mocks.updateCliIfNeeded.mockResolvedValue(null);
   mocks.renderStackEnvironment.mockReturnValue("rendered environment\n");
+  mocks.reconcileManagedSidecars.mockResolvedValue({
+    removed: [],
+    warnings: [],
+  });
   mocks.requireDocker.mockResolvedValue({
     stdout: "",
     stderr: "",
@@ -207,6 +215,17 @@ describe("managed updates", () => {
     expect(mocks.waitForApp).toHaveBeenCalledWith("http://127.0.0.1:4718");
     expect(mocks.installManagedConnector).not.toHaveBeenCalled();
     expect(mocks.writeInstallationConfig).toHaveBeenCalledWith(paths, current);
+    expect(mocks.reconcileManagedSidecars).toHaveBeenCalledWith(
+      "docker",
+      current,
+    );
+    expect(mocks.showSidecarReconciliation).toHaveBeenCalledWith({
+      removed: [],
+      warnings: [],
+    });
+    expect(
+      mocks.waitForApp.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.reconcileManagedSidecars.mock.invocationCallOrder[0]!);
     expect(mocks.outro).toHaveBeenCalledWith("Open: https://chat.example.com");
   });
 
@@ -221,7 +240,7 @@ describe("managed updates", () => {
     mocks.readInstallationConfig.mockResolvedValue(current);
     mocks.latestReleaseManifest.mockResolvedValue({
       format: 1,
-      cliVersion: "0.1.0",
+      cliVersion: "0.1.1",
       appVersion: "0.14.0",
       connectorVersion: "0.4.0",
       sttVersion: "0.1.0",
@@ -248,6 +267,9 @@ describe("managed updates", () => {
     expect(
       mocks.installManagedConnector.mock.invocationCallOrder[0],
     ).toBeLessThan(mocks.writeInstallationConfig.mock.invocationCallOrder[0]!);
+    expect(
+      mocks.writeInstallationConfig.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.reconcileManagedSidecars.mock.invocationCallOrder[0]!);
   });
 
   it("hands control to an updated CLI before touching the stack", async () => {
@@ -275,7 +297,7 @@ describe("managed updates", () => {
     );
     mocks.latestReleaseManifest.mockResolvedValue({
       format: 1,
-      cliVersion: "0.1.0",
+      cliVersion: "0.1.1",
       appVersion: "0.14.0",
       connectorVersion: "0.4.0",
       sttVersion: "0.1.0",
@@ -287,7 +309,21 @@ describe("managed updates", () => {
     expect(mocks.requireDocker).toHaveBeenCalledTimes(1);
     expect(mocks.waitForApp).not.toHaveBeenCalled();
     expect(mocks.installManagedConnector).not.toHaveBeenCalled();
+    expect(mocks.reconcileManagedSidecars).not.toHaveBeenCalled();
     expect(mocks.writeInstallationConfig).not.toHaveBeenCalled();
+    expect(mocks.spinnerStop).toHaveBeenCalledWith(
+      "OvertChat update failed",
+      1,
+    );
+  });
+
+  it("does not remove old sidecars when the replacement app is unhealthy", async () => {
+    mocks.waitForApp.mockRejectedValueOnce(new Error("app unhealthy"));
+
+    await expect(update()).rejects.toThrow("app unhealthy");
+
+    expect(mocks.writeInstallationConfig).not.toHaveBeenCalled();
+    expect(mocks.reconcileManagedSidecars).not.toHaveBeenCalled();
     expect(mocks.spinnerStop).toHaveBeenCalledWith(
       "OvertChat update failed",
       1,

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -11,6 +11,7 @@ import { renderStackEnvironment } from "./compose.js";
 import {
   detectDockerCommand,
   dockerComposeAvailable,
+  reconcileManagedSidecars,
   requireDocker,
 } from "./docker.js";
 import { runtimePaths } from "./paths.js";
@@ -20,7 +21,11 @@ import {
   latestReleaseManifest,
   updateCliIfNeeded,
 } from "./release.js";
-import { prepareFiles, waitForApp } from "./setup.js";
+import {
+  prepareFiles,
+  showSidecarReconciliation,
+  waitForApp,
+} from "./setup.js";
 
 export async function update(): Promise<void> {
   const paths = runtimePaths();
@@ -115,8 +120,11 @@ export async function update(): Promise<void> {
       await installManagedConnector(nextConfig, secrets.managementSecret);
     }
     await writeInstallationConfig(paths, nextConfig);
+    progress.message("Reconciling bundled services");
+    const reconciliation = await reconcileManagedSidecars(docker, nextConfig);
     progress.stop("OvertChat is up to date");
     progressActive = false;
+    showSidecarReconciliation(reconciliation);
     outro(`Open: ${nextConfig.publicUrl}`);
   } catch (error) {
     if (progressActive) progress.stop("OvertChat update failed", 1);

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.0"
+cli_version="0.1.1"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "cliVersion": "0.1.0",
+  "cliVersion": "0.1.1",
   "appVersion": "0.14.0",
   "connectorVersion": "0.4.0",
   "sttVersion": "0.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },


### PR DESCRIPTION
## Summary

- reconcile managed Compose sidecars after successful `overtchat setup` and `overtchat update` runs
- remove inactive SearXNG, Kokoro, or Parakeet containers only when their exact name and Compose project/service labels match the managed installation
- preserve images, bind-mounted configuration, model volumes, app data, and migration snapshots
- surface successful cleanup and non-fatal cleanup warnings in the CLI
- prepare CLI v0.1.1 so existing installations receive the fix through `overtchat update`

## Why

Docker Compose does not remove containers belonging to profiles that are no longer active. That left the legacy bundled SearXNG container running after adopting an existing installation configured to use an external SearXNG instance. The same stale-container case can occur when an installed bundled service is removed from the managed configuration or when local STT moves between CPU and NVIDIA profiles.

This reconciles the running sidecars with the profiles recorded in managed installation state. It deliberately does not remove a bundled provider merely because another provider is currently active when that bundled provider remains marked as installed; admins can still switch back to an installed local provider from Admin Settings.

## Safety

- cleanup runs only after the replacement app is healthy
- setup also completes provider synchronization and managed connector installation before cleanup
- failed pulls, startup, migrations, health checks, or connector installation remove nothing
- same-named containers without the expected Compose ownership labels are left untouched
- cleanup removes containers only; it never passes a volume-removal flag or deletes images/data
- cleanup failures are shown as warnings and do not turn a healthy setup/update into a reported failure

## Validation

- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- bundled CLI smoke check: `node apps/cli/dist/overtchat.mjs version` → `0.1.1`
