### PR TITLE
fix(web): collapse agent tool runs into summaries

### DIFF
--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -5,7 +5,6 @@ import {
   Brain,
   ChevronRight,
   CircleAlert,
-  CircleCheck,
   CircleX,
   FilePenLine,
   FileText,
@@ -22,6 +21,7 @@ import {
   describeAgentActivity,
   describeAgentTool,
   type AgentActivityEntry,
+  type AgentActivitySequencePosition,
   type AgentToolActivity,
   type AgentToolCategory,
   type AgentToolStatus,
@@ -109,9 +109,11 @@ export function AgentRunIndicator({
 export function AgentActivityGroup({
   entries,
   active,
+  sequencePosition,
 }: {
   entries: AgentActivityEntry[];
   active: boolean;
+  sequencePosition: AgentActivitySequencePosition;
 }) {
   const presentation = describeAgentActivity(entries, active);
   const hasError = presentation.status === "failed";
@@ -119,14 +121,22 @@ export function AgentActivityGroup({
   const singleEntry = entries.length === 1 ? entries[0] : null;
   if (singleEntry?.type === "tool") {
     return (
-      <div className="text-xs" data-testid="agent-activity-group">
+      <div
+        className="text-xs"
+        data-testid="agent-activity-group"
+        data-activity-sequence={sequencePosition}
+      >
         <ToolActivityStep tool={singleEntry.tool} active={active} showIcon />
       </div>
     );
   }
   if (singleEntry?.type === "subagent") {
     return (
-      <div className="text-xs" data-testid="agent-activity-group">
+      <div
+        className="text-xs"
+        data-testid="agent-activity-group"
+        data-activity-sequence={sequencePosition}
+      >
         <SubagentActivityStep activity={singleEntry.activity} showIcon />
       </div>
     );
@@ -151,18 +161,24 @@ export function AgentActivityGroup({
     open && live && hasDetailedSteps ? null : presentation.secondary;
 
   return (
-    <div className="text-xs" data-testid="agent-activity-group">
+    <div
+      className="text-xs"
+      data-testid="agent-activity-group"
+      data-activity-sequence={sequencePosition}
+    >
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
         aria-expanded={open}
-        className="group flex min-h-8 w-full items-center gap-2 rounded-md py-1 pr-1 text-left text-muted-foreground motion-colors hover:text-foreground"
+        className="group flex min-h-7 w-full items-center gap-2 rounded-md py-0.5 pr-1 text-left text-muted-foreground motion-colors hover:text-foreground"
       >
-        <ActivityIcon entries={entries} status={presentation.status} />
+        <DisclosureLeadIcon open={open}>
+          <ActivityIcon entries={entries} status={presentation.status} />
+        </DisclosureLeadIcon>
         <span className="min-w-0 flex flex-1 items-baseline gap-2">
           <span
             className={cn(
-              "shrink-0 font-medium text-foreground",
+              "shrink-0 font-normal motion-colors group-hover:text-foreground",
               live && !open && motionClasses.shimmer,
             )}
           >
@@ -179,12 +195,6 @@ export function AgentActivityGroup({
             {progress}
           </span>
         )}
-        <ChevronRight
-          className={cn(
-            "size-3.5 shrink-0 opacity-60 motion-transform",
-            open && "rotate-90",
-          )}
-        />
       </button>
 
       <div
@@ -320,14 +330,16 @@ function SubagentActivityStep({
         disabled={!canOpen}
         aria-expanded={canOpen ? open : undefined}
         className={cn(
-          "flex min-h-5 w-full items-start gap-2 text-left",
+          "group flex min-h-6 w-full items-start gap-2 rounded-md py-0.5 text-left text-muted-foreground motion-colors",
           canOpen && "cursor-pointer hover:text-foreground",
         )}
       >
         {showIcon && (
-          <Users className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+          <DisclosureLeadIcon open={open} interactive={canOpen}>
+            <Users className="size-3.5 text-muted-foreground" />
+          </DisclosureLeadIcon>
         )}
-        <span className="min-w-0 flex-1 font-medium text-foreground">
+        <span className="min-w-0 flex-1 font-normal text-muted-foreground motion-colors group-hover:text-foreground">
           {label}
         </span>
         {running ? (
@@ -337,10 +349,8 @@ function SubagentActivityStep({
               motionClasses.spinner,
             )}
           />
-        ) : (
-          <CircleCheck className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-        )}
-        {canOpen && (
+        ) : null}
+        {canOpen && !showIcon && (
           <ChevronRight
             className={cn(
               "mt-0.5 size-3 shrink-0 text-muted-foreground/60 motion-transform",
@@ -442,18 +452,20 @@ function ToolActivityStep({
         aria-expanded={canOpen ? open : undefined}
         aria-label={`${presentation.label}${presentation.summary ? `: ${presentation.summary}` : ""}, ${status}`}
         className={cn(
-          "flex min-h-5 w-full items-start gap-2 text-left",
+          "group flex min-h-6 w-full items-start gap-2 rounded-md py-0.5 text-left text-muted-foreground motion-colors",
           canOpen && "cursor-pointer hover:text-foreground",
         )}
       >
         {showIcon && (
-          <ToolCategoryIcon
-            category={presentation.category}
-            className="mt-0.5 size-3.5 shrink-0 text-muted-foreground"
-          />
+          <DisclosureLeadIcon open={open} interactive={canOpen}>
+            <ToolCategoryIcon
+              category={presentation.category}
+              className="size-3.5 text-muted-foreground"
+            />
+          </DisclosureLeadIcon>
         )}
         <span className="min-w-0 flex flex-1 items-baseline gap-2">
-          <span className="shrink-0 font-medium text-foreground">
+          <span className="shrink-0 font-normal motion-colors group-hover:text-foreground">
             {toolStepLabel(presentation.category, status)}
           </span>
           {presentation.summary && (
@@ -463,7 +475,7 @@ function ToolActivityStep({
           )}
         </span>
         <ToolStatusIcon status={status} />
-        {canOpen && (
+        {canOpen && !showIcon && (
           <ChevronRight
             className={cn(
               "mt-0.5 size-3 shrink-0 text-muted-foreground/60 motion-transform",
@@ -701,6 +713,39 @@ function ToolCategoryIcon({
   }
 }
 
+function DisclosureLeadIcon({
+  children,
+  open,
+  interactive = true,
+}: {
+  children: ReactNode;
+  open: boolean;
+  interactive?: boolean;
+}) {
+  return (
+    <span className="relative mt-0.5 flex size-3.5 shrink-0 items-center justify-center">
+      <span
+        className={cn(
+          "flex items-center justify-center",
+          interactive &&
+            "group-hover:invisible group-focus-visible:invisible",
+          interactive && open && "invisible",
+        )}
+      >
+        {children}
+      </span>
+      {interactive && (
+        <ChevronRight
+          className={cn(
+            "absolute hidden size-3.5 text-foreground/70 motion-transform group-hover:block group-focus-visible:block",
+            open && "block rotate-90",
+          )}
+        />
+      )}
+    </span>
+  );
+}
+
 function ActivityIcon({
   entries,
   status,
@@ -760,7 +805,7 @@ function ToolStatusIcon({ status }: { status: AgentToolStatus }) {
     case "running":
       return <Loader2 className={className} />;
     case "completed":
-      return <CircleCheck className={className} />;
+      return null;
     case "failed":
       return <CircleAlert className={className} />;
     case "stopped":

--- a/apps/web/components/agents/AgentActivity.tsx
+++ b/apps/web/components/agents/AgentActivity.tsx
@@ -119,17 +119,6 @@ export function AgentActivityGroup({
   const hasError = presentation.status === "failed";
   const [open, setOpen] = useState(hasError);
   const singleEntry = entries.length === 1 ? entries[0] : null;
-  if (singleEntry?.type === "tool") {
-    return (
-      <div
-        className="text-xs"
-        data-testid="agent-activity-group"
-        data-activity-sequence={sequencePosition}
-      >
-        <ToolActivityStep tool={singleEntry.tool} active={active} showIcon />
-      </div>
-    );
-  }
   if (singleEntry?.type === "subagent") {
     return (
       <div
@@ -142,38 +131,38 @@ export function AgentActivityGroup({
     );
   }
 
+  const toolSummary = entries.every((entry) => entry.type === "tool");
   const live = active && presentation.status === "running";
   const hasDetailedSteps = entries.some(
     (entry) =>
       entry.type === "tool" ||
       entry.type === "subagent",
   );
-  const completedCount = entries.filter(
-    (entry) =>
-      entry.type === "tool" &&
-      agentToolStatus(entry.tool, active) === "completed",
-  ).length;
-  const progress =
-    live && completedCount > 0 ? `${completedCount} completed` : null;
-  const headerLabel =
-    open && live && hasDetailedSteps ? "Activity" : presentation.label;
-  const headerSecondary =
-    open && live && hasDetailedSteps ? null : presentation.secondary;
 
   return (
     <div
       className="text-xs"
       data-testid="agent-activity-group"
       data-activity-sequence={sequencePosition}
+      data-agent-tool-summary={toolSummary ? "true" : undefined}
     >
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
         aria-expanded={open}
+        aria-label={
+          toolSummary
+            ? `${presentation.label}, ${presentation.status}`
+            : undefined
+        }
         className="group flex min-h-7 w-full items-center gap-2 rounded-md py-0.5 pr-1 text-left text-muted-foreground motion-colors hover:text-foreground"
       >
         <DisclosureLeadIcon open={open}>
-          <ActivityIcon entries={entries} status={presentation.status} />
+          <ActivityIcon
+            entries={entries}
+            status={presentation.status}
+            toolSummary={toolSummary}
+          />
         </DisclosureLeadIcon>
         <span className="min-w-0 flex flex-1 items-baseline gap-2">
           <span
@@ -182,50 +171,35 @@ export function AgentActivityGroup({
               live && !open && motionClasses.shimmer,
             )}
           >
-            {headerLabel}
+            {presentation.label}
           </span>
-          {headerSecondary && (
+          {presentation.secondary && (
             <span className="min-w-0 truncate font-mono text-[11px]">
-              {headerSecondary}
+              {presentation.secondary}
             </span>
           )}
         </span>
-        {progress && (
-          <span className="hidden shrink-0 tabular-nums text-[11px] sm:inline">
-            {progress}
-          </span>
-        )}
       </button>
 
-      <div
-        className={cn(
-          "grid",
-          motionClasses.collapse,
-          open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
-        )}
-      >
-        <div className="overflow-hidden">
-          <div
-            className={cn(
-              "relative mt-1 ml-2 pl-5",
-              hasDetailedSteps && "border-l border-border/70",
-            )}
-            data-testid="agent-activity-details"
-          >
-            {entries.map((entry, index) => (
-              <ActivityStep
-                key={entry.id}
-                entry={entry}
-                active={active}
-                last={index === entries.length - 1}
-                showDetailedStep={
-                  hasDetailedSteps || entries.length > 1
-                }
-              />
-            ))}
-          </div>
+      {open && (
+        <div
+          className={cn(
+            "relative mt-1 ml-2 max-h-[25rem] overflow-y-auto pl-5",
+            hasDetailedSteps && "border-l border-border/70",
+          )}
+          data-testid="agent-activity-details"
+        >
+          {entries.map((entry, index) => (
+            <ActivityStep
+              key={entry.id}
+              entry={entry}
+              active={active}
+              last={index === entries.length - 1}
+              showDetailedStep={hasDetailedSteps || entries.length > 1}
+            />
+          ))}
         </div>
-      </div>
+      )}
     </div>
   );
 }
@@ -749,26 +723,31 @@ function DisclosureLeadIcon({
 function ActivityIcon({
   entries,
   status,
+  toolSummary,
 }: {
   entries: AgentActivityEntry[];
   status: AgentToolStatus;
+  toolSummary: boolean;
 }) {
-  if (status === "running") {
-    return (
-      <Loader2
-        className={cn(
-          "size-3.5 shrink-0 text-muted-foreground",
-          motionClasses.spinner,
-        )}
-      />
-    );
-  }
   if (status === "failed" || status === "stopped") {
     return (
       <CircleAlert
         className={cn(
           "size-3.5 shrink-0",
           status === "failed" ? "text-destructive" : "text-muted-foreground",
+        )}
+      />
+    );
+  }
+  if (toolSummary) {
+    return <Wrench className="size-3.5 shrink-0 text-muted-foreground" />;
+  }
+  if (status === "running") {
+    return (
+      <Loader2
+        className={cn(
+          "size-3.5 shrink-0 text-muted-foreground",
+          motionClasses.spinner,
         )}
       />
     );

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -24,8 +24,11 @@ import {
   STREAMDOWN_PLUGINS,
 } from "@/lib/chat/markdown";
 import {
+  agentActivitySequencePosition,
+  describeAgentActivity,
   presentAgentError,
   projectAgentTranscript,
+  type AgentActivitySequencePosition,
   type AgentErrorPresentation,
   type AgentTranscriptItem,
 } from "@/lib/agents/presentation";
@@ -108,6 +111,12 @@ export function AgentMessageList({
     () => projectAgentTranscript(messages),
     [messages],
   );
+  const trailingItem = transcript.at(-1);
+  const activityAlreadyVisible =
+    activity === "working" &&
+    streaming &&
+    trailingItem?.type === "activity" &&
+    describeAgentActivity(trailingItem.entries, true).status === "running";
 
   return (
     <div
@@ -134,6 +143,10 @@ export function AgentMessageList({
             <div className="flex flex-col">
               {transcript.map((item, index) => {
                 const previous = transcript[index - 1];
+                const sequencePosition = agentActivitySequencePosition(
+                  transcript,
+                  index,
+                );
                 const compact =
                   previous &&
                   (item.type === "activity" ||
@@ -144,9 +157,9 @@ export function AgentMessageList({
                     key={item.key}
                     className={cn(
                       index > 0 && (compact ? "mt-3" : "mt-6"),
-                      item.type === "activity" &&
-                        previous?.type === "activity" &&
-                        "mt-1",
+                      (sequencePosition === "middle" ||
+                        sequencePosition === "last") &&
+                        "mt-0",
                       item.type === "turn_footer" && "mt-2",
                     )}
                   >
@@ -159,11 +172,12 @@ export function AgentMessageList({
                       onEditMessage={onEditMessage}
                       onForkMessage={onForkMessage}
                       onImplementPlan={onImplementPlan}
+                      activitySequencePosition={sequencePosition}
                     />
                   </div>
                 );
               })}
-              {activity && (
+              {activity && !activityAlreadyVisible && (
                 <AgentRunIndicator
                   activity={activity}
                   startedAt={activityStartedAt}
@@ -205,6 +219,7 @@ function AgentTranscriptRow({
   onEditMessage,
   onForkMessage,
   onImplementPlan,
+  activitySequencePosition,
 }: {
   item: AgentTranscriptItem;
   active: boolean;
@@ -214,6 +229,7 @@ function AgentTranscriptRow({
   onEditMessage: (messageId: string) => void;
   onForkMessage: (messageId: string) => void;
   onImplementPlan: (plan: string) => void;
+  activitySequencePosition: AgentActivitySequencePosition | null;
 }) {
   if (item.type === "message") {
     return (
@@ -264,7 +280,13 @@ function AgentTranscriptRow({
       />
     );
   }
-  return <AgentActivityGroup entries={item.entries} active={active} />;
+  return (
+    <AgentActivityGroup
+      entries={item.entries}
+      active={active}
+      sequencePosition={activitySequencePosition ?? "single"}
+    />
+  );
 }
 
 function AgentTurnFooter({

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -819,8 +819,19 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(sessionActivity).toBeVisible();
 
   const genericActivity = page.getByTestId("agent-run-activity");
-  await expect(genericActivity).toBeVisible();
-  await expect(genericActivity).toContainText(/\d+s/u);
+  await expect(genericActivity).toHaveCount(0);
+  await expect(
+    page.locator('[data-activity-sequence="single"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('[data-activity-sequence="first"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('[data-activity-sequence="middle"]'),
+  ).toHaveCount(2);
+  await expect(
+    page.locator('[data-activity-sequence="last"]'),
+  ).toHaveCount(1);
   await expect(
     page.getByText("I'm auditing the release state before merging anything."),
   ).toBeVisible();
@@ -1040,7 +1051,7 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(
     page.getByRole("button", { name: "Stopping Codex" }),
   ).toBeVisible();
-  await expect(genericActivity).toContainText("Working", { timeout: 2_000 });
+  await expect(genericActivity).toHaveCount(0, { timeout: 2_000 });
   await expect(page.getByRole("button", { name: "Stop Codex" })).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("runtime-activity-desktop.png"),

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -828,7 +828,7 @@ test("shows durable turn activity without changing completed tool status", async
   ).toHaveCount(1);
   await expect(
     page.locator('[data-activity-sequence="middle"]'),
-  ).toHaveCount(2);
+  ).toHaveCount(1);
   await expect(
     page.locator('[data-activity-sequence="last"]'),
   ).toHaveCount(1);
@@ -854,25 +854,36 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(page.getByTestId("agent-goal-bar")).toContainText(
     "Finish Codex parity",
   );
+  const toolSummaries = page.locator('[data-agent-tool-summary="true"]');
+  await expect(toolSummaries).toHaveCount(2);
+  const completedCommandSummary = page.getByRole("button", {
+    name: "Ran 1 command, completed",
+  });
+  await expect(completedCommandSummary).toBeVisible();
   const liveActivity = page.getByRole("button", {
-    name: "Search: runtimeStatus, running",
+    name: "Edited 1 file and searched 1 time, running",
   });
   await expect(liveActivity).toBeVisible();
+  const completedCommand = page.getByRole("button", {
+    name: "Terminal: printf done, completed",
+  });
+  const completedEdit = page.getByRole("button", {
+    name: "Edit: apps/web/runtime.ts, completed",
+  });
+  await expect(completedCommand).not.toBeVisible();
+  await expect(completedEdit).not.toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("runtime-activity-collapsed-desktop.png"),
     fullPage: true,
   });
-  const completedCommand = page.getByRole("button", {
-    name: "Terminal: printf done, completed",
-  });
+  await completedCommandSummary.click();
   await expect(completedCommand).toBeVisible();
   await completedCommand.click();
   await expect(page.getByText("$ printf done", { exact: true })).toBeVisible();
   await expect(page.getByText("done", { exact: true })).toBeVisible();
   await expect(page.getByText("› y", { exact: true })).toBeVisible();
-  const completedEdit = page.getByRole("button", {
-    name: "Edit: apps/web/runtime.ts, completed",
-  });
+  await liveActivity.click();
+  await expect(completedEdit).toBeVisible();
   await completedEdit.click();
   await expect(page.getByText("Changes", { exact: true }).first()).toBeVisible();
   await expect(

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -61,7 +61,7 @@ function projectedTools(messages: unknown[]) {
 }
 
 describe("projectAgentTranscript", () => {
-  it("projects reasoning and tools as distinct ordered activity rows", () => {
+  it("keeps reasoning distinct while grouping consecutive tool activity", () => {
     const projected = projectAgentTranscript([
       { role: "user", content: "Remove the old image", timestamp: 1 },
       assistant(
@@ -93,16 +93,16 @@ describe("projectAgentTranscript", () => {
       "message",
       "activity",
       "activity",
-      "activity",
       "assistant_text",
     ]);
-    expect(projected.slice(1, 4)).toEqual([
+    expect(projected.slice(1, 3)).toEqual([
       expect.objectContaining({
         type: "activity",
         entries: [expect.objectContaining({ type: "thinking" })],
       }),
       expect.objectContaining({
         type: "activity",
+        key: "activity:tool:inspect",
         entries: [
           expect.objectContaining({
             type: "tool",
@@ -112,11 +112,6 @@ describe("projectAgentTranscript", () => {
               hasResult: true,
             }),
           }),
-        ],
-      }),
-      expect.objectContaining({
-        type: "activity",
-        entries: [
           expect.objectContaining({
             type: "tool",
             tool: expect.objectContaining({
@@ -150,6 +145,37 @@ describe("projectAgentTranscript", () => {
       "assistant_text",
       "activity",
     ]);
+  });
+
+  it("uses reasoning and subagent activity as tool-group boundaries", () => {
+    const projected = projectAgentTranscript([
+      assistant([call("first", "bash", { command: "one" })], 1),
+      result("first", "bash", "one"),
+      assistant(
+        [
+          { type: "thinking", thinking: "I should delegate this." },
+          {
+            type: "subagent",
+            id: "child",
+            action: "spawnAgent",
+            status: "completed",
+            receivers: [],
+            events: [],
+          },
+        ],
+        2,
+      ),
+      assistant([call("second", "bash", { command: "two" })], 3),
+      result("second", "bash", "two"),
+    ]);
+
+    expect(
+      projected.map((item) =>
+        item.type === "activity"
+          ? item.entries.map((entry) => entry.type)
+          : item.type,
+      ),
+    ).toEqual([["tool"], ["thinking"], ["subagent"], ["tool"]]);
   });
 
   it("keeps commentary inline and puts timing on the turn footer", () => {
@@ -446,13 +472,13 @@ describe("agent activity presentation", () => {
         false,
       ),
     ).toEqual({
-      label: "Ran 1 command, read 1 file, and edited 1 file",
+      label: "Edited 1 file, ran 1 command, and read 1 file",
       secondary: null,
       status: "completed",
     });
   });
 
-  it("shows the current command while a single tool is running", () => {
+  it("keeps a single running tool in the aggregate summary", () => {
     const shell = {
       ...tool("shell", "bash", { command: "npm test" }),
       hasResult: false,
@@ -463,8 +489,8 @@ describe("agent activity presentation", () => {
         true,
       ),
     ).toEqual({
-      label: "Running command",
-      secondary: "npm test",
+      label: "Ran 1 command",
+      secondary: null,
       status: "running",
     });
   });
@@ -478,13 +504,13 @@ describe("agent activity presentation", () => {
         true,
       ),
     ).toEqual({
-      label: "Ran command",
-      secondary: "npm test",
+      label: "Ran 1 command",
+      secondary: null,
       status: "completed",
     });
   });
 
-  it("names the latest running action instead of showing a generic tool count", () => {
+  it("keeps the aggregate summary stable while its latest tool runs", () => {
     const shell = tool("shell", "bash", { command: "npm test" });
     const search = {
       ...tool("search", "grep", {
@@ -503,9 +529,31 @@ describe("agent activity presentation", () => {
         true,
       ),
     ).toEqual({
-      label: "Searching",
-      secondary: "runtimeStatus",
+      label: "Ran 1 command and searched 1 time",
+      secondary: null,
       status: "running",
+    });
+  });
+
+  it("counts unique read and edited paths like the collapsed overview", () => {
+    const firstRead = tool("read-1", "read", { path: "src/app.ts" });
+    const secondRead = tool("read-2", "read", { path: "src/app.ts" });
+    const edit = tool("edit", "apply_patch", { path: "src/app.ts" });
+    const write = tool("write", "write", { path: "src/app.ts" });
+
+    expect(
+      describeAgentActivity(
+        [firstRead, secondRead, edit, write].map((entry) => ({
+          type: "tool" as const,
+          id: entry.id,
+          tool: entry,
+        })),
+        false,
+      ),
+    ).toEqual({
+      label: "Edited 1 file and read 1 file",
+      secondary: null,
+      status: "completed",
     });
   });
 

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentActivitySequencePosition,
   agentToolStatus,
   describeAgentActivity,
   describeAgentTool,
@@ -359,6 +360,25 @@ describe("projectAgentTranscript", () => {
         { step: "Implement", status: "pending" },
       ],
     });
+  });
+});
+
+describe("agent activity sequences", () => {
+  it("positions adjacent activity without crossing conversational boundaries", () => {
+    const projected = projectAgentTranscript([
+      assistant([{ type: "thinking", thinking: "First thought" }], 1),
+      assistant([call("read", "read", { path: "a.ts" })], 2),
+      result("read", "read", "contents"),
+      assistant([{ type: "text", text: "Visible update" }], 3),
+      assistant([call("test", "bash", { command: "npm test" })], 4),
+      result("test", "bash", "passed"),
+    ]);
+
+    expect(
+      projected.map((item, index) =>
+        agentActivitySequencePosition(projected, index),
+      ),
+    ).toEqual(["first", "last", null, "single"]);
   });
 });
 

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -119,6 +119,29 @@ export type AgentActivityPresentation = {
   status: AgentToolStatus;
 };
 
+export type AgentActivitySequencePosition =
+  | "single"
+  | "first"
+  | "middle"
+  | "last";
+
+/**
+ * Activity stays individually addressable, but adjacent activity rows form one
+ * visual sequence. Any conversational or turn-level item is a hard boundary.
+ */
+export function agentActivitySequencePosition(
+  items: readonly AgentTranscriptItem[],
+  index: number,
+): AgentActivitySequencePosition | null {
+  if (items[index]?.type !== "activity") return null;
+  const hasPrevious = items[index - 1]?.type === "activity";
+  const hasNext = items[index + 1]?.type === "activity";
+  if (hasPrevious && hasNext) return "middle";
+  if (hasPrevious) return "last";
+  if (hasNext) return "first";
+  return "single";
+}
+
 function recordOf(value: unknown): UnknownRecord | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as UnknownRecord)

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -142,6 +142,56 @@ export function agentActivitySequencePosition(
   return "single";
 }
 
+function isGroupableToolActivity(
+  item: AgentTranscriptItem,
+): item is Extract<AgentTranscriptItem, { type: "activity" }> {
+  return (
+    item.type === "activity" &&
+    item.entries.length > 0 &&
+    item.entries.every(
+      (entry) =>
+        entry.type === "tool" && normalizedToolName(entry.tool.name) !== "speak",
+    )
+  );
+}
+
+/**
+ * Consecutive tool calls share one expandable summary in the transcript. The
+ * raw entries remain intact inside that summary, and any non-tool item seals
+ * the current run.
+ */
+export function groupAgentToolActivity(
+  items: readonly AgentTranscriptItem[],
+): AgentTranscriptItem[] {
+  const grouped: AgentTranscriptItem[] = [];
+  let pending: Array<Extract<AgentTranscriptItem, { type: "activity" }>> = [];
+
+  const flush = () => {
+    const first = pending[0];
+    if (!first) return;
+    grouped.push(
+      pending.length === 1
+        ? first
+        : {
+            ...first,
+            entries: pending.flatMap((item) => item.entries),
+          },
+    );
+    pending = [];
+  };
+
+  for (const item of items) {
+    if (isGroupableToolActivity(item)) {
+      pending.push(item);
+      continue;
+    }
+    flush();
+    grouped.push(item);
+  }
+  flush();
+  return grouped;
+}
+
 function recordOf(value: unknown): UnknownRecord | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as UnknownRecord)
@@ -585,7 +635,7 @@ export function projectAgentTranscript(
       message,
     });
   });
-  return items;
+  return groupAgentToolActivity(items);
 }
 
 function normalizedToolName(name: string): string {
@@ -711,56 +761,6 @@ export function agentToolStatus(
   return active ? "running" : "stopped";
 }
 
-function singleActivityLabel(
-  presentation: AgentToolPresentation,
-  status: AgentToolStatus,
-): string {
-  if (status === "failed") {
-    return presentation.category === "shell"
-      ? "Command failed"
-      : `${presentation.label} failed`;
-  }
-  if (status === "stopped") {
-    return presentation.category === "shell"
-      ? "Command stopped"
-      : `${presentation.label} stopped`;
-  }
-  if (status === "running") {
-    switch (presentation.category) {
-      case "shell":
-        return "Running command";
-      case "read":
-        return "Reading file";
-      case "edit":
-        return "Editing file";
-      case "write":
-        return "Writing file";
-      case "search":
-        return "Searching";
-      case "fetch":
-        return "Fetching page";
-      case "other":
-        return `Running ${presentation.label}`;
-    }
-  }
-  switch (presentation.category) {
-    case "shell":
-      return "Ran command";
-    case "read":
-      return "Read file";
-    case "edit":
-      return "Edited file";
-    case "write":
-      return "Wrote file";
-    case "search":
-      return "Searched";
-    case "fetch":
-      return "Fetched page";
-    case "other":
-      return `Used ${presentation.label}`;
-  }
-}
-
 function plural(count: number, one: string, many = `${one}s`): string {
   return `${count.toLocaleString()} ${count === 1 ? one : many}`;
 }
@@ -806,55 +806,51 @@ export function describeAgentActivity(
   }
 
   const statuses = tools.map((tool) => agentToolStatus(tool, active));
-  const status: AgentToolStatus = statuses.includes("failed")
-    ? "failed"
-    : statuses.includes("running")
-      ? "running"
+  const status: AgentToolStatus = statuses.includes("running")
+    ? "running"
+    : statuses.includes("failed")
+      ? "failed"
       : statuses.includes("stopped")
         ? "stopped"
         : "completed";
 
-  if (tools.length === 1) {
-    const presentation = describeAgentTool(tools[0]);
-    return {
-      label: singleActivityLabel(presentation, status),
-      secondary: presentation.summary,
-      status,
-    };
+  const editedFiles = new Set<string>();
+  const readFiles = new Set<string>();
+  let commandCount = 0;
+  let searchCount = 0;
+  let otherToolCount = 0;
+  for (const tool of tools) {
+    const presentation = describeAgentTool(tool);
+    const identity = presentation.summary?.trim() || `tool:${tool.id}`;
+    switch (presentation.category) {
+      case "edit":
+      case "write":
+        editedFiles.add(identity);
+        break;
+      case "shell":
+        commandCount += 1;
+        break;
+      case "read":
+        readFiles.add(identity);
+        break;
+      case "search":
+        searchCount += 1;
+        break;
+      case "fetch":
+      case "other":
+        otherToolCount += 1;
+        break;
+    }
   }
-
-  if (status === "running") {
-    const runningIndex = statuses.findLastIndex(
-      (candidate) => candidate === "running",
-    );
-    const runningTool = tools[runningIndex];
-    const current = describeAgentTool(runningTool);
-    return {
-      label: singleActivityLabel(current, "running"),
-      secondary: current.summary,
-      status,
-    };
-  }
-
-  const counts: Record<AgentToolCategory, number> = {
-    shell: 0,
-    read: 0,
-    edit: 0,
-    write: 0,
-    search: 0,
-    fetch: 0,
-    other: 0,
-  };
-  for (const tool of tools) counts[describeAgentTool(tool).category] += 1;
 
   const summary = [
-    counts.shell ? `ran ${plural(counts.shell, "command")}` : null,
-    counts.read ? `read ${plural(counts.read, "file")}` : null,
-    counts.edit ? `edited ${plural(counts.edit, "file")}` : null,
-    counts.write ? `wrote ${plural(counts.write, "file")}` : null,
-    counts.search ? `made ${plural(counts.search, "search", "searches")}` : null,
-    counts.fetch ? `fetched ${plural(counts.fetch, "page")}` : null,
-    counts.other ? `used ${plural(counts.other, "other tool")}` : null,
+    editedFiles.size ? `edited ${plural(editedFiles.size, "file")}` : null,
+    commandCount ? `ran ${plural(commandCount, "command")}` : null,
+    readFiles.size ? `read ${plural(readFiles.size, "file")}` : null,
+    searchCount ? `searched ${plural(searchCount, "time")}` : null,
+    otherToolCount
+      ? `used ${plural(otherToolCount, "other tool")}`
+      : null,
   ].filter((part): part is string => part !== null);
   const failed = statuses.filter((candidate) => candidate === "failed").length;
   const stopped = statuses.filter((candidate) => candidate === "stopped").length;

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.1}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Problem

Agent activity currently renders every tool event as an independent row. Longer Codex, Pi, and OMP runs therefore become repetitive Terminal / Read / Edit stacks, and tighter spacing alone does not make those runs meaningfully easier to scan. A generic Working row can also duplicate the live state already shown by the final activity.

The event projection is shared across providers, so this is one presentation-layer issue rather than separate provider bugs.

## Approach

This adopts the familiar Summary-mode interaction used by Paseo:

- Collapse each uninterrupted run of tool calls into one expandable aggregate such as Ran 5 commands or Edited 2 files and searched 3 times.
- Preserve every underlying tool entry and its details; expanding the aggregate restores the original rows.
- Keep the first tool identity stable while a live run grows so expansion state and rendering remain predictable.
- Seal groups at reasoning, subagent activity, assistant text, plans, errors, messages, and turn metadata.
- Count unique read and edited file paths while counting command and search invocations.
- Keep aggregate labels stable during streaming, cap expanded detail height, and retain visible running and failure state.
- Use compact sequence spacing around non-tool activity and hide the generic Working indicator only when trailing live activity already communicates that state.

## Verification

- npm run lint -w apps/web --
- npm run typecheck -w apps/web --
- npm run test -w apps/web -- (62 files, 441 tests)
- E2E_PORT=4731 npx playwright test e2e/agent-runtime.spec.ts -g "shows durable turn activity"