### PR TITLE
fix(agents): keep session runtime status live

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -51,12 +51,17 @@ jobs:
         id: version
         run: |
           version=$(node -p "require('./apps/cli/package.json').version")
+          grep -F "export const CLI_VERSION = \"$version\"" apps/cli/src/constants.ts
           grep -F "cli_version=\"$version\"" apps/site/public/install
           test "$(node -p "require('./apps/site/public/install-manifest.json').cliVersion")" = "$version"
+          connector_version=$(node -p "require('./apps/connector/package.json').version")
           test "$(node -p "require('./apps/site/public/install-manifest.json').connectorVersion")" = \
-            "$(node -p "require('./apps/connector/package.json').version")"
+            "$connector_version"
+          grep -F "export const CONNECTOR_VERSION = \"$connector_version\"" \
+            apps/cli/src/constants.ts
           app_version=$(node -p "require('./apps/site/public/install-manifest.json').appVersion")
           test "$(sed -n 's/.*${APP_VERSION:-\([^}]*\)}.*/\1/p' compose.yml)" = "$app_version"
+          grep -F "export const APP_VERSION = \"$app_version\"" apps/cli/src/constants.ts
           stt_version=$(node -p "require('./apps/site/public/install-manifest.json').sttVersion")
           grep -F "export const STT_VERSION = \"$stt_version\"" apps/cli/src/constants.ts
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,5 +1,5 @@
-export const CLI_VERSION = "0.1.1";
-export const APP_VERSION = "0.14.0";
+export const CLI_VERSION = "0.1.2";
+export const APP_VERSION = "0.14.2";
 export const CONNECTOR_VERSION = "0.5.0";
 export const STT_VERSION = "0.1.0";
 

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,6 +1,6 @@
 export const CLI_VERSION = "0.1.1";
 export const APP_VERSION = "0.14.0";
-export const CONNECTOR_VERSION = "0.4.0";
+export const CONNECTOR_VERSION = "0.5.0";
 export const STT_VERSION = "0.1.0";
 
 export const APP_IMAGE = "ghcr.io/yoloyash/overtchat-app";

--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/cli.ts
+++ b/apps/connector/src/cli.ts
@@ -168,6 +168,11 @@ async function main(): Promise<void> {
       await installManaged();
       return;
     case "run":
+      if (parsed.values.size > 0) {
+        throw new Error(
+          "The run command does not accept options; it uses the provisioned connector configuration.",
+        );
+      }
       await run();
       return;
     case "preflight":

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -190,6 +190,48 @@ describe.sequential("connector client compatibility", () => {
     await running;
   });
 
+  it("delivers session status through the durable event outbox", async () => {
+    const batches: HostConnectorEventBatch[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        if (String(input).endsWith("/channel")) return emptyChannel();
+        const batch = JSON.parse(String(init?.body)) as HostConnectorEventBatch;
+        batches.push(batch);
+        return Response.json({
+          connectorEpoch: batch.connectorEpoch,
+          acknowledgedSequence: batch.events.at(-1)!.sequence,
+        });
+      }),
+    );
+    const client = await ConnectorClient.create(await config());
+    const running = client.run();
+    const enqueue = Reflect.get(client, "enqueue") as (
+      value: HostConnectorEventPayload,
+    ) => void;
+    enqueue.call(client, {
+      type: "session_status",
+      sessionId: "session",
+      status: "running",
+    });
+
+    await vi.waitFor(() =>
+      expect(
+        batches.flatMap((batch) => batch.events).some(
+          (event) =>
+            event.payload.type === "session_status" &&
+            event.payload.sessionId === "session" &&
+            event.payload.status === "running",
+        ),
+      ).toBe(true),
+    );
+    expect(
+      Reflect.get(client, "liveEvents") as HostConnectorEventPayload[],
+    ).toHaveLength(0);
+    await client.stop();
+    await running;
+  });
+
   it("terminates the connector loop after an unrecoverable timeline failure", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => emptyChannel()));
     const client = await ConnectorClient.create(await config());

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -136,7 +136,7 @@ describe.sequential("connector client compatibility", () => {
     expect(headers.get("x-overtchat-connector-version")).toBe(
       HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     );
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.4.0");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.5.0");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );
@@ -190,7 +190,7 @@ describe.sequential("connector client compatibility", () => {
     await running;
   });
 
-  it("delivers session status through the durable event outbox", async () => {
+  it("delivers session-directory upserts through the event outbox", async () => {
     const batches: HostConnectorEventBatch[] = [];
     vi.stubGlobal(
       "fetch",
@@ -210,18 +210,17 @@ describe.sequential("connector client compatibility", () => {
       value: HostConnectorEventPayload,
     ) => void;
     enqueue.call(client, {
-      type: "session_status",
-      sessionId: "session",
-      status: "running",
+      type: "session_update",
+      session: { sessionId: "session", runtimeStatus: "running" },
     });
 
     await vi.waitFor(() =>
       expect(
         batches.flatMap((batch) => batch.events).some(
           (event) =>
-            event.payload.type === "session_status" &&
-            event.payload.sessionId === "session" &&
-            event.payload.status === "running",
+            event.payload.type === "session_update" &&
+            event.payload.session.sessionId === "session" &&
+            event.payload.session.runtimeStatus === "running",
         ),
       ).toBe(true),
     );

--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -547,6 +547,64 @@ describe("connector daemon command identity", () => {
     await journal.close();
   });
 
+  it("publishes runtime status without a detail-view subscription", async () => {
+    const { journal, timelines } = await openJournal();
+    const emitted: HostConnectorEventPayload[] = [];
+    let observer: ((event: AgentRuntimeEnvelope) => void) | undefined;
+    mocks.observe.mockImplementation((value) => {
+      observer = value;
+      return () => {};
+    });
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+    await daemon.handle({
+      type: "sync",
+      connectionEpoch: "connection-1",
+      activeSessionIds: ["session"],
+      serverInfo: {
+        protocolVersion: 1,
+        capabilities: ["session-status-v1"],
+      },
+    });
+    await daemon.handle({
+      type: "request",
+      requestId: "open",
+      request: { type: "open_session", session },
+    });
+
+    expect(emitted).toContainEqual({
+      type: "session_status",
+      sessionId: "session",
+      status: "running",
+    });
+    emitted.length = 0;
+    observer?.({
+      epoch: "runtime-ephemeral",
+      sequence: 1,
+      type: "runtime_event",
+      data: { type: "overtchat_status", status: "idle" },
+    });
+    await timelines.flush("session");
+
+    await vi.waitFor(() => {
+      expect(emitted).toContainEqual({
+        type: "session_status",
+        sessionId: "session",
+        status: "idle",
+      });
+    });
+    expect(emitted).not.toContainEqual(
+      expect.objectContaining({ type: "session_event" }),
+    );
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
   it("coalesces consecutive growing turn projections into one durable update", async () => {
     const { journal, timelines } = await openJournal();
     const emitted: HostConnectorEventPayload[] = [];

--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -323,7 +323,7 @@ describe("connector daemon command identity", () => {
     ]);
 
     expect(mocks.command).toHaveBeenCalledTimes(1);
-    expect(events).toEqual([
+    expect(events.filter((event) => event.type === "response")).toEqual([
       expect.objectContaining({
         type: "response",
         requestId: "request-1",
@@ -547,7 +547,7 @@ describe("connector daemon command identity", () => {
     await journal.close();
   });
 
-  it("publishes runtime status without a detail-view subscription", async () => {
+  it("publishes a session-directory snapshot and updates without a detail subscription", async () => {
     const { journal, timelines } = await openJournal();
     const emitted: HostConnectorEventPayload[] = [];
     let observer: ((event: AgentRuntimeEnvelope) => void) | undefined;
@@ -567,8 +567,12 @@ describe("connector daemon command identity", () => {
       activeSessionIds: ["session"],
       serverInfo: {
         protocolVersion: 1,
-        capabilities: ["session-status-v1"],
+        capabilities: [],
       },
+    });
+    expect(emitted).toContainEqual({
+      type: "session_directory",
+      sessions: [{ sessionId: "session", runtimeStatus: "idle" }],
     });
     await daemon.handle({
       type: "request",
@@ -577,9 +581,8 @@ describe("connector daemon command identity", () => {
     });
 
     expect(emitted).toContainEqual({
-      type: "session_status",
-      sessionId: "session",
-      status: "running",
+      type: "session_update",
+      session: { sessionId: "session", runtimeStatus: "running" },
     });
     emitted.length = 0;
     observer?.({
@@ -592,9 +595,8 @@ describe("connector daemon command identity", () => {
 
     await vi.waitFor(() => {
       expect(emitted).toContainEqual({
-        type: "session_status",
-        sessionId: "session",
-        status: "idle",
+        type: "session_update",
+        session: { sessionId: "session", runtimeStatus: "idle" },
       });
     });
     expect(emitted).not.toContainEqual(

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -124,7 +124,7 @@ export class ConnectorDaemon {
   private readonly registry: AgentRuntimeRegistry;
   private readonly subscriptions = new Map<string, SessionSubscription>();
   private readonly captures = new Map<string, TimelineCapture>();
-  private readonly publishedSessionStatuses = new Map<
+  private readonly publishedSessions = new Map<
     string,
     AgentRuntimeStatus
   >();
@@ -299,7 +299,7 @@ export class ConnectorDaemon {
     }
     if (this.connectionEpoch !== connectionEpoch) {
       this.connectionEpoch = connectionEpoch;
-      this.publishedSessionStatuses.clear();
+      this.publishedSessions.clear();
       for (const subscription of this.subscriptions.values()) {
         this.closeSubscription(subscription);
       }
@@ -318,10 +318,7 @@ export class ConnectorDaemon {
     );
     this.assertAccepting();
     await this.journal.retainSessions(active);
-    for (const [sessionId, capture] of this.captures) {
-      if (!active.has(sessionId)) continue;
-      this.publishSessionStatus(sessionId, capture.runtime.snapshot().status);
-    }
+    this.publishSessionDirectory(active);
   }
 
   private async handleRequest(request: AgentDaemonRequest): Promise<unknown> {
@@ -786,10 +783,25 @@ export class ConnectorDaemon {
     sessionId: string,
     status: AgentRuntimeStatus,
   ): void {
-    if (!this.serverCapabilities.has("session-status-v1")) return;
-    if (this.publishedSessionStatuses.get(sessionId) === status) return;
-    this.publishedSessionStatuses.set(sessionId, status);
-    this.emit({ type: "session_status", sessionId, status });
+    if (this.publishedSessions.get(sessionId) === status) return;
+    this.publishedSessions.set(sessionId, status);
+    this.emit({
+      type: "session_update",
+      session: { sessionId, runtimeStatus: status },
+    });
+  }
+
+  private publishSessionDirectory(sessionIds: ReadonlySet<string>): void {
+    const sessions = [...sessionIds].map((sessionId) => ({
+      sessionId,
+      runtimeStatus:
+        this.captures.get(sessionId)?.runtime.snapshot().status ?? "idle",
+    }));
+    this.publishedSessions.clear();
+    for (const session of sessions) {
+      this.publishedSessions.set(session.sessionId, session.runtimeStatus);
+    }
+    this.emit({ type: "session_directory", sessions });
   }
 
   private recordCaptureFailure(

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -6,6 +6,7 @@ import type {
   AgentDaemonWorkspaceDescriptor,
   AgentPromptImage,
   AgentRuntimeEnvelope,
+  AgentRuntimeStatus,
   HostConnectorCommand,
   HostConnectorEventPayload,
 } from "@overtchat/agent-bridge";
@@ -123,6 +124,10 @@ export class ConnectorDaemon {
   private readonly registry: AgentRuntimeRegistry;
   private readonly subscriptions = new Map<string, SessionSubscription>();
   private readonly captures = new Map<string, TimelineCapture>();
+  private readonly publishedSessionStatuses = new Map<
+    string,
+    AgentRuntimeStatus
+  >();
   private readonly sessionTails = new Map<string, Promise<void>>();
   private readonly activeRequests = new Set<Promise<void>>();
   private readonly shutdownAbort = new AbortController();
@@ -294,6 +299,7 @@ export class ConnectorDaemon {
     }
     if (this.connectionEpoch !== connectionEpoch) {
       this.connectionEpoch = connectionEpoch;
+      this.publishedSessionStatuses.clear();
       for (const subscription of this.subscriptions.values()) {
         this.closeSubscription(subscription);
       }
@@ -312,6 +318,10 @@ export class ConnectorDaemon {
     );
     this.assertAccepting();
     await this.journal.retainSessions(active);
+    for (const [sessionId, capture] of this.captures) {
+      if (!active.has(sessionId)) continue;
+      this.publishSessionStatus(sessionId, capture.runtime.snapshot().status);
+    }
   }
 
   private async handleRequest(request: AgentDaemonRequest): Promise<unknown> {
@@ -698,6 +708,7 @@ export class ConnectorDaemon {
       await capture.ready;
       this.assertAccepting();
       capture.initialized = true;
+      this.publishSessionStatus(sessionId, runtime.snapshot().status);
       for (const envelope of capture.buffered.splice(0)) {
         this.commitCapturedEnvelope(sessionId, capture, envelope);
       }
@@ -733,7 +744,12 @@ export class ConnectorDaemon {
   ): void {
     let operation: Promise<AgentRuntimeEnvelope | null>;
     try {
-      operation = this.timelines.commit(sessionId, envelope);
+      operation = this.timelines.commit(sessionId, envelope).then((committed) => {
+        if (committed) {
+          this.publishEnvelopeStatus(sessionId, committed);
+        }
+        return committed;
+      });
     } catch (error) {
       this.recordCaptureFailure(sessionId, capture, error);
       return;
@@ -745,6 +761,35 @@ export class ConnectorDaemon {
         return null;
       })
       .finally(() => capture.pending.delete(operation));
+  }
+
+  private publishEnvelopeStatus(
+    sessionId: string,
+    envelope: AgentRuntimeEnvelope,
+  ): void {
+    if (envelope.type === "snapshot") {
+      this.publishSessionStatus(sessionId, envelope.data.status);
+      return;
+    }
+    if (
+      envelope.data.type === "overtchat_status" &&
+      ["idle", "running", "exited"].includes(String(envelope.data.status))
+    ) {
+      this.publishSessionStatus(
+        sessionId,
+        envelope.data.status as AgentRuntimeStatus,
+      );
+    }
+  }
+
+  private publishSessionStatus(
+    sessionId: string,
+    status: AgentRuntimeStatus,
+  ): void {
+    if (!this.serverCapabilities.has("session-status-v1")) return;
+    if (this.publishedSessionStatuses.get(sessionId) === status) return;
+    this.publishedSessionStatuses.set(sessionId, status);
+    this.emit({ type: "session_status", sessionId, status });
   }
 
   private recordCaptureFailure(

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -9,6 +9,7 @@
 /install/connector/0.3.3 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.3/install-connector.sh 302
 /install/connector/0.3.4 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.4/install-connector.sh 302
 /install/connector/0.4.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.4.0/install-connector.sh 302
+/install/connector/0.5.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.5.0/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.4.0 302
+/install-connector.sh /install/connector/0.5.0 302

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.1"
+cli_version="0.1.2"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
-  "cliVersion": "0.1.1",
-  "appVersion": "0.14.1",
+  "cliVersion": "0.1.2",
+  "appVersion": "0.14.2",
   "connectorVersion": "0.5.0",
   "sttVersion": "0.1.0"
 }

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -2,6 +2,6 @@
   "format": 1,
   "cliVersion": "0.1.1",
   "appVersion": "0.14.1",
-  "connectorVersion": "0.4.0",
+  "connectorVersion": "0.5.0",
   "sttVersion": "0.1.0"
 }

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -5,7 +5,7 @@ import { auth } from "@/lib/auth/server";
 import { listChats } from "@/lib/db/chats";
 import { listProjects } from "@/lib/db/projects";
 import { listAgentConnections } from "@/lib/db/agentConnections";
-import { withAgentRuntimeStatuses } from "@/lib/agents/connector/status";
+import { withConnectorSessionDirectory } from "@/lib/agents/connector/directory";
 import { AppShell } from "@/components/AppShell";
 import { Sidebar } from "@/components/Sidebar";
 import { getQueryClient } from "@/lib/queryClient";
@@ -57,7 +57,7 @@ export default async function AppLayout({
       ? qc.prefetchQuery({
           queryKey: agentConnectionKeys.list(),
           queryFn: async (): Promise<AgentConnectionListItem[]> =>
-            withAgentRuntimeStatuses(
+            withConnectorSessionDirectory(
               await listAgentConnections(session.user.id),
             ),
         })

--- a/apps/web/app/(app)/settings/connections/page.tsx
+++ b/apps/web/app/(app)/settings/connections/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { auth } from "@/lib/auth/server";
 import { listAgentConnections } from "@/lib/db/agentConnections";
-import { withAgentRuntimeStatuses } from "@/lib/agents/connector/status";
+import { withConnectorSessionDirectory } from "@/lib/agents/connector/directory";
 import { getQueryClient } from "@/lib/queryClient";
 import { agentConnectionKeys } from "@/lib/queries/keys";
 import { ConnectionsPanel } from "./ConnectionsPanel";
@@ -23,7 +23,7 @@ export default async function Page({
   await queryClient.prefetchQuery({
     queryKey: agentConnectionKeys.list(),
     queryFn: async () =>
-      withAgentRuntimeStatuses(
+      withConnectorSessionDirectory(
         await listAgentConnections(session.user.id),
       ),
   });

--- a/apps/web/app/api/agent-connections/events/route.test.ts
+++ b/apps/web/app/api/agent-connections/events/route.test.ts
@@ -1,10 +1,14 @@
-import type { AgentRuntimeStatus } from "@overtchat/agent-bridge";
+import type { AgentSessionDirectoryEntry } from "@overtchat/agent-bridge";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type DirectoryEvent =
+  | { type: "snapshot"; sessions: AgentSessionDirectoryEntry[] }
+  | { type: "update"; session: AgentSessionDirectoryEntry };
 
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   listAgentConnections: vi.fn(),
-  subscribeSessionStatuses: vi.fn(),
+  subscribeSessionDirectory: vi.fn(),
   unsubscribe: vi.fn(),
 }));
 
@@ -17,16 +21,14 @@ vi.mock("@/lib/db/agentConnections", () => ({
 }));
 vi.mock("@/lib/agents/connector/broker", () => ({
   hostConnectorBroker: {
-    subscribeSessionStatuses: mocks.subscribeSessionStatuses,
+    subscribeSessionDirectory: mocks.subscribeSessionDirectory,
   },
 }));
 
 import { GET } from "./route";
 
-describe("agent connection status stream", () => {
-  let listener:
-    | ((sessionId: string, status: AgentRuntimeStatus) => void)
-    | undefined;
+describe("agent connection session-directory stream", () => {
+  let listener: ((event: DirectoryEvent) => void) | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,40 +44,55 @@ describe("agent connection status stream", () => {
         ],
       },
     ]);
-    mocks.subscribeSessionStatuses.mockImplementation(
+    mocks.subscribeSessionDirectory.mockImplementation(
       (
         _sessionIds: string[],
-        subscriber: (sessionId: string, status: AgentRuntimeStatus) => void,
+        subscriber: (event: DirectoryEvent) => void,
       ) => {
         listener = subscriber;
-        subscriber("session", "idle");
+        subscriber({
+          type: "snapshot",
+          sessions: [
+            { sessionId: "session", runtimeStatus: "idle" },
+            { sessionId: "other-session", runtimeStatus: "exited" },
+          ],
+        });
         return mocks.unsubscribe;
       },
     );
   });
 
-  it("streams authorized session status transitions and cleans up", async () => {
+  it("streams an authorized snapshot and session upserts, then cleans up", async () => {
     const response = await GET(
-      new Request("http://server.test/api/agent-connections/statuses"),
+      new Request("http://server.test/api/agent-connections/events"),
     );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain(
       "text/event-stream",
     );
-    expect(mocks.subscribeSessionStatuses).toHaveBeenCalledWith(
+    expect(mocks.subscribeSessionDirectory).toHaveBeenCalledWith(
       ["session", "other-session"],
       expect.any(Function),
     );
     const reader = response.body!.getReader();
     const initial = new TextDecoder().decode((await reader.read()).value);
-    expect(initial).toContain("event: status");
+    expect(initial).toContain("event: snapshot");
     expect(initial).toContain(
-      JSON.stringify({ sessionId: "session", runtimeStatus: "idle" }),
+      JSON.stringify({
+        sessions: [
+          { sessionId: "session", runtimeStatus: "idle" },
+          { sessionId: "other-session", runtimeStatus: "exited" },
+        ],
+      }),
     );
 
-    listener?.("session", "running");
+    listener?.({
+      type: "update",
+      session: { sessionId: "session", runtimeStatus: "running" },
+    });
     const running = new TextDecoder().decode((await reader.read()).value);
+    expect(running).toContain("event: update");
     expect(running).toContain(
       JSON.stringify({ sessionId: "session", runtimeStatus: "running" }),
     );
@@ -83,17 +100,17 @@ describe("agent connection status stream", () => {
     expect(mocks.unsubscribe).toHaveBeenCalledOnce();
   });
 
-  it("does not expose statuses to non-admin users", async () => {
+  it("does not expose the directory to non-admin users", async () => {
     mocks.getSession.mockResolvedValue({
       user: { id: "member", role: "user" },
     });
 
     const response = await GET(
-      new Request("http://server.test/api/agent-connections/statuses"),
+      new Request("http://server.test/api/agent-connections/events"),
     );
 
     expect(response.status).toBe(403);
     expect(mocks.listAgentConnections).not.toHaveBeenCalled();
-    expect(mocks.subscribeSessionStatuses).not.toHaveBeenCalled();
+    expect(mocks.subscribeSessionDirectory).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/agent-connections/events/route.ts
+++ b/apps/web/app/api/agent-connections/events/route.ts
@@ -1,18 +1,19 @@
-import type { AgentRuntimeStatus } from "@overtchat/agent-bridge";
 import { auth } from "@/lib/auth/server";
 import { connectionAccessError } from "@/lib/agents/access";
-import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import {
+  hostConnectorBroker,
+  type AgentSessionDirectoryEvent,
+} from "@/lib/agents/connector/broker";
 import { listAgentConnections } from "@/lib/db/agentConnections";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
-function encodeStatus(
-  sessionId: string,
-  runtimeStatus: AgentRuntimeStatus,
-): Uint8Array {
+function encodeEvent(event: AgentSessionDirectoryEvent): Uint8Array {
+  const data =
+    event.type === "snapshot" ? { sessions: event.sessions } : event.session;
   return new TextEncoder().encode(
-    `event: status\ndata: ${JSON.stringify({ sessionId, runtimeStatus })}\n\n`,
+    `event: ${event.type}\ndata: ${JSON.stringify(data)}\n\n`,
   );
 }
 
@@ -57,18 +58,18 @@ export async function GET(req: Request) {
           finish();
         }
       }, 15_000);
-      const stopStatuses = hostConnectorBroker.subscribeSessionStatuses(
+      const stopDirectory = hostConnectorBroker.subscribeSessionDirectory(
         sessionIds,
-        (sessionId, runtimeStatus) => {
+        (event) => {
           if (closed) return;
           try {
-            controller.enqueue(encodeStatus(sessionId, runtimeStatus));
+            controller.enqueue(encodeEvent(event));
           } catch {
             finish();
           }
         },
       );
-      unsubscribe = stopStatuses;
+      unsubscribe = stopDirectory;
       if (closed) unsubscribe();
       req.signal.addEventListener("abort", finish, { once: true });
       if (req.signal.aborted) finish();

--- a/apps/web/app/api/agent-connections/route.test.ts
+++ b/apps/web/app/api/agent-connections/route.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   createAgentConnection: vi.fn(),
   daemonRequest: vi.fn(),
   getOwnedHostConnector: vi.fn(),
-  withAgentRuntimeStatuses: vi.fn(),
+  withConnectorSessionDirectory: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -23,8 +23,8 @@ vi.mock("@/lib/agents/connector/broker", () => ({
 vi.mock("@/lib/db/hostConnectors", () => ({
   getOwnedHostConnector: mocks.getOwnedHostConnector,
 }));
-vi.mock("@/lib/agents/connector/status", () => ({
-  withAgentRuntimeStatuses: mocks.withAgentRuntimeStatuses,
+vi.mock("@/lib/agents/connector/directory", () => ({
+  withConnectorSessionDirectory: mocks.withConnectorSessionDirectory,
 }));
 
 import { GET, POST } from "./route";
@@ -49,7 +49,7 @@ describe("Agent Connections route", () => {
     });
     mocks.listAgentConnections.mockResolvedValue([]);
     mocks.getOwnedHostConnector.mockReturnValue({ id: "connector" });
-    mocks.withAgentRuntimeStatuses.mockImplementation(
+    mocks.withConnectorSessionDirectory.mockImplementation(
       (connections) => connections,
     );
   });
@@ -60,7 +60,7 @@ describe("Agent Connections route", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ connections: [] });
     expect(mocks.listAgentConnections).toHaveBeenCalledWith("admin");
-    expect(mocks.withAgentRuntimeStatuses).toHaveBeenCalledWith([]);
+    expect(mocks.withConnectorSessionDirectory).toHaveBeenCalledWith([]);
   });
 
   it("does not expose connections to non-admin users", async () => {

--- a/apps/web/app/api/agent-connections/route.ts
+++ b/apps/web/app/api/agent-connections/route.ts
@@ -8,7 +8,7 @@ import {
   type AgentConnectionListItem,
 } from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import { withAgentRuntimeStatuses } from "@/lib/agents/connector/status";
+import { withConnectorSessionDirectory } from "@/lib/agents/connector/directory";
 import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
 import {
   createAgentConnection,
@@ -25,7 +25,7 @@ export async function GET(req: Request) {
     return Response.json({ error: accessError }, { status: 403 });
   }
   return Response.json({
-    connections: withAgentRuntimeStatuses(
+    connections: withConnectorSessionDirectory(
       await listAgentConnections(session.user.id),
     ),
   });
@@ -82,7 +82,7 @@ export async function POST(req: Request) {
         detectedVersion: probe.version,
       },
     });
-    const connections = withAgentRuntimeStatuses(
+    const connections = withConnectorSessionDirectory(
       await listAgentConnections(session.user.id),
     );
     const connection = connections.find(

--- a/apps/web/app/api/agent-connections/statuses/route.test.ts
+++ b/apps/web/app/api/agent-connections/statuses/route.test.ts
@@ -1,0 +1,99 @@
+import type { AgentRuntimeStatus } from "@overtchat/agent-bridge";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  listAgentConnections: vi.fn(),
+  subscribeSessionStatuses: vi.fn(),
+  unsubscribe: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/agentConnections", () => ({
+  listAgentConnections: mocks.listAgentConnections,
+}));
+vi.mock("@/lib/agents/connector/broker", () => ({
+  hostConnectorBroker: {
+    subscribeSessionStatuses: mocks.subscribeSessionStatuses,
+  },
+}));
+
+import { GET } from "./route";
+
+describe("agent connection status stream", () => {
+  let listener:
+    | ((sessionId: string, status: AgentRuntimeStatus) => void)
+    | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "owner", role: "admin" },
+    });
+    mocks.listAgentConnections.mockResolvedValue([
+      {
+        workspaces: [
+          {
+            sessions: [{ id: "session" }, { id: "other-session" }],
+          },
+        ],
+      },
+    ]);
+    mocks.subscribeSessionStatuses.mockImplementation(
+      (
+        _sessionIds: string[],
+        subscriber: (sessionId: string, status: AgentRuntimeStatus) => void,
+      ) => {
+        listener = subscriber;
+        subscriber("session", "idle");
+        return mocks.unsubscribe;
+      },
+    );
+  });
+
+  it("streams authorized session status transitions and cleans up", async () => {
+    const response = await GET(
+      new Request("http://server.test/api/agent-connections/statuses"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain(
+      "text/event-stream",
+    );
+    expect(mocks.subscribeSessionStatuses).toHaveBeenCalledWith(
+      ["session", "other-session"],
+      expect.any(Function),
+    );
+    const reader = response.body!.getReader();
+    const initial = new TextDecoder().decode((await reader.read()).value);
+    expect(initial).toContain("event: status");
+    expect(initial).toContain(
+      JSON.stringify({ sessionId: "session", runtimeStatus: "idle" }),
+    );
+
+    listener?.("session", "running");
+    const running = new TextDecoder().decode((await reader.read()).value);
+    expect(running).toContain(
+      JSON.stringify({ sessionId: "session", runtimeStatus: "running" }),
+    );
+    await reader.cancel();
+    expect(mocks.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("does not expose statuses to non-admin users", async () => {
+    mocks.getSession.mockResolvedValue({
+      user: { id: "member", role: "user" },
+    });
+
+    const response = await GET(
+      new Request("http://server.test/api/agent-connections/statuses"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.listAgentConnections).not.toHaveBeenCalled();
+    expect(mocks.subscribeSessionStatuses).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/agent-connections/statuses/route.ts
+++ b/apps/web/app/api/agent-connections/statuses/route.ts
@@ -1,0 +1,89 @@
+import type { AgentRuntimeStatus } from "@overtchat/agent-bridge";
+import { auth } from "@/lib/auth/server";
+import { connectionAccessError } from "@/lib/agents/access";
+import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import { listAgentConnections } from "@/lib/db/agentConnections";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+function encodeStatus(
+  sessionId: string,
+  runtimeStatus: AgentRuntimeStatus,
+): Uint8Array {
+  return new TextEncoder().encode(
+    `event: status\ndata: ${JSON.stringify({ sessionId, runtimeStatus })}\n\n`,
+  );
+}
+
+export async function GET(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  const accessError = connectionAccessError(session.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+
+  const connections = await listAgentConnections(session.user.id);
+  const sessionIds = connections.flatMap((connection) =>
+    connection.workspaces.flatMap((workspace) =>
+      workspace.sessions.map((agentSession) => agentSession.id),
+    ),
+  );
+
+  let close = () => {};
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      let unsubscribe = () => {};
+      const finish = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(keepAlive);
+        req.signal.removeEventListener("abort", finish);
+        unsubscribe();
+        try {
+          controller.close();
+        } catch {
+          // The browser may already have closed the stream.
+        }
+      };
+      close = finish;
+      const keepAlive = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+        } catch {
+          finish();
+        }
+      }, 15_000);
+      const stopStatuses = hostConnectorBroker.subscribeSessionStatuses(
+        sessionIds,
+        (sessionId, runtimeStatus) => {
+          if (closed) return;
+          try {
+            controller.enqueue(encodeStatus(sessionId, runtimeStatus));
+          } catch {
+            finish();
+          }
+        },
+      );
+      unsubscribe = stopStatuses;
+      if (closed) unsubscribe();
+      req.signal.addEventListener("abort", finish, { once: true });
+      if (req.signal.aborted) finish();
+    },
+    cancel() {
+      close();
+    },
+  });
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/apps/web/app/api/host-connectors/channel/route.test.ts
+++ b/apps/web/app/api/host-connectors/channel/route.test.ts
@@ -117,6 +117,7 @@ describe("Host Connector command channel", () => {
     const wrongRelease = await GET(request("0.1.0"));
     expect(wrongRelease.status).toBe(409);
     await expect(wrongRelease.json()).resolves.toMatchObject({
+      error: expect.stringContaining("overtchat update"),
       code: "unsupported_connector_protocol",
       compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     });

--- a/apps/web/app/api/host-connectors/channel/route.ts
+++ b/apps/web/app/api/host-connectors/channel/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: Request) {
   ) {
     return Response.json(
       {
-        error: `This server requires the Host Connector protocol ${HOST_CONNECTOR_PROTOCOL_VERSION} agent-daemon wire shape.`,
+        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE}).`,
         code: "unsupported_connector_protocol",
         supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
         compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,

--- a/apps/web/app/api/host-connectors/events/route.test.ts
+++ b/apps/web/app/api/host-connectors/events/route.test.ts
@@ -197,7 +197,7 @@ describe("Host Connector event route", () => {
     expect(mocks.acceptBatch).not.toHaveBeenCalled();
   });
 
-  it("rejects the incompatible pre-agent-daemon wire shape", async () => {
+  it("rejects an outdated connector release with an update instruction", async () => {
     const response = await POST(
       request(
         {
@@ -221,6 +221,7 @@ describe("Host Connector event route", () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("overtchat update"),
       code: "unsupported_connector_protocol",
       compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     });

--- a/apps/web/app/api/host-connectors/events/route.ts
+++ b/apps/web/app/api/host-connectors/events/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: Request) {
   ) {
     return Response.json(
       {
-        error: `This server requires the Host Connector protocol ${HOST_CONNECTOR_PROTOCOL_VERSION} agent-daemon wire shape.`,
+        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE}).`,
         code: "unsupported_connector_protocol",
         supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
         compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,7 +80,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.4.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.5.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -133,9 +133,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.4.0",
+            version: "0.5.0",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.4.0 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.5.0 | sh -s -- --upgrade",
           },
         },
       ],
@@ -148,14 +148,14 @@ describe("Host Connectors route", () => {
         id: "current",
         name: "Current",
         managed: false,
-        version: "0.4.0",
+        version: "0.5.0",
         lastSeenAt: null,
       },
       {
         id: "newer",
         name: "Newer",
         managed: false,
-        version: "0.5.0",
+        version: "0.6.0",
         lastSeenAt: null,
       },
     ]);

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -21,7 +21,10 @@ import { SidebarConnections } from "@/components/SidebarConnections";
 import { useSidebar } from "@/components/sidebar-context";
 import { useChats } from "@/lib/queries/chats";
 import { useProjects } from "@/lib/queries/projects";
-import { useAgentConnections } from "@/lib/queries/agentConnections";
+import {
+  useAgentConnectionRuntimeStatuses,
+  useAgentConnections,
+} from "@/lib/queries/agentConnections";
 import { LinkPendingIndicator } from "@/components/ui/link-pending-indicator";
 import { cn } from "@/lib/utils";
 
@@ -149,6 +152,7 @@ export function SidebarClient({ isAdmin }: { isAdmin: boolean }) {
 
 function AdminConnections() {
   const { data: connections = [] } = useAgentConnections();
+  useAgentConnectionRuntimeStatuses(connections);
   const { closeMobile } = useSidebar();
 
   return (

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -22,7 +22,7 @@ import { useSidebar } from "@/components/sidebar-context";
 import { useChats } from "@/lib/queries/chats";
 import { useProjects } from "@/lib/queries/projects";
 import {
-  useAgentConnectionRuntimeStatuses,
+  useAgentConnectionSessionDirectory,
   useAgentConnections,
 } from "@/lib/queries/agentConnections";
 import { LinkPendingIndicator } from "@/components/ui/link-pending-indicator";
@@ -152,7 +152,7 @@ export function SidebarClient({ isAdmin }: { isAdmin: boolean }) {
 
 function AdminConnections() {
   const { data: connections = [] } = useAgentConnections();
-  useAgentConnectionRuntimeStatuses(connections);
+  useAgentConnectionSessionDirectory(connections);
   const { closeMobile } = useSidebar();
 
   return (

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -641,11 +641,13 @@ test("shows durable turn activity without changing completed tool status", async
     const sources: FakeEventSource[] = [];
     let online = true;
     class FakeEventSource extends EventTarget {
+      readonly url: string;
       onopen: ((event: Event) => void) | null = null;
       onerror: ((event: Event) => void) | null = null;
 
-      constructor() {
+      constructor(url: string | URL) {
         super();
+        this.url = String(url);
         sources.push(this);
         window.setTimeout(() => {
           if (online && sources.includes(this)) {
@@ -659,10 +661,16 @@ test("shows durable turn activity without changing completed tool status", async
         if (index >= 0) sources.splice(index, 1);
       }
     }
+    const runtimeSources = () =>
+      sources.filter(
+        (source) =>
+          source.url.includes("/api/agent-sessions/") &&
+          source.url.includes("/events"),
+      );
 
     const controls: RuntimeControls = {
       emit(envelope) {
-        for (const source of sources) {
+        for (const source of runtimeSources()) {
           source.dispatchEvent(
             new MessageEvent("runtime", {
               data: JSON.stringify(envelope),
@@ -673,19 +681,19 @@ test("shows durable turn activity without changing completed tool status", async
       async disconnect() {
         online = false;
         await setRuntimeAvailable(false);
-        for (const source of [...sources]) {
+        for (const source of runtimeSources()) {
           source.onerror?.(new Event("error"));
         }
       },
       async reconnect() {
         await setRuntimeAvailable(true);
         online = true;
-        for (const source of [...sources]) {
+        for (const source of runtimeSources()) {
           source.onopen?.(new Event("open"));
         }
       },
       connected() {
-        return sources.length > 0;
+        return runtimeSources().length > 0;
       },
     };
     Object.assign(window, {

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -62,6 +62,50 @@ function response(
 }
 
 describe("host connector daemon broker", () => {
+  it("projects provider-independent status without a detail subscription", async () => {
+    const listener = vi.fn();
+    const broker = new HostConnectorBroker(0);
+    const unsubscribe = broker.subscribeSessionStatuses(["session"], listener);
+    const disconnect = broker.register(
+      "connector",
+      ["session"],
+      vi.fn(),
+      ["session-status-v1"],
+    );
+
+    expect(listener).toHaveBeenCalledWith("session", "idle");
+    await broker.acceptBatch("connector", "daemon-epoch", [
+      {
+        sequence: 1,
+        payload: {
+          type: "session_status",
+          sessionId: "session",
+          status: "running",
+        },
+      },
+    ]);
+
+    expect(broker.runtimeStatusForSession("session")).toBe("running");
+    expect(listener).toHaveBeenLastCalledWith("session", "running");
+    disconnect();
+    await vi.waitFor(() => {
+      expect(broker.runtimeStatusForSession("session")).toBe("exited");
+    });
+    expect(listener).toHaveBeenLastCalledWith("session", "exited");
+    unsubscribe();
+    await broker.acceptBatch("connector", "daemon-epoch", [
+      {
+        sequence: 2,
+        payload: {
+          type: "session_status",
+          sessionId: "session",
+          status: "idle",
+        },
+      },
+    ]);
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
   it("starts an exact connection epoch and resolves agent-level requests", async () => {
     const commands: HostConnectorCommand[] = [];
     const broker = new HostConnectorBroker();

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -62,44 +62,54 @@ function response(
 }
 
 describe("host connector daemon broker", () => {
-  it("projects provider-independent status without a detail subscription", async () => {
+  it("projects the global session directory without a detail subscription", async () => {
     const listener = vi.fn();
     const broker = new HostConnectorBroker(0);
-    const unsubscribe = broker.subscribeSessionStatuses(["session"], listener);
+    const unsubscribe = broker.subscribeSessionDirectory(["session"], listener);
     const disconnect = broker.register(
       "connector",
       ["session"],
       vi.fn(),
-      ["session-status-v1"],
     );
 
-    expect(listener).toHaveBeenCalledWith("session", "idle");
+    expect(listener).toHaveBeenCalledWith({
+      type: "snapshot",
+      sessions: [{ sessionId: "session", runtimeStatus: "idle" }],
+    });
     await broker.acceptBatch("connector", "daemon-epoch", [
       {
         sequence: 1,
         payload: {
-          type: "session_status",
-          sessionId: "session",
-          status: "running",
+          type: "session_directory",
+          sessions: [
+            { sessionId: "session", runtimeStatus: "running" },
+            { sessionId: "unowned", runtimeStatus: "running" },
+          ],
         },
       },
     ]);
 
     expect(broker.runtimeStatusForSession("session")).toBe("running");
-    expect(listener).toHaveBeenLastCalledWith("session", "running");
+    expect(broker.runtimeStatusForSession("unowned")).toBe("idle");
+    expect(listener).toHaveBeenLastCalledWith({
+      type: "update",
+      session: { sessionId: "session", runtimeStatus: "running" },
+    });
     disconnect();
     await vi.waitFor(() => {
       expect(broker.runtimeStatusForSession("session")).toBe("exited");
     });
-    expect(listener).toHaveBeenLastCalledWith("session", "exited");
+    expect(listener).toHaveBeenLastCalledWith({
+      type: "update",
+      session: { sessionId: "session", runtimeStatus: "exited" },
+    });
     unsubscribe();
     await broker.acceptBatch("connector", "daemon-epoch", [
       {
         sequence: 2,
         payload: {
-          type: "session_status",
-          sessionId: "session",
-          status: "idle",
+          type: "session_update",
+          session: { sessionId: "session", runtimeStatus: "idle" },
         },
       },
     ]);
@@ -688,7 +698,6 @@ describe("host connector daemon broker", () => {
     const subscription = await subscribed;
     expect(subscription.sync).toEqual(initialSync);
     expect(subscription.authoritative).toBe(true);
-    expect(broker.runtimeStatusForSession("session")).toBe("running");
     broker.replaceSessionProviderSession("connector", "session", {
       providerSessionId: "edited-thread",
       providerSessionPath: "/edited-thread.jsonl",
@@ -768,7 +777,6 @@ describe("host connector daemon broker", () => {
     ]);
     await vi.waitFor(() => expect(synchronize).toHaveBeenCalledWith(reconnectSync));
     expect(order).toEqual(["sync:7", "runtime:8"]);
-    expect(broker.runtimeStatusForSession("session")).toBe("exited");
     subscription.unsubscribe();
   });
 

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -54,11 +54,18 @@ type SessionSubscription = {
   replayBuffer: AgentRuntimeEnvelope[] | null;
 };
 
+type SessionStatusSubscription = {
+  sessionIds: Set<string>;
+  subscriber: (sessionId: string, status: AgentRuntimeStatus) => void;
+};
+
 export class HostConnectorBroker {
   private readonly channels = new Map<string, Channel>();
   private readonly pending = new Map<string, PendingRequest>();
   private readonly subscriptions = new Map<string, SessionSubscription>();
   private readonly sessionStatuses = new Map<string, AgentRuntimeStatus>();
+  private readonly sessionConnectorIds = new Map<string, string>();
+  private readonly statusSubscriptions = new Set<SessionStatusSubscription>();
   private readonly disconnectTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(
@@ -71,6 +78,23 @@ export class HostConnectorBroker {
 
   runtimeStatusForSession(sessionId: string): AgentRuntimeStatus {
     return this.sessionStatuses.get(sessionId) ?? "idle";
+  }
+
+  subscribeSessionStatuses(
+    sessionIds: Iterable<string>,
+    subscriber: (sessionId: string, status: AgentRuntimeStatus) => void,
+  ): () => void {
+    const subscription = {
+      sessionIds: new Set(sessionIds),
+      subscriber,
+    };
+    this.statusSubscriptions.add(subscription);
+    for (const sessionId of subscription.sessionIds) {
+      subscriber(sessionId, this.runtimeStatusForSession(sessionId));
+    }
+    return () => {
+      this.statusSubscriptions.delete(subscription);
+    };
   }
 
   replaceSessionProviderSession(
@@ -108,6 +132,9 @@ export class HostConnectorBroker {
     );
     const channel = { send, capabilities };
     this.channels.set(connectorId, channel);
+    for (const sessionId of activeSessionIds) {
+      this.sessionConnectorIds.set(sessionId, connectorId);
+    }
     send({
       type: "sync",
       connectionEpoch: crypto.randomUUID(),
@@ -262,7 +289,7 @@ export class HostConnectorBroker {
       sync = this.readSessionSync(connectorId, session, after, result?.sync);
       if (sync) {
         subscription.after = sync.cursor;
-        this.projectSessionSyncStatus(session.sessionId, sync);
+        this.projectSessionSyncStatus(connectorId, session.sessionId, sync);
       }
       subscription.initialized = true;
     } catch (error) {
@@ -329,6 +356,10 @@ export class HostConnectorBroker {
       this.pending.delete(event.requestId);
       if (event.success) pending.resolve(event.data);
       else pending.reject(new Error(event.error));
+      return;
+    }
+    if (event.type === "session_status") {
+      this.setSessionStatus(connectorId, event.sessionId, event.status);
       return;
     }
     if (event.type === "session_metadata") {
@@ -402,7 +433,11 @@ export class HostConnectorBroker {
           );
           if (sync) {
             subscription.after = sync.cursor;
-            this.projectSessionSyncStatus(subscription.session.sessionId, sync);
+            this.projectSessionSyncStatus(
+              connectorId,
+              subscription.session.sessionId,
+              sync,
+            );
             subscription.synchronize(sync);
           }
           subscription.replayBuffer = null;
@@ -456,37 +491,59 @@ export class HostConnectorBroker {
         sequence: envelope.sequence,
       };
     }
-    this.projectEnvelopeStatus(subscription.session.sessionId, envelope);
+    this.projectEnvelopeStatus(
+      subscription.connectorId,
+      subscription.session.sessionId,
+      envelope,
+    );
     subscription.subscriber(envelope);
   }
 
   private projectSessionSyncStatus(
+    connectorId: string,
     sessionId: string,
     sync: AgentSessionSync,
   ): void {
     if (sync.reset) {
-      this.sessionStatuses.set(sessionId, sync.snapshot.status);
+      this.setSessionStatus(connectorId, sessionId, sync.snapshot.status);
       return;
     }
     for (const envelope of sync.events) {
-      this.projectEnvelopeStatus(sessionId, envelope);
+      this.projectEnvelopeStatus(connectorId, sessionId, envelope);
     }
   }
 
   private projectEnvelopeStatus(
+    connectorId: string,
     sessionId: string,
     envelope: AgentRuntimeEnvelope,
   ): void {
     if (envelope.type === "snapshot") {
-      this.sessionStatuses.set(sessionId, envelope.data.status);
+      this.setSessionStatus(connectorId, sessionId, envelope.data.status);
     } else if (
       envelope.data.type === "overtchat_status" &&
       ["idle", "running", "exited"].includes(String(envelope.data.status))
     ) {
-      this.sessionStatuses.set(
+      this.setSessionStatus(
+        connectorId,
         sessionId,
         envelope.data.status as AgentRuntimeStatus,
       );
+    }
+  }
+
+  private setSessionStatus(
+    connectorId: string,
+    sessionId: string,
+    status: AgentRuntimeStatus,
+  ): void {
+    this.sessionConnectorIds.set(sessionId, connectorId);
+    if (this.sessionStatuses.get(sessionId) === status) return;
+    this.sessionStatuses.set(sessionId, status);
+    for (const subscription of this.statusSubscriptions) {
+      if (subscription.sessionIds.has(sessionId)) {
+        subscription.subscriber(sessionId, status);
+      }
     }
   }
 
@@ -583,6 +640,10 @@ export class HostConnectorBroker {
         if (subscription.connectorId !== connectorId) continue;
         this.subscriptions.delete(subscriptionId);
         subscription.disconnect(error);
+      }
+      for (const [sessionId, ownerConnectorId] of this.sessionConnectorIds) {
+        if (ownerConnectorId !== connectorId) continue;
+        this.setSessionStatus(connectorId, sessionId, "exited");
       }
     }, this.disconnectGraceMs);
     timer.unref();

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -7,8 +7,8 @@ import {
   type AgentDaemonRequest,
   type AgentDaemonSessionDescriptor,
   type AgentRuntimeEnvelope,
+  type AgentSessionDirectoryEntry,
   type AgentSessionSync,
-  type AgentRuntimeStatus,
   type ConnectorSshHost,
   type HostConnectorCommand,
   type HostConnectorCapability,
@@ -24,6 +24,7 @@ const CONNECTOR_DISCONNECT_GRACE_MS = 5_000;
 type Channel = {
   send: (command: HostConnectorCommand) => void;
   capabilities: Set<HostConnectorCapability>;
+  sessionIds: Set<string>;
 };
 
 type PendingRequest = {
@@ -42,6 +43,20 @@ function isLedgerProtectedCommand(request: AgentDaemonRequest): boolean {
   );
 }
 
+function sessionIdForRequest(request: AgentDaemonRequest): string | undefined {
+  switch (request.type) {
+    case "create_session":
+    case "stop_session":
+      return request.sessionId;
+    case "open_session":
+    case "session_command":
+    case "subscribe_session":
+      return request.session.sessionId;
+    default:
+      return undefined;
+  }
+}
+
 type SessionSubscription = {
   connectorId: string;
   session: AgentDaemonSessionDescriptor;
@@ -54,18 +69,25 @@ type SessionSubscription = {
   replayBuffer: AgentRuntimeEnvelope[] | null;
 };
 
-type SessionStatusSubscription = {
+export type AgentSessionDirectoryEvent =
+  | { type: "snapshot"; sessions: AgentSessionDirectoryEntry[] }
+  | { type: "update"; session: AgentSessionDirectoryEntry };
+
+type SessionDirectorySubscription = {
   sessionIds: Set<string>;
-  subscriber: (sessionId: string, status: AgentRuntimeStatus) => void;
+  subscriber: (event: AgentSessionDirectoryEvent) => void;
 };
 
 export class HostConnectorBroker {
   private readonly channels = new Map<string, Channel>();
   private readonly pending = new Map<string, PendingRequest>();
   private readonly subscriptions = new Map<string, SessionSubscription>();
-  private readonly sessionStatuses = new Map<string, AgentRuntimeStatus>();
-  private readonly sessionConnectorIds = new Map<string, string>();
-  private readonly statusSubscriptions = new Set<SessionStatusSubscription>();
+  private readonly sessionDirectory = new Map<
+    string,
+    { connectorId: string; session: AgentSessionDirectoryEntry }
+  >();
+  private readonly directorySubscriptions =
+    new Set<SessionDirectorySubscription>();
   private readonly disconnectTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(
@@ -76,24 +98,32 @@ export class HostConnectorBroker {
     return this.channels.has(connectorId);
   }
 
-  runtimeStatusForSession(sessionId: string): AgentRuntimeStatus {
-    return this.sessionStatuses.get(sessionId) ?? "idle";
+  runtimeStatusForSession(
+    sessionId: string,
+  ): AgentSessionDirectoryEntry["runtimeStatus"] {
+    return (
+      this.sessionDirectory.get(sessionId)?.session.runtimeStatus ?? "idle"
+    );
   }
 
-  subscribeSessionStatuses(
+  subscribeSessionDirectory(
     sessionIds: Iterable<string>,
-    subscriber: (sessionId: string, status: AgentRuntimeStatus) => void,
+    subscriber: (event: AgentSessionDirectoryEvent) => void,
   ): () => void {
     const subscription = {
       sessionIds: new Set(sessionIds),
       subscriber,
     };
-    this.statusSubscriptions.add(subscription);
-    for (const sessionId of subscription.sessionIds) {
-      subscriber(sessionId, this.runtimeStatusForSession(sessionId));
-    }
+    this.directorySubscriptions.add(subscription);
+    subscriber({
+      type: "snapshot",
+      sessions: [...subscription.sessionIds].map((sessionId) => ({
+        sessionId,
+        runtimeStatus: this.runtimeStatusForSession(sessionId),
+      })),
+    });
     return () => {
-      this.statusSubscriptions.delete(subscription);
+      this.directorySubscriptions.delete(subscription);
     };
   }
 
@@ -130,10 +160,17 @@ export class HostConnectorBroker {
     const capabilities = new Set(
       connectorCapabilities.filter((capability) => supported.has(capability)),
     );
-    const channel = { send, capabilities };
+    const sessionIds = new Set(activeSessionIds);
+    const channel = { send, capabilities, sessionIds };
     this.channels.set(connectorId, channel);
-    for (const sessionId of activeSessionIds) {
-      this.sessionConnectorIds.set(sessionId, connectorId);
+    for (const sessionId of sessionIds) {
+      const current = this.sessionDirectory.get(sessionId);
+      if (!current || current.connectorId !== connectorId) {
+        this.sessionDirectory.set(sessionId, {
+          connectorId,
+          session: { sessionId, runtimeStatus: "idle" },
+        });
+      }
     }
     send({
       type: "sync",
@@ -164,6 +201,8 @@ export class HostConnectorBroker {
       );
     }
     const requestId = crypto.randomUUID();
+    const sessionId = sessionIdForRequest(request);
+    if (sessionId) channel.sessionIds.add(sessionId);
     const replaySafe =
       isLedgerProtectedCommand(request) &&
       channel.capabilities.has("command-wal-v1");
@@ -287,10 +326,7 @@ export class HostConnectorBroker {
         );
       }
       sync = this.readSessionSync(connectorId, session, after, result?.sync);
-      if (sync) {
-        subscription.after = sync.cursor;
-        this.projectSessionSyncStatus(connectorId, session.sessionId, sync);
-      }
+      if (sync) subscription.after = sync.cursor;
       subscription.initialized = true;
     } catch (error) {
       if (this.subscriptions.get(subscriptionId) === subscription) {
@@ -358,8 +394,12 @@ export class HostConnectorBroker {
       else pending.reject(new Error(event.error));
       return;
     }
-    if (event.type === "session_status") {
-      this.setSessionStatus(connectorId, event.sessionId, event.status);
+    if (event.type === "session_directory") {
+      this.acceptSessionDirectory(connectorId, event.sessions);
+      return;
+    }
+    if (event.type === "session_update") {
+      this.acceptSessionDirectory(connectorId, [event.session]);
       return;
     }
     if (event.type === "session_metadata") {
@@ -433,11 +473,6 @@ export class HostConnectorBroker {
           );
           if (sync) {
             subscription.after = sync.cursor;
-            this.projectSessionSyncStatus(
-              connectorId,
-              subscription.session.sessionId,
-              sync,
-            );
             subscription.synchronize(sync);
           }
           subscription.replayBuffer = null;
@@ -491,58 +526,36 @@ export class HostConnectorBroker {
         sequence: envelope.sequence,
       };
     }
-    this.projectEnvelopeStatus(
-      subscription.connectorId,
-      subscription.session.sessionId,
-      envelope,
-    );
     subscription.subscriber(envelope);
   }
 
-  private projectSessionSyncStatus(
+  private acceptSessionDirectory(
     connectorId: string,
-    sessionId: string,
-    sync: AgentSessionSync,
+    sessions: readonly AgentSessionDirectoryEntry[],
   ): void {
-    if (sync.reset) {
-      this.setSessionStatus(connectorId, sessionId, sync.snapshot.status);
+    const channel = this.channels.get(connectorId);
+    if (!channel) return;
+    for (const session of sessions) {
+      if (!channel.sessionIds.has(session.sessionId)) continue;
+      this.upsertSessionDirectory(connectorId, session);
+    }
+  }
+
+  private upsertSessionDirectory(
+    connectorId: string,
+    session: AgentSessionDirectoryEntry,
+  ): void {
+    const current = this.sessionDirectory.get(session.sessionId);
+    if (
+      current?.connectorId === connectorId &&
+      current.session.runtimeStatus === session.runtimeStatus
+    ) {
       return;
     }
-    for (const envelope of sync.events) {
-      this.projectEnvelopeStatus(connectorId, sessionId, envelope);
-    }
-  }
-
-  private projectEnvelopeStatus(
-    connectorId: string,
-    sessionId: string,
-    envelope: AgentRuntimeEnvelope,
-  ): void {
-    if (envelope.type === "snapshot") {
-      this.setSessionStatus(connectorId, sessionId, envelope.data.status);
-    } else if (
-      envelope.data.type === "overtchat_status" &&
-      ["idle", "running", "exited"].includes(String(envelope.data.status))
-    ) {
-      this.setSessionStatus(
-        connectorId,
-        sessionId,
-        envelope.data.status as AgentRuntimeStatus,
-      );
-    }
-  }
-
-  private setSessionStatus(
-    connectorId: string,
-    sessionId: string,
-    status: AgentRuntimeStatus,
-  ): void {
-    this.sessionConnectorIds.set(sessionId, connectorId);
-    if (this.sessionStatuses.get(sessionId) === status) return;
-    this.sessionStatuses.set(sessionId, status);
-    for (const subscription of this.statusSubscriptions) {
-      if (subscription.sessionIds.has(sessionId)) {
-        subscription.subscriber(sessionId, status);
+    this.sessionDirectory.set(session.sessionId, { connectorId, session });
+    for (const subscription of this.directorySubscriptions) {
+      if (subscription.sessionIds.has(session.sessionId)) {
+        subscription.subscriber({ type: "update", session });
       }
     }
   }
@@ -641,9 +654,12 @@ export class HostConnectorBroker {
         this.subscriptions.delete(subscriptionId);
         subscription.disconnect(error);
       }
-      for (const [sessionId, ownerConnectorId] of this.sessionConnectorIds) {
-        if (ownerConnectorId !== connectorId) continue;
-        this.setSessionStatus(connectorId, sessionId, "exited");
+      for (const entry of this.sessionDirectory.values()) {
+        if (entry.connectorId !== connectorId) continue;
+        this.upsertSessionDirectory(connectorId, {
+          ...entry.session,
+          runtimeStatus: "exited",
+        });
       }
     }, this.disconnectGraceMs);
     timer.unref();

--- a/apps/web/lib/agents/connector/directory.test.ts
+++ b/apps/web/lib/agents/connector/directory.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/lib/agents/connector/broker", () => ({
   },
 }));
 
-import { withAgentRuntimeStatuses } from "./status";
+import { withConnectorSessionDirectory } from "./directory";
 
 const connections: AgentConnectionListItem[] = [
   {
@@ -50,14 +50,14 @@ const connections: AgentConnectionListItem[] = [
   },
 ];
 
-describe("agent connection runtime statuses", () => {
+describe("connector session directory", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.runtimeStatusForSession.mockReturnValue("running");
   });
 
   it("overlays connector-projected status without mutating database data", () => {
-    const result = withAgentRuntimeStatuses(connections);
+    const result = withConnectorSessionDirectory(connections);
 
     expect(result[0]!.workspaces[0]!.sessions[0]!.runtimeStatus).toBe(
       "running",

--- a/apps/web/lib/agents/connector/directory.ts
+++ b/apps/web/lib/agents/connector/directory.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { AgentConnectionListItem } from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "./broker";
 
-export function withAgentRuntimeStatuses(
+export function withConnectorSessionDirectory(
   connections: AgentConnectionListItem[],
 ): AgentConnectionListItem[] {
   return connections.map((connection) => ({

--- a/apps/web/lib/agents/sidebar.test.ts
+++ b/apps/web/lib/agents/sidebar.test.ts
@@ -8,7 +8,7 @@ import {
   agentConnectionHasRunningSession,
   agentWorkspaceHasRunningSession,
   visibleAgentSessions,
-  withAgentSessionRuntimeStatus,
+  withAgentSessionDirectory,
 } from "./sidebar";
 
 function sessions(count: number): AgentSessionListItem[] {
@@ -111,18 +111,28 @@ describe("agent sessions in the sidebar", () => {
     };
 
     const connections = [connection];
-    const running = withAgentSessionRuntimeStatus(
-      connections,
-      "session-1",
-      "running",
-    );
+    const running = withAgentSessionDirectory(connections, [
+      { sessionId: "session-1", runtimeStatus: "running" },
+    ]);
     expect(running).not.toBe(connections);
     expect(running[0]!.workspaces[0]!.sessions[0]).toBe(all[0]);
     expect(running[0]!.workspaces[0]!.sessions[1]!.runtimeStatus).toBe(
       "running",
     );
     expect(
-      withAgentSessionRuntimeStatus(running, "missing", "idle"),
+      withAgentSessionDirectory(running, [
+        { sessionId: "missing", runtimeStatus: "idle" },
+      ]),
     ).toBe(running);
+
+    const snapshot = withAgentSessionDirectory(running, [
+      { sessionId: "session-0", runtimeStatus: "exited" },
+      { sessionId: "session-1", runtimeStatus: "idle" },
+    ]);
+    expect(
+      snapshot[0]!.workspaces[0]!.sessions.map(
+        (session) => session.runtimeStatus,
+      ),
+    ).toEqual(["exited", "idle"]);
   });
 });

--- a/apps/web/lib/agents/sidebar.test.ts
+++ b/apps/web/lib/agents/sidebar.test.ts
@@ -8,6 +8,7 @@ import {
   agentConnectionHasRunningSession,
   agentWorkspaceHasRunningSession,
   visibleAgentSessions,
+  withAgentSessionRuntimeStatus,
 } from "./sidebar";
 
 function sessions(count: number): AgentSessionListItem[] {
@@ -82,5 +83,46 @@ describe("agent sessions in the sidebar", () => {
       true,
     );
     expect(agentConnectionHasRunningSession(connection)).toBe(true);
+  });
+
+  it("projects live status into the matching session with structural sharing", () => {
+    const all = sessions(2);
+    const connection: AgentConnectionListItem = {
+      id: "connection",
+      provider: "codex",
+      executable: "codex",
+      detectedVersion: null,
+      lastValidatedAt: null,
+      host: {
+        id: "host",
+        connectorId: "connector",
+        name: "This machine",
+        transport: "local",
+        sshAlias: null,
+      },
+      workspaces: [
+        {
+          id: "workspace",
+          path: "/workspace",
+          name: "workspace",
+          sessions: all,
+        },
+      ],
+    };
+
+    const connections = [connection];
+    const running = withAgentSessionRuntimeStatus(
+      connections,
+      "session-1",
+      "running",
+    );
+    expect(running).not.toBe(connections);
+    expect(running[0]!.workspaces[0]!.sessions[0]).toBe(all[0]);
+    expect(running[0]!.workspaces[0]!.sessions[1]!.runtimeStatus).toBe(
+      "running",
+    );
+    expect(
+      withAgentSessionRuntimeStatus(running, "missing", "idle"),
+    ).toBe(running);
   });
 });

--- a/apps/web/lib/agents/sidebar.ts
+++ b/apps/web/lib/agents/sidebar.ts
@@ -1,5 +1,6 @@
 import type {
   AgentConnectionListItem,
+  AgentRuntimeStatus,
   AgentSessionListItem,
   AgentWorkspaceListItem,
 } from "@overtchat/agent-bridge";
@@ -22,6 +23,35 @@ export function agentConnectionHasRunningSession(
   connection: AgentConnectionListItem,
 ): boolean {
   return connection.workspaces.some(agentWorkspaceHasRunningSession);
+}
+
+export function withAgentSessionRuntimeStatus(
+  connections: AgentConnectionListItem[],
+  sessionId: string,
+  runtimeStatus: AgentRuntimeStatus,
+): AgentConnectionListItem[] {
+  let changed = false;
+  const next = connections.map((connection) => {
+    let connectionChanged = false;
+    const workspaces = connection.workspaces.map((workspace) => {
+      let workspaceChanged = false;
+      const sessions = workspace.sessions.map((session) => {
+        if (
+          session.id !== sessionId ||
+          session.runtimeStatus === runtimeStatus
+        ) {
+          return session;
+        }
+        changed = true;
+        connectionChanged = true;
+        workspaceChanged = true;
+        return { ...session, runtimeStatus };
+      });
+      return workspaceChanged ? { ...workspace, sessions } : workspace;
+    });
+    return connectionChanged ? { ...connection, workspaces } : connection;
+  });
+  return changed ? next : connections;
 }
 
 export function visibleAgentSessions(

--- a/apps/web/lib/agents/sidebar.ts
+++ b/apps/web/lib/agents/sidebar.ts
@@ -1,6 +1,6 @@
 import type {
   AgentConnectionListItem,
-  AgentRuntimeStatus,
+  AgentSessionDirectoryEntry,
   AgentSessionListItem,
   AgentWorkspaceListItem,
 } from "@overtchat/agent-bridge";
@@ -25,20 +25,23 @@ export function agentConnectionHasRunningSession(
   return connection.workspaces.some(agentWorkspaceHasRunningSession);
 }
 
-export function withAgentSessionRuntimeStatus(
+export function withAgentSessionDirectory(
   connections: AgentConnectionListItem[],
-  sessionId: string,
-  runtimeStatus: AgentRuntimeStatus,
+  sessions: readonly AgentSessionDirectoryEntry[],
 ): AgentConnectionListItem[] {
+  const runtimeStatuses = new Map(
+    sessions.map((session) => [session.sessionId, session.runtimeStatus]),
+  );
   let changed = false;
   const next = connections.map((connection) => {
     let connectionChanged = false;
     const workspaces = connection.workspaces.map((workspace) => {
       let workspaceChanged = false;
-      const sessions = workspace.sessions.map((session) => {
+      const workspaceSessions = workspace.sessions.map((session) => {
+        const runtimeStatus = runtimeStatuses.get(session.id);
         if (
-          session.id !== sessionId ||
-          session.runtimeStatus === runtimeStatus
+          runtimeStatus === undefined ||
+          runtimeStatus === session.runtimeStatus
         ) {
           return session;
         }
@@ -47,7 +50,9 @@ export function withAgentSessionRuntimeStatus(
         workspaceChanged = true;
         return { ...session, runtimeStatus };
       });
-      return workspaceChanged ? { ...workspace, sessions } : workspace;
+      return workspaceChanged
+        ? { ...workspace, sessions: workspaceSessions }
+        : workspace;
     });
     return connectionChanged ? { ...connection, workspaces } : connection;
   });

--- a/apps/web/lib/queries/agentConnections.test.tsx
+++ b/apps/web/lib/queries/agentConnections.test.tsx
@@ -5,7 +5,7 @@ import { parseHTML } from "linkedom";
 import type { AgentConnectionListItem } from "@overtchat/agent-bridge";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  useAgentConnectionRuntimeStatuses,
+  useAgentConnectionSessionDirectory,
   useAgentConnections,
 } from "./agentConnections";
 import { agentConnectionKeys } from "./keys";
@@ -77,11 +77,11 @@ class FakeEventSource {
 
 function Probe() {
   const query = useAgentConnections();
-  useAgentConnectionRuntimeStatuses(query.data ?? []);
+  useAgentConnectionSessionDirectory(query.data ?? []);
   return <div>{query.data?.[0]?.workspaces[0]?.sessions[0]?.runtimeStatus}</div>;
 }
 
-describe("agent connection runtime statuses", () => {
+describe("agent connection session directory", () => {
   let container: HTMLElement;
   let root: Root;
   let queryClient: QueryClient;
@@ -142,7 +142,7 @@ describe("agent connection runtime statuses", () => {
     originalGlobals.clear();
   });
 
-  it("updates idle and running sidebar state from the global status stream", async () => {
+  it("applies the global snapshot and later session upserts", async () => {
     await act(async () => {
       root.render(
         <QueryClientProvider client={queryClient}>
@@ -154,12 +154,25 @@ describe("agent connection runtime statuses", () => {
     expect(container.textContent).toBe("idle");
     expect(FakeEventSource.instances).toHaveLength(1);
     expect(FakeEventSource.instances[0]!.url).toBe(
-      "/api/agent-connections/statuses",
+      "/api/agent-connections/events",
     );
 
     await act(async () => {
       FakeEventSource.instances[0]!.emit(
-        "status",
+        "snapshot",
+        JSON.stringify({
+          sessions: [
+            { sessionId: "session", runtimeStatus: "exited" },
+          ],
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(container.textContent).toBe("exited");
+
+    await act(async () => {
+      FakeEventSource.instances[0]!.emit(
+        "update",
         JSON.stringify({
           sessionId: "session",
           runtimeStatus: "running",

--- a/apps/web/lib/queries/agentConnections.test.tsx
+++ b/apps/web/lib/queries/agentConnections.test.tsx
@@ -1,0 +1,178 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { parseHTML } from "linkedom";
+import type { AgentConnectionListItem } from "@overtchat/agent-bridge";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useAgentConnectionRuntimeStatuses,
+  useAgentConnections,
+} from "./agentConnections";
+import { agentConnectionKeys } from "./keys";
+
+const connections: AgentConnectionListItem[] = [
+  {
+    id: "connection",
+    provider: "codex",
+    executable: "codex",
+    detectedVersion: null,
+    lastValidatedAt: null,
+    host: {
+      id: "host",
+      connectorId: "connector",
+      name: "This machine",
+      transport: "local",
+      sshAlias: null,
+    },
+    workspaces: [
+      {
+        id: "workspace",
+        path: "/workspace",
+        name: "workspace",
+        sessions: [
+          {
+            id: "session",
+            providerSessionId: "provider-session",
+            name: "Session",
+            firstMessage: null,
+            messageCount: 0,
+            createdAt: null,
+            modifiedAt: null,
+            runtimeStatus: "idle",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+
+  readonly url: string;
+  private readonly listeners = new Map<string, Set<EventListener>>();
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string, data: string) {
+    const event = new MessageEvent(type, { data });
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  close = vi.fn();
+}
+
+function Probe() {
+  const query = useAgentConnections();
+  useAgentConnectionRuntimeStatuses(query.data ?? []);
+  return <div>{query.data?.[0]?.workspaces[0]?.sessions[0]?.runtimeStatus}</div>;
+}
+
+describe("agent connection runtime statuses", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let queryClient: QueryClient;
+  const originalGlobals = new Map<
+    PropertyKey,
+    PropertyDescriptor | undefined
+  >();
+
+  beforeEach(() => {
+    const { window } = parseHTML(
+      "<!doctype html><html><body><div id=\"root\"></div></body></html>",
+    );
+    for (const [key, value] of Object.entries({
+      window,
+      document: window.document,
+      navigator: window.navigator,
+      HTMLElement: window.HTMLElement,
+      Event: window.Event,
+      MessageEvent: window.MessageEvent,
+      EventSource: FakeEventSource,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    })) {
+      originalGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        writable: true,
+        value,
+      });
+    }
+    FakeEventSource.instances = [];
+    container = window.document.getElementById("root") as HTMLElement;
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { gcTime: Infinity, retry: false, staleTime: Infinity },
+      },
+    });
+    queryClient.setQueryData(agentConnectionKeys.list(), connections);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        Response.json({ connections }),
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    queryClient.clear();
+    vi.restoreAllMocks();
+    for (const [key, descriptor] of originalGlobals) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, key, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, key);
+      }
+    }
+    originalGlobals.clear();
+  });
+
+  it("updates idle and running sidebar state from the global status stream", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Probe />
+        </QueryClientProvider>,
+      );
+    });
+
+    expect(container.textContent).toBe("idle");
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]!.url).toBe(
+      "/api/agent-connections/statuses",
+    );
+
+    await act(async () => {
+      FakeEventSource.instances[0]!.emit(
+        "status",
+        JSON.stringify({
+          sessionId: "session",
+          runtimeStatus: "running",
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(container.textContent).toBe("running");
+    expect(
+      queryClient.getQueryData<AgentConnectionListItem[]>(
+        agentConnectionKeys.list(),
+      )?.[0]?.workspaces[0]?.sessions[0]?.runtimeStatus,
+    ).toBe("running");
+  });
+});

--- a/apps/web/lib/queries/agentConnections.ts
+++ b/apps/web/lib/queries/agentConnections.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   AddAgentWorkspaceInput,
@@ -9,6 +10,7 @@ import type {
   AgentDiscoveryTarget,
   AgentDirectoryListing,
   AgentReadyConnectionProbe,
+  AgentRuntimeStatus,
   AgentSshHostCandidate,
   AgentWorkspaceListItem,
   DetectedAgentInstallation,
@@ -16,7 +18,10 @@ import type {
   HostConnectorPairing,
 } from "@overtchat/agent-bridge";
 import { agentConnectionKeys } from "@/lib/queries/keys";
-import { agentConnectionHasRunningSession } from "@/lib/agents/sidebar";
+import {
+  agentConnectionHasRunningSession,
+  withAgentSessionRuntimeStatus,
+} from "@/lib/agents/sidebar";
 
 async function responseError(response: Response): Promise<Error> {
   const data = (await response.json().catch(() => null)) as {
@@ -43,6 +48,58 @@ export function useAgentConnections() {
         ? 2_000
         : false,
   });
+}
+
+export function useAgentConnectionRuntimeStatuses(
+  connections: AgentConnectionListItem[],
+) {
+  const queryClient = useQueryClient();
+  const sessionFingerprint = connections
+    .flatMap((connection) =>
+      connection.workspaces.flatMap((workspace) =>
+        workspace.sessions.map((session) => session.id),
+      ),
+    )
+    .sort()
+    .join("\n");
+
+  useEffect(() => {
+    if (!sessionFingerprint) return;
+    const source = new EventSource("/api/agent-connections/statuses");
+    const receiveStatus = (event: Event) => {
+      let value: unknown;
+      try {
+        value = JSON.parse((event as MessageEvent<string>).data);
+      } catch {
+        return;
+      }
+      if (!value || typeof value !== "object" || Array.isArray(value)) return;
+      const sessionId = Reflect.get(value, "sessionId");
+      const runtimeStatus = Reflect.get(value, "runtimeStatus");
+      if (
+        typeof sessionId !== "string" ||
+        !["idle", "running", "exited"].includes(String(runtimeStatus))
+      ) {
+        return;
+      }
+      queryClient.setQueryData<AgentConnectionListItem[]>(
+        agentConnectionKeys.list(),
+        (current) =>
+          current
+            ? withAgentSessionRuntimeStatus(
+                current,
+                sessionId,
+                runtimeStatus as AgentRuntimeStatus,
+              )
+            : current,
+      );
+    };
+    source.addEventListener("status", receiveStatus);
+    return () => {
+      source.removeEventListener("status", receiveStatus);
+      source.close();
+    };
+  }, [queryClient, sessionFingerprint]);
 }
 
 export function useHostConnectors() {

--- a/apps/web/lib/queries/agentConnections.ts
+++ b/apps/web/lib/queries/agentConnections.ts
@@ -10,17 +10,18 @@ import type {
   AgentDiscoveryTarget,
   AgentDirectoryListing,
   AgentReadyConnectionProbe,
-  AgentRuntimeStatus,
+  AgentSessionDirectoryEntry,
   AgentSshHostCandidate,
   AgentWorkspaceListItem,
   DetectedAgentInstallation,
   HostConnectorListItem,
   HostConnectorPairing,
 } from "@overtchat/agent-bridge";
+import { isAgentSessionDirectoryEntry } from "@overtchat/agent-bridge";
 import { agentConnectionKeys } from "@/lib/queries/keys";
 import {
   agentConnectionHasRunningSession,
-  withAgentSessionRuntimeStatus,
+  withAgentSessionDirectory,
 } from "@/lib/agents/sidebar";
 
 async function responseError(response: Response): Promise<Error> {
@@ -50,7 +51,7 @@ export function useAgentConnections() {
   });
 }
 
-export function useAgentConnectionRuntimeStatuses(
+export function useAgentConnectionSessionDirectory(
   connections: AgentConnectionListItem[],
 ) {
   const queryClient = useQueryClient();
@@ -65,38 +66,43 @@ export function useAgentConnectionRuntimeStatuses(
 
   useEffect(() => {
     if (!sessionFingerprint) return;
-    const source = new EventSource("/api/agent-connections/statuses");
-    const receiveStatus = (event: Event) => {
-      let value: unknown;
+    const source = new EventSource("/api/agent-connections/events");
+    const parseEvent = (event: Event): unknown => {
       try {
-        value = JSON.parse((event as MessageEvent<string>).data);
+        return JSON.parse((event as MessageEvent<string>).data);
       } catch {
-        return;
+        return null;
       }
-      if (!value || typeof value !== "object" || Array.isArray(value)) return;
-      const sessionId = Reflect.get(value, "sessionId");
-      const runtimeStatus = Reflect.get(value, "runtimeStatus");
-      if (
-        typeof sessionId !== "string" ||
-        !["idle", "running", "exited"].includes(String(runtimeStatus))
-      ) {
-        return;
-      }
+    };
+    const applySessions = (sessions: AgentSessionDirectoryEntry[]) => {
       queryClient.setQueryData<AgentConnectionListItem[]>(
         agentConnectionKeys.list(),
         (current) =>
-          current
-            ? withAgentSessionRuntimeStatus(
-                current,
-                sessionId,
-                runtimeStatus as AgentRuntimeStatus,
-              )
-            : current,
+          current ? withAgentSessionDirectory(current, sessions) : current,
       );
     };
-    source.addEventListener("status", receiveStatus);
+    const receiveSnapshot = (event: Event) => {
+      const value = parseEvent(event);
+      if (!value || typeof value !== "object" || Array.isArray(value)) return;
+      const sessions = Reflect.get(value, "sessions");
+      if (
+        !Array.isArray(sessions) ||
+        !sessions.every(isAgentSessionDirectoryEntry)
+      ) {
+        return;
+      }
+      applySessions(sessions);
+    };
+    const receiveUpdate = (event: Event) => {
+      const value = parseEvent(event);
+      if (!isAgentSessionDirectoryEntry(value)) return;
+      applySessions([value]);
+    };
+    source.addEventListener("snapshot", receiveSnapshot);
+    source.addEventListener("update", receiveUpdate);
     return () => {
-      source.removeEventListener("status", receiveStatus);
+      source.removeEventListener("snapshot", receiveSnapshot);
+      source.removeEventListener("update", receiveUpdate);
       source.close();
     };
   }, [queryClient, sessionFingerprint]);

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.1}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.2}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -53,6 +53,30 @@ npm run dev
 
 Open [http://localhost:4717](http://localhost:4717). Add `searxng` or `kokoro` to the Compose command when working on search or text-to-speech.
 
+For a complete managed build from the current worktree, including the Host
+Connector, run:
+
+```bash
+npm run dev -w apps/cli -- setup --development
+```
+
+This uses the same managed provisioning path as `overtchat setup`: the CLI
+requests connector credentials through the app's internal management endpoint
+and installs the user service. It does not create or consume a pairing code in
+Settings.
+
+To debug the connector TypeScript process after it has been provisioned, stop
+the installed service so the two processes do not compete for the same
+identity, then run the source process:
+
+```bash
+systemctl --user stop overtchat-connector.service
+npm run dev -w apps/connector
+```
+
+The source process reads `~/.config/overtchat/connector.json`; its `run`
+command does not accept `--server`. Restart the installed service when done.
+
 ## Deploying updates
 
 ```bash
@@ -63,8 +87,8 @@ This updates the management CLI, app image, selected local sidecars, and managed
 Agent Connector as one coordinated release. Database migrations run
 automatically when the app starts; the existing data mount is not replaced.
 
-Legacy manually paired connectors still update through the command shown in
-**Settings → Connections**.
+Running `overtchat setup` adopts an older manually paired connector, rotates
+its credentials, and brings it under managed updates.
 
 ## Manual Compose installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -4,6 +4,7 @@ import type {
   AgentProviderId,
   AgentRuntimeCursor,
   AgentRuntimeEnvelope,
+  AgentRuntimeStatus,
   AgentSessionSync,
   AgentSessionCommand,
   ConnectorShellMode,
@@ -29,6 +30,7 @@ export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 export const HOST_CONNECTOR_CAPABILITIES = [
   "session-sync-v1",
   "command-wal-v1",
+  "session-status-v1",
 ] as const;
 export type HostConnectorCapability =
   (typeof HOST_CONNECTOR_CAPABILITIES)[number];
@@ -155,6 +157,11 @@ export type HostConnectorEventPayload =
         messageCount?: number;
         providerModifiedAt?: number;
       };
+    }
+  | {
+      type: "session_status";
+      sessionId: string;
+      status: AgentRuntimeStatus;
     };
 
 export type HostConnectorEvent = {
@@ -489,6 +496,12 @@ export function isHostConnectorEvent(
       (payload.patch.providerModifiedAt === undefined ||
         (typeof payload.patch.providerModifiedAt === "number" &&
           Number.isFinite(payload.patch.providerModifiedAt)))
+    );
+  }
+  if (payload.type === "session_status") {
+    return (
+      isNonEmptyString(payload.sessionId) &&
+      ["idle", "running", "exited"].includes(String(payload.status))
     );
   }
   return false;

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -20,17 +20,16 @@ import {
 export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
 /**
  * Protocol 1 was accidentally reused for two incompatible connector designs.
- * Release 0.2.0 is the compatibility baseline for the current agent-daemon
+ * Release 0.5.0 is the compatibility baseline for the current agent-daemon
  * wire shape and remains stable even when the connector build version changes.
  */
-export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.2.0";
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.4.0";
+export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.5.0";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.5.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [
   "session-sync-v1",
   "command-wal-v1",
-  "session-status-v1",
 ] as const;
 export type HostConnectorCapability =
   (typeof HOST_CONNECTOR_CAPABILITIES)[number];
@@ -74,6 +73,11 @@ export type AgentDaemonSessionDescriptor = AgentDaemonWorkspaceDescriptor & {
   sessionId: string;
   providerSessionId: string;
   providerSessionPath: string;
+};
+
+export type AgentSessionDirectoryEntry = {
+  sessionId: string;
+  runtimeStatus: AgentRuntimeStatus;
 };
 
 export type AgentDaemonRequest =
@@ -158,11 +162,8 @@ export type HostConnectorEventPayload =
         providerModifiedAt?: number;
       };
     }
-  | {
-      type: "session_status";
-      sessionId: string;
-      status: AgentRuntimeStatus;
-    };
+  | { type: "session_directory"; sessions: AgentSessionDirectoryEntry[] }
+  | { type: "session_update"; session: AgentSessionDirectoryEntry };
 
 export type HostConnectorEvent = {
   sequence: number;
@@ -395,6 +396,16 @@ export function isAgentRuntimeEnvelope(
     : isNonEmptyString(value.data.type);
 }
 
+export function isAgentSessionDirectoryEntry(
+  value: unknown,
+): value is AgentSessionDirectoryEntry {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.sessionId) &&
+    ["idle", "running", "exited"].includes(String(value.runtimeStatus))
+  );
+}
+
 export function isAgentSessionSync(value: unknown): value is AgentSessionSync {
   if (
     !isRecord(value) ||
@@ -498,11 +509,16 @@ export function isHostConnectorEvent(
           Number.isFinite(payload.patch.providerModifiedAt)))
     );
   }
-  if (payload.type === "session_status") {
+  if (payload.type === "session_directory") {
     return (
-      isNonEmptyString(payload.sessionId) &&
-      ["idle", "running", "exited"].includes(String(payload.status))
+      Array.isArray(payload.sessions) &&
+      payload.sessions.every(isAgentSessionDirectoryEntry) &&
+      new Set(payload.sessions.map((session) => session.sessionId)).size ===
+        payload.sessions.length
     );
+  }
+  if (payload.type === "session_update") {
+    return isAgentSessionDirectoryEntry(payload.session);
   }
   return false;
 }

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./index";
 
 describe("Host Connector protocol compatibility", () => {
-  it("keeps the agent-daemon v1 compatibility token independent of builds", () => {
-    expect(HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE).toBe("0.2.0");
+  it("rejects connector builds from the previous v1 wire shape", () => {
+    expect(HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE).toBe("0.5.0");
   });
 
   it("selects known capabilities and ignores unknown additive tokens", () => {
@@ -45,24 +45,36 @@ describe("Host Connector protocol compatibility", () => {
     ).toBe(true);
   });
 
-  it("accepts provider-independent session status events", () => {
+  it("accepts a session-directory snapshot and provider-independent upserts", () => {
     expect(
       isHostConnectorEvent({
         sequence: 1,
         payload: {
-          type: "session_status",
-          sessionId: "session",
-          status: "running",
+          type: "session_directory",
+          sessions: [
+            { sessionId: "session", runtimeStatus: "running" },
+          ],
         },
       }),
     ).toBe(true);
     expect(
       isHostConnectorEvent({
-        sequence: 1,
+        sequence: 2,
         payload: {
-          type: "session_status",
-          sessionId: "session",
-          status: "working",
+          type: "session_update",
+          session: { sessionId: "session", runtimeStatus: "idle" },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isHostConnectorEvent({
+        sequence: 3,
+        payload: {
+          type: "session_directory",
+          sessions: [
+            { sessionId: "session", runtimeStatus: "idle" },
+            { sessionId: "session", runtimeStatus: "running" },
+          ],
         },
       }),
     ).toBe(false);

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -3,6 +3,7 @@ import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
   isHostConnectorCommand,
+  isHostConnectorEvent,
   parseHostConnectorCapabilities,
 } from "./index";
 
@@ -42,5 +43,28 @@ describe("Host Connector protocol compatibility", () => {
         activeSessionIds: [],
       }),
     ).toBe(true);
+  });
+
+  it("accepts provider-independent session status events", () => {
+    expect(
+      isHostConnectorEvent({
+        sequence: 1,
+        payload: {
+          type: "session_status",
+          sessionId: "session",
+          status: "running",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isHostConnectorEvent({
+        sequence: 1,
+        payload: {
+          type: "session_status",
+          sessionId: "session",
+          status: "working",
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.4.0"
+connector_version="0.5.0"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

- replace the one-off `session-status-v1` path with a lightweight connector-owned session runtime directory
- publish one complete `session_directory` snapshot when the connector synchronizes, followed by global `session_update` upserts as runtime state changes
- keep the per-session detail timeline separate from directory/list state, so sidebar activity no longer depends on an open detail stream
- expose the authorized directory to the browser as one SSE snapshot/update feed and project it into the Agent Connections query cache
- validate connector ownership before accepting directory entries and mark its sessions `exited` after a real disconnect
- advance the connector and v1 wire compatibility baseline to `0.5.0`; mismatched installs fail fast with an `overtchat update` instruction, and the CLI/manifest/installer pins move together

## Architecture

This follows Paseo's directory pattern at OvertChat's connector/server boundary: the runtime owner sends a current snapshot, then global upserts, while detail timeline subscriptions remain independent.

OvertChat's server still owns durable connection, workspace, and session metadata. The live directory intentionally carries only `sessionId + runtimeStatus`; this avoids duplicating Paseo's full daemon-owned agent model where OvertChat does not need it.

## Problem

The sidebar spinner read broker state that was primarily projected from per-session detail subscriptions. Background Codex, Pi, or OMP work could therefore remain `idle`, while leaving a detail view could strand a previous `running` value.

The provider adapters already normalize lifecycle signals into `idle | running | exited`. The connector now publishes that normalized projection globally, independent of which detail page is open.

## Compatibility and risk

This changes the connector wire shape intentionally instead of adding a status-specific compatibility capability. OvertChat's supported deployment updates the app and same-host connector together; either side rejects the previous v1 wire baseline before exchanging incompatible events and tells the operator to run `overtchat update`.

Existing session timeline synchronization and command write-ahead-log behavior are unchanged.

## Validation

- `npm test` — 737 tests passed; 4 configured integration tests skipped
- `npm run typecheck` — all 8 workspaces passed
- `npm run lint` — all configured workspace linters passed
- `git diff --check`
- legacy-name audit confirms `session-status-v1`, `session_status`, and the `/statuses` route are gone


## Release

- prepare OvertChat app `0.14.2`, management CLI `0.1.2`, and Host Connector `0.5.0` as one coordinated release
- enforce release-time agreement between the CLI constants, installer manifest, Compose app tag, and connector package version
