### PR TITLE
fix(agents): use provider-defined Codex permission modes

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,6 +1,6 @@
-export const CLI_VERSION = "0.1.3";
-export const APP_VERSION = "0.14.2";
-export const CONNECTOR_VERSION = "0.5.0";
+export const CLI_VERSION = "0.1.4";
+export const APP_VERSION = "0.14.3";
+export const CONNECTOR_VERSION = "0.6.0";
 export const STT_VERSION = "0.1.1";
 
 export const APP_IMAGE = "ghcr.io/yoloyash/overtchat-app";

--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -136,7 +136,7 @@ describe.sequential("connector client compatibility", () => {
     expect(headers.get("x-overtchat-connector-version")).toBe(
       HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
     );
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.5.0");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.6.0");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -10,6 +10,7 @@
 /install/connector/0.3.4 https://github.com/yoloyash/overtchat/releases/download/connector-v0.3.4/install-connector.sh 302
 /install/connector/0.4.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.4.0/install-connector.sh 302
 /install/connector/0.5.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.5.0/install-connector.sh 302
+/install/connector/0.6.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.6.0/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.5.0 302
+/install-connector.sh /install/connector/0.6.0 302

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.3"
+cli_version="0.1.4"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
-  "cliVersion": "0.1.3",
-  "appVersion": "0.14.2",
-  "connectorVersion": "0.5.0",
+  "cliVersion": "0.1.4",
+  "appVersion": "0.14.3",
+  "connectorVersion": "0.6.0",
   "sttVersion": "0.1.1"
 }

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,7 +80,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.5.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.6.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -133,9 +133,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.5.0",
+            version: "0.6.0",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.5.0 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.6.0 | sh -s -- --upgrade",
           },
         },
       ],
@@ -148,14 +148,14 @@ describe("Host Connectors route", () => {
         id: "current",
         name: "Current",
         managed: false,
-        version: "0.5.0",
+        version: "0.6.0",
         lastSeenAt: null,
       },
       {
         id: "newer",
         name: "Newer",
         managed: false,
-        version: "0.6.0",
+        version: "0.7.0",
         lastSeenAt: null,
       },
     ]);

--- a/apps/web/components/agents/AgentComposerControls.tsx
+++ b/apps/web/components/agents/AgentComposerControls.tsx
@@ -10,7 +10,6 @@ import {
   ChevronDown,
   ChevronRight,
   ListTodo,
-  Shield,
   ShieldAlert,
   ShieldCheck,
   X,
@@ -19,8 +18,8 @@ import {
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import { Button } from "@/components/ui/button";
 import type {
-  AgentAccessMode,
   AgentCollaborationMode,
+  AgentMode,
   AgentModel,
   AgentThinkingLevel,
 } from "@overtchat/agent-bridge";
@@ -38,14 +37,14 @@ export interface AgentComposerControlsProps {
   collaborationModes: AgentCollaborationMode[];
   fastModeEnabled: boolean;
   fastModeAvailable: boolean;
-  accessMode: AgentAccessMode;
-  accessModes: AgentAccessMode[];
+  modeId: string;
+  modes: AgentMode[];
   disabled: boolean;
   onSelectModel: (model: AgentModel) => void;
   onSelectThinking: (level: AgentThinkingLevel) => void;
   onSelectCollaborationMode: (mode: AgentCollaborationMode) => void;
   onToggleFastMode: (enabled: boolean) => void;
-  onSelectAccessMode: (mode: AgentAccessMode) => void;
+  onSelectMode: (modeId: string) => void;
   onMenuOpenChange?: (open: boolean) => void;
 }
 
@@ -61,7 +60,7 @@ export function AgentComposerControls(props: AgentComposerControlsProps) {
     (props.thinkingLevels.length > 1 && props.thinkingLevel !== null);
   const hasControls =
     hasModelOrEffort ||
-    props.accessModes.length > 0 ||
+    props.modes.length > 0 ||
     props.collaborationMode === "plan" ||
     props.fastModeEnabled;
 
@@ -73,7 +72,7 @@ export function AgentComposerControls(props: AgentComposerControlsProps) {
       className="flex min-w-0 items-center gap-0.5"
     >
       {hasModelOrEffort && <ModelEffortControl {...props} />}
-      {props.accessModes.length > 0 && <AccessModeControl {...props} />}
+      {props.modes.length > 0 && <ModeControl {...props} />}
       {props.collaborationMode === "plan" && (
         <PlanModeControl
           disabled={props.disabled}
@@ -101,40 +100,20 @@ export function AgentComposerControls(props: AgentComposerControlsProps) {
   );
 }
 
-const accessModeMetadata: Record<
-  AgentAccessMode,
-  { label: string; description: string }
-> = {
-  inherit: {
-    label: "Codex default",
-    description: "Use the permissions from your Codex configuration",
-  },
-  default: {
-    label: "Default permissions",
-    description: "Workspace writes; ask before broader access",
-  },
-  "auto-review": {
-    label: "Auto-review",
-    description: "Codex reviews approval requests automatically",
-  },
-  "full-access": {
-    label: "Full access",
-    description: "No sandbox or approval prompts",
-  },
-};
-
-function AccessModeControl(props: AgentComposerControlsProps) {
+function ModeControl(props: AgentComposerControlsProps) {
   const [fullAccessOpen, setFullAccessOpen] = useState(false);
-  const selected = accessModeMetadata[props.accessMode];
-  const dangerous = props.accessMode === "full-access";
+  const selected =
+    props.modes.find((mode) => mode.id === props.modeId) ?? props.modes[0];
+  if (!selected) return null;
+  const dangerous = selected.dangerous === true;
 
-  function select(mode: AgentAccessMode) {
-    if (mode === props.accessMode) return;
-    if (mode === "full-access") {
+  function select(mode: AgentMode) {
+    if (mode.id === props.modeId) return;
+    if (mode.dangerous) {
       setFullAccessOpen(true);
       return;
     }
-    props.onSelectAccessMode(mode);
+    props.onSelectMode(mode.id);
   }
 
   return (
@@ -155,8 +134,6 @@ function AccessModeControl(props: AgentComposerControlsProps) {
         >
           {dangerous ? (
             <ShieldAlert className="size-3.5" />
-          ) : props.accessMode === "inherit" ? (
-            <Shield className="size-3.5" />
           ) : (
             <ShieldCheck className="size-3.5" />
           )}
@@ -172,12 +149,11 @@ function AccessModeControl(props: AgentComposerControlsProps) {
                 motionClasses.popup,
               )}
             >
-              {props.accessModes.map((mode) => {
-                const metadata = accessModeMetadata[mode];
-                const isDangerous = mode === "full-access";
+              {props.modes.map((mode) => {
+                const isDangerous = mode.dangerous === true;
                 return (
                   <Menu.Item
-                    key={mode}
+                    key={mode.id}
                     onClick={() => select(mode)}
                     className={cn(
                       choiceItemClassName,
@@ -187,19 +163,17 @@ function AccessModeControl(props: AgentComposerControlsProps) {
                   >
                     {isDangerous ? (
                       <ShieldAlert className="size-4 shrink-0" />
-                    ) : mode === "inherit" ? (
-                      <Shield className="size-4 shrink-0 text-muted-foreground" />
                     ) : (
                       <ShieldCheck className="size-4 shrink-0 text-muted-foreground" />
                     )}
                     <span className="min-w-0 flex-1">
-                      <span className="block font-medium">{metadata.label}</span>
+                      <span className="block font-medium">{mode.label}</span>
                       <span className="block text-xs text-muted-foreground">
-                        {metadata.description}
+                        {mode.description}
                       </span>
                     </span>
                     <span className="flex size-4 shrink-0 items-center justify-center">
-                      {mode === props.accessMode && (
+                      {mode.id === props.modeId && (
                         <Check className="size-3.5" />
                       )}
                     </span>
@@ -243,7 +217,10 @@ function AccessModeControl(props: AgentComposerControlsProps) {
                 size="sm"
                 onClick={() => {
                   setFullAccessOpen(false);
-                  props.onSelectAccessMode("full-access");
+                  const dangerousMode = props.modes.find(
+                    (mode) => mode.dangerous,
+                  );
+                  if (dangerousMode) props.onSelectMode(dangerousMode.id);
                 }}
               >
                 Enable Full access

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -17,9 +17,9 @@ import { SidebarToggle } from "@/components/SidebarToggle";
 import { toast } from "@/components/ui/toast";
 import { AGENT_GOAL_STATUSES } from "@overtchat/agent-bridge";
 import type {
-  AgentAccessMode,
   AgentCollaborationMode,
   AgentGoal,
+  AgentMode,
   AgentPromptImage,
   AgentProviderId,
   AgentRuntimeSnapshot,
@@ -98,25 +98,28 @@ function currentCollaborationMode(
   return snapshot.state.collaborationMode === "plan" ? "plan" : "default";
 }
 
-function accessModes(snapshot: AgentRuntimeSnapshot): AgentAccessMode[] {
-  const value = snapshot.state.accessModes;
+function agentModes(snapshot: AgentRuntimeSnapshot): AgentMode[] {
+  const value = snapshot.state.modes;
   if (!Array.isArray(value)) return [];
-  return value.filter(
-    (mode): mode is AgentAccessMode =>
-      mode === "inherit" ||
-      mode === "default" ||
-      mode === "auto-review" ||
-      mode === "full-access",
-  );
+  return value.flatMap((value) => {
+    const mode = recordOf(value);
+    return typeof mode?.id === "string" &&
+      typeof mode.label === "string" &&
+      typeof mode.description === "string"
+      ? [{
+          id: mode.id,
+          label: mode.label,
+          description: mode.description,
+          ...(mode.dangerous === true ? { dangerous: true } : {}),
+        }]
+      : [];
+  });
 }
 
-function currentAccessMode(snapshot: AgentRuntimeSnapshot): AgentAccessMode {
-  const mode = snapshot.state.accessMode;
-  return mode === "default" ||
-    mode === "auto-review" ||
-    mode === "full-access"
-    ? mode
-    : "inherit";
+function currentModeId(snapshot: AgentRuntimeSnapshot): string {
+  return typeof snapshot.state.modeId === "string"
+    ? snapshot.state.modeId
+    : "";
 }
 
 function currentGoal(snapshot: AgentRuntimeSnapshot): AgentGoal | null {
@@ -338,8 +341,8 @@ export function AgentSessionView({
   const collaborationMode = currentCollaborationMode(snapshot);
   const fastModeEnabled = snapshot.state.fastModeEnabled === true;
   const fastModeAvailable = snapshot.state.fastModeAvailable === true;
-  const availableAccessModes = accessModes(snapshot);
-  const accessMode = currentAccessMode(snapshot);
+  const availableModes = agentModes(snapshot);
+  const modeId = currentModeId(snapshot);
   const goal = currentGoal(snapshot);
   const runtimeError =
     snapshot.error ??
@@ -496,8 +499,8 @@ export function AgentSessionView({
               collaborationModes: availableCollaborationModes,
               fastModeEnabled,
               fastModeAvailable,
-              accessMode,
-              accessModes: availableAccessModes,
+              modeId,
+              modes: availableModes,
               disabled: controlsDisabled,
               onSelectModel: (selected) =>
                 void run({
@@ -511,8 +514,12 @@ export function AgentSessionView({
                 void run({ type: "set_collaboration_mode", mode }),
               onToggleFastMode: (enabled) =>
                 void run({ type: "set_fast_mode", enabled }),
-              onSelectAccessMode: (mode) =>
-                void run({ type: "set_access_mode", mode }),
+              onSelectMode: (selectedModeId) => {
+                if (running) {
+                  toast.success("Permission mode applies next turn");
+                }
+                void run({ type: "set_mode", modeId: selectedModeId });
+              },
               onMenuOpenChange: setComposerMenuOpen,
             }}
             contextUsage={snapshot.stats.contextUsage}

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -102,8 +102,25 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
       collaborationModes: ["default", "plan"],
       fastModeEnabled: false,
       fastModeAvailable: true,
-      accessMode: "inherit",
-      accessModes: ["inherit", "default", "auto-review", "full-access"],
+      modeId: "auto",
+      modes: [
+        {
+          id: "auto",
+          label: "Default Permissions",
+          description: "Edit files and run commands with Codex's default approval flow.",
+        },
+        {
+          id: "auto-review",
+          label: "Auto-review",
+          description: "Route eligible approvals through Codex's auto-reviewer.",
+        },
+        {
+          id: "full-access",
+          label: "Full Access",
+          description: "Run without additional prompts.",
+          dangerous: true,
+        },
+      ],
       goalsSupported: true,
       goal: {
         objective: "Finish Codex parity",
@@ -486,8 +503,8 @@ test("shows durable turn activity without changing completed tool status", async
         if (command.type === "set_fast_mode") {
           snapshot.state.fastModeEnabled = command.enabled;
         }
-        if (command.type === "set_access_mode") {
-          snapshot.state.accessMode = command.mode;
+        if (command.type === "set_mode") {
+          snapshot.state.modeId = command.modeId;
         }
         if (command.type === "update_goal") {
           if (command.action === "clear") {
@@ -746,20 +763,21 @@ test("shows durable turn activity without changing completed tool status", async
     agentComposer.getByRole("button", { name: "Fast", exact: true }),
   ).toHaveCount(0);
   const permissionsControl = agentComposer.getByRole("button", {
-    name: "Permissions: Codex default",
+    name: "Permissions: Default Permissions",
   });
   await expect(permissionsControl).toBeEnabled();
   await permissionsControl.click();
   await page
     .getByRole("menu", { name: "Permissions" })
-    .getByRole("menuitem", { name: /Default permissions/u })
+    .getByRole("menuitem", { name: /Auto-review/u })
     .click();
   await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
-    type: "set_access_mode",
-    mode: "default",
+    type: "set_mode",
+    modeId: "auto-review",
   });
+  await expect(page.getByText("Permission mode applies next turn")).toBeVisible();
   const defaultPermissionsControl = agentComposer.getByRole("button", {
-    name: "Permissions: Default permissions",
+    name: "Permissions: Auto-review",
   });
   await defaultPermissionsControl.click();
   await page
@@ -773,8 +791,8 @@ test("shows durable turn activity without changing completed tool status", async
     .getByRole("button", { name: "Enable Full access" })
     .click();
   await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
-    type: "set_access_mode",
-    mode: "full-access",
+    type: "set_mode",
+    modeId: "full-access",
   });
   await expect(
     agentComposer.getByRole("button", {
@@ -1261,8 +1279,25 @@ test("shows durable turn activity without changing completed tool status", async
         collaborationModes: ["default", "plan"],
         fastModeEnabled: false,
         fastModeAvailable: true,
-        accessMode: "default",
-        accessModes: ["inherit", "default", "auto-review", "full-access"],
+        modeId: "auto",
+        modes: [
+          {
+            id: "auto",
+            label: "Default Permissions",
+            description: "Use Codex's default approval flow.",
+          },
+          {
+            id: "auto-review",
+            label: "Auto-review",
+            description: "Route eligible approvals through Codex's auto-reviewer.",
+          },
+          {
+            id: "full-access",
+            label: "Full Access",
+            description: "Run without additional prompts.",
+            dangerous: true,
+          },
+        ],
       },
     });
   }, imageModel);

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -782,7 +782,7 @@ test("shows durable turn activity without changing completed tool status", async
   await defaultPermissionsControl.click();
   await page
     .getByRole("menu", { name: "Permissions" })
-    .getByRole("menuitem", { name: /Full access/u })
+    .getByRole("menuitem", { name: /Full Access/u })
     .click();
   const fullAccessDialog = page.getByRole("alertdialog", {
     name: "Enable Full access?",

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -414,7 +414,7 @@ export function useAgentSessionCommand(id: string) {
         command.type === "set_thinking_level" ||
         command.type === "set_collaboration_mode" ||
         command.type === "set_fast_mode" ||
-        command.type === "set_access_mode" ||
+        command.type === "set_mode" ||
         command.type === "update_goal" ||
         command.type === "implement_plan" ||
         command.type === "compact" ||

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.2}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.3}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },
@@ -68,7 +68,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -271,13 +271,12 @@ export const AGENT_COLLABORATION_MODES = ["default", "plan"] as const;
 export type AgentCollaborationMode =
   (typeof AGENT_COLLABORATION_MODES)[number];
 
-export const AGENT_ACCESS_MODES = [
-  "inherit",
-  "default",
-  "auto-review",
-  "full-access",
-] as const;
-export type AgentAccessMode = (typeof AGENT_ACCESS_MODES)[number];
+export type AgentMode = {
+  id: string;
+  label: string;
+  description: string;
+  dangerous?: boolean;
+};
 
 export const AGENT_GOAL_STATUSES = [
   "active",
@@ -365,8 +364,8 @@ export const agentSessionCommandSchema = z.discriminatedUnion("type", [
     enabled: z.boolean(),
   }),
   z.object({
-    type: z.literal("set_access_mode"),
-    mode: z.enum(AGENT_ACCESS_MODES),
+    type: z.literal("set_mode"),
+    modeId: z.string().trim().min(1).max(120),
   }),
   z.object({
     type: z.literal("update_goal"),

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -20,11 +20,11 @@ import {
 export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
 /**
  * Protocol 1 was accidentally reused for two incompatible connector designs.
- * Release 0.5.0 is the compatibility baseline for the current agent-daemon
+ * Release 0.6.0 is the compatibility baseline for the current agent-daemon
  * wire shape and remains stable even when the connector build version changes.
  */
-export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.5.0";
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.5.0";
+export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.6.0";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.6.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("Host Connector protocol compatibility", () => {
   it("rejects connector builds from the previous v1 wire shape", () => {
-    expect(HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE).toBe("0.5.0");
+    expect(HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE).toBe("0.6.0");
   });
 
   it("selects known capabilities and ignores unknown additive tokens", () => {

--- a/packages/agent-bridge/src/state.ts
+++ b/packages/agent-bridge/src/state.ts
@@ -525,11 +525,11 @@ export function applyAgentRuntimeEnvelope(
         ...(typeof event.fastModeAvailable === "boolean"
           ? { fastModeAvailable: event.fastModeAvailable }
           : {}),
-        ...(typeof event.accessMode === "string"
-          ? { accessMode: event.accessMode }
+        ...(typeof event.modeId === "string"
+          ? { modeId: event.modeId }
           : {}),
-        ...(Array.isArray(event.accessModes)
-          ? { accessModes: event.accessModes }
+        ...(Array.isArray(event.modes)
+          ? { modes: event.modes }
           : {}),
         ...(typeof event.goalsSupported === "boolean"
           ? { goalsSupported: event.goalsSupported }

--- a/packages/agent-runtime/src/codex/client.test.ts
+++ b/packages/agent-runtime/src/codex/client.test.ts
@@ -574,6 +574,85 @@ describe("CodexRuntimeClient", () => {
       .toMatchObject({ params: { model: "default-model" } });
   });
 
+  it.each([
+    {
+      source: "saved configuration",
+      savedConfig: { model: "gpt-5.6", modelReasoningEffort: "xhigh" },
+      config: { model_reasoning_effort: "high" },
+      expected: "xhigh",
+    },
+    {
+      source: "resolved configuration",
+      savedConfig: null,
+      config: { model: "gpt-5.6", model_reasoning_effort: "low" },
+      expected: "low",
+    },
+  ])("preserves reasoning from Codex $source", async ({
+    savedConfig,
+    config,
+    expected,
+  }) => {
+    server.savedConfig = savedConfig;
+    server.config = config;
+
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+
+    await expect(client.getState()).resolves.toMatchObject({
+      model: { provider: "codex", id: "gpt-5.6" },
+      thinkingLevel: expected,
+    });
+    await expect(client.getAvailableThinkingLevels()).resolves.toContain(
+      expected,
+    );
+    await client.prompt("Keep my configured reasoning");
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: { model: "gpt-5.6", effort: expected },
+    });
+  });
+
+  it("switches to the selected model's default reasoning", async () => {
+    server.models = [
+      {
+        id: "gpt-5.6",
+        displayName: "GPT-5.6",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low" },
+          { reasoningEffort: "high" },
+        ],
+        defaultReasoningEffort: "high",
+      },
+      {
+        id: "gpt-5.6-mini",
+        displayName: "GPT-5.6 Mini",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low" },
+          { reasoningEffort: "medium" },
+        ],
+        defaultReasoningEffort: "medium",
+      },
+    ];
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+
+    await client.setModel("codex", "gpt-5.6-mini");
+    await expect(client.getState()).resolves.toMatchObject({
+      model: { provider: "codex", id: "gpt-5.6-mini" },
+      thinkingLevel: "medium",
+    });
+    await client.prompt("Use the new model defaults");
+    expect(server.requests.at(-1)).toMatchObject({
+      method: "turn/start",
+      params: { model: "gpt-5.6-mini", effort: "medium" },
+    });
+  });
+
   it("supports native goals, Code/Plan modes, Fast turns, and access modes", async () => {
     server.goalSupported = true;
     server.threadAccess = {

--- a/packages/agent-runtime/src/codex/client.test.ts
+++ b/packages/agent-runtime/src/codex/client.test.ts
@@ -49,6 +49,8 @@ class FakeCodexServer {
   goal: Record<string, unknown> | null = null;
   threadAccess: Record<string, unknown> = {};
   config: Record<string, unknown> | null = null;
+  savedConfig: Record<string, unknown> | null = null;
+  models: Record<string, unknown>[] | null = null;
   readonly threadReads = new Map<string, Record<string, unknown>>();
   private notification: Listener<{ method: string; params?: unknown }> =
     () => {};
@@ -75,7 +77,7 @@ class FakeCodexServer {
     this.requests.push({ method, params });
     if (method === "model/list") {
       return {
-        data: [
+        data: this.models ?? [
           {
             id: "gpt-5.6",
             model: "gpt-5.6",
@@ -96,6 +98,9 @@ class FakeCodexServer {
     }
     if (method === "config/read") {
       return this.config ? { config: this.config } : {};
+    }
+    if (method === "getUserSavedConfig") {
+      return this.savedConfig ? { config: this.savedConfig } : {};
     }
     if (method === "thread/goal/get") {
       if (!this.goalSupported) throw new Error("Method not found");
@@ -381,6 +386,8 @@ describe("CodexRuntimeClient", () => {
     server.goal = null;
     server.threadAccess = {};
     server.config = null;
+    server.savedConfig = null;
+    server.models = null;
     server.threadReads.clear();
     server.respondError.mockClear();
     mocks.startCodexAppServer.mockResolvedValue(server);
@@ -537,6 +544,36 @@ describe("CodexRuntimeClient", () => {
     });
   });
 
+  it("starts new threads with the model from Codex saved configuration", async () => {
+    server.savedConfig = { model: "gpt-5.6-saved" };
+    server.config = { model: "gpt-5.6-config" };
+
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+
+    expect(server.requests.find((request) => request.method === "thread/start"))
+      .toMatchObject({ params: { model: "gpt-5.6-saved" } });
+  });
+
+  it("uses model/list isDefault when Codex has no configured model", async () => {
+    server.models = [
+      { id: "first-model", displayName: "First" },
+      { id: "default-model", displayName: "Default", isDefault: true },
+    ];
+
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+
+    expect(server.requests.find((request) => request.method === "thread/start"))
+      .toMatchObject({ params: { model: "default-model" } });
+  });
+
   it("supports native goals, Code/Plan modes, Fast turns, and access modes", async () => {
     server.goalSupported = true;
     server.threadAccess = {
@@ -572,8 +609,12 @@ describe("CodexRuntimeClient", () => {
       collaborationModes: ["default", "plan"],
       fastModeEnabled: false,
       fastModeAvailable: true,
-      accessMode: "inherit",
-      accessModes: ["inherit", "default", "auto-review", "full-access"],
+      modeId: "auto",
+      modes: [
+        expect.objectContaining({ id: "auto", label: "Default Permissions" }),
+        expect.objectContaining({ id: "auto-review", label: "Auto-review" }),
+        expect.objectContaining({ id: "full-access", label: "Full Access" }),
+      ],
       goalsSupported: true,
       goal: null,
     });
@@ -602,7 +643,7 @@ describe("CodexRuntimeClient", () => {
 
     await client.setCollaborationMode("plan");
     await client.setFastMode(true);
-    await client.setAccessMode("auto-review");
+    await client.setMode("auto-review");
     await expect(client.getCommands()).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -640,7 +681,7 @@ describe("CodexRuntimeClient", () => {
       },
     });
 
-    await client.setAccessMode("full-access");
+    await client.setMode("full-access");
     await client.prompt("Apply the approved change");
     expect(server.requests.at(-1)).toMatchObject({
       method: "turn/start",
@@ -651,14 +692,14 @@ describe("CodexRuntimeClient", () => {
       },
     });
 
-    await client.setAccessMode("inherit");
-    await client.prompt("Use my Codex defaults again");
+    await client.setMode("auto");
+    await client.prompt("Use default permissions again");
     expect(server.requests.at(-1)).toMatchObject({
       method: "turn/start",
       params: {
-        approvalPolicy: "untrusted",
+        approvalPolicy: "on-request",
         approvalsReviewer: "user",
-        sandboxPolicy: { type: "readOnly", networkAccess: false },
+        sandboxPolicy: expect.objectContaining({ type: "workspaceWrite" }),
       },
     });
 
@@ -698,9 +739,12 @@ describe("CodexRuntimeClient", () => {
     );
 
     await expect(client.getState()).resolves.toMatchObject({
-      accessModes: ["inherit", "default", "full-access"],
+      modes: [
+        expect.objectContaining({ id: "auto" }),
+        expect.objectContaining({ id: "full-access" }),
+      ],
     });
-    await expect(client.setAccessMode("auto-review")).rejects.toThrow(
+    await expect(client.setMode("auto-review")).rejects.toThrow(
       "does not provide Auto-review",
     );
   });
@@ -721,18 +765,18 @@ describe("CodexRuntimeClient", () => {
     );
 
     await expect(client.getState()).resolves.toMatchObject({
-      accessMode: "full-access",
+      modeId: "full-access",
     });
   });
 
-  it("restores Codex configuration when leaving an explicit access mode", async () => {
+  it("preserves Codex workspace-write configuration in Default Permissions", async () => {
     server.config = {
       approval_policy: "on-request",
       approvals_reviewer: "user",
       sandbox_mode: "workspace-write",
       sandbox_workspace_write: {
-        writable_roots: [],
-        network_access: false,
+        writable_roots: ["/var/cache/npm"],
+        network_access: true,
         exclude_tmpdir_env_var: false,
         exclude_slash_tmp: false,
       },
@@ -752,9 +796,9 @@ describe("CodexRuntimeClient", () => {
     );
 
     await expect(client.getState()).resolves.toMatchObject({
-      accessMode: "full-access",
+      modeId: "full-access",
     });
-    await client.setAccessMode("inherit");
+    await client.setMode("auto");
     await client.prompt("Use my configured permissions");
     expect(server.requests.at(-1)).toMatchObject({
       method: "turn/start",
@@ -763,8 +807,8 @@ describe("CodexRuntimeClient", () => {
         approvalsReviewer: "user",
         sandboxPolicy: {
           type: "workspaceWrite",
-          writableRoots: [],
-          networkAccess: false,
+          writableRoots: ["/var/cache/npm"],
+          networkAccess: true,
           excludeTmpdirEnvVar: false,
           excludeSlashTmp: false,
         },

--- a/packages/agent-runtime/src/codex/client.ts
+++ b/packages/agent-runtime/src/codex/client.ts
@@ -71,6 +71,14 @@ const CODEX_GOALS_MIN_VERSION = [0, 128, 0] as const;
 const CODEX_AUTO_REVIEW_MIN_VERSION = [0, 115, 0] as const;
 
 type CodexModeId = "auto" | "auto-review" | "full-access";
+const CODEX_THINKING_LEVELS: readonly AgentThinkingLevel[] = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
 
 const CODEX_MODES: AgentMode[] = [
   {
@@ -355,8 +363,28 @@ function modeFromThreadConfiguration(
   return "auto";
 }
 
-function configuredModel(value: unknown): string | null {
-  return stringOf(recordOf(recordOf(value)?.config), "model");
+type CodexConfiguredDefaults = {
+  model: string | null;
+  thinkingLevel: AgentThinkingLevel | null;
+};
+
+function configuredDefaults(
+  savedValue: unknown,
+  resolvedValue: unknown,
+): CodexConfiguredDefaults {
+  const saved = recordOf(recordOf(savedValue)?.config);
+  const resolved = recordOf(recordOf(resolvedValue)?.config);
+  const savedThinking = stringOf(saved, "modelReasoningEffort");
+  const resolvedThinking = stringOf(resolved, "model_reasoning_effort");
+  const thinkingLevel = savedThinking ?? resolvedThinking;
+  return {
+    model: stringOf(saved, "model") ?? stringOf(resolved, "model"),
+    thinkingLevel:
+      thinkingLevel &&
+      CODEX_THINKING_LEVELS.includes(thinkingLevel as AgentThinkingLevel)
+        ? (thinkingLevel as AgentThinkingLevel)
+        : null,
+  };
 }
 
 function defaultModelFromList(value: unknown): string | null {
@@ -1049,7 +1077,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
 
   async getAvailableThinkingLevels(): Promise<AgentThinkingLevel[]> {
     await this.readyPromise;
-    return codexThinkingLevels(this.modelResponse, this.selectedModel);
+    const levels = codexThinkingLevels(this.modelResponse, this.selectedModel);
+    return this.selectedThinking && !levels.includes(this.selectedThinking)
+      ? [...levels, this.selectedThinking]
+      : levels;
   }
 
   async getCommands(): Promise<AgentSlashCommand[]> {
@@ -1161,6 +1192,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       throw new Error(`Codex model ${modelId} is not available.`);
     }
     this.selectedModel = modelId;
+    this.selectedThinking = codexDefaultThinkingLevel(
+      this.modelResponse,
+      modelId,
+    );
     if (!codexModelSupportsFastMode(modelId)) this.fastModeEnabled = false;
     this.emitConfig();
     return { model: modelId };
@@ -1564,6 +1599,18 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     const collaborationModePromise = this.server
       .request("collaborationMode/list", {})
       .catch(() => null);
+    this.modelResponse = await modelPromise;
+    const savedConfig = await savedConfigPromise;
+    const resolvedConfig = await configPromise;
+    const defaults = configuredDefaults(savedConfig, resolvedConfig);
+    this.selectedModel =
+      defaults.model ??
+      defaultModelFromList(this.modelResponse) ??
+      parseCodexModels(this.modelResponse)[0]?.id ??
+      "";
+    this.selectedThinking =
+      defaults.thinkingLevel ??
+      codexDefaultThinkingLevel(this.modelResponse, this.selectedModel);
     let threadResponse: UnknownRecord;
     let hydratedThread: UnknownRecord;
     if (this.launch.resume) {
@@ -1586,15 +1633,6 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         includeTurns: true,
       });
     } else {
-      this.modelResponse = await modelPromise;
-      const savedConfig = await savedConfigPromise;
-      const config = await configPromise;
-      this.selectedModel =
-        configuredModel(savedConfig) ??
-        configuredModel(config) ??
-        defaultModelFromList(this.modelResponse) ??
-        parseCodexModels(this.modelResponse)[0]?.id ??
-        "";
       threadResponse = await this.server.request<UnknownRecord>(
         "thread/start",
         {
@@ -1606,13 +1644,12 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       this.threadSubscribed = true;
       hydratedThread = threadResponse;
     }
-    this.modelResponse = await modelPromise;
     this.configuredAccessOverrides = accessOverridesFromConfig(
-      await configPromise,
+      resolvedConfig,
     );
     this.loadCollaborationModes(await collaborationModePromise);
     this.hydrateThread(hydratedThread);
-    this.applyThreadConfiguration(threadResponse);
+    this.applyThreadConfiguration(threadResponse, !this.launch.resume);
     await this.hydrateSubagentHistories();
     await this.loadGoal();
   }
@@ -1632,7 +1669,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     }
   }
 
-  private applyThreadConfiguration(threadResponse: UnknownRecord): void {
+  private applyThreadConfiguration(
+    threadResponse: UnknownRecord,
+    preserveResolvedDefaults = false,
+  ): void {
     const inheritedSandbox = recordOf(threadResponse.sandbox);
     const effectiveAccessOverrides = {
       ...(threadResponse.approvalPolicy !== undefined
@@ -1646,20 +1686,26 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     this.inheritedAccessOverrides =
       this.configuredAccessOverrides ?? effectiveAccessOverrides;
     this.selectedMode = modeFromThreadConfiguration(threadResponse);
-    this.selectedModel =
-      stringOf(threadResponse, "model") ||
-      this.selectedModel ||
-      parseCodexModels(this.modelResponse)[0]?.id ||
-      "";
+    const configuredModel = this.selectedModel;
+    if (!preserveResolvedDefaults) {
+      this.selectedModel =
+        stringOf(threadResponse, "model") || configuredModel || "";
+    }
     const effort = stringOf(threadResponse, "reasoningEffort");
     if (
+      !preserveResolvedDefaults &&
       effort &&
-      codexThinkingLevels(this.modelResponse, this.selectedModel).includes(
-        effort as AgentThinkingLevel,
-      )
+      CODEX_THINKING_LEVELS.includes(effort as AgentThinkingLevel)
     ) {
       this.selectedThinking = effort as AgentThinkingLevel;
-    } else {
+    } else if (
+      !preserveResolvedDefaults &&
+      (this.selectedModel !== configuredModel ||
+        !this.selectedThinking ||
+        !codexThinkingLevels(this.modelResponse, this.selectedModel).includes(
+          this.selectedThinking,
+        ))
+    ) {
       this.selectedThinking = codexDefaultThinkingLevel(
         this.modelResponse,
         this.selectedModel,

--- a/packages/agent-runtime/src/codex/client.ts
+++ b/packages/agent-runtime/src/codex/client.ts
@@ -1,9 +1,9 @@
 import type {
-  AgentAccessMode,
   AgentCollaborationMode,
   AgentGoal,
   AgentGoalStatus,
   AgentInteractionValue,
+  AgentMode,
   AgentModel,
   AgentSessionStats,
   AgentSlashCommand,
@@ -69,6 +69,28 @@ const MAX_PENDING_SUBAGENT_THREADS = 32;
 const MAX_PENDING_SUBAGENT_NOTIFICATIONS = 50;
 const CODEX_GOALS_MIN_VERSION = [0, 128, 0] as const;
 const CODEX_AUTO_REVIEW_MIN_VERSION = [0, 115, 0] as const;
+
+type CodexModeId = "auto" | "auto-review" | "full-access";
+
+const CODEX_MODES: AgentMode[] = [
+  {
+    id: "auto",
+    label: "Default Permissions",
+    description: "Edit files and run commands with Codex's default approval flow.",
+  },
+  {
+    id: "auto-review",
+    label: "Auto-review",
+    description:
+      "Same workspace-write permissions as Default, but eligible `on-request` approvals are routed through the auto-reviewer subagent.",
+  },
+  {
+    id: "full-access",
+    label: "Full Access",
+    description: "Edit files, run commands, and access the network without additional prompts.",
+    dangerous: true,
+  },
+];
 
 type CodexCollaborationPreset = {
   name: string;
@@ -317,9 +339,9 @@ function codexVersionAtLeast(
   return true;
 }
 
-function accessModeFromThreadConfiguration(
+function modeFromThreadConfiguration(
   threadResponse: UnknownRecord,
-): AgentAccessMode {
+): CodexModeId {
   const approvalPolicy = stringOf(threadResponse, "approvalPolicy");
   const approvalsReviewer = stringOf(threadResponse, "approvalsReviewer");
   const sandbox = recordOf(threadResponse.sandbox);
@@ -328,9 +350,24 @@ function accessModeFromThreadConfiguration(
     return "full-access";
   }
   if (approvalPolicy === "on-request" && sandboxType === "workspaceWrite") {
-    return approvalsReviewer === "auto_review" ? "auto-review" : "default";
+    return approvalsReviewer === "auto_review" ? "auto-review" : "auto";
   }
-  return "inherit";
+  return "auto";
+}
+
+function configuredModel(value: unknown): string | null {
+  return stringOf(recordOf(recordOf(value)?.config), "model");
+}
+
+function defaultModelFromList(value: unknown): string | null {
+  const response = recordOf(value);
+  if (!Array.isArray(response?.data)) return null;
+  const model = response.data
+    .map(recordOf)
+    .find((candidate) => candidate?.isDefault === true);
+  return model
+    ? stringOf(model, "model") ?? stringOf(model, "id")
+    : null;
 }
 
 function accessOverridesFromConfig(value: unknown): Record<string, unknown> | null {
@@ -921,7 +958,8 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
   private collaborationModes: CodexCollaborationPreset[] = [];
   private selectedCollaborationMode: AgentCollaborationMode = "default";
   private fastModeEnabled = false;
-  private selectedAccessMode: AgentAccessMode = "inherit";
+  private selectedMode: CodexModeId = "auto";
+  private hasModeOverride = false;
   private inheritedAccessOverrides: Record<string, unknown> = {};
   private configuredAccessOverrides: Record<string, unknown> | null = null;
   private goalsSupported = false;
@@ -976,8 +1014,8 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       collaborationModes: this.availableCollaborationModes(),
       fastModeEnabled: this.fastModeEnabled,
       fastModeAvailable: codexModelSupportsFastMode(this.selectedModel),
-      accessMode: this.selectedAccessMode,
-      accessModes: this.availableAccessModes(),
+      modeId: this.selectedMode,
+      modes: this.availableModes(),
       goalsSupported: this.goalsSupported,
       goal: this.goal,
       ...(this.readOnly
@@ -1170,19 +1208,31 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     return { fastModeEnabled: enabled };
   }
 
-  async setAccessMode(mode: AgentAccessMode): Promise<unknown> {
+  async setMode(modeId: string): Promise<unknown> {
     await this.readyPromise;
     this.assertInteractive();
-    if (!this.availableAccessModes().includes(mode)) {
+    const mode = modeId as CodexModeId;
+    if (!this.availableModes().some((candidate) => candidate.id === mode)) {
       throw new Error(
         mode === "auto-review"
           ? "This Codex installation does not provide Auto-review."
-          : `Codex access mode ${mode} is not available.`,
+          : `Codex mode ${mode} is not available.`,
       );
     }
-    this.selectedAccessMode = mode;
+    this.selectedMode = mode;
+    this.hasModeOverride = true;
     this.emitConfig();
-    return { accessMode: mode };
+    return {
+      modeId: mode,
+      ...(this.activeTurnId
+        ? {
+            notice: {
+              type: "warning",
+              message: "Permission mode applies next turn",
+            },
+          }
+        : {}),
+    };
   }
 
   async updateGoal(
@@ -1508,6 +1558,9 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     await this.server.ready();
     const modelPromise = this.server.request("model/list", { limit: 200 });
     const configPromise = this.server.request("config/read", {}).catch(() => null);
+    const savedConfigPromise = this.server
+      .request("getUserSavedConfig", {})
+      .catch(() => null);
     const collaborationModePromise = this.server
       .request("collaborationMode/list", {})
       .catch(() => null);
@@ -1533,10 +1586,20 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         includeTurns: true,
       });
     } else {
+      this.modelResponse = await modelPromise;
+      const savedConfig = await savedConfigPromise;
+      const config = await configPromise;
+      this.selectedModel =
+        configuredModel(savedConfig) ??
+        configuredModel(config) ??
+        defaultModelFromList(this.modelResponse) ??
+        parseCodexModels(this.modelResponse)[0]?.id ??
+        "";
       threadResponse = await this.server.request<UnknownRecord>(
         "thread/start",
         {
           cwd: this.launch.cwd,
+          model: this.selectedModel || null,
           ephemeral: false,
         },
       );
@@ -1582,19 +1645,11 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     };
     this.inheritedAccessOverrides =
       this.configuredAccessOverrides ?? effectiveAccessOverrides;
-    const inheritedAccessMode = accessModeFromThreadConfiguration(threadResponse);
-    const effectiveMatchesConfigured =
-      this.configuredAccessOverrides !== null &&
-      JSON.stringify(effectiveAccessOverrides) ===
-        JSON.stringify(this.configuredAccessOverrides);
-    this.selectedAccessMode = effectiveMatchesConfigured
-      ? "inherit"
-      : this.availableAccessModes().includes(inheritedAccessMode)
-      ? inheritedAccessMode
-      : "inherit";
+    this.selectedMode = modeFromThreadConfiguration(threadResponse);
     this.selectedModel =
-      stringOf(threadResponse, "model") ??
-      parseCodexModels(this.modelResponse)[0]?.id ??
+      stringOf(threadResponse, "model") ||
+      this.selectedModel ||
+      parseCodexModels(this.modelResponse)[0]?.id ||
       "";
     const effort = stringOf(threadResponse, "reasoningEffort");
     if (
@@ -2886,8 +2941,8 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
       collaborationModes: this.availableCollaborationModes(),
       fastModeEnabled: this.fastModeEnabled,
       fastModeAvailable: codexModelSupportsFastMode(this.selectedModel),
-      accessMode: this.selectedAccessMode,
-      accessModes: this.availableAccessModes(),
+      modeId: this.selectedMode,
+      modes: this.availableModes(),
       goalsSupported: this.goalsSupported,
       goal: this.goal,
       ...(this.selectedThinking
@@ -2896,42 +2951,41 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     });
   }
 
-  private availableAccessModes(): AgentAccessMode[] {
-    return [
-      "inherit",
-      "default",
-      ...(codexVersionAtLeast(
-        this.launch.detectedVersion,
-        CODEX_AUTO_REVIEW_MIN_VERSION,
-      )
-        ? (["auto-review"] as const)
-        : []),
-      "full-access",
-    ];
+  private availableModes(): AgentMode[] {
+    return CODEX_MODES.filter(
+      (mode) =>
+        mode.id !== "auto-review" ||
+        codexVersionAtLeast(
+          this.launch.detectedVersion,
+          CODEX_AUTO_REVIEW_MIN_VERSION,
+        ),
+    );
   }
 
   private accessOverrides(): Record<string, unknown> {
-    if (this.selectedAccessMode === "inherit") {
-      return this.inheritedAccessOverrides;
-    }
-    if (this.selectedAccessMode === "full-access") {
+    if (!this.hasModeOverride) return {};
+    if (this.selectedMode === "full-access") {
       return {
         approvalPolicy: "never",
         approvalsReviewer: "user",
         sandboxPolicy: { type: "dangerFullAccess" },
       };
     }
+    const resolvedSandbox = recordOf(this.inheritedAccessOverrides.sandboxPolicy);
     return {
       approvalPolicy: "on-request",
       approvalsReviewer:
-        this.selectedAccessMode === "auto-review" ? "auto_review" : "user",
-      sandboxPolicy: {
-        type: "workspaceWrite",
-        writableRoots: [],
-        networkAccess: false,
-        excludeTmpdirEnvVar: false,
-        excludeSlashTmp: false,
-      },
+        this.selectedMode === "auto-review" ? "auto_review" : "user",
+      sandboxPolicy:
+        stringOf(resolvedSandbox, "type") === "workspaceWrite"
+          ? resolvedSandbox
+          : {
+              type: "workspaceWrite",
+              writableRoots: [],
+              networkAccess: false,
+              excludeTmpdirEnvVar: false,
+              excludeSlashTmp: false,
+            },
     };
   }
 

--- a/packages/agent-runtime/src/providers/types.ts
+++ b/packages/agent-runtime/src/providers/types.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentAccessMode,
   AgentCollaborationMode,
   AgentConnectionDraft,
   AgentGoal,
@@ -85,7 +84,7 @@ export interface AgentRuntimeClient {
   setThinkingLevel(level: string): Promise<unknown>;
   setCollaborationMode?(mode: AgentCollaborationMode): Promise<unknown>;
   setFastMode?(enabled: boolean): Promise<unknown>;
-  setAccessMode?(mode: AgentAccessMode): Promise<unknown>;
+  setMode?(modeId: string): Promise<unknown>;
   updateGoal?(
     action: "set" | "pause" | "resume" | "clear",
     objective?: string,

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -484,11 +484,11 @@ export class AgentSessionRuntime {
           ...(typeof event.fastModeAvailable === "boolean"
             ? { fastModeAvailable: event.fastModeAvailable }
             : {}),
-          ...(typeof event.accessMode === "string"
-            ? { accessMode: event.accessMode }
+          ...(typeof event.modeId === "string"
+            ? { modeId: event.modeId }
             : {}),
-          ...(Array.isArray(event.accessModes)
-            ? { accessModes: event.accessModes }
+          ...(Array.isArray(event.modes)
+            ? { modes: event.modes }
             : {}),
           ...(typeof event.goalsSupported === "boolean"
             ? { goalsSupported: event.goalsSupported }
@@ -719,15 +719,15 @@ export class AgentSessionRuntime {
           await this.refresh();
           return value;
         });
-      case "set_access_mode":
-        if (!this.client.setAccessMode) {
+      case "set_mode":
+        if (!this.client.setMode) {
           return Promise.reject(
             new Error(
-              `${agentProviderMetadata(this.provider).label} does not provide access modes.`,
+              `${agentProviderMetadata(this.provider).label} does not provide modes.`,
             ),
           );
         }
-        return this.client.setAccessMode(command.mode).then(async (value) => {
+        return this.client.setMode(command.modeId).then(async (value) => {
           await this.refresh();
           return value;
         });

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.5.0"
+connector_version="0.6.0"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

- replace the fixed cross-provider access enum with provider-defined agent modes
- expose provider-native Codex modes: Default Permissions, Auto-review, and Full Access
- preserve Codex workspace-write configuration when applying permission presets and show that active-run changes apply next turn
- resolve new-thread model and reasoning from saved config, resolved config, then `model/list` defaults
- keep configured reasoning visible when model metadata is incomplete and reconcile reasoning when switching models

## Why

OvertChat previously exposed a synthetic “Codex default” permission choice and lost important native sandbox details when switching modes. It also fell back to catalog defaults instead of the configured Codex model and reasoning effort. The provider-defined mode and model-resolution contract carries native behavior through the Host Connector without maintaining a separate cross-provider abstraction.

## Validation

- `npm test -w packages/agent-bridge`
- `npm test -w packages/agent-runtime`
- `env -u OVERTCHAT_CONNECTOR_CONFIG -u OVERTCHAT_CONNECTOR_LOCK -u OVERTCHAT_CONNECTOR_STATE -u OVERTCHAT_CONNECTOR_TIMELINES npm test -w apps/connector`
- `npm test -w apps/web -- --run`
- `npm run lint -w apps/web -- --max-warnings=0`
- `npm run typecheck -w apps/web`
- `npm run build -w apps/web -- --webpack`
- `E2E_PORT=4722 npm run test:e2e -w apps/web -- agent-runtime.spec.ts`