### PR TITLE
fix(release): publish app version 0.14.1

### DIFF
--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.1",
-  "appVersion": "0.14.0",
+  "appVersion": "0.14.1",
   "connectorVersion": "0.4.0",
   "sttVersion": "0.1.0"
 }


### PR DESCRIPTION
## Summary

- publish app version 0.14.1 through the managed-install manifest
- restore `overtchat update` discovery for the already-published 0.14.1 image

## Validation

- confirmed the manifest and `compose.yml` both resolve to 0.14.1
- `npm run test -w apps/site --` (19 tests passed)