### PR TITLE
ci(mobile): gate releases on emulator smoke test

### DIFF
--- a/.github/scripts/android-release-smoke.sh
+++ b/.github/scripts/android-release-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APK_PATH="${1:?usage: android-release-smoke.sh <apk-path> [diagnostics-directory]}"
+DIAGNOSTICS_DIR="${2:-dist/mobile/smoke-diagnostics}"
+PACKAGE_NAME="com.overtchat.mobile"
+UI_DUMP_DEVICE_PATH="/sdcard/overtchat-window.xml"
+
+mkdir -p "$DIAGNOSTICS_DIR"
+
+capture_diagnostics() {
+  adb exec-out screencap -p > "$DIAGNOSTICS_DIR/screenshot.png" 2>/dev/null || true
+  adb logcat -d > "$DIAGNOSTICS_DIR/logcat.txt" 2>/dev/null || true
+  adb shell dumpsys activity activities > "$DIAGNOSTICS_DIR/activities.txt" 2>/dev/null || true
+  adb shell uiautomator dump "$UI_DUMP_DEVICE_PATH" >/dev/null 2>&1 || true
+  adb pull "$UI_DUMP_DEVICE_PATH" "$DIAGNOSTICS_DIR/window.xml" >/dev/null 2>&1 || true
+}
+trap capture_diagnostics EXIT
+
+test -f "$APK_PATH"
+adb logcat -c
+adb install --no-streaming -r "$APK_PATH"
+adb shell am force-stop "$PACKAGE_NAME"
+
+LAUNCH_OUTPUT="$(adb shell monkey \
+  -p "$PACKAGE_NAME" \
+  -c android.intent.category.LAUNCHER \
+  1 2>&1)"
+printf '%s\n' "$LAUNCH_OUTPUT"
+grep -Fq "Events injected: 1" <<< "$LAUNCH_OUTPUT"
+
+for attempt in {1..30}; do
+  if adb shell pidof "$PACKAGE_NAME" >/dev/null 2>&1 && \
+    adb shell dumpsys activity activities | grep -Fq "$PACKAGE_NAME"; then
+    break
+  fi
+
+  if (( attempt == 30 )); then
+    echo "The OvertChat process did not reach a resumed activity." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+for attempt in {1..30}; do
+  adb shell uiautomator dump "$UI_DUMP_DEVICE_PATH" >/dev/null 2>&1 || true
+  adb pull "$UI_DUMP_DEVICE_PATH" "$DIAGNOSTICS_DIR/window.xml" >/dev/null 2>&1 || true
+
+  if grep -Fq "Get started" "$DIAGNOSTICS_DIR/window.xml" 2>/dev/null; then
+    echo "Production APK launched and rendered the OvertChat welcome screen."
+    exit 0
+  fi
+
+  if ! adb shell pidof "$PACKAGE_NAME" >/dev/null 2>&1; then
+    echo "The OvertChat process exited before rendering its welcome screen." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "The OvertChat welcome screen did not render within 30 seconds." >&2
+exit 1

--- a/.github/workflows/mobile-eas.yml
+++ b/.github/workflows/mobile-eas.yml
@@ -6,10 +6,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  android:
+  build-android:
     runs-on: self-hosted
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      expected_tag: ${{ steps.version.outputs.expected_tag }}
+      version: ${{ steps.version.outputs.version }}
     defaults:
       run:
         shell: bash
@@ -98,23 +101,104 @@ jobs:
             --platform android --profile production-apk \
             --output "../../dist/mobile/overtchat-v${{ steps.version.outputs.version }}.apk"
 
+      - name: Upload signed Android artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: overtchat-mobile-${{ steps.version.outputs.version }}
+          path: |
+            dist/mobile/overtchat-v${{ steps.version.outputs.version }}.aab
+            dist/mobile/overtchat-v${{ steps.version.outputs.version }}.apk
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 3
+
+  smoke-android:
+    needs: build-android
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download signed Android artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: overtchat-mobile-${{ needs.build-android.outputs.version }}
+          path: dist/mobile
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Smoke-test production APK
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_7_pro
+          disable-animations: true
+          script: >-
+            bash .github/scripts/android-release-smoke.sh
+            "dist/mobile/overtchat-v${{ needs.build-android.outputs.version }}.apk"
+            "dist/mobile/smoke-diagnostics"
+
+      - name: Upload smoke-test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: overtchat-mobile-smoke-diagnostics-${{ needs.build-android.outputs.version }}
+          path: dist/mobile/smoke-diagnostics/
+          if-no-files-found: warn
+          retention-days: 14
+
+  publish-android:
+    if: startsWith(github.ref, 'refs/tags/mobile-v')
+    needs: [build-android, smoke-android]
+    runs-on: self-hosted
+    permissions:
+      contents: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download verified Android artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: overtchat-mobile-${{ needs.build-android.outputs.version }}
+          path: dist/mobile
+
       - name: Submit AAB to Play
-        if: startsWith(github.ref, 'refs/tags/mobile-v')
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           npx eas-cli@20 submit --non-interactive \
             --platform android --profile production \
-            --path "../../dist/mobile/overtchat-v${{ steps.version.outputs.version }}.aab"
+            --path "../../dist/mobile/overtchat-v${{ needs.build-android.outputs.version }}.aab"
 
       - name: Attach APK to GitHub release
-        if: startsWith(github.ref, 'refs/tags/mobile-v')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ steps.version.outputs.expected_tag }}"
-          APK="dist/mobile/overtchat-v${{ steps.version.outputs.version }}.apk"
+          TAG="${{ needs.build-android.outputs.expected_tag }}"
+          APK="dist/mobile/overtchat-v${{ needs.build-android.outputs.version }}.apk"
 
           gh release view "$TAG" >/dev/null 2>&1 || \
             gh release create "$TAG" --draft --title "$TAG" --notes "Draft - fill in notes before publishing."


### PR DESCRIPTION
## Summary

- split the Android release into build, emulator smoke, and publish jobs
- smoke-test the signed production APK on a clean API 35 emulator before Play submission
- retain screenshots, activity state, UI hierarchy, and logcat when the gate fails
- keep manual dispatch as a non-publishing release rehearsal

## Validation

- `actionlint .github/workflows/mobile-eas.yml`
- `bash -n .github/scripts/android-release-smoke.sh`
- `npm run typecheck -w apps/mobile`
- [live workflow-dispatch rehearsal](https://github.com/yoloyash/overtchat/actions/runs/32598354971): signed AAB/APK built on the self-hosted runner; production APK installed and rendered the welcome screen on a clean API 35 emulator; publish job skipped as intended
- PR Validate and Web E2E checks passed

## Out of scope

The broader server/CLI/container/site release-orchestration cleanup remains a separate follow-up PR.