### PR TITLE
feat: add MCP server support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,16 +26,17 @@ RUN DATABASE_URL=:memory: \
 
 FROM base AS runner
 RUN groupadd --system --gid 1001 nodejs \
- && useradd --system --uid 1001 --gid nodejs nextjs
+ && useradd --system --create-home --home-dir /home/nextjs --uid 1001 --gid nodejs nextjs
 
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/drizzle ./apps/web/drizzle
 
-RUN mkdir -p /app/data && chown -R nextjs:nodejs /app/data
+RUN mkdir -p /app/data /app/npm-cache \
+ && chown -R nextjs:nodejs /app/data /app/npm-cache
 
 USER nextjs
-ENV HOSTNAME=0.0.0.0 PORT=4717 DATABASE_URL=/app/data/chat.db MIGRATIONS_FOLDER=/app/apps/web/drizzle
+ENV HOSTNAME=0.0.0.0 PORT=4717 DATABASE_URL=/app/data/chat.db MIGRATIONS_FOLDER=/app/apps/web/drizzle NPM_CONFIG_CACHE=/app/npm-cache
 EXPOSE 4717
 
 CMD ["node", "apps/web/server.js"]

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Prefer to manage Compose yourself or deploy from source? See the
 | vLLM · llama.cpp · SGLang | SearXNG · Kokoro TTS · Parakeet STT | Codex · Pi · Oh My Pi |
 
 First-class setup and model discovery for local inference servers, plus hosted
-providers and custom endpoints. The installer can also wire up local search,
-playback, and dictation—no extra integrations or API keys to stitch together.
+providers, custom endpoints, and MCP servers. The installer can also wire up
+local search, playback, and dictation—no extra integrations or API keys to
+stitch together.
 
 ## When you need more than chat
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/compose.test.ts
+++ b/apps/cli/src/compose.test.ts
@@ -93,6 +93,8 @@ describe("managed Compose configuration", () => {
     expect(compose).toContain("profiles: [stt-cpu]");
     expect(compose).toContain("profiles: [stt-gpu]");
     expect(compose).toContain('device_ids: ["${STT_GPU_DEVICE_ID}"]');
+    expect(compose).toContain("- overtchat-npm-cache:/app/npm-cache");
+    expect(compose).toContain("\n  overtchat-npm-cache:\n");
     expect(compose).toContain("external: true");
     expect(compose).not.toContain("BRAVE_SEARCH_API_KEY");
     expect(compose).not.toContain("TTS_API_KEY");
@@ -109,6 +111,7 @@ describe("managed Compose configuration", () => {
 
     expect(compose).toContain("type: bind");
     expect(compose).toContain("source: ${OVERTCHAT_DATA_SOURCE}");
+    expect(compose).toContain("- overtchat-npm-cache:/app/npm-cache");
     expect(compose).not.toContain("external: true");
   });
 });

--- a/apps/cli/src/compose.ts
+++ b/apps/cli/src/compose.ts
@@ -151,6 +151,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
 ${appDataMount}
+      - overtchat-npm-cache:/app/npm-cache
     depends_on:
       redis:
         condition: service_healthy
@@ -233,7 +234,8 @@ ${appDataMount}
               capabilities: [gpu]
 
 volumes:
-${appDataVolume}  overtchat-stt-models:
+${appDataVolume}  overtchat-npm-cache:
+  overtchat-stt-models:
     name: overtchat-stt-models
 `;
 }

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,5 +1,5 @@
-export const CLI_VERSION = "0.1.5";
-export const APP_VERSION = "0.14.4";
+export const CLI_VERSION = "0.1.6";
+export const APP_VERSION = "0.15.0";
 export const CONNECTOR_VERSION = "0.7.0";
 export const STT_VERSION = "0.1.1";
 

--- a/apps/mobile/src/components/chat/ChainOfThought.tsx
+++ b/apps/mobile/src/components/chat/ChainOfThought.tsx
@@ -20,14 +20,20 @@ import {
   faviconUrl,
   type FetchUrlPart,
   isToolSettled,
+  parseMcpToolName,
   type WebSearchPart,
   type WebSearchResult,
 } from "@overtchat/shared";
+import type { DynamicToolUIPart } from "ai";
 import { useTheme } from "@/lib/theme";
 import { MarkdownBody } from "./MarkdownBody";
 
 type ReasoningPart = { type: "reasoning"; text: string; state?: string };
-export type ActivityPart = WebSearchPart | FetchUrlPart | ReasoningPart;
+export type ActivityPart =
+  | WebSearchPart
+  | FetchUrlPart
+  | DynamicToolUIPart
+  | ReasoningPart;
 
 function isWebSearch(p: ActivityPart): p is WebSearchPart {
   return p.type === "tool-web_search";
@@ -37,6 +43,9 @@ function isFetchUrl(p: ActivityPart): p is FetchUrlPart {
 }
 function isReasoning(p: ActivityPart): p is ReasoningPart {
   return p.type === "reasoning";
+}
+function isMcpTool(p: ActivityPart): p is DynamicToolUIPart {
+  return p.type === "dynamic-tool" && parseMcpToolName(p.toolName) !== null;
 }
 
 /**
@@ -80,10 +89,14 @@ export function ChainOfThought({
     }
   }, [active]);
 
-  const hasTools = parts.some((p) => isWebSearch(p) || isFetchUrl(p));
+  const hasTools = parts.some(
+    (p) => isWebSearch(p) || isFetchUrl(p) || isMcpTool(p),
+  );
   const lastTool = [...parts]
     .reverse()
-    .find((part) => isWebSearch(part) || isFetchUrl(part));
+    .find(
+      (part) => isWebSearch(part) || isFetchUrl(part) || isMcpTool(part),
+    );
   const lastToolFailed = lastTool?.state === "output-error";
   const last = parts[parts.length - 1];
   const label = active ? activeLabel(last) : settledLabel(parts, duration);
@@ -220,13 +233,15 @@ function ShimmerLabel({
 /** A single timeline node: left rail (icon + connector) + the step's content. */
 function Step({ part, isLast }: { part: ActivityPart; isLast: boolean }) {
   const icon =
-    (isWebSearch(part) || isFetchUrl(part)) &&
+    (isWebSearch(part) || isFetchUrl(part) || isMcpTool(part)) &&
     part.state === "output-error"
         ? "failed"
       : isWebSearch(part)
           ? "search"
           : isFetchUrl(part)
             ? "globe"
+            : isMcpTool(part)
+              ? "tool"
             : "brain";
 
   return (
@@ -237,6 +252,8 @@ function Step({ part, isLast }: { part: ActivityPart; isLast: boolean }) {
           <SearchStep part={part} />
         ) : isFetchUrl(part) ? (
           <FetchStep part={part} />
+        ) : isMcpTool(part) ? (
+          <McpStep part={part} />
         ) : isReasoning(part) ? (
           <ThinkingContent content={part.text} />
         ) : null}
@@ -245,7 +262,7 @@ function Step({ part, isLast }: { part: ActivityPart; isLast: boolean }) {
   );
 }
 
-type RailIcon = "search" | "globe" | "brain" | "failed";
+type RailIcon = "search" | "globe" | "tool" | "brain" | "failed";
 
 /** Left gutter: the step's icon with a connecting line down to the next node. */
 function Rail({ icon, isLast }: { icon: RailIcon; isLast: boolean }) {
@@ -259,6 +276,8 @@ function Rail({ icon, isLast }: { icon: RailIcon; isLast: boolean }) {
           <Ionicons name="search" size={11} color={colors.mutedForeground} />
         ) : icon === "globe" ? (
           <Ionicons name="globe-outline" size={11} color={colors.mutedForeground} />
+        ) : icon === "tool" ? (
+          <MaterialCommunityIcons name="wrench-outline" size={11} color={colors.mutedForeground} />
         ) : (
           <MaterialCommunityIcons name="brain" size={11} color={colors.mutedForeground} />
         )}
@@ -268,6 +287,102 @@ function Rail({ icon, isLast }: { icon: RailIcon; isLast: boolean }) {
       ) : null}
     </View>
   );
+}
+
+function McpStep({ part }: { part: DynamicToolUIPart }) {
+  const { colors, fonts } = useTheme();
+  const parsed = parseMcpToolName(part.toolName);
+  const title = part.title ?? parsed?.toolName ?? part.toolName;
+  const server = parsed?.serverName ?? "MCP";
+  const running = !["output-available", "output-error", "output-denied"].includes(
+    part.state,
+  );
+
+  return (
+    <View style={styles.searchStep}>
+      <View style={styles.searchHeader}>
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.stepTitle,
+            { color: colors.foreground, fontFamily: fonts.sansMedium },
+          ]}
+        >
+          {server} · {title}
+        </Text>
+        <Text
+          style={[
+            styles.metaText,
+            { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
+          ]}
+        >
+          {running ? "Running" : part.state === "output-error" ? "Failed" : "Done"}
+        </Text>
+      </View>
+      {part.state === "output-error" ? (
+        <Text
+          style={[
+            styles.errorText,
+            { color: colors.destructive, fontFamily: fonts.sansRegular },
+          ]}
+        >
+          {part.errorText}
+        </Text>
+      ) : (
+        <ToolValue label="Input" value={part.input} />
+      )}
+      {part.state === "output-available" ? (
+        <ToolValue label="Output" value={part.output} />
+      ) : null}
+    </View>
+  );
+}
+
+function ToolValue({ label, value }: { label: string; value: unknown }) {
+  const { colors, fonts } = useTheme();
+  if (value === undefined) return null;
+  const text = formatToolValue(value);
+  if (!text) return null;
+  return (
+    <View
+      style={[
+        styles.toolValue,
+        { borderColor: colors.border, backgroundColor: colors.muted },
+      ]}
+    >
+      <Text
+        style={[
+          styles.toolValueLabel,
+          { color: colors.mutedForeground, fontFamily: fonts.sansMedium },
+        ]}
+      >
+        {label.toUpperCase()}
+      </Text>
+      <Text
+        selectable
+        style={[
+          styles.toolValueText,
+          { color: colors.foreground, fontFamily: fonts.sansRegular },
+        ]}
+      >
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+function formatToolValue(value: unknown): string {
+  let text: string;
+  if (typeof value === "string") {
+    text = value;
+  } else {
+    try {
+      text = JSON.stringify(value, null, 2);
+    } catch {
+      text = String(value);
+    }
+  }
+  return text.length > 20_000 ? `${text.slice(0, 20_000)}\n…` : text;
 }
 
 /** A reasoning part's markdown, rendered as muted text inside a step. */
@@ -515,13 +630,21 @@ function activeLabel(last: ActivityPart | undefined): string {
     const url = last.input?.url;
     return url ? `Reading ${cleanDomain(url)}` : "Reading page…";
   }
+  if (isMcpTool(last)) {
+    const parsed = parseMcpToolName(last.toolName);
+    return parsed
+      ? `Running ${parsed.serverName} · ${parsed.toolName}`
+      : "Running MCP tool…";
+  }
   return "Thinking";
 }
 
 function settledLabel(parts: ActivityPart[], duration: number): string {
   const lastTool = [...parts]
     .reverse()
-    .find((part) => isWebSearch(part) || isFetchUrl(part));
+    .find(
+      (part) => isWebSearch(part) || isFetchUrl(part) || isMcpTool(part),
+    );
   if (lastTool?.type === "tool-web_search") {
     if (lastTool.state === "output-error") return "Web search failed";
     if (lastTool.state === "output-available") return "Searched the web";
@@ -531,6 +654,15 @@ function settledLabel(parts: ActivityPart[], duration: number): string {
     if (lastTool.state === "output-error") return "Page fetch failed";
     if (lastTool.state === "output-available") return "Searched the web";
     return "Page fetch did not complete";
+  }
+  if (lastTool && isMcpTool(lastTool)) {
+    const parsed = parseMcpToolName(lastTool.toolName);
+    const label = parsed
+      ? `${parsed.serverName} · ${parsed.toolName}`
+      : "MCP tool";
+    if (lastTool.state === "output-error") return `${label} failed`;
+    if (lastTool.state === "output-available") return `Used ${label}`;
+    return `${label} did not complete`;
   }
   return duration > 0 ? `Thought for ${duration}s` : "Thoughts";
 }
@@ -572,6 +704,15 @@ const styles = StyleSheet.create({
   stepTitle: { flexShrink: 1, fontSize: 13 },
   metaText: { fontSize: 12 },
   errorText: { fontSize: 12 },
+  toolValue: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    gap: 4,
+  },
+  toolValueLabel: { fontSize: 9, letterSpacing: 0.5 },
+  toolValueText: { fontSize: 11, lineHeight: 16 },
 
   resultList: {
     borderWidth: StyleSheet.hairlineWidth,

--- a/apps/mobile/src/lib/chat/parts.ts
+++ b/apps/mobile/src/lib/chat/parts.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import { isMcpToolName } from "@overtchat/shared";
 
 type AnyPart = UIMessage["parts"][number];
 
@@ -9,7 +10,10 @@ const ACTIVITY_TYPES = new Set([
 ]);
 
 export function isActivityPart(part: AnyPart): boolean {
-  return ACTIVITY_TYPES.has(part.type);
+  return (
+    ACTIVITY_TYPES.has(part.type) ||
+    (part.type === "dynamic-tool" && isMcpToolName(part.toolName))
+  );
 }
 
 export type Segment =

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.5"
+cli_version="0.1.6"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
-  "cliVersion": "0.1.5",
-  "appVersion": "0.14.4",
+  "cliVersion": "0.1.6",
+  "appVersion": "0.15.0",
   "connectorVersion": "0.7.0",
   "sttVersion": "0.1.1"
 }

--- a/apps/web/app/(app)/settings/SettingsNav.tsx
+++ b/apps/web/app/(app)/settings/SettingsNav.tsx
@@ -110,7 +110,8 @@ function Section({
 }
 
 function NavLink({ item, pathname }: { item: Item; pathname: string }) {
-  const active = pathname === item.href;
+  const active =
+    pathname === item.href || pathname.startsWith(`${item.href}/`);
   const Icon = item.icon;
   return (
     <Link

--- a/apps/web/app/(app)/settings/tools/AvailableMcpServersPanel.tsx
+++ b/apps/web/app/(app)/settings/tools/AvailableMcpServersPanel.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Server } from "lucide-react";
+import { useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "@/components/ui/toast";
+import { getErrorMessage } from "@/lib/errors";
+import type { AvailableMcpServer } from "@/lib/mcp/schema";
+import {
+  useAvailableMcpServers,
+  useSetMcpServerPreference,
+} from "@/lib/queries/mcpServers";
+import { SettingsSection } from "../_components/SettingsRows";
+
+export function AvailableMcpServersPanel() {
+  const { data: servers = [] } = useAvailableMcpServers();
+  const setPreference = useSetMcpServerPreference();
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  async function toggle(server: AvailableMcpServer, enabled: boolean) {
+    setTogglingId(server.id);
+    try {
+      await setPreference.mutateAsync({ id: server.id, enabled });
+    } catch (error) {
+      toast.error({
+        title: `Failed to ${enabled ? "enable" : "disable"} MCP server`,
+        description: getErrorMessage(error, "Your preference was not changed."),
+      });
+    } finally {
+      setTogglingId(null);
+    }
+  }
+
+  return (
+    <SettingsSection
+      title="MCP servers"
+      description="Choose which available MCP servers can provide tools in your chats."
+    >
+      {servers.length === 0 ? (
+        <div className="py-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            No MCP servers are available to you.
+          </p>
+        </div>
+      ) : (
+        servers.map((server) => (
+          <div
+            key={server.id}
+            className="flex items-center justify-between gap-4 py-3"
+          >
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/30">
+                <Server className="size-4" />
+              </div>
+              <p className="truncate text-sm font-medium">{server.name}</p>
+            </div>
+            <Switch
+              checked={server.enabled}
+              disabled={togglingId === server.id}
+              onCheckedChange={(enabled) => void toggle(server, enabled)}
+              aria-label={`${server.enabled ? "Disable" : "Enable"} ${server.name} for my chats`}
+            />
+          </div>
+        ))
+      )}
+    </SettingsSection>
+  );
+}

--- a/apps/web/app/(app)/settings/tools/McpHealthBadge.tsx
+++ b/apps/web/app/(app)/settings/tools/McpHealthBadge.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { motionClasses } from "@/lib/motion";
+import { useMcpServerHealth } from "@/lib/queries/mcpServers";
+
+export function McpHealthBadge({ id }: { id: string }) {
+  const { data, isFetching, refetch } = useMcpServerHealth(id);
+
+  let dotClass = "bg-muted-foreground/30";
+  let label = "Check";
+  let title = "Click to check connection";
+  if (isFetching) {
+    label = "Checking…";
+    title = "Checking connection…";
+  } else if (data?.ok === true) {
+    dotClass = "bg-emerald-500";
+    label = `${data.toolCount} ${data.toolCount === 1 ? "tool" : "tools"}`;
+    title = `Working — discovered ${label} in ${data.elapsedMs}ms`;
+  } else if (data?.ok === false) {
+    dotClass = "bg-destructive";
+    label = "Down";
+    title = data.error;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (!isFetching) void refetch();
+      }}
+      disabled={isFetching}
+      title={title}
+      aria-label={title}
+      className="inline-flex shrink-0 items-center gap-1 rounded-full border bg-card/60 px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none text-muted-foreground motion-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      {isFetching ? (
+        <Loader2 className={`size-2.5 ${motionClasses.spinner}`} />
+      ) : (
+        <span className={`size-1.5 rounded-full ${dotClass}`} aria-hidden />
+      )}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/apps/web/app/(app)/settings/tools/McpServersPanel.tsx
+++ b/apps/web/app/(app)/settings/tools/McpServersPanel.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { AlertDialog } from "@base-ui/react/alert-dialog";
+import { Pencil, Plus, Server, Trash2 } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/toast";
+import { getErrorMessage } from "@/lib/errors";
+import type {
+  McpServer,
+  McpServerAvailability,
+} from "@/lib/mcp/schema";
+import { motionClasses } from "@/lib/motion";
+import {
+  useDeleteMcpServer,
+  useMcpServers,
+  useUpdateMcpServer,
+} from "@/lib/queries/mcpServers";
+import { cn } from "@/lib/utils";
+import {
+  SettingsNotice,
+  SettingsSection,
+} from "../_components/SettingsRows";
+import { McpHealthBadge } from "./McpHealthBadge";
+
+export function McpServersPanel() {
+  const { data: servers = [] } = useMcpServers();
+  const updateServer = useUpdateMcpServer();
+  const deleteServer = useDeleteMcpServer();
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<McpServer | null>(null);
+  const [deleteError, setDeleteError] = useState("");
+
+  async function setAvailability(
+    server: McpServer,
+    availability: McpServerAvailability,
+  ) {
+    setTogglingId(server.id);
+    try {
+      await updateServer.mutateAsync({
+        id: server.id,
+        input: { name: server.name, availability, config: server.config },
+      });
+    } catch (error) {
+      toast.error({
+        title: "Failed to change MCP server availability",
+        description: getErrorMessage(error, "The server was not changed."),
+      });
+    } finally {
+      setTogglingId(null);
+    }
+  }
+
+  async function confirmDelete() {
+    if (!pendingDelete) return;
+    setDeleteError("");
+    try {
+      await deleteServer.mutateAsync(pendingDelete.id);
+      toast.success({
+        title: "MCP server deleted",
+        description: pendingDelete.name,
+      });
+      setPendingDelete(null);
+    } catch (error) {
+      setDeleteError(getErrorMessage(error, "Failed to delete MCP server"));
+    }
+  }
+
+  return (
+    <>
+      <SettingsSection
+        title="Manage MCP servers"
+        description="Connect external tool servers and choose who can use them. Commands run inside the OvertChat server environment."
+        action={
+          <Button
+            render={<Link href="/settings/tools/mcp/new" />}
+            size="sm"
+          >
+            <Plus /> Add server
+          </Button>
+        }
+      >
+        {servers.length === 0 ? (
+          <div className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No MCP servers configured.
+            </p>
+          </div>
+        ) : (
+          servers.map((server) => (
+            <div
+              key={server.id}
+              className={cn(
+                "grid gap-3 py-3 @xl:grid-cols-[minmax(0,1fr)_auto] @xl:items-center",
+                server.availability === "disabled" && "opacity-65",
+              )}
+            >
+              <div className="flex min-w-0 items-start gap-3">
+                <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/30">
+                  <Server className="size-4" />
+                </div>
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <p className="truncate text-sm font-medium">{server.name}</p>
+                    <McpHealthBadge id={server.id} />
+                  </div>
+                  <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                    {server.config.transport === "stdio"
+                      ? [server.config.command, ...server.config.args].join(" ")
+                      : server.config.url}
+                  </p>
+                  <p className="mt-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+                    {server.config.transport === "stdio"
+                      ? "STDIO"
+                      : "Streamable HTTP"}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-end gap-2">
+                <span className="hidden text-xs text-muted-foreground @2xl:inline">
+                  Available to
+                </span>
+                <Select
+                  value={server.availability}
+                  disabled={togglingId === server.id}
+                  onValueChange={(availability) => {
+                    if (!availability) return;
+                    void setAvailability(
+                      server,
+                      availability as McpServerAvailability,
+                    );
+                  }}
+                >
+                  <SelectTrigger
+                    size="sm"
+                    className="w-32"
+                    aria-label={`Available to for ${server.name}`}
+                  >
+                    <SelectValue>
+                      {server.availability === "everyone"
+                        ? "Everyone"
+                        : server.availability === "admins"
+                          ? "Admins only"
+                          : "Disabled"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="everyone">Everyone</SelectItem>
+                    <SelectItem value="admins">Admins only</SelectItem>
+                    <SelectItem value="disabled">Disabled</SelectItem>
+                  </SelectContent>
+                </Select>
+                <div className="h-6 w-px bg-border" aria-hidden="true" />
+                <Button
+                  render={<Link href={`/settings/tools/mcp/${server.id}`} />}
+                  variant="outline"
+                  size="sm"
+                >
+                  <Pencil /> Edit
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                  onClick={() => {
+                    setDeleteError("");
+                    setPendingDelete(server);
+                  }}
+                >
+                  <Trash2 /> Delete
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </SettingsSection>
+
+      <AlertDialog.Root
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open && !deleteServer.isPending) setPendingDelete(null);
+        }}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Backdrop
+            className={cn(
+              "fixed inset-0 z-40 bg-black/40",
+              motionClasses.overlay,
+            )}
+          />
+          <AlertDialog.Popup
+            className={cn(
+              "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-card p-6 shadow-lg outline-none",
+              motionClasses.dialog,
+            )}
+          >
+            <AlertDialog.Title className="text-base font-semibold">
+              Delete MCP server?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {pendingDelete?.name}
+              </span>{" "}
+              and its configuration will be removed.
+            </AlertDialog.Description>
+            {deleteError && (
+              <SettingsNotice tone="error" className="mt-3 text-xs">
+                {deleteError}
+              </SettingsNotice>
+            )}
+            <div className="mt-5 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={deleteServer.isPending}
+                onClick={() => setPendingDelete(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={deleteServer.isPending}
+                onClick={() => void confirmDelete()}
+              >
+                {deleteServer.isPending ? "Deleting…" : "Delete"}
+              </Button>
+            </div>
+          </AlertDialog.Popup>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+    </>
+  );
+}

--- a/apps/web/app/(app)/settings/tools/ToolsForm.tsx
+++ b/apps/web/app/(app)/settings/tools/ToolsForm.tsx
@@ -11,8 +11,10 @@ import {
   SettingsRow,
   SettingsSection,
 } from "../_components/SettingsRows";
+import { AvailableMcpServersPanel } from "./AvailableMcpServersPanel";
+import { McpServersPanel } from "./McpServersPanel";
 
-export function ToolsForm() {
+export function ToolsForm({ isAdmin }: { isAdmin: boolean }) {
   const [webSearchEnabled, setWebSearchEnabled] = useLocalStorage<boolean>(
     WEB_SEARCH_ENABLED_STORAGE_KEY,
     DEFAULT_WEB_SEARCH_ENABLED,
@@ -22,7 +24,7 @@ export function ToolsForm() {
     <div className="max-w-3xl space-y-8">
       <SettingsPageHeader
         title="Tools"
-        description="Control which capabilities models can use in this browser."
+        description="Control model capabilities and connect external tool servers."
       />
 
       <SettingsSection
@@ -44,6 +46,10 @@ export function ToolsForm() {
           />
         </SettingsRow>
       </SettingsSection>
+
+      <AvailableMcpServersPanel />
+
+      {isAdmin && <McpServersPanel />}
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/tools/mcp/McpServerEditor.tsx
+++ b/apps/web/app/(app)/settings/tools/mcp/McpServerEditor.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { ArrowLeft, Globe2, Plus, Trash2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/components/ui/toast";
+import { getErrorMessage } from "@/lib/errors";
+import {
+  McpServerInputSchema,
+  type McpServer,
+  type McpServerConfig,
+  type McpServerInput,
+} from "@/lib/mcp/schema";
+import {
+  useCreateMcpServer,
+  useUpdateMcpServer,
+} from "@/lib/queries/mcpServers";
+import { cn } from "@/lib/utils";
+import {
+  SettingsActions,
+  SettingsNotice,
+  SettingsPageHeader,
+} from "../../_components/SettingsRows";
+
+type Pair = { id: string; key: string; value: string };
+type ValueRow = { id: string; value: string };
+
+function rowId() {
+  return crypto.randomUUID();
+}
+
+function pairs(value: Record<string, string>): Pair[] {
+  const entries = Object.entries(value).map(([key, item]) => ({
+    id: rowId(),
+    key,
+    value: item,
+  }));
+  return entries.length ? entries : [{ id: rowId(), key: "", value: "" }];
+}
+
+function values(items: string[]): ValueRow[] {
+  const rows = items.map((value) => ({ id: rowId(), value }));
+  return rows.length ? rows : [{ id: rowId(), value: "" }];
+}
+
+export function McpServerEditor({ server }: { server?: McpServer }) {
+  const router = useRouter();
+  const createServer = useCreateMcpServer();
+  const updateServer = useUpdateMcpServer();
+  const existingConfig = server?.config;
+
+  const [name, setName] = useState(server?.name ?? "");
+  const [transport, setTransport] = useState<"stdio" | "http">(
+    existingConfig?.transport ?? "stdio",
+  );
+  const [command, setCommand] = useState(
+    existingConfig?.transport === "stdio" ? existingConfig.command : "",
+  );
+  const [args, setArgs] = useState<ValueRow[]>(
+    values(existingConfig?.transport === "stdio" ? existingConfig.args : []),
+  );
+  const [environment, setEnvironment] = useState<Pair[]>(
+    pairs(existingConfig?.transport === "stdio" ? existingConfig.env : {}),
+  );
+  const [passthrough, setPassthrough] = useState<ValueRow[]>(
+    values(
+      existingConfig?.transport === "stdio"
+        ? existingConfig.envPassthrough
+        : [],
+    ),
+  );
+  const [cwd, setCwd] = useState(
+    existingConfig?.transport === "stdio" ? (existingConfig.cwd ?? "") : "",
+  );
+  const [url, setUrl] = useState(
+    existingConfig?.transport === "http" ? existingConfig.url : "",
+  );
+  const [headers, setHeaders] = useState<Pair[]>(
+    pairs(existingConfig?.transport === "http" ? existingConfig.headers : {}),
+  );
+  const [envHeaders, setEnvHeaders] = useState<Pair[]>(
+    pairs(
+      existingConfig?.transport === "http"
+        ? (existingConfig.envHeaders ?? {})
+        : {},
+    ),
+  );
+  const [bearerTokenEnvVar, setBearerTokenEnvVar] = useState(
+    existingConfig?.transport === "http"
+      ? (existingConfig.bearerTokenEnvVar ?? "")
+      : "",
+  );
+  const [error, setError] = useState("");
+  const saving = createServer.isPending || updateServer.isPending;
+
+  function configFromForm(): McpServerConfig {
+    if (transport === "stdio") {
+      return {
+        transport,
+        command,
+        args: args.map((row) => row.value).filter((value) => value.length > 0),
+        env: Object.fromEntries(
+          environment
+            .filter((row) => row.key.trim())
+            .map((row) => [row.key.trim(), row.value]),
+        ),
+        envPassthrough: passthrough
+          .map((row) => row.value.trim())
+          .filter(Boolean),
+        ...(cwd.trim() ? { cwd: cwd.trim() } : {}),
+      };
+    }
+    return {
+      transport,
+      url: url.trim(),
+      headers: Object.fromEntries(
+        headers
+          .filter((row) => row.key.trim())
+          .map((row) => [row.key.trim(), row.value]),
+      ),
+      envHeaders: Object.fromEntries(
+        envHeaders
+          .filter((row) => row.key.trim())
+          .map((row) => [row.key.trim(), row.value.trim()]),
+      ),
+      ...(bearerTokenEnvVar.trim()
+        ? { bearerTokenEnvVar: bearerTokenEnvVar.trim() }
+        : {}),
+    };
+  }
+
+  function validatedInput(): McpServerInput | null {
+    const parsed = McpServerInputSchema.safeParse({
+      name,
+      availability: server?.availability ?? "everyone",
+      config: configFromForm(),
+    });
+    if (parsed.success) return parsed.data;
+    setError(parsed.error.issues[0]?.message ?? "Check the server configuration.");
+    return null;
+  }
+
+  async function save(event: React.FormEvent) {
+    event.preventDefault();
+    setError("");
+    const input = validatedInput();
+    if (!input) return;
+    try {
+      if (server) {
+        await updateServer.mutateAsync({ id: server.id, input });
+      } else {
+        await createServer.mutateAsync(input);
+      }
+      toast.success({
+        title: server ? "MCP server updated" : "MCP server added",
+        description: input.name,
+      });
+      router.push("/settings/tools");
+    } catch (cause) {
+      setError(getErrorMessage(cause, "Failed to save MCP server"));
+    }
+  }
+
+  return (
+    <form onSubmit={save} className="max-w-4xl space-y-5">
+      <SettingsPageHeader
+        leading={
+          <Button
+            render={<Link href="/settings/tools" />}
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Back to tools"
+          >
+            <ArrowLeft />
+          </Button>
+        }
+        title={server ? "Edit custom MCP" : "Connect to a custom MCP"}
+        description={
+          <a
+            href="https://modelcontextprotocol.io/docs"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 hover:text-foreground"
+          >
+            Docs <Globe2 className="size-3.5" />
+          </a>
+        }
+      />
+
+      <FieldCard>
+        <Field label="Name" htmlFor="mcp-name">
+          <Input
+            id="mcp-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="MCP server name"
+            autoComplete="off"
+          />
+        </Field>
+        <div className="flex items-center justify-between gap-4 border-t pt-4">
+          <Label>Type</Label>
+          <div className="flex rounded-lg bg-muted p-0.5">
+            <TransportButton
+              active={transport === "stdio"}
+              onClick={() => setTransport("stdio")}
+            >
+              STDIO
+            </TransportButton>
+            <TransportButton
+              active={transport === "http"}
+              onClick={() => setTransport("http")}
+            >
+              Streamable HTTP
+            </TransportButton>
+          </div>
+        </div>
+      </FieldCard>
+
+      {transport === "stdio" ? (
+        <>
+          <FieldCard>
+            <Field label="Command to launch" htmlFor="mcp-command">
+              <Input
+                id="mcp-command"
+                value={command}
+                onChange={(event) => setCommand(event.target.value)}
+                placeholder="npx"
+                autoComplete="off"
+                className="font-mono"
+              />
+            </Field>
+          </FieldCard>
+
+          <FieldCard>
+            <RepeatableValues
+              label="Arguments"
+              rows={args}
+              placeholder="-y"
+              addLabel="Add argument"
+              onChange={setArgs}
+            />
+          </FieldCard>
+
+          <FieldCard>
+            <RepeatablePairs
+              label="Environment variables"
+              rows={environment}
+              keyPlaceholder="Key"
+              valuePlaceholder="Value"
+              addLabel="Add environment variable"
+              onChange={setEnvironment}
+            />
+          </FieldCard>
+
+          <FieldCard>
+            <RepeatableValues
+              label="Environment variable passthrough"
+              rows={passthrough}
+              placeholder="VARIABLE_NAME"
+              addLabel="Add variable"
+              onChange={setPassthrough}
+            />
+          </FieldCard>
+
+          <FieldCard>
+            <Field label="Working directory" htmlFor="mcp-cwd">
+              <Input
+                id="mcp-cwd"
+                value={cwd}
+                onChange={(event) => setCwd(event.target.value)}
+                placeholder="/app"
+                autoComplete="off"
+                className="font-mono"
+              />
+            </Field>
+          </FieldCard>
+        </>
+      ) : (
+        <>
+          <FieldCard>
+            <Field label="Server URL" htmlFor="mcp-url">
+              <Input
+                id="mcp-url"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder="https://example.com/mcp"
+                autoComplete="off"
+                className="font-mono"
+              />
+            </Field>
+          </FieldCard>
+
+          <FieldCard>
+            <RepeatablePairs
+              label="HTTP headers"
+              rows={headers}
+              keyPlaceholder="Header"
+              valuePlaceholder="Value"
+              addLabel="Add header"
+              onChange={setHeaders}
+            />
+          </FieldCard>
+
+          <FieldCard>
+            <RepeatablePairs
+              label="Environment variable HTTP headers"
+              rows={envHeaders}
+              keyPlaceholder="Header"
+              valuePlaceholder="Environment variable"
+              addLabel="Add environment header"
+              onChange={setEnvHeaders}
+            />
+          </FieldCard>
+
+          <FieldCard>
+            <Field
+              label="Bearer token environment variable"
+              htmlFor="mcp-bearer-env"
+            >
+              <Input
+                id="mcp-bearer-env"
+                value={bearerTokenEnvVar}
+                onChange={(event) => setBearerTokenEnvVar(event.target.value)}
+                placeholder="MCP_API_TOKEN"
+                autoComplete="off"
+                className="font-mono"
+              />
+            </Field>
+          </FieldCard>
+        </>
+      )}
+
+      {error && <SettingsNotice tone="error">{error}</SettingsNotice>}
+
+      <SettingsActions>
+        <Button type="submit" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </SettingsActions>
+    </form>
+  );
+}
+
+function FieldCard({ children }: { children: React.ReactNode }) {
+  return (
+    <section className="space-y-4 rounded-2xl border bg-card/40 p-4">
+      {children}
+    </section>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function TransportButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick(): void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-md px-3 py-1.5 text-sm motion-colors",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function RepeatableValues({
+  label,
+  rows,
+  placeholder,
+  addLabel,
+  onChange,
+}: {
+  label: string;
+  rows: ValueRow[];
+  placeholder: string;
+  addLabel: string;
+  onChange(rows: ValueRow[]): void;
+}) {
+  return (
+    <div className="space-y-3">
+      <Label>{label}</Label>
+      {rows.map((row) => (
+        <div key={row.id} className="flex items-center gap-2">
+          <Input
+            value={row.value}
+            onChange={(event) =>
+              onChange(
+                rows.map((item) =>
+                  item.id === row.id
+                    ? { ...item, value: event.target.value }
+                    : item,
+                ),
+              )
+            }
+            placeholder={placeholder}
+            autoComplete="off"
+            className="font-mono"
+          />
+          <RemoveButton
+            label={`Remove ${label.toLowerCase()} row`}
+            disabled={rows.length === 1 && row.value === ""}
+            onClick={() => onChange(rows.filter((item) => item.id !== row.id))}
+          />
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="secondary"
+        className="w-full"
+        onClick={() => onChange([...rows, { id: rowId(), value: "" }])}
+      >
+        <Plus /> {addLabel}
+      </Button>
+    </div>
+  );
+}
+
+function RepeatablePairs({
+  label,
+  rows,
+  keyPlaceholder,
+  valuePlaceholder,
+  addLabel,
+  onChange,
+}: {
+  label: string;
+  rows: Pair[];
+  keyPlaceholder: string;
+  valuePlaceholder: string;
+  addLabel: string;
+  onChange(rows: Pair[]): void;
+}) {
+  return (
+    <div className="space-y-3">
+      <Label>{label}</Label>
+      {rows.map((row) => (
+        <div key={row.id} className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2">
+          <Input
+            value={row.key}
+            onChange={(event) =>
+              onChange(
+                rows.map((item) =>
+                  item.id === row.id
+                    ? { ...item, key: event.target.value }
+                    : item,
+                ),
+              )
+            }
+            placeholder={keyPlaceholder}
+            autoComplete="off"
+            className="font-mono"
+          />
+          <Input
+            value={row.value}
+            onChange={(event) =>
+              onChange(
+                rows.map((item) =>
+                  item.id === row.id
+                    ? { ...item, value: event.target.value }
+                    : item,
+                ),
+              )
+            }
+            placeholder={valuePlaceholder}
+            autoComplete="off"
+            className="font-mono"
+          />
+          <RemoveButton
+            label={`Remove ${label.toLowerCase()} row`}
+            disabled={rows.length === 1 && row.key === "" && row.value === ""}
+            onClick={() => onChange(rows.filter((item) => item.id !== row.id))}
+          />
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="secondary"
+        className="w-full"
+        onClick={() =>
+          onChange([...rows, { id: rowId(), key: "", value: "" }])
+        }
+      >
+        <Plus /> {addLabel}
+      </Button>
+    </div>
+  );
+}
+
+function RemoveButton({
+  label,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  disabled: boolean;
+  onClick(): void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="text-muted-foreground hover:text-destructive"
+    >
+      <Trash2 />
+    </Button>
+  );
+}

--- a/apps/web/app/(app)/settings/tools/mcp/[id]/page.tsx
+++ b/apps/web/app/(app)/settings/tools/mcp/[id]/page.tsx
@@ -1,0 +1,20 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth/server";
+import { getMcpServer, toMcpServer } from "@/lib/db/mcpServers";
+import { McpServerEditor } from "../McpServerEditor";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+  if (session.user.role !== "admin") redirect("/settings/tools");
+
+  const { id } = await params;
+  const row = await getMcpServer(id);
+  if (!row) redirect("/settings/tools");
+  return <McpServerEditor server={toMcpServer(row)} />;
+}

--- a/apps/web/app/(app)/settings/tools/mcp/new/page.tsx
+++ b/apps/web/app/(app)/settings/tools/mcp/new/page.tsx
@@ -1,0 +1,11 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth/server";
+import { McpServerEditor } from "../McpServerEditor";
+
+export default async function Page() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+  if (session.user.role !== "admin") redirect("/settings/tools");
+  return <McpServerEditor />;
+}

--- a/apps/web/app/(app)/settings/tools/page.tsx
+++ b/apps/web/app/(app)/settings/tools/page.tsx
@@ -1,5 +1,40 @@
+import { headers } from "next/headers";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { auth } from "@/lib/auth/server";
+import {
+  listAvailableMcpServers,
+  listMcpServers,
+  toMcpServer,
+} from "@/lib/db/mcpServers";
+import { getQueryClient } from "@/lib/queryClient";
+import { mcpServerKeys } from "@/lib/queries/keys";
 import { ToolsForm } from "./ToolsForm";
 
-export default function Page() {
-  return <ToolsForm />;
+export default async function Page() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return null;
+  const isAdmin = session?.user.role === "admin";
+
+  const queryClient = getQueryClient();
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: mcpServerKeys.availableList(),
+      queryFn: () =>
+        listAvailableMcpServers(session.user.id, session.user.role),
+    }),
+    ...(isAdmin
+      ? [
+          queryClient.prefetchQuery({
+            queryKey: mcpServerKeys.adminList(),
+            queryFn: async () => (await listMcpServers()).map(toMcpServer),
+          }),
+        ]
+      : []),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ToolsForm isAdmin={isAdmin} />
+    </HydrationBoundary>
+  );
 }

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -20,6 +20,9 @@ const mocks = vi.hoisted(() => {
     getModelConfig: vi.fn(),
     getTaskModelConfig: vi.fn(),
     getServerCapability: vi.fn(),
+    listEffectiveMcpServers: vi.fn(),
+    acquireMcpBinding: vi.fn(),
+    releaseMcpBinding: vi.fn(),
     getProject: vi.fn(),
     generateChatTitle: vi.fn(),
     getProvider: vi.fn(),
@@ -110,6 +113,12 @@ vi.mock("@/lib/db/modelConfigs", () => ({
 }));
 vi.mock("@/lib/db/serverCapabilities", () => ({
   getServerCapability: mocks.getServerCapability,
+}));
+vi.mock("@/lib/db/mcpServers", () => ({
+  listEffectiveMcpServers: mocks.listEffectiveMcpServers,
+}));
+vi.mock("@/lib/mcp/manager", () => ({
+  acquireMcpBinding: mocks.acquireMcpBinding,
 }));
 vi.mock("@/lib/db/projects", () => ({ getProject: mocks.getProject }));
 vi.mock("@/lib/title", () => ({
@@ -214,6 +223,12 @@ describe("chat route setup boundary", () => {
     mocks.getModelConfig.mockResolvedValue({ ...modelConfig });
     mocks.getTaskModelConfig.mockReturnValue(null);
     mocks.getServerCapability.mockReturnValue({ provider: "bundled" });
+    mocks.listEffectiveMcpServers.mockResolvedValue([]);
+    mocks.releaseMcpBinding.mockResolvedValue(undefined);
+    mocks.acquireMcpBinding.mockResolvedValue({
+      tools: {},
+      release: mocks.releaseMcpBinding,
+    });
     mocks.getChat.mockResolvedValue(null);
     mocks.getProject.mockResolvedValue(null);
     mocks.getChatMessage.mockResolvedValue(null);
@@ -308,6 +323,21 @@ describe("chat route setup boundary", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "exp://mobile",
     );
+    expect(mocks.commitChatTurn).not.toHaveBeenCalled();
+    expect(mocks.cancelRegister).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("does not mutate chat when MCP preparation fails", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.listEffectiveMcpServers.mockResolvedValue([{ id: "reference" }]);
+    mocks.acquireMcpBinding.mockRejectedValue(
+      new Error("MCP configuration failed"),
+    );
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
     expect(mocks.commitChatTurn).not.toHaveBeenCalled();
     expect(mocks.cancelRegister).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
@@ -641,6 +671,68 @@ describe("chat route setup boundary", () => {
     expect(mocks.toUIMessageStream).toHaveBeenCalledWith(
       expect.objectContaining({ tools: undefined }),
     );
+  });
+
+  it("uses persistent MCP tools without web tools", async () => {
+    const mcpTool = { description: "MCP echo" };
+    const mcpTools = {
+      mcp__reference__abc1234__echo__def12: mcpTool,
+    };
+    mocks.parseChatRequest.mockResolvedValue({
+      ...parsedRequest,
+      webSearchEnabled: false,
+      forceSearch: true,
+    });
+    mocks.listEffectiveMcpServers.mockResolvedValue([{ id: "reference" }]);
+    mocks.acquireMcpBinding.mockResolvedValue({
+      tools: mcpTools,
+      release: mocks.releaseMcpBinding,
+    });
+    mocks.agentStream.mockResolvedValue({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    });
+
+    await POST(request());
+
+    expect(mocks.agentSettings[0]).toEqual(
+      expect.objectContaining({
+        tools: mcpTools,
+        toolOrder: Object.keys(mcpTools),
+        toolChoice: "auto",
+      }),
+    );
+    expect(mocks.agentSettings[0]?.prepareStep).toBeUndefined();
+    expect(mocks.toUIMessageStream).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: mcpTools }),
+    );
+    expect(mocks.acquireMcpBinding).toHaveBeenCalledWith(
+      { userId: "user", chatId: "chat" },
+      [{ id: "reference" }],
+    );
+    const observed = mocks.uiStreamOptions?.stream as
+      | ReadableStream<unknown>
+      | undefined;
+    await observed?.pipeTo(new WritableStream());
+    expect(mocks.releaseMcpBinding).toHaveBeenCalledOnce();
+  });
+
+  it("releases an MCP binding when the atomic chat claim fails", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.listEffectiveMcpServers.mockResolvedValue([{ id: "reference" }]);
+    mocks.commitChatTurn.mockImplementation(() => {
+      throw new Error("database unavailable");
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
+    expect(mocks.releaseMcpBinding).toHaveBeenCalledOnce();
+    expect(mocks.agentStream).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 
   it("labels project context between model and web instructions", async () => {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import {
   toUIMessageStream,
   type LanguageModelUsage,
   type TextStreamPart,
+  type ToolSet,
 } from "ai";
 import type { MessageStats } from "@/lib/chat/stats";
 import { currentDateSystemPrompt } from "@/lib/chat/current-date";
@@ -39,6 +40,8 @@ import {
   getTaskModelConfig,
 } from "@/lib/db/modelConfigs";
 import { getProject } from "@/lib/db/projects";
+import { listEffectiveMcpServers } from "@/lib/db/mcpServers";
+import { acquireMcpBinding } from "@/lib/mcp/manager";
 import { generateChatTitle } from "@/lib/title";
 import { getProvider, modelIconForModel } from "@/lib/providers/catalog";
 import { isProviderConfigurationError } from "@/lib/providers/server/errors";
@@ -205,6 +208,14 @@ async function handlePost(req: Request): Promise<Response> {
         )
       : { role: "system" as const, content: system }
     : undefined;
+  const mcpServers = toolCallingEnabled
+    ? await listEffectiveMcpServers(userId, session.user.role)
+    : [];
+  const mcpBinding =
+    mcpServers.length > 0
+      ? await acquireMcpBinding({ userId, chatId }, mcpServers)
+      : null;
+  const mcpTools = mcpBinding?.tools ?? {};
 
   const last = messages[messages.length - 1];
   const userMessageCount = messages.filter(
@@ -235,6 +246,7 @@ async function handlePost(req: Request): Promise<Response> {
         streamClaimed = true;
       } else if (commitResult === "stream-active") {
         cancelRegistry.unregister(streamId);
+        await mcpBinding?.release();
         return withCors(
           req,
           new Response("Stream already in progress for this chat", {
@@ -243,6 +255,7 @@ async function handlePost(req: Request): Promise<Response> {
         );
       } else if (commitResult === "history-conflict") {
         cancelRegistry.unregister(streamId);
+        await mcpBinding?.release();
         return withCors(
           req,
           new Response("Chat history changed; refresh and try again", {
@@ -251,10 +264,12 @@ async function handlePost(req: Request): Promise<Response> {
         );
       } else {
         cancelRegistry.unregister(streamId);
+        await mcpBinding?.release();
         return withCors(req, new Response("Not found", { status: 404 }));
       }
     } catch (error) {
       cancelRegistry.unregister(streamId);
+      await mcpBinding?.release();
       throw error;
     }
   }
@@ -269,15 +284,31 @@ async function handlePost(req: Request): Promise<Response> {
 
   try {
     const abortSignal = controller?.signal ?? req.signal;
-    const result = webToolsEnabled
-      ? await new ToolLoopAgent<never, typeof chatTools>({
+    const hasMcpTools = Object.keys(mcpTools).length > 0;
+    const agentTools: ToolSet = hasMcpTools
+      ? webToolsEnabled
+        ? { ...chatTools, ...mcpTools }
+        : mcpTools
+      : webToolsEnabled
+        ? chatTools
+        : {};
+    const agentToolNames = Object.keys(agentTools);
+    const toolsEnabled = agentToolNames.length > 0;
+    const toolOrder = [
+      ...(webToolsEnabled ? CHAT_TOOL_ORDER : []),
+      ...agentToolNames.filter(
+        (name) => !CHAT_TOOL_ORDER.includes(name as keyof typeof chatTools),
+      ),
+    ];
+    const result = toolsEnabled
+      ? await new ToolLoopAgent<never, ToolSet>({
           model,
           instructions,
-          tools: chatTools,
-          toolOrder: CHAT_TOOL_ORDER,
+          tools: agentTools,
+          toolOrder,
           stopWhen: isStepCount(50),
           toolChoice: "auto",
-          prepareStep: forceSearch
+          prepareStep: forceSearch && webToolsEnabled
             ? ({ stepNumber }) =>
                 stepNumber === 0
                   ? {
@@ -313,7 +344,7 @@ async function handlePost(req: Request): Promise<Response> {
     const streamHeaders = corsHeaders(req);
     streamHeaders.set("Content-Encoding", "none");
     const observedStream = observeChatStream(
-      result.stream as ReadableStream<TextStreamPart<typeof chatTools>>,
+      result.stream as ReadableStream<TextStreamPart<ToolSet>>,
       {
         onFirstToken() {
           firstTokenAt ??= Date.now();
@@ -342,11 +373,14 @@ async function handlePost(req: Request): Promise<Response> {
             console.error("[chat-stream]", error);
           }
         },
+        onDone() {
+          void mcpBinding?.release();
+        },
       },
     );
     const uiStream = toUIMessageStream({
       stream: observedStream,
-      tools: webToolsEnabled ? chatTools : undefined,
+      tools: toolsEnabled ? agentTools : undefined,
       sendReasoning: true,
       originalMessages: messages,
       generateMessageId: () => crypto.randomUUID(),
@@ -506,6 +540,7 @@ async function handlePost(req: Request): Promise<Response> {
     if (resumableSetup) await resumableSetup;
     return response;
   } catch (error) {
+    await mcpBinding?.release();
     controller?.abort();
     if (controller) cancelRegistry.unregister(streamId);
     if (streamClaimed) {
@@ -520,20 +555,22 @@ async function handlePost(req: Request): Promise<Response> {
 }
 
 function observeChatStream(
-  stream: ReadableStream<TextStreamPart<typeof chatTools>>,
+  stream: ReadableStream<TextStreamPart<ToolSet>>,
   callbacks: {
     onFirstToken(): void;
     onFinishStep(usage: LanguageModelUsage): void;
     onError(error: unknown): void;
+    onDone(): void;
   },
-): ReadableStream<TextStreamPart<typeof chatTools>> {
+): ReadableStream<TextStreamPart<ToolSet>> {
   const reader = stream.getReader();
 
-  return new ReadableStream<TextStreamPart<typeof chatTools>>({
+  return new ReadableStream<TextStreamPart<ToolSet>>({
     async pull(controller) {
       try {
         const { done, value: part } = await reader.read();
         if (done) {
+          callbacks.onDone();
           controller.close();
           return;
         }
@@ -551,10 +588,12 @@ function observeChatStream(
         controller.enqueue(part);
       } catch (error) {
         callbacks.onError(error);
+        callbacks.onDone();
         controller.error(error);
       }
     },
     cancel(reason) {
+      callbacks.onDone();
       return reader.cancel(reason);
     },
   });

--- a/apps/web/app/api/chats/[id]/route.test.ts
+++ b/apps/web/app/api/chats/[id]/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  deleteChat: vi.fn(),
+  renameChat: vi.fn(),
+  moveChatToProject: vi.fn(),
+  closeChatMcpRuntime: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/chats", () => ({
+  deleteChat: mocks.deleteChat,
+  renameChat: mocks.renameChat,
+}));
+vi.mock("@/lib/db/projects", () => ({
+  moveChatToProject: mocks.moveChatToProject,
+}));
+vi.mock("@/lib/mcp/manager", () => ({
+  closeChatMcpRuntime: mocks.closeChatMcpRuntime,
+}));
+
+import { DELETE } from "./route";
+
+describe("chat deletion MCP cleanup", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getSession.mockResolvedValue({ user: { id: "user" } });
+    mocks.deleteChat.mockResolvedValue(undefined);
+    mocks.closeChatMcpRuntime.mockResolvedValue(undefined);
+  });
+
+  it("closes the deleted chat's MCP runtime", async () => {
+    const response = await DELETE(
+      new Request("http://server.test/api/chats/chat", { method: "DELETE" }),
+      { params: Promise.resolve({ id: "chat" }) },
+    );
+
+    expect(response.status).toBe(204);
+    expect(mocks.deleteChat).toHaveBeenCalledWith("chat", "user");
+    expect(mocks.closeChatMcpRuntime).toHaveBeenCalledWith({
+      chatId: "chat",
+      userId: "user",
+    });
+  });
+
+  it("does not touch a runtime for an unauthenticated request", async () => {
+    mocks.getSession.mockResolvedValue(null);
+
+    const response = await DELETE(
+      new Request("http://server.test/api/chats/chat", { method: "DELETE" }),
+      { params: Promise.resolve({ id: "chat" }) },
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.deleteChat).not.toHaveBeenCalled();
+    expect(mocks.closeChatMcpRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/chats/[id]/route.ts
+++ b/apps/web/app/api/chats/[id]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth/server";
 import { deleteChat, renameChat } from "@/lib/db/chats";
+import { closeChatMcpRuntime } from "@/lib/mcp/manager";
 import { moveChatToProject } from "@/lib/db/projects";
 
 type PatchBody = {
@@ -36,5 +37,6 @@ export async function DELETE(
 
   const { id } = await params;
   await deleteChat(id, session.user.id);
+  await closeChatMcpRuntime({ chatId: id, userId: session.user.id });
   return new Response(null, { status: 204 });
 }

--- a/apps/web/app/api/mcp-server-preferences/[id]/route.ts
+++ b/apps/web/app/api/mcp-server-preferences/[id]/route.ts
@@ -1,0 +1,36 @@
+import { auth } from "@/lib/auth/server";
+import { setMcpServerPreference } from "@/lib/db/mcpServers";
+import { McpServerPreferenceInputSchema } from "@/lib/mcp/schema";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = McpServerPreferenceInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input" },
+      { status: 400 },
+    );
+  }
+
+  const { id } = await params;
+  const mcpServer = await setMcpServerPreference(
+    session.user.id,
+    session.user.role,
+    id,
+    parsed.data.enabled,
+  );
+  if (!mcpServer) return new Response("Not found", { status: 404 });
+  return Response.json({ mcpServer });
+}

--- a/apps/web/app/api/mcp-server-preferences/route.test.ts
+++ b/apps/web/app/api/mcp-server-preferences/route.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  listAvailableMcpServers: vi.fn(),
+  setMcpServerPreference: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/mcpServers", () => ({
+  listAvailableMcpServers: mocks.listAvailableMcpServers,
+  setMcpServerPreference: mocks.setMcpServerPreference,
+}));
+
+import { PATCH } from "./[id]/route";
+import { GET } from "./route";
+
+function request(method: string, body?: unknown) {
+  return new Request("http://server.test/api/mcp-server-preferences", {
+    method,
+    ...(body === undefined
+      ? {}
+      : {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+  });
+}
+
+describe("MCP server preference routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "user", role: "user" },
+    });
+  });
+
+  it("requires authentication", async () => {
+    mocks.getSession.mockResolvedValue(null);
+    expect((await GET(request("GET"))).status).toBe(401);
+    expect(
+      (
+        await PATCH(request("PATCH", { enabled: false }), {
+          params: Promise.resolve({ id: "server" }),
+        })
+      ).status,
+    ).toBe(401);
+  });
+
+  it("returns only the user-safe available server projection", async () => {
+    mocks.listAvailableMcpServers.mockResolvedValue([
+      { id: "server", name: "Reference", enabled: true },
+    ]);
+
+    const response = await GET(request("GET"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      mcpServers: [{ id: "server", name: "Reference", enabled: true }],
+    });
+    expect(mocks.listAvailableMcpServers).toHaveBeenCalledWith("user", "user");
+  });
+
+  it("updates an authorized server preference", async () => {
+    mocks.setMcpServerPreference.mockResolvedValue({
+      id: "server",
+      name: "Reference",
+      enabled: false,
+    });
+
+    const response = await PATCH(request("PATCH", { enabled: false }), {
+      params: Promise.resolve({ id: "server" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.setMcpServerPreference).toHaveBeenCalledWith(
+      "user",
+      "user",
+      "server",
+      false,
+    );
+  });
+
+  it("does not reveal unavailable server IDs", async () => {
+    mocks.setMcpServerPreference.mockResolvedValue(null);
+
+    const response = await PATCH(request("PATCH", { enabled: true }), {
+      params: Promise.resolve({ id: "admin-only" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/web/app/api/mcp-server-preferences/route.ts
+++ b/apps/web/app/api/mcp-server-preferences/route.ts
@@ -1,0 +1,13 @@
+import { auth } from "@/lib/auth/server";
+import { listAvailableMcpServers } from "@/lib/db/mcpServers";
+
+export async function GET(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+
+  const mcpServers = await listAvailableMcpServers(
+    session.user.id,
+    session.user.role,
+  );
+  return Response.json({ mcpServers });
+}

--- a/apps/web/app/api/mcp-servers/[id]/health/route.ts
+++ b/apps/web/app/api/mcp-servers/[id]/health/route.ts
@@ -1,0 +1,20 @@
+import { auth } from "@/lib/auth/server";
+import { getMcpServer } from "@/lib/db/mcpServers";
+import { checkMcpServerHealth } from "@/lib/mcp/health";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const { id } = await params;
+  const server = await getMcpServer(id);
+  if (!server) return new Response("Not found", { status: 404 });
+
+  return Response.json(await checkMcpServerHealth(server));
+}

--- a/apps/web/app/api/mcp-servers/[id]/route.ts
+++ b/apps/web/app/api/mcp-servers/[id]/route.ts
@@ -1,0 +1,64 @@
+import { auth } from "@/lib/auth/server";
+import {
+  deleteMcpServer,
+  getMcpServer,
+  toMcpServer,
+  updateMcpServer,
+} from "@/lib/db/mcpServers";
+import { McpServerInputSchema } from "@/lib/mcp/schema";
+
+async function requireAdmin(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+  return null;
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireAdmin(req);
+  if (denied) return denied;
+
+  const { id } = await params;
+  if (!(await getMcpServer(id))) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = McpServerInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input" },
+      { status: 400 },
+    );
+  }
+
+  const row = await updateMcpServer(id, parsed.data);
+  if (!row) return new Response("Not found", { status: 404 });
+  return Response.json({ mcpServer: toMcpServer(row) });
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireAdmin(req);
+  if (denied) return denied;
+
+  const { id } = await params;
+  if (!(await getMcpServer(id))) {
+    return new Response("Not found", { status: 404 });
+  }
+  await deleteMcpServer(id);
+  return new Response(null, { status: 204 });
+}

--- a/apps/web/app/api/mcp-servers/route.test.ts
+++ b/apps/web/app/api/mcp-servers/route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  listMcpServers: vi.fn(),
+  createMcpServer: vi.fn(),
+  getMcpServer: vi.fn(),
+  updateMcpServer: vi.fn(),
+  deleteMcpServer: vi.fn(),
+  checkMcpServerHealth: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/mcpServers", () => ({
+  listMcpServers: mocks.listMcpServers,
+  createMcpServer: mocks.createMcpServer,
+  getMcpServer: mocks.getMcpServer,
+  updateMcpServer: mocks.updateMcpServer,
+  deleteMcpServer: mocks.deleteMcpServer,
+  toMcpServer: (row: unknown) => row,
+}));
+vi.mock("@/lib/mcp/health", () => ({
+  checkMcpServerHealth: mocks.checkMcpServerHealth,
+}));
+
+import { DELETE, PATCH } from "./[id]/route";
+import { POST as HEALTH } from "./[id]/health/route";
+import { GET, POST } from "./route";
+
+const input = {
+  name: "Reference MCP",
+  availability: "everyone" as const,
+  config: {
+    transport: "stdio" as const,
+    command: "npx",
+    args: ["-y", "reference-mcp"],
+    env: {},
+    envPassthrough: [],
+  },
+};
+
+function request(method: string, body?: unknown) {
+  return new Request("http://server.test/api/mcp-servers", {
+    method,
+    ...(body === undefined
+      ? {}
+      : {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+  });
+}
+
+describe("MCP server routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getSession.mockResolvedValue({ user: { id: "admin", role: "admin" } });
+  });
+
+  it("keeps configuration admin-only", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "user", role: "user" } });
+    expect((await GET(request("GET"))).status).toBe(403);
+    expect((await POST(request("POST", input))).status).toBe(403);
+    expect(
+      (
+        await HEALTH(request("POST"), {
+          params: Promise.resolve({ id: "server" }),
+        })
+      ).status,
+    ).toBe(403);
+    expect(mocks.listMcpServers).not.toHaveBeenCalled();
+    expect(mocks.createMcpServer).not.toHaveBeenCalled();
+  });
+
+  it("lists configured servers", async () => {
+    mocks.listMcpServers.mockResolvedValue([{ id: "server", ...input }]);
+    const response = await GET(request("GET"));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      mcpServers: [{ id: "server", ...input }],
+    });
+  });
+
+  it("validates and creates a server", async () => {
+    mocks.createMcpServer.mockImplementation(async (value) => ({
+      id: "server",
+      ...value,
+    }));
+    const response = await POST(request("POST", input));
+    expect(response.status).toBe(201);
+    expect(mocks.createMcpServer).toHaveBeenCalledWith(input);
+  });
+
+  it("rejects malformed configurations", async () => {
+    const response = await POST(
+      request("POST", {
+        name: "Broken",
+        config: { transport: "stdio", command: "" },
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.createMcpServer).not.toHaveBeenCalled();
+  });
+
+  it("updates and deletes existing servers", async () => {
+    mocks.getMcpServer.mockResolvedValue({ id: "server", ...input });
+    mocks.updateMcpServer.mockResolvedValue({ id: "server", ...input });
+
+    const context = { params: Promise.resolve({ id: "server" }) };
+    expect((await PATCH(request("PATCH", input), context)).status).toBe(200);
+    expect(mocks.updateMcpServer).toHaveBeenCalledWith("server", input);
+    expect((await DELETE(request("DELETE"), context)).status).toBe(204);
+    expect(mocks.deleteMcpServer).toHaveBeenCalledWith("server");
+  });
+
+  it("checks a server with a temporary MCP connection", async () => {
+    const server = { id: "server", ...input };
+    mocks.getMcpServer.mockResolvedValue(server);
+    mocks.checkMcpServerHealth.mockResolvedValue({
+      ok: true,
+      elapsedMs: 125,
+      toolCount: 3,
+    });
+
+    const response = await HEALTH(request("POST"), {
+      params: Promise.resolve({ id: "server" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      elapsedMs: 125,
+      toolCount: 3,
+    });
+    expect(mocks.checkMcpServerHealth).toHaveBeenCalledWith(server);
+  });
+});

--- a/apps/web/app/api/mcp-servers/route.ts
+++ b/apps/web/app/api/mcp-servers/route.ts
@@ -1,0 +1,47 @@
+import { auth } from "@/lib/auth/server";
+import {
+  createMcpServer,
+  listMcpServers,
+  toMcpServer,
+} from "@/lib/db/mcpServers";
+import { McpServerInputSchema } from "@/lib/mcp/schema";
+
+async function requireAdmin(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+  return null;
+}
+
+export async function GET(req: Request) {
+  const denied = await requireAdmin(req);
+  if (denied) return denied;
+
+  const rows = await listMcpServers();
+  return Response.json({ mcpServers: rows.map(toMcpServer) });
+}
+
+export async function POST(req: Request) {
+  const denied = await requireAdmin(req);
+  if (denied) return denied;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = McpServerInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid input" },
+      { status: 400 },
+    );
+  }
+
+  const row = await createMcpServer(parsed.data);
+  return Response.json({ mcpServer: toMcpServer(row) }, { status: 201 });
+}

--- a/apps/web/components/chat/ChainOfThought.tsx
+++ b/apps/web/components/chat/ChainOfThought.tsx
@@ -7,6 +7,7 @@ import {
   CircleAlert,
   Globe,
   Loader2,
+  Wrench,
   type LucideIcon,
   Search,
 } from "lucide-react";
@@ -19,10 +20,16 @@ import {
   type WebSearchPart,
   type WebSearchResult,
 } from "@overtchat/shared";
+import { parseMcpToolName } from "@overtchat/shared";
+import type { DynamicToolUIPart } from "ai";
 import { ThinkingContent } from "./ThinkingContent";
 
 type ReasoningPart = { type: "reasoning"; text: string; state?: string };
-export type ActivityPart = WebSearchPart | FetchUrlPart | ReasoningPart;
+export type ActivityPart =
+  | WebSearchPart
+  | FetchUrlPart
+  | DynamicToolUIPart
+  | ReasoningPart;
 
 function isWebSearch(p: ActivityPart): p is WebSearchPart {
   return p.type === "tool-web_search";
@@ -32,6 +39,9 @@ function isFetchUrl(p: ActivityPart): p is FetchUrlPart {
 }
 function isReasoning(p: ActivityPart): p is ReasoningPart {
   return p.type === "reasoning";
+}
+function isMcpTool(p: ActivityPart): p is DynamicToolUIPart {
+  return p.type === "dynamic-tool" && parseMcpToolName(p.toolName) !== null;
 }
 
 /**
@@ -74,10 +84,14 @@ export function ChainOfThought({
     }
   }, [active]);
 
-  const hasTools = parts.some((p) => isWebSearch(p) || isFetchUrl(p));
+  const hasTools = parts.some(
+    (p) => isWebSearch(p) || isFetchUrl(p) || isMcpTool(p),
+  );
   const lastTool = [...parts]
     .reverse()
-    .find((part) => isWebSearch(part) || isFetchUrl(part));
+    .find(
+      (part) => isWebSearch(part) || isFetchUrl(part) || isMcpTool(part),
+    );
   const lastToolFailed = lastTool?.state === "output-error";
   const last = parts[parts.length - 1];
 
@@ -141,13 +155,15 @@ export function ChainOfThought({
 /** A single timeline node: left rail (icon + connector) + the step's content. */
 function Step({ part, isLast }: { part: ActivityPart; isLast: boolean }) {
   const icon =
-    (isWebSearch(part) || isFetchUrl(part)) &&
+    (isWebSearch(part) || isFetchUrl(part) || isMcpTool(part)) &&
     part.state === "output-error"
       ? CircleAlert
       : isWebSearch(part)
         ? Search
         : isFetchUrl(part)
           ? Globe
+          : isMcpTool(part)
+            ? Wrench
           : Brain;
 
   return (
@@ -158,12 +174,74 @@ function Step({ part, isLast }: { part: ActivityPart; isLast: boolean }) {
           <SearchStep part={part} />
         ) : isFetchUrl(part) ? (
           <FetchStep part={part} />
+        ) : isMcpTool(part) ? (
+          <McpStep part={part} />
         ) : isReasoning(part) ? (
           <ThinkingContent content={part.text} />
         ) : null}
       </div>
     </div>
   );
+}
+
+function McpStep({ part }: { part: DynamicToolUIPart }) {
+  const parsed = parseMcpToolName(part.toolName);
+  const title = part.title ?? parsed?.toolName ?? part.toolName;
+  const server = parsed?.serverName ?? "MCP";
+  const running = !["output-available", "output-error", "output-denied"].includes(
+    part.state,
+  );
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="min-w-0 truncate font-medium text-foreground">
+          {server} · {title}
+        </span>
+        <span className="shrink-0 text-muted-foreground">
+          {running ? "Running" : part.state === "output-error" ? "Failed" : "Done"}
+        </span>
+      </div>
+      {part.state === "output-error" ? (
+        <p className="text-destructive">{part.errorText}</p>
+      ) : (
+        <ToolValue label="Input" value={part.input} />
+      )}
+      {part.state === "output-available" && (
+        <ToolValue label="Output" value={part.output} />
+      )}
+    </div>
+  );
+}
+
+function ToolValue({ label, value }: { label: string; value: unknown }) {
+  if (value === undefined) return null;
+  const text = formatToolValue(value);
+  if (!text) return null;
+  return (
+    <div className="rounded-lg border bg-background/40 px-2.5 py-2">
+      <p className="mb-1 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+        {label}
+      </p>
+      <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-foreground">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+function formatToolValue(value: unknown): string {
+  let text: string;
+  if (typeof value === "string") {
+    text = value;
+  } else {
+    try {
+      text = JSON.stringify(value, null, 2);
+    } catch {
+      text = String(value);
+    }
+  }
+  return text.length > 20_000 ? `${text.slice(0, 20_000)}\n…` : text;
 }
 
 /** Left gutter: the step's icon with a connecting line down to the next node. */
@@ -320,13 +398,21 @@ function activeLabel(last: ActivityPart | undefined): string {
     const url = last.input?.url;
     return url ? `Reading ${cleanDomain(url)}` : "Reading page…";
   }
+  if (isMcpTool(last)) {
+    const parsed = parseMcpToolName(last.toolName);
+    return parsed
+      ? `Running ${parsed.serverName} · ${parsed.toolName}`
+      : "Running MCP tool…";
+  }
   return "Thinking";
 }
 
 function settledLabel(parts: ActivityPart[], duration: number): string {
   const lastTool = [...parts]
     .reverse()
-    .find((part) => isWebSearch(part) || isFetchUrl(part));
+    .find(
+      (part) => isWebSearch(part) || isFetchUrl(part) || isMcpTool(part),
+    );
   if (lastTool?.type === "tool-web_search") {
     if (lastTool.state === "output-error") return "Web search failed";
     if (lastTool.state === "output-available") return "Searched the web";
@@ -336,6 +422,15 @@ function settledLabel(parts: ActivityPart[], duration: number): string {
     if (lastTool.state === "output-error") return "Page fetch failed";
     if (lastTool.state === "output-available") return "Searched the web";
     return "Page fetch did not complete";
+  }
+  if (lastTool && isMcpTool(lastTool)) {
+    const parsed = parseMcpToolName(lastTool.toolName);
+    const label = parsed
+      ? `${parsed.serverName} · ${parsed.toolName}`
+      : "MCP tool";
+    if (lastTool.state === "output-error") return `${label} failed`;
+    if (lastTool.state === "output-available") return `Used ${label}`;
+    return `${label} did not complete`;
   }
   return duration > 0 ? `Thought for ${duration}s` : "Thoughts";
 }

--- a/apps/web/drizzle/0012_ancient_martin_li.sql
+++ b/apps/web/drizzle/0012_ancient_martin_li.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `mcp_servers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`availability` text DEFAULT 'everyone' NOT NULL,
+	`config` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `user_mcp_server_preferences` (
+	`user_id` text NOT NULL,
+	`server_id` text NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	PRIMARY KEY(`user_id`, `server_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`server_id`) REFERENCES `mcp_servers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `user_mcp_server_preferences_serverId_idx` ON `user_mcp_server_preferences` (`server_id`);

--- a/apps/web/drizzle/meta/0012_snapshot.json
+++ b/apps/web/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1993 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8d8a520e-33bc-4532-9e77-2fbc9dac4b47",
+  "prevId": "723cc92c-1ec9-4664-965d-7a7fb08fef36",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connections": {
+      "name": "agent_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shell_mode": {
+          "name": "shell_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "detected_version": {
+          "name": "detected_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_connections_hostId_provider_idx": {
+          "name": "agent_connections_hostId_provider_idx",
+          "columns": [
+            "host_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connections_host_id_agent_hosts_id_fk": {
+          "name": "agent_connections_host_id_agent_hosts_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "agent_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_hosts": {
+      "name": "agent_hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_alias": {
+          "name": "ssh_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_hosts_userId_updatedAt_idx": {
+          "name": "agent_hosts_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "agent_hosts_connectorId_idx": {
+          "name": "agent_hosts_connectorId_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_hosts_user_id_user_id_fk": {
+          "name": "agent_hosts_user_id_user_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_hosts_connector_id_host_connectors_id_fk": {
+          "name": "agent_hosts_connector_id_host_connectors_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "host_connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_sessions": {
+      "name": "agent_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_path": {
+          "name": "provider_session_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking_option_id": {
+          "name": "thinking_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_modified_at": {
+          "name": "provider_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_sessions_workspaceId_providerSessionPath_idx": {
+          "name": "agent_sessions_workspaceId_providerSessionPath_idx",
+          "columns": [
+            "workspace_id",
+            "provider_session_path"
+          ],
+          "isUnique": true
+        },
+        "agent_sessions_workspaceId_providerModifiedAt_idx": {
+          "name": "agent_sessions_workspaceId_providerModifiedAt_idx",
+          "columns": [
+            "workspace_id",
+            "provider_modified_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_workspace_id_agent_workspaces_id_fk": {
+          "name": "agent_sessions_workspace_id_agent_workspaces_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_workspaces": {
+      "name": "agent_workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_workspaces_connectionId_path_idx": {
+          "name": "agent_workspaces_connectionId_path_idx",
+          "columns": [
+            "connection_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_connection_id_agent_connections_id_fk": {
+          "name": "agent_workspaces_connection_id_agent_connections_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "agent_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "chats_userId_updatedAt_idx": {
+          "name": "chats_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "chats_userId_projectId_updatedAt_idx": {
+          "name": "chats_userId_projectId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_user_id_fk": {
+          "name": "chats_user_id_user_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_usage": {
+      "name": "generation_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_cost_nano_usd": {
+          "name": "input_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_cost_nano_usd": {
+          "name": "output_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_cost_nano_usd": {
+          "name": "cache_read_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_nano_usd": {
+          "name": "cache_write_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_nano_usd": {
+          "name": "total_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generation_usage_userId_occurredAt_idx": {
+          "name": "generation_usage_userId_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_userId_providerId_model_occurredAt_idx": {
+          "name": "generation_usage_userId_providerId_model_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "provider_id",
+            "model",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_context_occurredAt_idx": {
+          "name": "generation_usage_context_occurredAt_idx",
+          "columns": [
+            "context",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_chatId_idx": {
+          "name": "generation_usage_chatId_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_messageId_idx": {
+          "name": "generation_usage_messageId_idx",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "generation_usage_user_id_user_id_fk": {
+          "name": "generation_usage_user_id_user_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_usage_chat_id_chats_id_fk": {
+          "name": "generation_usage_chat_id_chats_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_usage_message_id_messages_id_fk": {
+          "name": "generation_usage_message_id_messages_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connector_pairings": {
+      "name": "host_connector_pairings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connector_pairings_userId_idx": {
+          "name": "host_connector_pairings_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connector_pairings_user_id_user_id_fk": {
+          "name": "host_connector_pairings_user_id_user_id_fk",
+          "tableFrom": "host_connector_pairings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connectors": {
+      "name": "host_connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connectors_userId_idx": {
+          "name": "host_connectors_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connectors_user_id_user_id_fk": {
+          "name": "host_connectors_user_id_user_id_fk",
+          "tableFrom": "host_connectors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'everyone'"
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "messages_chatId_createdAt_idx": {
+          "name": "messages_chatId_createdAt_idx",
+          "columns": [
+            "chat_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "api_format": {
+          "name": "api_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai-chat'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_context_window": {
+          "name": "discovered_context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_capabilities": {
+          "name": "discovered_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calling_enabled": {
+          "name": "tool_calling_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "task_model": {
+          "name": "task_model",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "model_configs_taskModel_idx": {
+          "name": "model_configs_taskModel_idx",
+          "columns": [
+            "task_model"
+          ],
+          "isUnique": true,
+          "where": "\"model_configs\".\"task_model\" = true"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "projects_userId_updatedAt_idx": {
+          "name": "projects_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_user_id_fk": {
+          "name": "projects_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "server_capabilities": {
+      "name": "server_capabilities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bundled_installed": {
+          "name": "bundled_installed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploads": {
+      "name": "uploads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "uploads_user_id_user_id_fk": {
+          "name": "uploads_user_id_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_server_preferences": {
+      "name": "user_mcp_server_preferences",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_mcp_server_preferences_serverId_idx": {
+          "name": "user_mcp_server_preferences_serverId_idx",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_server_preferences_user_id_user_id_fk": {
+          "name": "user_mcp_server_preferences_user_id_user_id_fk",
+          "tableFrom": "user_mcp_server_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mcp_server_preferences_server_id_mcp_servers_id_fk": {
+          "name": "user_mcp_server_preferences_server_id_mcp_servers_id_fk",
+          "tableFrom": "user_mcp_server_preferences",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_mcp_server_preferences_user_id_server_id_pk": {
+          "columns": [
+            "user_id",
+            "server_id"
+          ],
+          "name": "user_mcp_server_preferences_user_id_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1787078954158,
       "tag": "0011_exotic_banshee",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1787121893745,
+      "tag": "0012_ancient_martin_li",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/chat/parts.test.ts
+++ b/apps/web/lib/chat/parts.test.ts
@@ -16,6 +16,15 @@ const search = (query: string): Part =>
   }) as unknown as Part;
 const file = (): Part =>
   ({ type: "file", mediaType: "image/png", url: "x" }) as Part;
+const mcpTool = (): Part =>
+  ({
+    type: "dynamic-tool",
+    toolName: "mcp__reference__echo",
+    toolCallId: "echo",
+    state: "output-available",
+    input: { value: "hello" },
+    output: { content: [{ type: "text", text: "hello" }] },
+  }) as Part;
 
 describe("groupMessageParts", () => {
   it("collapses interleaved reasoning + tools into one activity block", () => {
@@ -75,5 +84,20 @@ describe("groupMessageParts", () => {
     const activity = segs[0] as Extract<Segment, { kind: "activity" }>;
     expect(activity.parts).toHaveLength(4); // reasoning + 3 searches, blanks dropped
     expect(segs[1]).toMatchObject({ kind: "text", index: 6 });
+  });
+
+  it("groups dynamic MCP tools into the activity timeline", () => {
+    const segs = groupMessageParts([
+      reasoning("calling a tool"),
+      mcpTool(),
+      text("done"),
+    ]);
+    expect(segs.map((segment) => segment.kind)).toEqual([
+      "activity",
+      "text",
+    ]);
+    expect(
+      (segs[0] as Extract<Segment, { kind: "activity" }>).parts,
+    ).toHaveLength(2);
   });
 });

--- a/apps/web/lib/chat/parts.ts
+++ b/apps/web/lib/chat/parts.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import { isMcpToolName } from "@overtchat/shared";
 
 type AnyPart = UIMessage["parts"][number];
 
@@ -9,7 +10,10 @@ const ACTIVITY_TYPES = new Set([
 ]);
 
 export function isActivityPart(part: AnyPart): boolean {
-  return ACTIVITY_TYPES.has(part.type);
+  return (
+    ACTIVITY_TYPES.has(part.type) ||
+    (part.type === "dynamic-tool" && isMcpToolName(part.toolName))
+  );
 }
 
 export type Segment =

--- a/apps/web/lib/db/mcpServers.test.ts
+++ b/apps/web/lib/db/mcpServers.test.ts
@@ -1,0 +1,200 @@
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invalidateMcpServer: vi.fn().mockResolvedValue(undefined),
+  invalidateUserMcpServer: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/mcp/manager", () => ({
+  invalidateMcpServer: mocks.invalidateMcpServer,
+  invalidateUserMcpServer: mocks.invalidateUserMcpServer,
+}));
+
+const databasePath = path.join(
+  os.tmpdir(),
+  `overtchat-mcp-servers-${process.pid}-${Date.now()}.db`,
+);
+process.env.DATABASE_URL = databasePath;
+
+const raw = new Database(databasePath);
+raw.exec(`
+  CREATE TABLE user (
+    id TEXT PRIMARY KEY NOT NULL
+  );
+  CREATE TABLE mcp_servers (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    availability TEXT DEFAULT 'everyone' NOT NULL,
+    config TEXT NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+    updated_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer))
+  );
+  CREATE TABLE user_mcp_server_preferences (
+    user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+    server_id TEXT NOT NULL REFERENCES mcp_servers(id) ON DELETE CASCADE,
+    enabled INTEGER DEFAULT true NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+    updated_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+    PRIMARY KEY (user_id, server_id)
+  );
+`);
+
+let repository: typeof import("./mcpServers");
+
+beforeAll(async () => {
+  repository = await import("./mcpServers");
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  raw.exec(`
+    DELETE FROM user_mcp_server_preferences;
+    DELETE FROM mcp_servers;
+    DELETE FROM user;
+    INSERT INTO user (id) VALUES ('user'), ('admin');
+    INSERT INTO mcp_servers (id, name, availability, config)
+    VALUES (
+      'reference',
+      'Reference',
+      'everyone',
+      '{"transport":"http","url":"https://mcp.example.test","headers":{}}'
+    ), (
+      'admin-reference',
+      'Admin Reference',
+      'admins',
+      '{"transport":"http","url":"https://admin.example.test","headers":{}}'
+    ), (
+      'disabled-reference',
+      'Disabled Reference',
+      'disabled',
+      '{"transport":"http","url":"https://disabled.example.test","headers":{}}'
+    );
+  `);
+});
+
+afterAll(() => {
+  raw.close();
+  fs.rmSync(databasePath, { force: true });
+});
+
+describe("MCP server connection invalidation", () => {
+  it("closes the previous connection after an update", async () => {
+    await repository.updateMcpServer("reference", {
+      name: "Updated Reference",
+      availability: "everyone",
+      config: {
+        transport: "http",
+        url: "https://updated.example.test/mcp",
+        headers: {},
+      },
+    });
+
+    expect(mocks.invalidateMcpServer).toHaveBeenCalledOnce();
+    expect(mocks.invalidateMcpServer).toHaveBeenCalledWith("reference", {
+      disconnect: true,
+    });
+  });
+
+  it("closes the connection after deletion", async () => {
+    await repository.deleteMcpServer("reference");
+
+    expect(mocks.invalidateMcpServer).toHaveBeenCalledOnce();
+    expect(mocks.invalidateMcpServer).toHaveBeenCalledWith("reference");
+  });
+
+  it("reprojects a rename without disconnecting the server", async () => {
+    await repository.updateMcpServer("reference", {
+      name: "Renamed Reference",
+      availability: "everyone",
+      config: {
+        transport: "http",
+        url: "https://mcp.example.test",
+        headers: {},
+      },
+    });
+
+    expect(mocks.invalidateMcpServer).toHaveBeenCalledWith("reference", {
+      disconnect: false,
+    });
+  });
+
+  it("disconnects the server when its audience changes", async () => {
+    await repository.updateMcpServer("reference", {
+      name: "Reference",
+      availability: "admins",
+      config: {
+        transport: "http",
+        url: "https://mcp.example.test",
+        headers: {},
+      },
+    });
+
+    expect(mocks.invalidateMcpServer).toHaveBeenCalledWith("reference", {
+      disconnect: true,
+    });
+  });
+});
+
+describe("MCP server visibility and preferences", () => {
+  it("shows regular users only everyone servers", async () => {
+    await expect(
+      repository.listAvailableMcpServers("user", "user"),
+    ).resolves.toEqual([
+      { id: "reference", name: "Reference", enabled: true },
+    ]);
+  });
+
+  it("shows admins everyone and admin-only servers but never disabled servers", async () => {
+    await expect(
+      repository.listAvailableMcpServers("admin", "admin"),
+    ).resolves.toEqual([
+      { id: "admin-reference", name: "Admin Reference", enabled: true },
+      { id: "reference", name: "Reference", enabled: true },
+    ]);
+  });
+
+  it("defaults missing preferences to enabled and omits personally disabled servers at runtime", async () => {
+    await repository.setMcpServerPreference(
+      "user",
+      "user",
+      "reference",
+      false,
+    );
+
+    await expect(
+      repository.listAvailableMcpServers("user", "user"),
+    ).resolves.toEqual([
+      { id: "reference", name: "Reference", enabled: false },
+    ]);
+    await expect(
+      repository.listEffectiveMcpServers("user", "user"),
+    ).resolves.toEqual([]);
+    expect(mocks.invalidateUserMcpServer).toHaveBeenCalledWith(
+      "user",
+      "reference",
+    );
+  });
+
+  it("does not let a user create a preference for an unauthorized server", async () => {
+    await expect(
+      repository.setMcpServerPreference(
+        "user",
+        "user",
+        "admin-reference",
+        true,
+      ),
+    ).resolves.toBeNull();
+
+    expect(mocks.invalidateUserMcpServer).not.toHaveBeenCalled();
+    expect(
+      raw
+        .prepare("SELECT count(*) AS count FROM user_mcp_server_preferences")
+        .get(),
+    ).toEqual({ count: 0 });
+  });
+});

--- a/apps/web/lib/db/mcpServers.ts
+++ b/apps/web/lib/db/mcpServers.ts
@@ -1,0 +1,150 @@
+import "server-only";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { mcpServers, userMcpServerPreferences } from "@/lib/db/schema";
+import type {
+  AvailableMcpServer,
+  McpServer,
+  McpServerInput,
+} from "@/lib/mcp/schema";
+import {
+  invalidateMcpServer,
+  invalidateUserMcpServer,
+} from "@/lib/mcp/manager";
+
+export type McpServerRow = typeof mcpServers.$inferSelect;
+
+export function toMcpServer(row: McpServerRow): McpServer {
+  return {
+    id: row.id,
+    name: row.name,
+    availability: row.availability,
+    config: row.config,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export async function listMcpServers(): Promise<McpServerRow[]> {
+  return db.select().from(mcpServers).orderBy(asc(mcpServers.name));
+}
+
+function availableToRole(role: string | null | undefined) {
+  return role === "admin"
+    ? inArray(mcpServers.availability, ["everyone", "admins"])
+    : eq(mcpServers.availability, "everyone");
+}
+
+async function listAuthorizedMcpServers(
+  userId: string,
+  role: string | null | undefined,
+) {
+  return db
+    .select({
+      server: mcpServers,
+      preferenceEnabled: userMcpServerPreferences.enabled,
+    })
+    .from(mcpServers)
+    .leftJoin(
+      userMcpServerPreferences,
+      and(
+        eq(userMcpServerPreferences.serverId, mcpServers.id),
+        eq(userMcpServerPreferences.userId, userId),
+      ),
+    )
+    .where(availableToRole(role))
+    .orderBy(asc(mcpServers.name));
+}
+
+export async function listAvailableMcpServers(
+  userId: string,
+  role: string | null | undefined,
+): Promise<AvailableMcpServer[]> {
+  const rows = await listAuthorizedMcpServers(userId, role);
+  return rows.map(({ server, preferenceEnabled }) => ({
+    id: server.id,
+    name: server.name,
+    enabled: preferenceEnabled ?? true,
+  }));
+}
+
+export async function listEffectiveMcpServers(
+  userId: string,
+  role: string | null | undefined,
+): Promise<McpServerRow[]> {
+  const rows = await listAuthorizedMcpServers(userId, role);
+  return rows
+    .filter(({ preferenceEnabled }) => preferenceEnabled !== false)
+    .map(({ server }) => server);
+}
+
+export async function getMcpServer(id: string): Promise<McpServerRow | null> {
+  const [row] = await db
+    .select()
+    .from(mcpServers)
+    .where(eq(mcpServers.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function createMcpServer(
+  input: McpServerInput,
+): Promise<McpServerRow> {
+  const [row] = await db
+    .insert(mcpServers)
+    .values({ id: crypto.randomUUID(), ...input })
+    .returning();
+  return row;
+}
+
+export async function updateMcpServer(
+  id: string,
+  input: McpServerInput,
+): Promise<McpServerRow | null> {
+  const previous = await getMcpServer(id);
+  const [row] = await db
+    .update(mcpServers)
+    .set({ ...input, updatedAt: new Date() })
+    .where(eq(mcpServers.id, id))
+    .returning();
+  if (row) {
+    const disconnect =
+      !previous ||
+      previous.availability !== row.availability ||
+      JSON.stringify(previous.config) !== JSON.stringify(row.config);
+    await invalidateMcpServer(id, { disconnect });
+  }
+  return row ?? null;
+}
+
+export async function setMcpServerPreference(
+  userId: string,
+  role: string | null | undefined,
+  serverId: string,
+  enabled: boolean,
+): Promise<AvailableMcpServer | null> {
+  const [server] = await db
+    .select({ id: mcpServers.id, name: mcpServers.name })
+    .from(mcpServers)
+    .where(and(eq(mcpServers.id, serverId), availableToRole(role)))
+    .limit(1);
+  if (!server) return null;
+
+  await db
+    .insert(userMcpServerPreferences)
+    .values({ userId, serverId, enabled })
+    .onConflictDoUpdate({
+      target: [
+        userMcpServerPreferences.userId,
+        userMcpServerPreferences.serverId,
+      ],
+      set: { enabled, updatedAt: new Date() },
+    });
+  await invalidateUserMcpServer(userId, serverId);
+  return { ...server, enabled };
+}
+
+export async function deleteMcpServer(id: string): Promise<void> {
+  await db.delete(mcpServers).where(eq(mcpServers.id, id));
+  await invalidateMcpServer(id);
+}

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -4,6 +4,7 @@ import {
   text,
   integer,
   index,
+  primaryKey,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 import type { UIMessagePart, UIDataTypes, UITools } from "ai";
@@ -13,6 +14,7 @@ import {
   PROVIDER_IDS,
 } from "@/lib/providers/catalog";
 import type { ModelPricing } from "@/lib/model-config/schema";
+import type { McpServerConfig } from "@/lib/mcp/schema";
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -623,6 +625,50 @@ export const modelConfigs = sqliteTable(
     uniqueIndex("model_configs_taskModel_idx")
       .on(table.taskModel)
       .where(sql`${table.taskModel} = true`),
+  ],
+);
+
+export const mcpServers = sqliteTable("mcp_servers", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  availability: text("availability", {
+    enum: ["everyone", "admins", "disabled"],
+  })
+    .default("everyone")
+    .notNull(),
+  config: text("config", { mode: "json" }).$type<McpServerConfig>().notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .$onUpdate(() => new Date())
+    .notNull(),
+});
+
+export const userMcpServerPreferences = sqliteTable(
+  "user_mcp_server_preferences",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    serverId: text("server_id")
+      .notNull()
+      .references(() => mcpServers.id, { onDelete: "cascade" }),
+    enabled: integer("enabled", { mode: "boolean" })
+      .default(true)
+      .notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.serverId] }),
+    index("user_mcp_server_preferences_serverId_idx").on(table.serverId),
   ],
 );
 

--- a/apps/web/lib/mcp/client.integration.test.ts
+++ b/apps/web/lib/mcp/client.integration.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { createConfiguredMcpClient } from "./client";
+
+const MODERN_MCP_FIXTURE = String.raw`
+const readline = require("node:readline");
+const lines = readline.createInterface({ input: process.stdin });
+
+function result(id, value) {
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    result: { resultType: "complete", ...value },
+  }) + "\n");
+}
+
+function error(id, message) {
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32601, message },
+  }) + "\n");
+}
+
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "server/discover") {
+    result(message.id, {
+      supportedVersions: ["2026-07-28"],
+      capabilities: { tools: {} },
+      _meta: {
+        "io.modelcontextprotocol/serverInfo": {
+          name: "overtchat-test",
+          version: "1.0.0",
+        },
+      },
+    });
+    return;
+  }
+  if (message.method === "initialize") {
+    error(message.id, "Legacy initialization is not supported by this fixture");
+    return;
+  }
+  if (message.method === "tools/list") {
+    result(message.id, {
+      tools: [{
+        name: "read_cache",
+        description: "Return the npm cache seen by the child process",
+        inputSchema: { type: "object", properties: {} },
+      }],
+    });
+    return;
+  }
+  if (message.method === "tools/call") {
+    result(message.id, {
+      content: [{
+        type: "text",
+        text: process.env.NPM_CONFIG_CACHE || "",
+      }],
+    });
+    return;
+  }
+  if (message.id !== undefined) {
+    error(message.id, "Unsupported method: " + message.method);
+  }
+});
+`;
+
+describe("MCP STDIO integration", () => {
+  it("preserves modern discovery and passes the runtime npm cache to the child", async () => {
+    const previousCache = process.env.NPM_CONFIG_CACHE;
+    process.env.NPM_CONFIG_CACHE = "/app/npm-cache";
+    let client: Awaited<ReturnType<typeof createConfiguredMcpClient>> | null =
+      null;
+
+    try {
+      client = await createConfiguredMcpClient({
+        transport: "stdio",
+        command: process.execPath,
+        args: ["-e", MODERN_MCP_FIXTURE],
+        env: {},
+        envPassthrough: [],
+      });
+
+      expect(client.initializeResult.protocolVersion).toBe("2026-07-28");
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: "read_cache" }],
+      });
+      await expect(
+        client.callTool({ name: "read_cache" }),
+      ).resolves.toMatchObject({
+        content: [{ type: "text", text: "/app/npm-cache" }],
+      });
+    } finally {
+      await client?.close();
+      if (previousCache === undefined) {
+        delete process.env.NPM_CONFIG_CACHE;
+      } else {
+        process.env.NPM_CONFIG_CACHE = previousCache;
+      }
+    }
+  });
+});

--- a/apps/web/lib/mcp/client.test.ts
+++ b/apps/web/lib/mcp/client.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
+
+const mocks = vi.hoisted(() => ({
+  createMCPClient: vi.fn(),
+  stdioConfigs: [] as Array<Record<string, unknown>>,
+  stdioTransports: [] as Array<{
+    onclose?: () => void;
+    send: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@ai-sdk/mcp", () => ({
+  createMCPClient: mocks.createMCPClient,
+}));
+vi.mock("@ai-sdk/mcp/mcp-stdio", () => ({
+  Experimental_StdioMCPTransport: class MockStdioTransport {
+    readonly supportsProtocolVersionDiscovery = true;
+    readonly supportsMcpToolParameterHeaders = true;
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: unknown) => void;
+    send = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn().mockResolvedValue(undefined);
+
+    constructor(config: Record<string, unknown>) {
+      mocks.stdioConfigs.push(config);
+      mocks.stdioTransports.push(this);
+    }
+
+    start() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+import {
+  createConfiguredMcpClient,
+  listAllMcpTools,
+} from "./client";
+
+const close = vi.fn();
+
+describe("MCP clients", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.stdioConfigs.length = 0;
+    mocks.stdioTransports.length = 0;
+    close.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.OVERTCHAT_MCP_TEST_PARENT;
+    delete process.env.OVERTCHAT_MCP_TEST_TOKEN;
+    delete process.env.OVERTCHAT_MCP_HEADER_TOKEN;
+    delete process.env.NPM_CONFIG_CACHE;
+  });
+
+  it("builds STDIO transports with explicit and passthrough environment", async () => {
+    process.env.OVERTCHAT_MCP_TEST_PARENT = "inherited";
+    process.env.NPM_CONFIG_CACHE = "/app/npm-cache";
+    const client = { close };
+    mocks.createMCPClient.mockResolvedValue(client);
+
+    await expect(
+      createConfiguredMcpClient({
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "example-mcp"],
+        env: { DIRECT: "configured" },
+        envPassthrough: ["OVERTCHAT_MCP_TEST_PARENT", "MISSING_VALUE"],
+        cwd: "/app",
+      }),
+    ).resolves.toBe(client);
+
+    expect(mocks.stdioConfigs).toEqual([
+      {
+        command: "npx",
+        args: ["-y", "example-mcp"],
+        env: {
+          NPM_CONFIG_CACHE: "/app/npm-cache",
+          OVERTCHAT_MCP_TEST_PARENT: "inherited",
+          DIRECT: "configured",
+        },
+        cwd: "/app",
+      },
+    ]);
+  });
+
+  it("allows explicit MCP environment to override the runtime npm cache", async () => {
+    process.env.NPM_CONFIG_CACHE = "/app/npm-cache";
+    mocks.createMCPClient.mockResolvedValue({ close });
+
+    await createConfiguredMcpClient({
+      transport: "stdio",
+      command: "npx",
+      args: [],
+      env: { NPM_CONFIG_CACHE: "/custom/cache" },
+      envPassthrough: [],
+    });
+
+    expect(mocks.stdioConfigs[0]?.env).toEqual({
+      NPM_CONFIG_CACHE: "/custom/cache",
+    });
+  });
+
+  it("forwards STDIO transport capabilities and request options", async () => {
+    const client = { close };
+    const signal = new AbortController().signal;
+    const message = { jsonrpc: "2.0", method: "ping" };
+    const sendOptions = { signal, relatedRequestId: "request-1" };
+    const closeOptions = { signal };
+    mocks.createMCPClient.mockImplementation(async ({ transport }) => {
+      expect(transport.supportsProtocolVersionDiscovery).toBe(true);
+      expect(transport.supportsMcpToolParameterHeaders).toBe(true);
+      await transport.send(message, sendOptions);
+      await transport.close(closeOptions);
+      return client;
+    });
+
+    await createConfiguredMcpClient({
+      transport: "stdio",
+      command: "node",
+      args: [],
+      env: {},
+      envPassthrough: [],
+    });
+
+    expect(mocks.stdioTransports[0]?.send).toHaveBeenCalledWith(
+      message,
+      sendOptions,
+    );
+    expect(mocks.stdioTransports[0]?.close).toHaveBeenCalledWith(closeOptions);
+  });
+
+  it("resolves bearer tokens from the OvertChat environment", async () => {
+    process.env.OVERTCHAT_MCP_TEST_TOKEN = "secret";
+    mocks.createMCPClient.mockResolvedValue({ close });
+
+    await createConfiguredMcpClient({
+      transport: "http",
+      url: "https://mcp.example.test/mcp",
+      headers: { "X-Test": "value" },
+      bearerTokenEnvVar: "OVERTCHAT_MCP_TEST_TOKEN",
+    });
+
+    expect(mocks.createMCPClient).toHaveBeenCalledWith({
+      clientName: "overtchat",
+      initializationOptions: { timeout: 30_000 },
+      transport: {
+        type: "http",
+        url: "https://mcp.example.test/mcp",
+        headers: {
+          "X-Test": "value",
+          Authorization: "Bearer secret",
+        },
+      },
+    });
+  });
+
+  it("resolves HTTP header values from environment variables", async () => {
+    process.env.OVERTCHAT_MCP_HEADER_TOKEN = "environment-secret";
+    mocks.createMCPClient.mockResolvedValue({ close });
+
+    await createConfiguredMcpClient({
+      transport: "http",
+      url: "https://mcp.example.test/mcp",
+      headers: { "X-Literal": "literal" },
+      envHeaders: { "X-Secret": "OVERTCHAT_MCP_HEADER_TOKEN" },
+    });
+
+    expect(mocks.createMCPClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: expect.objectContaining({
+          headers: {
+            "X-Literal": "literal",
+            "X-Secret": "environment-secret",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("expands a home-relative working directory like Codex", async () => {
+    mocks.createMCPClient.mockResolvedValue({ close });
+
+    await createConfiguredMcpClient({
+      transport: "stdio",
+      command: "npx",
+      args: [],
+      env: {},
+      envPassthrough: [],
+      cwd: "~/code",
+    });
+
+    expect(mocks.stdioConfigs[0]?.cwd).toBe(path.join(os.homedir(), "code"));
+  });
+
+  it("reports an unexpected STDIO disconnect to its lifecycle owner", async () => {
+    const onDisconnect = vi.fn();
+    const client = { close };
+    mocks.createMCPClient.mockImplementation(async ({ transport }) => {
+      transport.onclose = vi.fn();
+      await transport.start();
+      return client;
+    });
+
+    await createConfiguredMcpClient(
+      {
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "example-mcp"],
+        env: {},
+        envPassthrough: [],
+      },
+      { onDisconnect },
+    );
+    mocks.stdioTransports[0]?.onclose?.();
+
+    expect(onDisconnect).toHaveBeenCalledOnce();
+  });
+
+  it("collects paginated tool catalogs", async () => {
+    const listTools = vi
+      .fn()
+      .mockResolvedValueOnce({
+        tools: [{ name: "echo", description: "Echo input" }],
+        nextCursor: "next",
+      })
+      .mockResolvedValueOnce({
+        tools: [{ name: "lookup", description: "Look up input" }],
+      });
+    const client = {
+      listTools,
+      close,
+    };
+
+    await expect(
+      listAllMcpTools(
+        client as never,
+        new AbortController().signal,
+      ),
+    ).resolves.toEqual({
+      tools: [
+        { name: "echo", description: "Echo input" },
+        { name: "lookup", description: "Look up input" },
+      ],
+    });
+    expect(listTools).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ params: { cursor: "next" } }),
+    );
+  });
+});

--- a/apps/web/lib/mcp/client.ts
+++ b/apps/web/lib/mcp/client.ts
@@ -1,0 +1,207 @@
+import "server-only";
+import {
+  createMCPClient,
+  type ListToolsResult,
+  type MCPClient,
+  type MCPTransport,
+} from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import os from "node:os";
+import path from "node:path";
+import type {
+  McpServerConfig,
+  StdioMcpConfig,
+  StreamableHttpMcpConfig,
+} from "@/lib/mcp/schema";
+
+export const MCP_SETUP_TIMEOUT_MS = 30_000;
+export const MCP_TOOL_TIMEOUT_MS = 300_000;
+const MAX_MCP_CATALOG_ITEMS = 2_048;
+
+type ClientLifecycle = {
+  onDisconnect?(): void;
+  initializationSignal?: AbortSignal;
+};
+
+function initializationOptions(lifecycle: ClientLifecycle) {
+  return {
+    timeout: MCP_SETUP_TIMEOUT_MS,
+    ...(lifecycle.initializationSignal
+      ? { signal: lifecycle.initializationSignal }
+      : {}),
+  };
+}
+
+class LifecycleMcpTransport implements MCPTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: MCPTransport["onmessage"];
+
+  constructor(
+    private readonly transport: MCPTransport,
+    private readonly lifecycle: ClientLifecycle,
+  ) {}
+
+  get supportsProtocolVersionDiscovery() {
+    return this.transport.supportsProtocolVersionDiscovery;
+  }
+
+  get supportsMcpToolParameterHeaders() {
+    return this.transport.supportsMcpToolParameterHeaders;
+  }
+
+  get protocolVersion() {
+    return this.transport.protocolVersion;
+  }
+
+  set protocolVersion(value: string | undefined) {
+    this.transport.protocolVersion = value;
+  }
+
+  setProtocolVersion(version: string) {
+    if (this.transport.setProtocolVersion) {
+      this.transport.setProtocolVersion(version);
+    } else {
+      this.transport.protocolVersion = version;
+    }
+  }
+
+  async start() {
+    this.transport.onclose = () => {
+      this.lifecycle.onDisconnect?.();
+      this.onclose?.();
+    };
+    this.transport.onerror = (error) => this.onerror?.(error);
+    this.transport.onmessage = (message) => this.onmessage?.(message);
+    await this.transport.start();
+  }
+
+  send(
+    message: Parameters<MCPTransport["send"]>[0],
+    options?: Parameters<MCPTransport["send"]>[1],
+  ) {
+    return this.transport.send(message, options);
+  }
+
+  close(options?: Parameters<MCPTransport["close"]>[0]) {
+    return this.transport.close(options);
+  }
+}
+
+function stdioEnvironment(config: StdioMcpConfig): Record<string, string> {
+  const runtime = Object.fromEntries(
+    ["NPM_CONFIG_CACHE"].flatMap((name) => {
+      const value = process.env[name];
+      return value === undefined ? [] : [[name, value]];
+    }),
+  );
+  const inherited = Object.fromEntries(
+    config.envPassthrough.flatMap((name) => {
+      const value = process.env[name];
+      return value === undefined ? [] : [[name, value]];
+    }),
+  );
+  return { ...runtime, ...inherited, ...config.env };
+}
+
+function httpHeaders(config: StreamableHttpMcpConfig): Record<string, string> {
+  const headers = { ...config.headers };
+  for (const [header, environmentName] of Object.entries(
+    config.envHeaders ?? {},
+  )) {
+    const value = process.env[environmentName];
+    if (value === undefined) {
+      throw new Error(`Environment variable ${environmentName} is not set`);
+    }
+    headers[header] = value;
+  }
+  if (config.bearerTokenEnvVar) {
+    const token = process.env[config.bearerTokenEnvVar];
+    if (!token) {
+      throw new Error(
+        `Environment variable ${config.bearerTokenEnvVar} is not set`,
+      );
+    }
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+function workingDirectory(cwd: string | undefined): string | undefined {
+  if (!cwd) return undefined;
+  if (cwd === "~") return os.homedir();
+  if (cwd.startsWith("~/") || cwd.startsWith("~\\")) {
+    return path.join(os.homedir(), cwd.slice(2));
+  }
+  return cwd;
+}
+
+export async function createConfiguredMcpClient(
+  config: McpServerConfig,
+  lifecycle: ClientLifecycle = {},
+): Promise<MCPClient> {
+  if (config.transport === "stdio") {
+    const transport = new LifecycleMcpTransport(
+      new Experimental_StdioMCPTransport({
+        command: config.command,
+        args: config.args,
+        env: stdioEnvironment(config),
+        cwd: workingDirectory(config.cwd),
+      }),
+      lifecycle,
+    );
+    return createMCPClient({
+      clientName: "overtchat",
+      transport,
+      initializationOptions: initializationOptions(lifecycle),
+      ...(lifecycle.onDisconnect
+        ? { onUncaughtError: lifecycle.onDisconnect }
+        : {}),
+    });
+  }
+
+  return createMCPClient({
+    clientName: "overtchat",
+    initializationOptions: initializationOptions(lifecycle),
+    ...(lifecycle.onDisconnect
+      ? { onUncaughtError: lifecycle.onDisconnect }
+      : {}),
+    transport: {
+      type: "http",
+      url: config.url,
+      headers: httpHeaders(config),
+    },
+  });
+}
+
+export async function listAllMcpTools(
+  client: MCPClient,
+  signal: AbortSignal,
+): Promise<ListToolsResult> {
+  const tools: ListToolsResult["tools"] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  do {
+    if (cursor && !seenCursors.add(cursor)) {
+      throw new Error("MCP tools/list returned a repeated pagination cursor");
+    }
+    const page = await client.listTools({
+      ...(cursor ? { params: { cursor } } : {}),
+      options: { signal },
+    });
+    tools.push(...page.tools);
+    if (tools.length > MAX_MCP_CATALOG_ITEMS) {
+      throw new Error(
+        `MCP tools/list exceeded the catalog limit of ${MAX_MCP_CATALOG_ITEMS} items`,
+      );
+    }
+    cursor = page.nextCursor;
+  } while (cursor);
+
+  return { tools };
+}
+
+export function mcpSetupSignal(): AbortSignal {
+  return AbortSignal.timeout(MCP_SETUP_TIMEOUT_MS);
+}

--- a/apps/web/lib/mcp/health.test.ts
+++ b/apps/web/lib/mcp/health.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connectMcpServer: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/mcp/runtime", () => ({
+  connectMcpServer: mocks.connectMcpServer,
+}));
+
+import type { McpServerRow } from "@/lib/db/mcpServers";
+import { checkMcpServerHealth } from "./health";
+
+const server: McpServerRow = {
+  id: "reference",
+  name: "Reference",
+  availability: "disabled",
+  config: {
+    transport: "http",
+    url: "https://mcp.example.test",
+    headers: {},
+  },
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+
+describe("MCP server health", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("discovers tools and closes the diagnostic connection", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    mocks.connectMcpServer.mockResolvedValue({
+      rawTools: { echo: {}, lookup: {} },
+      close,
+    });
+
+    await expect(checkMcpServerHealth(server)).resolves.toMatchObject({
+      ok: true,
+      toolCount: 2,
+    });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("returns connection failures as health results", async () => {
+    mocks.connectMcpServer.mockRejectedValue(new Error("connection refused"));
+
+    await expect(checkMcpServerHealth(server)).resolves.toMatchObject({
+      ok: false,
+      error: "connection refused",
+    });
+  });
+});

--- a/apps/web/lib/mcp/health.ts
+++ b/apps/web/lib/mcp/health.ts
@@ -1,0 +1,22 @@
+import "server-only";
+import type { McpServerRow } from "@/lib/db/mcpServers";
+import type { McpServerHealth } from "@/lib/mcp/schema";
+import { connectMcpServer } from "@/lib/mcp/runtime";
+
+export async function checkMcpServerHealth(
+  server: McpServerRow,
+): Promise<McpServerHealth> {
+  const startedAt = Date.now();
+  try {
+    const connection = await connectMcpServer(server);
+    const toolCount = Object.keys(connection.rawTools).length;
+    await connection.close();
+    return { ok: true, elapsedMs: Date.now() - startedAt, toolCount };
+  } catch (error) {
+    return {
+      ok: false,
+      elapsedMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/apps/web/lib/mcp/manager.test.ts
+++ b/apps/web/lib/mcp/manager.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { MCPClient } from "@ai-sdk/mcp";
+import type { ToolSet } from "ai";
+import type { McpServerRow } from "@/lib/db/mcpServers";
+import { McpManager } from "./manager";
+import { McpConnection, mcpConnectionRevision } from "./runtime";
+
+function server(): McpServerRow {
+  return {
+    id: "reference",
+    name: "Reference",
+    availability: "everyone",
+    config: {
+      transport: "http",
+      url: "https://reference.example.test/mcp",
+      headers: {},
+    },
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+function factory() {
+  const clients: Array<{ close: ReturnType<typeof vi.fn> }> = [];
+  const connect = vi.fn(async (value: McpServerRow) => {
+    const client = { close: vi.fn().mockResolvedValue(undefined) };
+    clients.push(client);
+    return new McpConnection(
+      mcpConnectionRevision(value),
+      client as unknown as MCPClient,
+      { echo: { description: "echo" } } as unknown as ToolSet,
+      { connected: true },
+    );
+  });
+  return { connect, clients };
+}
+
+describe("MCP manager", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shares a runtime across turns in one chat but isolates different chats", async () => {
+    const created = factory();
+    const manager = new McpManager({ connect: created.connect });
+    const firstScope = { userId: "user", chatId: "first" };
+    const secondScope = { userId: "user", chatId: "second" };
+
+    const first = await manager.acquire(firstScope, [server()]);
+    await first.release();
+    const repeated = await manager.acquire(firstScope, [server()]);
+    await repeated.release();
+    const isolated = await manager.acquire(secondScope, [server()]);
+    await isolated.release();
+
+    expect(created.connect).toHaveBeenCalledTimes(2);
+    await manager.closeAll();
+  });
+
+  it("uses both the user and chat as the isolation boundary", async () => {
+    const created = factory();
+    const manager = new McpManager({ connect: created.connect });
+
+    const first = await manager.acquire(
+      { userId: "first-user", chatId: "shared-chat-id" },
+      [server()],
+    );
+    await first.release();
+    const second = await manager.acquire(
+      { userId: "second-user", chatId: "shared-chat-id" },
+      [server()],
+    );
+    await second.release();
+
+    expect(created.connect).toHaveBeenCalledTimes(2);
+    await manager.closeAll();
+  });
+
+  it("closes an idle chat runtime after its retention window", async () => {
+    vi.useFakeTimers();
+    const created = factory();
+    const manager = new McpManager({
+      connect: created.connect,
+      idleTimeoutMs: 1_000,
+    });
+    const binding = await manager.acquire(
+      { userId: "user", chatId: "chat" },
+      [server()],
+    );
+    await binding.release();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(created.clients[0]?.close).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => {
+      expect(created.clients[0]?.close).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("does not expire a runtime while a binding is active", async () => {
+    vi.useFakeTimers();
+    const created = factory();
+    const manager = new McpManager({
+      connect: created.connect,
+      idleTimeoutMs: 1_000,
+    });
+    const binding = await manager.acquire(
+      { userId: "user", chatId: "chat" },
+      [server()],
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(created.clients[0]?.close).not.toHaveBeenCalled();
+    await binding.release();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => {
+      expect(created.clients[0]?.close).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("closes only the deleted conversation runtime", async () => {
+    const created = factory();
+    const manager = new McpManager({ connect: created.connect });
+    const firstScope = { userId: "user", chatId: "first" };
+    const secondScope = { userId: "user", chatId: "second" };
+    const first = await manager.acquire(firstScope, [server()]);
+    await first.release();
+    const second = await manager.acquire(secondScope, [server()]);
+    await second.release();
+
+    await manager.closeScope(firstScope);
+    expect(created.clients[0]?.close).toHaveBeenCalledOnce();
+    expect(created.clients[1]?.close).not.toHaveBeenCalled();
+
+    await manager.closeAll();
+  });
+
+  it("invalidates a personal preference only across that user's chats", async () => {
+    const created = factory();
+    const manager = new McpManager({ connect: created.connect });
+    const first = await manager.acquire(
+      { userId: "first-user", chatId: "first-chat" },
+      [server()],
+    );
+    await first.release();
+    const second = await manager.acquire(
+      { userId: "first-user", chatId: "second-chat" },
+      [server()],
+    );
+    await second.release();
+    const otherUser = await manager.acquire(
+      { userId: "other-user", chatId: "chat" },
+      [server()],
+    );
+    await otherUser.release();
+
+    await manager.invalidateUserServer("first-user", "reference");
+
+    expect(created.clients[0]?.close).toHaveBeenCalledOnce();
+    expect(created.clients[1]?.close).toHaveBeenCalledOnce();
+    expect(created.clients[2]?.close).not.toHaveBeenCalled();
+    await manager.closeAll();
+  });
+});

--- a/apps/web/lib/mcp/manager.ts
+++ b/apps/web/lib/mcp/manager.ts
@@ -1,0 +1,224 @@
+import "server-only";
+import type { ToolSet } from "ai";
+import type { McpServerRow } from "@/lib/db/mcpServers";
+import {
+  McpRuntime,
+  type McpBinding,
+  type McpConnectionFactory,
+} from "@/lib/mcp/runtime";
+
+const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1_000;
+const DEFAULT_MAX_IDLE_RUNTIMES = 32;
+
+export type McpRuntimeScope = {
+  userId: string;
+  chatId: string;
+};
+
+type RuntimeEntry = {
+  scope: McpRuntimeScope;
+  runtime: McpRuntime;
+  lastUsedAt: number;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+};
+
+export type ManagedMcpBinding = {
+  tools: ToolSet;
+  release(): Promise<void>;
+};
+
+function scopeKey(scope: McpRuntimeScope): string {
+  return `${scope.userId.length}:${scope.userId}${scope.chatId}`;
+}
+
+export class McpManager {
+  private readonly runtimes = new Map<string, RuntimeEntry>();
+
+  constructor(
+    private readonly options: {
+      connect?: McpConnectionFactory;
+      idleTimeoutMs?: number;
+      maxIdleRuntimes?: number;
+    } = {},
+  ) {}
+
+  async acquire(
+    scope: McpRuntimeScope,
+    servers: McpServerRow[],
+  ): Promise<ManagedMcpBinding> {
+    const key = scopeKey(scope);
+    let entry = this.runtimes.get(key);
+    if (!entry) {
+      this.evictIdleForCapacity();
+      entry = {
+        scope,
+        runtime: new McpRuntime(this.options.connect),
+        lastUsedAt: Date.now(),
+        idleTimer: null,
+      };
+      this.runtimes.set(key, entry);
+    }
+    this.touch(entry);
+
+    let binding: McpBinding;
+    try {
+      binding = await entry.runtime.acquire(servers);
+    } catch (error) {
+      this.scheduleIdleClose(key, entry);
+      throw error;
+    }
+
+    let released = false;
+    return {
+      tools: binding.tools,
+      release: async () => {
+        if (released) return;
+        released = true;
+        await binding.release();
+        this.touch(entry);
+        this.scheduleIdleClose(key, entry);
+      },
+    };
+  }
+
+  async invalidateServer(serverId: string, disconnect = true): Promise<void> {
+    await Promise.allSettled(
+      [...this.runtimes.values()].map((entry) =>
+        entry.runtime.invalidate(serverId, disconnect),
+      ),
+    );
+  }
+
+  async invalidateUserServer(
+    userId: string,
+    serverId: string,
+    disconnect = true,
+  ): Promise<void> {
+    await Promise.allSettled(
+      [...this.runtimes.values()]
+        .filter((entry) => entry.scope.userId === userId)
+        .map((entry) => entry.runtime.invalidate(serverId, disconnect)),
+    );
+  }
+
+  async closeScope(scope: McpRuntimeScope): Promise<void> {
+    const key = scopeKey(scope);
+    const entry = this.runtimes.get(key);
+    if (!entry) return;
+    this.runtimes.delete(key);
+    if (entry.idleTimer) clearTimeout(entry.idleTimer);
+    await entry.runtime.close();
+  }
+
+  async closeAll(): Promise<void> {
+    const entries = [...this.runtimes.values()];
+    this.runtimes.clear();
+    for (const entry of entries) {
+      if (entry.idleTimer) clearTimeout(entry.idleTimer);
+    }
+    await Promise.allSettled(entries.map((entry) => entry.runtime.close()));
+  }
+
+  closeAllOnExit(): void {
+    const entries = [...this.runtimes.values()];
+    this.runtimes.clear();
+    for (const entry of entries) {
+      if (entry.idleTimer) clearTimeout(entry.idleTimer);
+      entry.runtime.closeOnExit();
+    }
+  }
+
+  private touch(entry: RuntimeEntry): void {
+    entry.lastUsedAt = Date.now();
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer);
+      entry.idleTimer = null;
+    }
+  }
+
+  private scheduleIdleClose(key: string, entry: RuntimeEntry): void {
+    if (this.runtimes.get(key) !== entry || entry.runtime.inUse) return;
+    if (entry.idleTimer) clearTimeout(entry.idleTimer);
+    const idleTimeoutMs =
+      this.options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+    entry.idleTimer = setTimeout(() => {
+      entry.idleTimer = null;
+      if (
+        this.runtimes.get(key) !== entry ||
+        entry.runtime.inUse ||
+        Date.now() - entry.lastUsedAt < idleTimeoutMs
+      ) {
+        this.scheduleIdleClose(key, entry);
+        return;
+      }
+      this.runtimes.delete(key);
+      void entry.runtime.close();
+    }, idleTimeoutMs);
+    entry.idleTimer.unref?.();
+  }
+
+  private evictIdleForCapacity(): void {
+    const maxIdleRuntimes =
+      this.options.maxIdleRuntimes ?? DEFAULT_MAX_IDLE_RUNTIMES;
+    if (this.runtimes.size < maxIdleRuntimes) return;
+
+    const idle = [...this.runtimes.entries()]
+      .filter(([, entry]) => !entry.runtime.inUse)
+      .sort(([, left], [, right]) => left.lastUsedAt - right.lastUsedAt);
+    while (this.runtimes.size >= maxIdleRuntimes && idle.length > 0) {
+      const candidate = idle.shift();
+      if (!candidate) break;
+      const [key, entry] = candidate;
+      if (this.runtimes.get(key) !== entry) continue;
+      this.runtimes.delete(key);
+      if (entry.idleTimer) clearTimeout(entry.idleTimer);
+      void entry.runtime.close();
+    }
+  }
+}
+
+type McpGlobal = typeof globalThis & {
+  __overtchatMcpManager?: McpManager;
+  __overtchatMcpExitHandler?: boolean;
+};
+
+const mcpGlobal = globalThis as McpGlobal;
+const manager = mcpGlobal.__overtchatMcpManager ?? new McpManager();
+mcpGlobal.__overtchatMcpManager = manager;
+
+if (!mcpGlobal.__overtchatMcpExitHandler) {
+  mcpGlobal.__overtchatMcpExitHandler = true;
+  process.once("exit", () => manager.closeAllOnExit());
+}
+
+export function acquireMcpBinding(
+  scope: McpRuntimeScope,
+  servers: McpServerRow[],
+): Promise<ManagedMcpBinding> {
+  return manager.acquire(scope, servers);
+}
+
+export function invalidateMcpServer(
+  serverId: string,
+  options: { disconnect?: boolean } = {},
+): Promise<void> {
+  return manager.invalidateServer(serverId, options.disconnect ?? true);
+}
+
+export function invalidateUserMcpServer(
+  userId: string,
+  serverId: string,
+  options: { disconnect?: boolean } = {},
+): Promise<void> {
+  return manager.invalidateUserServer(
+    userId,
+    serverId,
+    options.disconnect ?? true,
+  );
+}
+
+export function closeChatMcpRuntime(
+  scope: McpRuntimeScope,
+): Promise<void> {
+  return manager.closeScope(scope);
+}

--- a/apps/web/lib/mcp/names.test.ts
+++ b/apps/web/lib/mcp/names.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMcpToolName,
+  mcpToolName,
+  mcpToolNames,
+  parseMcpToolName,
+} from "@overtchat/shared";
+
+describe("MCP tool names", () => {
+  it("creates stable provider-safe names with readable labels", () => {
+    const name = mcpToolName(
+      { id: "server-1", name: "GitHub Enterprise" },
+      "search-code",
+    );
+    expect(name).toBe("mcp__GitHub_Enterprise__search-code");
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(parseMcpToolName(name)).toEqual({
+      serverName: "GitHub Enterprise",
+      toolName: "search-code",
+    });
+    expect(isMcpToolName(name)).toBe(true);
+  });
+
+  it("keeps normalized tool-name collisions distinct", () => {
+    const server = { id: "server-1", name: "Server" };
+    const [first, second] = mcpToolNames([
+      { server, toolName: "foo bar" },
+      { server, toolName: "foo_bar" },
+    ]);
+    expect(first).not.toBe(second);
+  });
+
+  it("hashes only colliding namespaces and keeps names within API limits", () => {
+    const names = mcpToolNames([
+      {
+        server: { id: "first", name: "Same Server" },
+        toolName: "a".repeat(100),
+      },
+      {
+        server: { id: "second", name: "Same_Server" },
+        toolName: "lookup",
+      },
+    ]);
+
+    expect(names[0]).not.toBe(names[1]);
+    expect(names.every((name) => name.length <= 64)).toBe(true);
+    expect(names.every((name) => /^mcp__[A-Za-z0-9_-]+__[A-Za-z0-9_-]+$/.test(name))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/web/lib/mcp/runtime.test.ts
+++ b/apps/web/lib/mcp/runtime.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { MCPClient } from "@ai-sdk/mcp";
+import type { ToolSet } from "ai";
+import type { McpServerRow } from "@/lib/db/mcpServers";
+import {
+  McpConnection,
+  McpRuntime,
+  mcpConnectionRevision,
+} from "./runtime";
+
+function server(
+  id: string,
+  name = id,
+  updatedAt = new Date(0),
+): McpServerRow {
+  return {
+    id,
+    name,
+    availability: "everyone",
+    config: {
+      transport: "http",
+      url: `https://${id}.example.test/mcp`,
+      headers: {},
+    },
+    createdAt: new Date(0),
+    updatedAt,
+  };
+}
+
+function connection(value: McpServerRow, toolName = "echo") {
+  const close = vi.fn().mockResolvedValue(undefined);
+  const state = { connected: true };
+  const rawTools = {
+    [toolName]: { description: `${value.name} ${toolName}` },
+  } as unknown as ToolSet;
+  return {
+    value: new McpConnection(
+      mcpConnectionRevision(value),
+      { close } as unknown as MCPClient,
+      rawTools,
+      state,
+    ),
+    close,
+    state,
+  };
+}
+
+describe("conversation MCP runtime", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts each server once and reuses its tools across turns", async () => {
+    const connected = connection(server("reference", "Reference"));
+    const connect = vi.fn().mockResolvedValue(connected.value);
+    const runtime = new McpRuntime(connect);
+
+    const first = await runtime.acquire([server("reference", "Reference")]);
+    await first.release();
+    const second = await runtime.acquire([server("reference", "Reference")]);
+
+    expect(connect).toHaveBeenCalledOnce();
+    expect(second.tools).toEqual(first.tools);
+    expect(connected.close).not.toHaveBeenCalled();
+
+    await second.release();
+    await runtime.close();
+    expect(connected.close).toHaveBeenCalledOnce();
+  });
+
+  it("publishes changed configuration without interrupting an in-flight binding", async () => {
+    const originalServer = server("reference", "Reference", new Date(1));
+    const replacementServer = server(
+      "reference",
+      "Renamed Reference",
+      new Date(2),
+    );
+    replacementServer.config = {
+      transport: "http",
+      url: "https://replacement.example.test/mcp",
+      headers: {},
+    };
+    const original = connection(originalServer);
+    const replacement = connection(replacementServer);
+    const connect = vi
+      .fn()
+      .mockResolvedValueOnce(original.value)
+      .mockResolvedValueOnce(replacement.value);
+    const runtime = new McpRuntime(connect);
+
+    const oldBinding = await runtime.acquire([originalServer]);
+    const newBinding = await runtime.acquire([replacementServer]);
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(original.close).not.toHaveBeenCalled();
+    expect(replacement.close).not.toHaveBeenCalled();
+
+    await oldBinding.release();
+    expect(original.close).toHaveBeenCalledOnce();
+    expect(replacement.close).not.toHaveBeenCalled();
+
+    await newBinding.release();
+    await runtime.close();
+    expect(replacement.close).toHaveBeenCalledOnce();
+  });
+
+  it("reuses unchanged servers when another server changes", async () => {
+    const stableServer = server("stable", "Stable");
+    const oldChangingServer = server("changing", "Changing", new Date(1));
+    const newChangingServer = server("changing", "Changed", new Date(2));
+    newChangingServer.config = {
+      transport: "http",
+      url: "https://changed.example.test/mcp",
+      headers: {},
+    };
+    const stable = connection(stableServer);
+    const oldChanging = connection(oldChangingServer);
+    const newChanging = connection(newChangingServer);
+    const connect = vi.fn(async (value: McpServerRow) => {
+      if (value.id === "stable") return stable.value;
+      return value.updatedAt.getTime() === 1
+        ? oldChanging.value
+        : newChanging.value;
+    });
+    const runtime = new McpRuntime(connect);
+
+    const first = await runtime.acquire([stableServer, oldChangingServer]);
+    await first.release();
+    const second = await runtime.acquire([stableServer, newChangingServer]);
+
+    expect(connect).toHaveBeenCalledTimes(3);
+    expect(stable.close).not.toHaveBeenCalled();
+    expect(oldChanging.close).toHaveBeenCalledOnce();
+
+    await second.release();
+    await runtime.close();
+  });
+
+  it("reprojects a renamed server without restarting its connection", async () => {
+    const originalServer = server("reference", "Original", new Date(1));
+    const renamedServer = server("reference", "Renamed", new Date(2));
+    const connected = connection(originalServer);
+    const connect = vi.fn().mockResolvedValue(connected.value);
+    const runtime = new McpRuntime(connect);
+
+    const first = await runtime.acquire([originalServer]);
+    await first.release();
+    const second = await runtime.acquire([renamedServer]);
+
+    expect(connect).toHaveBeenCalledOnce();
+    expect(Object.keys(first.tools)).toEqual(["mcp__Original__echo"]);
+    expect(Object.keys(second.tools)).toEqual(["mcp__Renamed__echo"]);
+    expect(connected.close).not.toHaveBeenCalled();
+
+    await second.release();
+    await runtime.close();
+  });
+
+  it("isolates startup failures and retries only failed servers", async () => {
+    const offlineServer = server("offline", "Offline");
+    const healthyServer = server("healthy", "Healthy");
+    const recovered = connection(offlineServer);
+    const healthy = connection(healthyServer);
+    let offlineAttempts = 0;
+    const connect = vi.fn(async (value: McpServerRow) => {
+      if (value.id === "healthy") return healthy.value;
+      offlineAttempts += 1;
+      if (offlineAttempts === 1) throw new Error("offline");
+      return recovered.value;
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const runtime = new McpRuntime(connect);
+
+    const first = await runtime.acquire([offlineServer, healthyServer]);
+    expect(Object.keys(first.tools)).toHaveLength(1);
+    await first.release();
+
+    const second = await runtime.acquire([offlineServer, healthyServer]);
+    expect(Object.keys(second.tools)).toHaveLength(2);
+    expect(connect).toHaveBeenCalledTimes(3);
+    expect(healthy.close).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+
+    await second.release();
+    await runtime.close();
+  });
+
+  it("reconnects a transport that disconnected between turns", async () => {
+    const value = server("reference", "Reference");
+    const disconnected = connection(value);
+    const replacement = connection(value);
+    const connect = vi
+      .fn()
+      .mockResolvedValueOnce(disconnected.value)
+      .mockResolvedValueOnce(replacement.value);
+    const runtime = new McpRuntime(connect);
+
+    const first = await runtime.acquire([value]);
+    await first.release();
+    disconnected.state.connected = false;
+    const second = await runtime.acquire([value]);
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(disconnected.close).toHaveBeenCalledOnce();
+    await second.release();
+    await runtime.close();
+  });
+
+  it("drains an invalidated connection after its active binding finishes", async () => {
+    const value = server("reference", "Reference");
+    const connected = connection(value);
+    const replacement = connection(value);
+    const connect = vi
+      .fn()
+      .mockResolvedValueOnce(connected.value)
+      .mockResolvedValueOnce(replacement.value);
+    const runtime = new McpRuntime(connect);
+
+    const binding = await runtime.acquire([value]);
+    await runtime.invalidate(value.id);
+    expect(connected.close).not.toHaveBeenCalled();
+
+    await binding.release();
+    expect(connected.close).toHaveBeenCalledOnce();
+
+    const next = await runtime.acquire([value]);
+    expect(connect).toHaveBeenCalledTimes(2);
+    await next.release();
+    await runtime.close();
+  });
+
+  it("keeps leased connections alive when the conversation closes", async () => {
+    const connected = connection(server("reference", "Reference"));
+    const runtime = new McpRuntime(vi.fn().mockResolvedValue(connected.value));
+    const binding = await runtime.acquire([server("reference", "Reference")]);
+
+    await runtime.close();
+    expect(connected.close).not.toHaveBeenCalled();
+
+    await binding.release();
+    expect(connected.close).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/mcp/runtime.ts
+++ b/apps/web/lib/mcp/runtime.ts
@@ -1,0 +1,332 @@
+import "server-only";
+import type { MCPClient } from "@ai-sdk/mcp";
+import { mcpToolNames } from "@overtchat/shared";
+import type { ToolSet } from "ai";
+import type { McpServerRow } from "@/lib/db/mcpServers";
+import {
+  createConfiguredMcpClient,
+  listAllMcpTools,
+  MCP_TOOL_TIMEOUT_MS,
+  mcpSetupSignal,
+} from "@/lib/mcp/client";
+
+type ConnectionState = { connected: boolean };
+
+export type McpConnectionFactory = (
+  server: McpServerRow,
+) => Promise<McpConnection>;
+
+export type McpBinding = {
+  tools: ToolSet;
+  release(): Promise<void>;
+};
+
+type RuntimeSnapshot = {
+  desiredRevision: string;
+  servers: Map<string, McpServerView>;
+  failedServerIds: Set<string>;
+  tools: ToolSet;
+};
+
+type McpServerView = {
+  server: McpServerRow;
+  connection: McpConnection;
+};
+
+export function mcpServerRevision(server: McpServerRow): string {
+  return JSON.stringify({
+    name: server.name,
+    availability: server.availability,
+    config: server.config,
+    updatedAt: server.updatedAt.getTime(),
+  });
+}
+
+export function mcpConnectionRevision(server: McpServerRow): string {
+  return JSON.stringify(server.config);
+}
+
+function desiredRevision(servers: McpServerRow[]): string {
+  return JSON.stringify(
+    servers
+      .map((server) => [server.id, mcpServerRevision(server)] as const)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function timeoutTool(tool: ToolSet[string]): ToolSet[string] {
+  const execute = tool.execute;
+  if (!execute) return tool;
+
+  return {
+    ...tool,
+    async execute(input: unknown, options: Parameters<typeof execute>[1]) {
+      const timeoutSignal = AbortSignal.timeout(MCP_TOOL_TIMEOUT_MS);
+      const abortSignal = options.abortSignal
+        ? AbortSignal.any([options.abortSignal, timeoutSignal])
+        : timeoutSignal;
+      return execute(input, { ...options, abortSignal });
+    },
+  } as ToolSet[string];
+}
+
+export class McpConnection {
+  private references = 0;
+  private closing: Promise<void> | null = null;
+
+  constructor(
+    readonly revision: string,
+    readonly client: MCPClient,
+    readonly rawTools: ToolSet,
+    private readonly state: ConnectionState,
+  ) {}
+
+  get reusable(): boolean {
+    return this.state.connected && this.closing === null;
+  }
+
+  retain(): void {
+    if (this.closing) throw new Error("Cannot retain a closing MCP connection");
+    this.references += 1;
+  }
+
+  async release(): Promise<void> {
+    if (this.references === 0) return;
+    this.references -= 1;
+    if (this.references === 0) await this.close();
+  }
+
+  close(): Promise<void> {
+    this.state.connected = false;
+    this.closing ??= this.client.close().catch(() => undefined);
+    return this.closing;
+  }
+}
+
+export async function connectMcpServer(
+  server: McpServerRow,
+): Promise<McpConnection> {
+  const state: ConnectionState = { connected: true };
+  const setupSignal = mcpSetupSignal();
+  const client = await createConfiguredMcpClient(server.config, {
+    initializationSignal: setupSignal,
+    onDisconnect: () => {
+      state.connected = false;
+    },
+  });
+
+  try {
+    const definitions = await listAllMcpTools(client, setupSignal);
+    const converted = client.toolsFromDefinitions(definitions);
+    const rawTools: ToolSet = {};
+    for (const [name, tool] of Object.entries(converted)) {
+      rawTools[name] = timeoutTool(tool as ToolSet[string]);
+    }
+    return new McpConnection(
+      mcpConnectionRevision(server),
+      client,
+      rawTools,
+      state,
+    );
+  } catch (error) {
+    await client.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+function toolsForServers(servers: Map<string, McpServerView>): ToolSet {
+  const catalog = [...servers.values()].flatMap(({ server, connection }) =>
+    Object.entries(connection.rawTools).map(([toolName, tool]) => ({
+      server,
+      toolName,
+      tool,
+    })),
+  );
+  const names = mcpToolNames(
+    catalog.map(({ server, toolName }) => ({
+      server,
+      toolName,
+    })),
+  );
+  const tools: ToolSet = {};
+  catalog.forEach(({ tool }, index) => {
+    const name = names[index];
+    if (name) tools[name] = tool;
+  });
+  return tools;
+}
+
+/** Owns the live MCP connections for exactly one OvertChat conversation. */
+export class McpRuntime {
+  private current: RuntimeSnapshot | null = null;
+  private operation: Promise<void> = Promise.resolve();
+  private activeBindings = 0;
+  private closed = false;
+
+  constructor(
+    private readonly connect: McpConnectionFactory = connectMcpServer,
+  ) {}
+
+  get inUse(): boolean {
+    return this.activeBindings > 0;
+  }
+
+  acquire(servers: McpServerRow[]): Promise<McpBinding> {
+    return this.exclusive(async () => {
+      if (this.closed) throw new Error("MCP runtime is closed");
+      const snapshot = await this.reconcile(servers);
+      const connections = [...snapshot.servers.values()].map(
+        ({ connection }) => connection,
+      );
+      for (const connection of connections) connection.retain();
+      this.activeBindings += 1;
+
+      let released = false;
+      return {
+        tools: snapshot.tools,
+        release: async () => {
+          if (released) return;
+          released = true;
+          this.activeBindings -= 1;
+          await Promise.allSettled(
+            connections.map((connection) => connection.release()),
+          );
+        },
+      };
+    });
+  }
+
+  invalidate(serverId: string, disconnect = true): Promise<void> {
+    return this.exclusive(async () => {
+      const current = this.current;
+      if (!current) return;
+
+      const servers = new Map(current.servers);
+      if (!disconnect) {
+        current.desiredRevision = "";
+        return;
+      }
+      if (!servers.delete(serverId)) {
+        current.desiredRevision = "";
+        current.failedServerIds.add(serverId);
+        return;
+      }
+
+      const next: RuntimeSnapshot = {
+        desiredRevision: "",
+        servers,
+        failedServerIds: new Set([...current.failedServerIds, serverId]),
+        tools: toolsForServers(servers),
+      };
+      await this.publish(next);
+    });
+  }
+
+  close(): Promise<void> {
+    return this.exclusive(async () => {
+      if (this.closed) return;
+      this.closed = true;
+      const current = this.current;
+      this.current = null;
+      if (current) {
+        await Promise.allSettled(
+          [...current.servers.values()].map(({ connection }) =>
+            connection.release(),
+          ),
+        );
+      }
+    });
+  }
+
+  closeOnExit(): void {
+    this.closed = true;
+    for (const view of this.current?.servers.values() ?? []) {
+      void view.connection.close();
+    }
+    this.current = null;
+  }
+
+  private async reconcile(servers: McpServerRow[]): Promise<RuntimeSnapshot> {
+    const revision = desiredRevision(servers);
+    const current = this.current;
+    if (
+      current?.desiredRevision === revision &&
+      current.failedServerIds.size === 0 &&
+      [...current.servers.values()].every(
+        ({ connection }) => connection.reusable,
+      )
+    ) {
+      return current;
+    }
+
+    const settled = await Promise.allSettled(
+      servers.map(async (server) => {
+        const existing = current?.servers.get(server.id)?.connection;
+        const expectedRevision = mcpConnectionRevision(server);
+        if (existing?.revision === expectedRevision && existing.reusable) {
+          return { server, connection: existing };
+        }
+        return { server, connection: await this.connect(server) };
+      }),
+    );
+    const connectedServers = new Map<string, McpServerView>();
+    const failedServerIds = new Set<string>();
+
+    settled.forEach((result, index) => {
+      const server = servers[index];
+      if (!server) return;
+      if (result.status === "fulfilled") {
+        connectedServers.set(server.id, result.value);
+      } else {
+        failedServerIds.add(server.id);
+        console.warn(
+          `[mcp] Failed to connect to ${JSON.stringify(server.name)}:`,
+          result.reason,
+        );
+      }
+    });
+
+    const next: RuntimeSnapshot = {
+      desiredRevision: revision,
+      servers: connectedServers,
+      failedServerIds,
+      tools: toolsForServers(connectedServers),
+    };
+    await this.publish(next);
+    return next;
+  }
+
+  private async publish(next: RuntimeSnapshot): Promise<void> {
+    const previous = this.current;
+    const retained: McpConnection[] = [];
+    try {
+      for (const { connection } of next.servers.values()) {
+        connection.retain();
+        retained.push(connection);
+      }
+    } catch (error) {
+      await Promise.allSettled(
+        retained.map((connection) => connection.release()),
+      );
+      throw error;
+    }
+
+    this.current = next;
+    if (previous) {
+      await Promise.allSettled(
+        [...previous.servers.values()].map(({ connection }) =>
+          connection.release(),
+        ),
+      );
+    }
+  }
+
+  private exclusive<T>(work: () => Promise<T>): Promise<T> {
+    const result = this.operation.then(work, work);
+    this.operation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}

--- a/apps/web/lib/mcp/schema.test.ts
+++ b/apps/web/lib/mcp/schema.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { McpServerConfigSchema, McpServerInputSchema } from "./schema";
+
+describe("MCP server configuration", () => {
+  it("normalizes a Codex-style STDIO configuration", () => {
+    expect(
+      McpServerInputSchema.parse({
+        name: " Example Server ",
+        config: {
+          transport: "stdio",
+          command: " npx ",
+          args: ["-y", "@example/mcp-server@1.0.0"],
+          env: { EXAMPLE_API_URL: "https://api.example.test" },
+          envPassthrough: [" HTTP_PROXY "],
+          cwd: " /app ",
+        },
+      }),
+    ).toEqual({
+      name: "Example Server",
+      availability: "everyone",
+      config: {
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "@example/mcp-server@1.0.0"],
+        env: { EXAMPLE_API_URL: "https://api.example.test" },
+        envPassthrough: ["HTTP_PROXY"],
+        cwd: "/app",
+      },
+    });
+  });
+
+  it("accepts Streamable HTTP and rejects other URL schemes", () => {
+    expect(
+      McpServerConfigSchema.parse({
+        transport: "http",
+        url: "https://mcp.example.test/mcp",
+        headers: { "X-Workspace": "overtchat" },
+        envHeaders: { "X-Token": "MCP_HEADER_TOKEN" },
+        bearerTokenEnvVar: "MCP_TOKEN",
+      }),
+    ).toMatchObject({ transport: "http" });
+
+    expect(() =>
+      McpServerConfigSchema.parse({
+        transport: "http",
+        url: "file:///tmp/mcp.sock",
+      }),
+    ).toThrow(/http or https/);
+  });
+
+  it("accepts only the supported admin availability policies", () => {
+    const base = {
+      name: "Reference",
+      config: {
+        transport: "stdio" as const,
+        command: "reference-mcp",
+      },
+    };
+
+    expect(
+      McpServerInputSchema.parse({ ...base, availability: "admins" }),
+    ).toMatchObject({ availability: "admins" });
+    expect(() =>
+      McpServerInputSchema.parse({ ...base, availability: "private" }),
+    ).toThrow();
+  });
+
+  it("rejects invalid environment variable names", () => {
+    expect(() =>
+      McpServerConfigSchema.parse({
+        transport: "stdio",
+        command: "node",
+        env: { "NOT VALID": "value" },
+      }),
+    ).toThrow(/letters, numbers, and underscores/);
+
+    expect(() =>
+      McpServerConfigSchema.parse({
+        transport: "http",
+        url: "https://mcp.example.test/mcp",
+        envHeaders: { "X-Token": "NOT VALID" },
+      }),
+    ).toThrow(/letters, numbers, and underscores/);
+  });
+});

--- a/apps/web/lib/mcp/schema.ts
+++ b/apps/web/lib/mcp/schema.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+const environmentNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Environment variable names cannot be empty")
+  .regex(
+    /^[A-Za-z_][A-Za-z0-9_]*$/,
+    "Environment variable names must contain only letters, numbers, and underscores",
+  );
+
+const stringMapSchema = z.record(z.string(), z.string());
+
+function validateEnvironmentNames(
+  value: Record<string, string>,
+  ctx: z.RefinementCtx,
+) {
+  for (const key of Object.keys(value)) {
+    const parsed = environmentNameSchema.safeParse(key);
+    if (!parsed.success) {
+      ctx.addIssue({
+        code: "custom",
+        path: [key],
+        message: parsed.error.issues[0]?.message ?? "Invalid environment variable",
+      });
+    }
+  }
+}
+
+function validateEnvironmentValues(
+  value: Record<string, string>,
+  ctx: z.RefinementCtx,
+) {
+  for (const [key, name] of Object.entries(value)) {
+    const parsed = environmentNameSchema.safeParse(name);
+    if (!parsed.success) {
+      ctx.addIssue({
+        code: "custom",
+        path: [key],
+        message:
+          parsed.error.issues[0]?.message ?? "Invalid environment variable",
+      });
+    }
+  }
+}
+
+export const StdioMcpConfigSchema = z.object({
+  transport: z.literal("stdio"),
+  command: z.string().trim().min(1, "Command is required"),
+  args: z.array(z.string()).default([]),
+  env: stringMapSchema.superRefine(validateEnvironmentNames).default({}),
+  envPassthrough: z.array(environmentNameSchema).default([]),
+  cwd: z.string().trim().optional(),
+});
+
+export const StreamableHttpMcpConfigSchema = z.object({
+  transport: z.literal("http"),
+  url: z
+    .url("Enter a valid Streamable HTTP URL")
+    .refine((value) => ["http:", "https:"].includes(new URL(value).protocol), {
+      message: "Streamable HTTP URLs must use http or https",
+    }),
+  headers: stringMapSchema.default({}),
+  envHeaders: stringMapSchema
+    .superRefine(validateEnvironmentValues)
+    .optional(),
+  bearerTokenEnvVar: environmentNameSchema.optional(),
+});
+
+export const McpServerConfigSchema = z.discriminatedUnion("transport", [
+  StdioMcpConfigSchema,
+  StreamableHttpMcpConfigSchema,
+]);
+
+export const MCP_SERVER_AVAILABILITIES = [
+  "everyone",
+  "admins",
+  "disabled",
+] as const;
+
+export const McpServerAvailabilitySchema = z.enum(
+  MCP_SERVER_AVAILABILITIES,
+);
+
+export const McpServerInputSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(100),
+  availability: McpServerAvailabilitySchema.default("everyone"),
+  config: McpServerConfigSchema,
+});
+
+export const McpServerPreferenceInputSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export type StdioMcpConfig = z.infer<typeof StdioMcpConfigSchema>;
+export type StreamableHttpMcpConfig = z.infer<
+  typeof StreamableHttpMcpConfigSchema
+>;
+export type McpServerConfig = z.infer<typeof McpServerConfigSchema>;
+export type McpServerAvailability = z.infer<
+  typeof McpServerAvailabilitySchema
+>;
+export type McpServerInput = z.infer<typeof McpServerInputSchema>;
+export type McpServerPreferenceInput = z.infer<
+  typeof McpServerPreferenceInputSchema
+>;
+
+export type McpServer = McpServerInput & {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AvailableMcpServer = {
+  id: string;
+  name: string;
+  enabled: boolean;
+};
+
+export type McpServerHealth =
+  | { ok: true; elapsedMs: number; toolCount: number }
+  | { ok: false; elapsedMs: number; error: string };

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -54,6 +54,13 @@ export const modelConfigKeys = {
   health: (id: string) => [...modelConfigKeys.all(), "health", id] as const,
 };
 
+export const mcpServerKeys = {
+  all: () => ["mcpServers"] as const,
+  adminList: () => [...mcpServerKeys.all(), "list", "admin"] as const,
+  availableList: () => [...mcpServerKeys.all(), "list", "available"] as const,
+  health: (id: string) => [...mcpServerKeys.all(), "health", id] as const,
+};
+
 export const serverCapabilityKeys = {
   all: () => ["serverCapabilities"] as const,
   list: () => [...serverCapabilityKeys.all(), "list"] as const,

--- a/apps/web/lib/queries/mcpServers.ts
+++ b/apps/web/lib/queries/mcpServers.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  AvailableMcpServer,
+  McpServer,
+  McpServerHealth,
+  McpServerInput,
+} from "@/lib/mcp/schema";
+import { mcpServerKeys } from "@/lib/queries/keys";
+
+async function responseError(response: Response): Promise<Error> {
+  const body = (await response.json().catch(() => ({}))) as { error?: string };
+  return new Error(body.error ?? `HTTP ${response.status}`);
+}
+
+export function useMcpServers() {
+  return useQuery({
+    queryKey: mcpServerKeys.adminList(),
+    queryFn: async (): Promise<McpServer[]> => {
+      const response = await fetch("/api/mcp-servers");
+      if (!response.ok) throw await responseError(response);
+      const body = (await response.json()) as { mcpServers: McpServer[] };
+      return body.mcpServers;
+    },
+  });
+}
+
+export function useAvailableMcpServers() {
+  return useQuery({
+    queryKey: mcpServerKeys.availableList(),
+    queryFn: async (): Promise<AvailableMcpServer[]> => {
+      const response = await fetch("/api/mcp-server-preferences");
+      if (!response.ok) throw await responseError(response);
+      const body = (await response.json()) as {
+        mcpServers: AvailableMcpServer[];
+      };
+      return body.mcpServers;
+    },
+  });
+}
+
+export function useMcpServerHealth(id: string) {
+  return useQuery({
+    queryKey: mcpServerKeys.health(id),
+    enabled: false,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: false,
+    queryFn: async (): Promise<McpServerHealth> => {
+      const response = await fetch(`/api/mcp-servers/${id}/health`, {
+        method: "POST",
+      });
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: `HTTP ${response.status}`,
+          elapsedMs: 0,
+        };
+      }
+      return (await response.json()) as McpServerHealth;
+    },
+  });
+}
+
+function invalidateMcpServers(client: ReturnType<typeof useQueryClient>) {
+  client.invalidateQueries({ queryKey: mcpServerKeys.all() });
+}
+
+export function useCreateMcpServer() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: McpServerInput) => {
+      const response = await fetch("/api/mcp-servers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!response.ok) throw await responseError(response);
+      return ((await response.json()) as { mcpServer: McpServer }).mcpServer;
+    },
+    onSuccess: () => invalidateMcpServers(client),
+  });
+}
+
+export function useUpdateMcpServer() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, input }: { id: string; input: McpServerInput }) => {
+      const response = await fetch(`/api/mcp-servers/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!response.ok) throw await responseError(response);
+      return ((await response.json()) as { mcpServer: McpServer }).mcpServer;
+    },
+    onSuccess: () => invalidateMcpServers(client),
+  });
+}
+
+export function useDeleteMcpServer() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const response = await fetch(`/api/mcp-servers/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) throw await responseError(response);
+    },
+    onSuccess: () => invalidateMcpServers(client),
+  });
+}
+
+export function useSetMcpServerPreference() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {
+      const response = await fetch(`/api/mcp-server-preferences/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!response.ok) throw await responseError(response);
+      return ((await response.json()) as { mcpServer: AvailableMcpServer })
+        .mcpServer;
+    },
+    onSuccess: (server) => {
+      client.setQueryData<AvailableMcpServer[]>(
+        mcpServerKeys.availableList(),
+        (current) =>
+          current?.map((item) => (item.id === server.id ? server : item)),
+      );
+    },
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.16",
     "@ai-sdk/google": "^4.0.18",
+    "@ai-sdk/mcp": "^2.0.33",
     "@ai-sdk/open-responses": "^2.0.11",
     "@ai-sdk/openai": "^4.0.16",
     "@ai-sdk/openai-compatible": "^3.0.12",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.14.4}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.15.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - overtchat-data:/app/data
+      - overtchat-npm-cache:/app/npm-cache
     depends_on:
       searxng:
         condition: service_healthy
@@ -133,4 +134,5 @@ services:
 
 volumes:
   overtchat-data:
+  overtchat-npm-cache:
   overtchat-stt-models:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -152,6 +152,22 @@ The app container makes the upstream LLM calls, so the base URL you set in **Set
 - **LLM running on the host (not in docker):** use `http://host.docker.internal:<port>/v1`. Baked into `compose.yml` via `extra_hosts`, works on Linux / macOS / Windows.
 - **Public provider (OpenAI / Groq / etc.):** use the provider's base URL + API key.
 
+## MCP servers
+
+Admins can add STDIO or Streamable HTTP MCP servers under **Settings → Tools**.
+STDIO commands run inside the app container, which includes Node.js, npm, and
+npx:
+
+```text
+Command: npx
+Arguments: -y, @example/mcp-server@1.0.0
+```
+
+MCP addresses are resolved from inside the container. Use
+`host.docker.internal` for the Docker host or a Compose service name for a
+container on the same network. Downloads launched through npm use the separate
+`overtchat-npm-cache` volume.
+
 ## Reusing sidecars
 
 SearXNG and Kokoro are bundled by default. To point the app at existing services, set container-reachable URLs in `.env`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1364,6 +1364,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.16",
         "@ai-sdk/google": "^4.0.18",
+        "@ai-sdk/mcp": "^2.0.33",
         "@ai-sdk/open-responses": "^2.0.11",
         "@ai-sdk/openai": "^4.0.16",
         "@ai-sdk/openai-compatible": "^3.0.12",
@@ -1428,6 +1429,54 @@
         "tsx": "^4.23.1",
         "typescript": "^5",
         "vitest": "^4.1.6"
+      }
+    },
+    "apps/web/node_modules/@ai-sdk/mcp": {
+      "version": "2.0.33",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.33.tgz",
+      "integrity": "sha512-fpzMLW1RNpRvHWf9Bj7IKgsBYhpPhpBemPARJzmE3g31WYJtKK+9X+WPDl2M+JQ8qL2b0Ltv8ikbSvXAvBmuJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "apps/web/node_modules/@ai-sdk/provider": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "apps/web/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.27.tgz",
+      "integrity": "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.7",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "apps/web/node_modules/@better-auth/core": {
@@ -25951,6 +26000,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,4 +6,5 @@ export * from "./tools";
 export * from "./tool-preferences";
 export * from "./citations";
 export * from "./search";
+export * from "./mcp";
 export * from "./theme/tokens";

--- a/packages/shared/src/mcp.ts
+++ b/packages/shared/src/mcp.ts
@@ -1,0 +1,127 @@
+const MCP_TOOL_PREFIX = "mcp__";
+const MCP_TOOL_DELIMITER = "__";
+const MAX_MCP_TOOL_NAME_LENGTH = 64;
+
+function hashSegment(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36).padStart(7, "0").slice(0, 7);
+}
+
+function safeSegment(value: string, fallback: string): string {
+  const segment = value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^A-Za-z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+  return segment || fallback;
+}
+
+function withHash(value: string, identity: string): string {
+  return `${value}_${hashSegment(identity)}`;
+}
+
+function fitName(namespace: string, tool: string, identity: string): string {
+  const candidate = `${namespace}${MCP_TOOL_DELIMITER}${tool}`;
+  if (candidate.length <= MAX_MCP_TOOL_NAME_LENGTH) return candidate;
+
+  const suffix = `_${hashSegment(identity)}`;
+  const namespaceBudget = Math.min(
+    namespace.length,
+    Math.floor((MAX_MCP_TOOL_NAME_LENGTH - MCP_TOOL_DELIMITER.length) / 2),
+  );
+  const fittedNamespace = namespace
+    .slice(0, namespaceBudget)
+    .replace(/[_-]+$/g, "");
+  const toolBudget =
+    MAX_MCP_TOOL_NAME_LENGTH -
+    fittedNamespace.length -
+    MCP_TOOL_DELIMITER.length -
+    suffix.length;
+  const fittedTool = tool
+    .slice(0, Math.max(0, toolBudget))
+    .replace(/[_-]+$/g, "");
+  return `${fittedNamespace}${MCP_TOOL_DELIMITER}${fittedTool}${suffix}`;
+}
+
+export type McpToolIdentity = {
+  server: { id: string; name: string };
+  toolName: string;
+};
+
+/** Produces Codex-style `mcp__server__tool` names, hashing only collisions. */
+export function mcpToolNames(tools: McpToolIdentity[]): string[] {
+  const candidates = tools.map(({ server, toolName }) => ({
+    server,
+    toolName,
+    namespace: `${MCP_TOOL_PREFIX}${safeSegment(server.name, "server")}`,
+    callable: safeSegment(toolName, "tool"),
+    serverIdentity: `${server.id}\0${server.name}`,
+    toolIdentity: `${server.id}\0${server.name}\0${toolName}`,
+  }));
+
+  const namespaceIdentities = new Map<string, Set<string>>();
+  for (const candidate of candidates) {
+    const identities =
+      namespaceIdentities.get(candidate.namespace) ?? new Set<string>();
+    identities.add(candidate.serverIdentity);
+    namespaceIdentities.set(candidate.namespace, identities);
+  }
+  for (const candidate of candidates) {
+    if ((namespaceIdentities.get(candidate.namespace)?.size ?? 0) > 1) {
+      candidate.namespace = withHash(
+        candidate.namespace,
+        candidate.serverIdentity,
+      );
+    }
+  }
+
+  const callableIdentities = new Map<string, Set<string>>();
+  for (const candidate of candidates) {
+    const key = `${candidate.namespace}\0${candidate.callable}`;
+    const identities = callableIdentities.get(key) ?? new Set<string>();
+    identities.add(candidate.toolIdentity);
+    callableIdentities.set(key, identities);
+  }
+
+  return candidates.map((candidate) => {
+    const key = `${candidate.namespace}\0${candidate.callable}`;
+    const callable =
+      (callableIdentities.get(key)?.size ?? 0) > 1
+        ? withHash(candidate.callable, candidate.toolIdentity)
+        : candidate.callable;
+    return fitName(candidate.namespace, callable, candidate.toolIdentity);
+  });
+}
+
+export function mcpToolName(
+  server: { id: string; name: string },
+  toolName: string,
+): string {
+  return mcpToolNames([{ server, toolName }])[0] as string;
+}
+
+export function parseMcpToolName(name: string): {
+  serverName: string;
+  toolName: string;
+} | null {
+  if (!name.startsWith(MCP_TOOL_PREFIX)) return null;
+  const segments = name.slice(MCP_TOOL_PREFIX.length).split(MCP_TOOL_DELIMITER);
+  if (segments.length !== 2) return null;
+  const [serverName, toolName] = segments;
+  if (!serverName || !toolName) return null;
+  return {
+    serverName: serverName
+      .replaceAll("_", " ")
+      .replace(/\b\w/g, (character) => character.toUpperCase()),
+    toolName: toolName.replaceAll("_", " "),
+  };
+}
+
+export function isMcpToolName(name: string): boolean {
+  return parseMcpToolName(name) !== null;
+}


### PR DESCRIPTION
## Summary

- add admin-managed STDIO and Streamable HTTP MCP server configuration
- separate instance availability from per-user enablement
- expose MCP tools to supported chat models with stable names and web/mobile activity rendering
- retain MCP connections per user and conversation, with bounded idle cleanup and targeted invalidation
- add on-demand admin health checks that initialize, discover tools, report status, and close immediately
- make npx-based servers work in the production image with a dedicated persistent npm cache

## Safety and behavior

- MCP configuration remains admin-only; user APIs expose only server ID, name, and personal enabled state
- STDIO uses the AI SDK transport with shell execution disabled and explicit environment handling
- failed servers are isolated and retried without taking down healthy MCP servers
- deleting a chat closes its retained MCP runtime
- health checks are manual and cached rather than launching processes on every settings visit

## Data and release

- add one migration for MCP servers and per-user preferences
- prepare app v0.15.0 and CLI v0.1.6 in a separate follow-up commit
- keep connector and mobile release versions unchanged

## Verification

- npm run lint
- npm run test
- npm run build -w apps/web
- clean database migration
- git diff --check