### PR TITLE
feat: polish settings navigation and surface updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,8 @@ BETTER_AUTH_URL=http://localhost:4718
 APP_PORT=4718
 EXTRA_TRUSTED_ORIGINS=
 
+# Prevent the admin account menu from checking overtchat.com for new releases.
+DISABLE_UPDATE_CHECK=false
+
 # Used by `npm run dev`; the app container overrides this with redis://redis:6379.
 REDIS_URL=redis://localhost:6379

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/compose.test.ts
+++ b/apps/cli/src/compose.test.ts
@@ -74,6 +74,7 @@ describe("managed Compose configuration", () => {
     expect(environment).toContain(
       'HOST_CONNECTOR_URL="http://192.168.1.10:4718"',
     );
+    expect(environment).toContain('DISABLE_UPDATE_CHECK="false"');
     expect(environment).toContain('STT_GPU_DEVICE_ID="GPU-abc"');
     expect(environment).toContain(
       'OVERTCHAT_DATA_SOURCE="existing_overtchat-data"',
@@ -93,6 +94,9 @@ describe("managed Compose configuration", () => {
     expect(compose).toContain("profiles: [stt-cpu]");
     expect(compose).toContain("profiles: [stt-gpu]");
     expect(compose).toContain('device_ids: ["${STT_GPU_DEVICE_ID}"]');
+    expect(compose).toContain(
+      "DISABLE_UPDATE_CHECK: ${DISABLE_UPDATE_CHECK:-false}",
+    );
     expect(compose).toContain("- overtchat-npm-cache:/app/npm-cache");
     expect(compose).toContain("\n  overtchat-npm-cache:\n");
     expect(compose).toContain("external: true");

--- a/apps/cli/src/compose.ts
+++ b/apps/cli/src/compose.ts
@@ -52,6 +52,7 @@ export function renderStackEnvironment(
     ["BETTER_AUTH_URL", config.publicUrl],
     ["EXTRA_TRUSTED_ORIGINS", trustedOrigins.join(",")],
     ["HOST_CONNECTOR_URL", config.connectorServerUrl],
+    ["DISABLE_UPDATE_CHECK", String(config.disableUpdateCheck ?? false)],
     ["BETTER_AUTH_SECRET", secrets.betterAuthSecret],
     ["OVERTCHAT_MANAGEMENT_SECRET", secrets.managementSecret],
     ["SEARXNG_SECRET", secrets.searxngSecret],
@@ -134,6 +135,7 @@ services:
       BETTER_AUTH_URL: \${BETTER_AUTH_URL}
       EXTRA_TRUSTED_ORIGINS: \${EXTRA_TRUSTED_ORIGINS:-}
       HOST_CONNECTOR_URL: \${HOST_CONNECTOR_URL}
+      DISABLE_UPDATE_CHECK: \${DISABLE_UPDATE_CHECK:-false}
       OVERTCHAT_MANAGEMENT_SECRET: \${OVERTCHAT_MANAGEMENT_SECRET}
       OVERTCHAT_INSTALLED_CAPABILITIES: \${OVERTCHAT_INSTALLED_CAPABILITIES:-}
       WEB_SEARCH_PROVIDER: \${WEB_SEARCH_PROVIDER}

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   defaultInstallationConfig,
   initialSecrets,
@@ -9,6 +9,10 @@ import {
   writeInstallationConfig,
 } from "./config.js";
 import type { ExistingInstallation, RuntimePaths } from "./types.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 function existing(
   overrides: Partial<ExistingInstallation> = {},
@@ -74,6 +78,14 @@ describe("existing installation adoption", () => {
     expect(config.appVersion).toBe("9.1.0");
     expect(config.appImage).toBe("ghcr.io/yoloyash/overtchat-app:9.1.0");
   });
+
+  it("preserves an explicit update-check opt-out", () => {
+    vi.stubEnv("DISABLE_UPDATE_CHECK", "true");
+
+    expect(defaultInstallationConfig(existing()).disableUpdateCheck).toBe(
+      true,
+    );
+  });
 });
 
 describe("managed installation state", () => {
@@ -108,10 +120,12 @@ describe("managed installation state", () => {
       expect(contents).not.toContain("tts-secret");
       expect(contents).not.toContain("stt-secret");
       expect(contents).not.toContain("apiKey");
+      vi.stubEnv("DISABLE_UPDATE_CHECK", "true");
       const loaded = await readInstallationConfig(paths);
       expect(loaded?.search.apiKey).toBeUndefined();
       expect(loaded?.tts.apiKey).toBeUndefined();
       expect(loaded?.stt.apiKey).toBeUndefined();
+      expect(loaded?.disableUpdateCheck).toBe(true);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -26,6 +26,11 @@ function generatedSecret(): string {
   return randomBytes(32).toString("hex");
 }
 
+function environmentFlag(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  return /^(1|true|yes)$/iu.test(value.trim());
+}
+
 function newerVersion(left: string | undefined, right: string): boolean {
   if (!left || !/^\d+\.\d+\.\d+$/u.test(left)) return false;
   const leftParts = left.split(".").map(Number);
@@ -69,6 +74,10 @@ export function defaultInstallationConfig(
     connectorServerUrl:
       existing?.environment.get("HOST_CONNECTOR_URL") ??
       `http://127.0.0.1:${existing?.appPort ?? DEFAULT_APP_PORT}`,
+    disableUpdateCheck:
+      environmentFlag(process.env.DISABLE_UPDATE_CHECK) ??
+      environmentFlag(existing?.environment.get("DISABLE_UPDATE_CHECK")) ??
+      false,
     composeProject: existing?.composeProject ?? DEFAULT_COMPOSE_PROJECT,
     dataMountType: existing?.dataMountType ?? "volume",
     dataVolume: existing?.dataVolume ?? DEFAULT_DATA_VOLUME,
@@ -125,6 +134,10 @@ export async function readInstallationConfig(
       extraTrustedOrigins: config.extraTrustedOrigins ?? [],
       connectorServerUrl:
         config.connectorServerUrl ?? `http://127.0.0.1:${config.appPort}`,
+      disableUpdateCheck:
+        environmentFlag(process.env.DISABLE_UPDATE_CHECK) ??
+        config.disableUpdateCheck ??
+        false,
     });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,5 +1,5 @@
-export const CLI_VERSION = "0.1.7";
-export const APP_VERSION = "0.16.0";
+export const CLI_VERSION = "0.1.8";
+export const APP_VERSION = "0.16.1";
 export const CONNECTOR_VERSION = "0.7.0";
 export const STT_VERSION = "0.1.1";
 

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -51,6 +51,7 @@ export type InstallationConfig = {
   publicUrl: string;
   extraTrustedOrigins: string[];
   connectorServerUrl: string;
+  disableUpdateCheck?: boolean;
   composeProject: string;
   dataMountType: "volume" | "bind";
   dataVolume: string;

--- a/apps/site/app/privacy/page.tsx
+++ b/apps/site/app/privacy/page.tsx
@@ -19,7 +19,7 @@ export default function PrivacyPage() {
         <header className="legal-header">
           <p className="eyebrow">Legal</p>
           <h1 className="page-title">Privacy Policy</h1>
-          <p className="legal-updated">Last updated 23 July 2026</p>
+          <p className="legal-updated">Last updated 22 August 2026</p>
           <p className="page-lede">
             OvertChat is an open-source chat client that connects to a server you
             choose. The short version: we do not operate a hosted chat service,
@@ -158,6 +158,25 @@ export default function PrivacyPage() {
               <a href="https://sentry.io/security/">security information</a>. If
               you would prefer no crash reports leave your device, you can build
               the app from source without the Sentry DSN configured.
+            </p>
+          </section>
+
+          <section>
+            <h2>Server version checks</h2>
+            <p>
+              When an administrator opens the account menu, an OvertChat server
+              may request the public release manifest from overtchat.com to
+              determine whether a newer server version is available. The result
+              is cached for 12 hours. The request does not include an instance
+              identifier, account information, server configuration, chat data,
+              or the installed version.
+            </p>
+            <p>
+              Cloudflare processes ordinary request data such as the server IP
+              address and request time when delivering the manifest. Server
+              operators can disable version checks by setting the documented
+              {" "}
+              <code>DISABLE_UPDATE_CHECK</code> environment variable.
             </p>
           </section>
 

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.7"
+cli_version="0.1.8"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
-  "cliVersion": "0.1.7",
-  "appVersion": "0.16.0",
+  "cliVersion": "0.1.8",
+  "appVersion": "0.16.1",
   "connectorVersion": "0.7.0",
   "sttVersion": "0.1.1"
 }

--- a/apps/web/app/(app)/settings/SettingsNav.tsx
+++ b/apps/web/app/(app)/settings/SettingsNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   Cable,
   Cpu,
@@ -15,6 +15,15 @@ import {
 } from "lucide-react";
 import { BetaBadge } from "@/components/BetaBadge";
 import { LinkPendingIndicator } from "@/components/ui/link-pending-indicator";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { authClient } from "@/lib/auth/client";
 
@@ -25,15 +34,24 @@ type Item = {
   beta?: boolean;
 };
 
-const USER_ITEMS: Item[] = [
+type Group = {
+  label: string;
+  items: Item[];
+};
+
+const PREFERENCE_ITEMS: Item[] = [
   { href: "/settings/general", label: "General", icon: Settings2 },
   { href: "/settings/tools", label: "Tools", icon: Wrench },
+];
+
+const ACCOUNT_ITEMS: Item[] = [
   { href: "/settings/profile", label: "Profile", icon: UserRound },
-  { href: "/settings/account", label: "Account", icon: KeyRound },
+  { href: "/settings/account", label: "Security", icon: KeyRound },
   { href: "/settings/data", label: "Data", icon: Database },
 ];
 
 const ADMIN_ITEMS: Item[] = [
+  { href: "/settings/models", label: "Models", icon: Cpu },
   {
     href: "/settings/services",
     label: "Services",
@@ -45,41 +63,76 @@ const ADMIN_ITEMS: Item[] = [
     icon: Cable,
     beta: true,
   },
-  { href: "/settings/models", label: "Models", icon: Cpu },
   { href: "/settings/users", label: "Users", icon: Users },
 ];
 
+const USER_GROUPS: Group[] = [
+  { label: "Preferences", items: PREFERENCE_ITEMS },
+  { label: "Account", items: ACCOUNT_ITEMS },
+];
+
+const ADMIN_GROUP: Group = {
+  label: "Administration",
+  items: ADMIN_ITEMS,
+};
+
 export function SettingsNav() {
   const pathname = usePathname();
+  const router = useRouter();
   const { data: session } = authClient.useSession();
   const isAdmin = session?.user?.role === "admin";
 
-  const items = isAdmin ? [...USER_ITEMS, ...ADMIN_ITEMS] : USER_ITEMS;
+  const groups = isAdmin ? [...USER_GROUPS, ADMIN_GROUP] : USER_GROUPS;
+  const currentItem =
+    groups
+      .flatMap((group) => group.items)
+      .find((item) => isActive(item, pathname)) ?? PREFERENCE_ITEMS[0];
+  const CurrentIcon = currentItem.icon;
 
   return (
-    <nav
-      aria-label="Settings"
-      className="-mx-1 flex gap-1 overflow-x-auto md:mx-0 md:flex-col md:gap-0 md:space-y-5 md:overflow-visible"
-    >
-      <Section
-        label="Personal settings"
-        items={USER_ITEMS}
-        pathname={pathname}
-        className="hidden md:block"
-      />
-      {isAdmin && (
+    <nav aria-label="Settings" className="w-full md:space-y-4">
+      <div className="md:hidden">
+        <Select
+          value={currentItem.href}
+          onValueChange={(href) => {
+            if (href && href !== currentItem.href) router.push(href);
+          }}
+        >
+          <SelectTrigger aria-label="Settings page" className="w-full">
+            <SelectValue>
+              <CurrentIcon className="size-3.5" />
+              <span>{currentItem.label}</span>
+              {currentItem.beta && <BetaBadge />}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent align="start">
+            {groups.map((group) => (
+              <SelectGroup key={group.label}>
+                <SelectLabel>{group.label}</SelectLabel>
+                {group.items.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <SelectItem key={item.href} value={item.href}>
+                      <Icon className="size-3.5" />
+                      <span>{item.label}</span>
+                      {item.beta && <BetaBadge />}
+                    </SelectItem>
+                  );
+                })}
+              </SelectGroup>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {groups.map((group) => (
         <Section
-          label="Admin settings"
-          items={ADMIN_ITEMS}
+          key={group.label}
+          label={group.label}
+          items={group.items}
           pathname={pathname}
           className="hidden md:block"
         />
-      )}
-      <div className="flex shrink-0 gap-1 md:hidden">
-        {items.map((item) => (
-          <NavLink key={item.href} item={item} pathname={pathname} />
-        ))}
-      </div>
+      ))}
     </nav>
   );
 }
@@ -110,8 +163,7 @@ function Section({
 }
 
 function NavLink({ item, pathname }: { item: Item; pathname: string }) {
-  const active =
-    pathname === item.href || pathname.startsWith(`${item.href}/`);
+  const active = isActive(item, pathname);
   const Icon = item.icon;
   return (
     <Link
@@ -129,4 +181,8 @@ function NavLink({ item, pathname }: { item: Item; pathname: string }) {
       <LinkPendingIndicator />
     </Link>
   );
+}
+
+function isActive(item: Item, pathname: string) {
+  return pathname === item.href || pathname.startsWith(`${item.href}/`);
 }

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -42,7 +42,7 @@ export function AccountForm({ email }: { email: string }) {
   return (
     <div className="max-w-3xl space-y-8">
       <SettingsPageHeader
-        title="Account"
+        title="Security"
         description={
           <>
             Signed in as <span className="text-foreground">{email}</span>.

--- a/apps/web/app/(app)/settings/layout.tsx
+++ b/apps/web/app/(app)/settings/layout.tsx
@@ -25,10 +25,10 @@ export default function SettingsLayout({
         </Button>
       </header>
       <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
-        <aside className="shrink-0 overflow-y-auto border-b p-3 md:w-56 md:border-r md:border-b-0">
+        <aside className="shrink-0 overflow-y-auto border-b p-3 md:w-52 md:border-r md:border-b-0 md:p-4">
           <SettingsNav />
         </aside>
-        <div className="min-w-0 flex-1 overflow-y-auto p-4 md:p-8">
+        <div className="min-w-0 flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">
           {children}
         </div>
       </div>

--- a/apps/web/app/api/app-update/route.test.ts
+++ b/apps/web/app/api/app-update/route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getAppUpdateStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/update-check", () => ({
+  getAppUpdateStatus: mocks.getAppUpdateStatus,
+}));
+
+import { GET } from "./route";
+
+const request = () => new Request("http://server.test/api/app-update");
+
+describe("GET /api/app-update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "admin", role: "admin" },
+    });
+    mocks.getAppUpdateStatus.mockResolvedValue({
+      currentVersion: "0.16.0",
+      latestVersion: "0.17.0",
+      updateAvailable: true,
+    });
+  });
+
+  it("requires an administrator", async () => {
+    mocks.getSession.mockResolvedValueOnce(null);
+    expect((await GET(request())).status).toBe(401);
+
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: "member", role: "user" },
+    });
+    expect((await GET(request())).status).toBe(403);
+    expect(mocks.getAppUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns the cached update status without HTTP caching", async () => {
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    await expect(response.json()).resolves.toEqual({
+      currentVersion: "0.16.0",
+      latestVersion: "0.17.0",
+      updateAvailable: true,
+    });
+  });
+});

--- a/apps/web/app/api/app-update/route.ts
+++ b/apps/web/app/api/app-update/route.ts
@@ -1,0 +1,14 @@
+import { auth } from "@/lib/auth/server";
+import { getAppUpdateStatus } from "@/lib/update-check";
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  if (session.user.role !== "admin") {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  return Response.json(await getAppUpdateStatus(), {
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}

--- a/apps/web/app/api/ping/route.test.ts
+++ b/apps/web/app/api/ping/route.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { APP_VERSION } from "@/lib/version";
+import { GET } from "./route";
+
+describe("GET /api/ping", () => {
+  it("reports the same release version shown in the app", async () => {
+    const response = GET(new Request("http://localhost/api/ping"));
+
+    expect(await response.json()).toEqual({
+      ok: true,
+      name: "overtchat",
+      version: APP_VERSION,
+    });
+  });
+});

--- a/apps/web/app/api/ping/route.ts
+++ b/apps/web/app/api/ping/route.ts
@@ -1,10 +1,13 @@
 import type { PingResponse } from "@overtchat/shared";
 import { withCors, preflight } from "@/lib/cors";
-
-const VERSION = process.env.npm_package_version ?? "0.1.0";
+import { APP_VERSION } from "@/lib/version";
 
 export function GET(req: Request) {
-  const body: PingResponse = { ok: true, name: "overtchat", version: VERSION };
+  const body: PingResponse = {
+    ok: true,
+    name: "overtchat",
+    version: APP_VERSION,
+  };
   return withCors(req, Response.json(body));
 }
 

--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -2,8 +2,20 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { Menu } from "@base-ui/react/menu";
-import { ChevronUp, LogOut, Settings, User } from "lucide-react";
+import {
+  ChevronUp,
+  CircleArrowUp,
+  ExternalLink,
+  FileText,
+  LogOut,
+  ServerCog,
+  Settings,
+  ShieldCheck,
+  User,
+  UserRound,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
 import { toast } from "@/components/ui/toast";
@@ -11,11 +23,20 @@ import { authClient } from "@/lib/auth/client";
 import { getErrorMessage } from "@/lib/errors";
 import { motionClasses } from "@/lib/motion";
 import { cn } from "@/lib/utils";
+import { APP_VERSION } from "@/lib/version";
+import { useAppUpdate } from "@/lib/queries/appUpdate";
 import { useSidebar } from "@/components/sidebar-context";
 
 export function AccountMenu() {
   const router = useRouter();
+  const [menuOpen, setMenuOpen] = useState(false);
   const { data: session, isPending } = authClient.useSession();
+  const isAdmin = session?.user.role === "admin";
+  const { data: update } = useAppUpdate(menuOpen && isAdmin);
+  const availableVersion = update?.updateAvailable
+    ? update.latestVersion
+    : null;
+  const updateAvailable = availableVersion !== null;
   // Portal the menu into the drawer's Dialog.Popup on mobile so the Dialog's
   // dismiss logic recognizes menu-item taps as "inside" events. On desktop
   // the drawer isn't mounted, ref.current is null, and base-ui falls back to
@@ -43,13 +64,13 @@ export function AccountMenu() {
   }
 
   return (
-    <Menu.Root>
+    <Menu.Root onOpenChange={setMenuOpen}>
       <Menu.Trigger
         render={
           <Button
             variant="ghost"
             size="sm"
-            className="h-auto w-full justify-start gap-2 px-2 py-2 text-sidebar-foreground hover:bg-sidebar-accent"
+            className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-sidebar-foreground hover:bg-sidebar-accent"
           />
         }
       >
@@ -65,20 +86,15 @@ export function AccountMenu() {
             size="sm"
           />
         )}
-        <span className="flex min-w-0 flex-1 flex-col text-left">
+        <span className="min-w-0 flex-1 text-left">
           {isPending || !session ? (
-            <span className="text-sm font-medium text-muted-foreground">
+            <span className="block truncate text-sm font-medium text-muted-foreground">
               Loading…
             </span>
           ) : (
-            <>
-              <span className="truncate text-sm font-medium leading-tight">
-                {session.user.name}
-              </span>
-              <span className="truncate text-xs leading-tight text-muted-foreground">
-                {session.user.email}
-              </span>
-            </>
+            <span className="block truncate text-sm font-medium">
+              {session.user.name}
+            </span>
           )}
         </span>
         <ChevronUp className="size-3.5 shrink-0 text-muted-foreground" />
@@ -91,13 +107,104 @@ export function AccountMenu() {
               motionClasses.popup,
             )}
           >
+            <div className="flex min-w-0 items-center gap-2 px-2 py-2">
+              {isPending || !session ? (
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                  <User className="size-3.5" />
+                </span>
+              ) : (
+                <ProfileAvatar
+                  id={session.user.id}
+                  name={session.user.name}
+                  image={session.user.image ?? null}
+                  size="sm"
+                />
+              )}
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-sm font-medium leading-tight">
+                  {session?.user.name ?? "Loading…"}
+                </span>
+                {session && (
+                  <span className="truncate text-xs leading-tight text-muted-foreground">
+                    {session.user.email}
+                  </span>
+                )}
+              </span>
+            </div>
+            <Menu.Separator className="mx-1 my-1 h-px bg-border" />
             <Menu.Item
-              render={<Link href="/settings" onClick={closeMobile} />}
+              render={
+                <Link href="/settings/profile" onClick={closeMobile} />
+              }
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+            >
+              <UserRound className="size-3.5 shrink-0 text-muted-foreground" />
+              <span>Profile</span>
+            </Menu.Item>
+            <Menu.Item
+              render={
+                <Link href="/settings/general" onClick={closeMobile} />
+              }
               className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
             >
               <Settings className="size-3.5 shrink-0 text-muted-foreground" />
               <span>Settings</span>
             </Menu.Item>
+            {isAdmin && (
+              <Menu.Item
+                render={
+                  <Link href="/settings/models" onClick={closeMobile} />
+                }
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              >
+                <ServerCog className="size-3.5 shrink-0 text-muted-foreground" />
+                <span>Administration</span>
+              </Menu.Item>
+            )}
+            <Menu.Separator className="mx-1 my-1 h-px bg-border" />
+            <Menu.Item
+              render={
+                <a
+                  href="https://overtchat.com/releases/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={closeMobile}
+                />
+              }
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+            >
+              {updateAvailable ? (
+                <CircleArrowUp className="size-3.5 shrink-0 text-ring" />
+              ) : (
+                <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+              <span className={cn("flex-1", updateAvailable && "font-medium")}>
+                {updateAvailable ? "Update available" : "Release notes"}
+              </span>
+              {updateAvailable ? (
+                <span className="text-xs font-medium text-ring">
+                  v{availableVersion}
+                </span>
+              ) : (
+                <ExternalLink className="size-3 shrink-0 text-muted-foreground" />
+              )}
+            </Menu.Item>
+            <Menu.Item
+              render={
+                <a
+                  href="https://overtchat.com/privacy/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={closeMobile}
+                />
+              }
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+            >
+              <ShieldCheck className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="flex-1">Privacy</span>
+              <ExternalLink className="size-3 shrink-0 text-muted-foreground" />
+            </Menu.Item>
+            <Menu.Separator className="mx-1 my-1 h-px bg-border" />
             <Menu.Item
               onClick={logOut}
               className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
@@ -105,6 +212,9 @@ export function AccountMenu() {
               <LogOut className="size-3.5 shrink-0 text-muted-foreground" />
               <span>Log out</span>
             </Menu.Item>
+            <div className="px-2 pt-1.5 pb-1 text-[11px] text-muted-foreground">
+              OvertChat v{APP_VERSION}
+            </div>
           </Menu.Popup>
         </Menu.Positioner>
       </Menu.Portal>

--- a/apps/web/e2e/motion.spec.ts
+++ b/apps/web/e2e/motion.spec.ts
@@ -81,7 +81,7 @@ test("interactive surfaces remain usable with reduced motion", async ({ page }) 
     await page.goto("/");
     await page.getByText("Motion Admin").click();
     await page.getByRole("menuitem", { name: "Settings" }).click();
-    await page.waitForURL("**/settings");
+    await page.waitForURL("**/settings/general");
 
     await page.getByRole("link", { name: /Users/ }).click();
     await page.waitForURL("**/settings/users");

--- a/apps/web/e2e/sidebar.spec.ts
+++ b/apps/web/e2e/sidebar.spec.ts
@@ -24,12 +24,38 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
   test.setTimeout(60_000);
   await page.emulateMedia({ reducedMotion: "no-preference" });
   await page.setViewportSize({ width: 1280, height: 720 });
+  await page.route("**/api/app-update", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        currentVersion: "0.16.0",
+        latestVersion: "99.0.0",
+        updateAvailable: true,
+      }),
+    });
+  });
   await page.goto("/signup");
   await page.locator("#name").fill("Sidebar Admin");
   await page.locator("#email").fill("sidebar-admin@overtchat-test.local");
   await page.locator("#password").fill("test-password-123");
   await page.getByRole("button", { name: "Create account" }).click();
   await page.waitForURL("**/");
+
+  await page.getByText("Sidebar Admin", { exact: true }).click();
+  await expect(page.getByRole("menuitem", { name: "Profile" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Settings" })).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: "Administration" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: "Update available v99.0.0" }),
+  ).toHaveAttribute("href", "https://overtchat.com/releases/");
+  await expect(page.getByRole("menuitem", { name: "Privacy" })).toHaveAttribute(
+    "href",
+    "https://overtchat.com/privacy/",
+  );
+  await expect(page.getByText(/^OvertChat v\d+\.\d+\.\d+$/)).toBeVisible();
+  await page.keyboard.press("Escape");
 
   const desktopSidebar = page.locator("[data-desktop-sidebar]");
   const desktopPanel = page.locator("[data-desktop-sidebar-panel]");
@@ -64,6 +90,23 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
   await page.waitForURL("**/projects/**");
 
   await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/settings/general");
+  const settingsPicker = page.getByRole("combobox", {
+    name: "Settings page",
+  });
+  await expect(settingsPicker).toContainText("General");
+  await settingsPicker.click();
+  const settingsOptions = page.getByRole("listbox");
+  await expect(
+    settingsOptions.getByText("Preferences", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    settingsOptions.getByText("Administration", { exact: true }),
+  ).toBeVisible();
+  await settingsOptions.getByRole("option", { name: "Security" }).click();
+  await page.waitForURL("**/settings/account");
+  await expect(page.getByRole("heading", { name: "Security" })).toBeVisible();
+
   await page.getByRole("button", { name: "Open sidebar" }).click();
   expect(await getTransitionProperties(page)).toContain("translate");
   const drawer = page.getByRole("dialog", { name: "Navigation" });

--- a/apps/web/lib/queries/appUpdate.ts
+++ b/apps/web/lib/queries/appUpdate.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { appUpdateKeys } from "@/lib/queries/keys";
+
+const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1_000;
+
+export type AppUpdateStatus = {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+};
+
+export function useAppUpdate(enabled: boolean) {
+  return useQuery({
+    queryKey: appUpdateKeys.status(),
+    queryFn: async (): Promise<AppUpdateStatus> => {
+      const response = await fetch("/api/app-update");
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json() as Promise<AppUpdateStatus>;
+    },
+    enabled,
+    retry: false,
+    staleTime: CHECK_INTERVAL_MS,
+  });
+}

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -83,3 +83,8 @@ export const searchKeys = {
   all: () => ["search"] as const,
   byQuery: (q: string) => [...searchKeys.all(), q] as const,
 };
+
+export const appUpdateKeys = {
+  all: () => ["appUpdate"] as const,
+  status: () => [...appUpdateKeys.all(), "status"] as const,
+};

--- a/apps/web/lib/update-check.test.ts
+++ b/apps/web/lib/update-check.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+describe("app update check", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("compares stable semantic versions", async () => {
+    const { isNewerVersion } = await import("./update-check");
+
+    expect(isNewerVersion("0.16.0", "0.17.0")).toBe(true);
+    expect(isNewerVersion("0.16.0", "1.0.0")).toBe(true);
+    expect(isNewerVersion("0.16.0", "0.16.1")).toBe(true);
+    expect(isNewerVersion("0.16.0", "0.16.0")).toBe(false);
+    expect(isNewerVersion("0.16.0", "0.15.9")).toBe(false);
+    expect(isNewerVersion("development", "0.17.0")).toBe(false);
+    expect(isNewerVersion("0.16.0", "not-a-version")).toBe(false);
+  });
+
+  it("caches the public manifest result across checks", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        Response.json({ format: 1, appVersion: "99.0.0" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const { getAppUpdateStatus } = await import("./update-check");
+
+    await expect(getAppUpdateStatus()).resolves.toMatchObject({
+      latestVersion: "99.0.0",
+      updateAvailable: true,
+    });
+    await getAppUpdateStatus();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://overtchat.com/install-manifest.json",
+      expect.objectContaining({ headers: { Accept: "application/json" } }),
+    );
+  });
+
+  it("fails silently and caches an unavailable result", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { getAppUpdateStatus } = await import("./update-check");
+
+    await expect(getAppUpdateStatus()).resolves.toMatchObject({
+      latestVersion: null,
+      updateAvailable: false,
+    });
+    await getAppUpdateStatus();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not make a request when checks are disabled", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("DISABLE_UPDATE_CHECK", "true");
+    const { getAppUpdateStatus } = await import("./update-check");
+
+    await expect(getAppUpdateStatus()).resolves.toMatchObject({
+      latestVersion: null,
+      updateAvailable: false,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/update-check.ts
+++ b/apps/web/lib/update-check.ts
@@ -1,0 +1,97 @@
+import "server-only";
+import { APP_VERSION } from "@/lib/version";
+
+const RELEASE_MANIFEST_URL = "https://overtchat.com/install-manifest.json";
+const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1_000;
+const REQUEST_TIMEOUT_MS = 5_000;
+const SEMVER_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/u;
+
+export type AppUpdateStatus = {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+};
+
+type CacheEntry = {
+  checkedAt: number;
+  latestVersion: string | null;
+};
+
+let cached: CacheEntry | null = null;
+let pending: Promise<string | null> | null = null;
+
+function updateCheckDisabled(): boolean {
+  return /^(1|true|yes)$/iu.test(
+    process.env.DISABLE_UPDATE_CHECK?.trim() ?? "",
+  );
+}
+
+function parseVersion(version: string): [number, number, number] | null {
+  const match = SEMVER_PATTERN.exec(version.trim());
+  if (!match) return null;
+  const parts = match.slice(1).map(Number);
+  if (parts.some((part) => !Number.isSafeInteger(part))) return null;
+  return parts as [number, number, number];
+}
+
+export function isNewerVersion(current: string, candidate: string): boolean {
+  const currentParts = parseVersion(current);
+  const candidateParts = parseVersion(candidate);
+  if (!currentParts || !candidateParts) return false;
+
+  for (let index = 0; index < currentParts.length; index += 1) {
+    if (candidateParts[index]! > currentParts[index]!) return true;
+    if (candidateParts[index]! < currentParts[index]!) return false;
+  }
+  return false;
+}
+
+function manifestVersion(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const manifest = value as { format?: unknown; appVersion?: unknown };
+  if (manifest.format !== 1 || typeof manifest.appVersion !== "string") {
+    return null;
+  }
+  return parseVersion(manifest.appVersion) ? manifest.appVersion.trim() : null;
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const response = await fetch(RELEASE_MANIFEST_URL, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    return manifestVersion(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+async function latestVersion(): Promise<string | null> {
+  const now = Date.now();
+  if (cached && now - cached.checkedAt < CHECK_INTERVAL_MS) {
+    return cached.latestVersion;
+  }
+  if (pending) return pending;
+
+  pending = fetchLatestVersion()
+    .then((version) => {
+      cached = { checkedAt: Date.now(), latestVersion: version };
+      return version;
+    })
+    .finally(() => {
+      pending = null;
+    });
+  return pending;
+}
+
+export async function getAppUpdateStatus(): Promise<AppUpdateStatus> {
+  const latest = updateCheckDisabled() ? null : await latestVersion();
+  return {
+    currentVersion: APP_VERSION,
+    latestVersion: latest,
+    updateAvailable:
+      latest !== null && isNewerVersion(APP_VERSION, latest),
+  };
+}

--- a/apps/web/lib/version.ts
+++ b/apps/web/lib/version.ts
@@ -1,0 +1,10 @@
+import installManifest from "../../site/public/install-manifest.json";
+
+/**
+ * The install manifest is the release source of truth used by compose, the
+ * installer, and the marketing site. An explicit public value can identify a
+ * custom build without requiring a second version file.
+ */
+export const APP_VERSION =
+  process.env.NEXT_PUBLIC_OVERTCHAT_VERSION?.trim() ||
+  installManifest.appVersion;

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:4718}
+      DISABLE_UPDATE_CHECK: ${DISABLE_UPDATE_CHECK:-false}
       HOST_CONNECTOR_URL: ${HOST_CONNECTOR_URL:-http://127.0.0.1:${APP_PORT:-4718}}
       SEARXNG_URL: ${OVERTCHAT_SEARXNG_URL:-http://searxng:8080}
       KOKORO_URL: ${OVERTCHAT_KOKORO_URL:-http://kokoro:8880}

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.1}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -125,6 +125,15 @@ This updates the management CLI, app image, selected local sidecars, and managed
 Agent Connector as one coordinated release. Database migrations run
 automatically when the app starts; the existing data mount is not replaced.
 
+When an administrator opens the account menu, OvertChat checks the public
+release manifest at `overtchat.com` and shows an update notice when a newer app
+image is available. The result is cached by the server for 12 hours; the check
+does not send an instance identifier, account data, configuration, or the
+installed version. For a manual Compose installation, set
+`DISABLE_UPDATE_CHECK=true` in the root `.env` file. For an installation made
+with the guided manager, run `DISABLE_UPDATE_CHECK=true overtchat setup` once
+to persist the same opt-out.
+
 Running `overtchat setup` adopts an older manually paired connector, rotates
 its credentials, and brings it under managed updates.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },


### PR DESCRIPTION
## Summary

- reorganize settings into clear Preferences, Account, and Administration groups with a compact mobile-web page picker
- expand the account menu with profile, administration, release notes, privacy, version, and admin-only update availability
- add a privacy-conscious cached release check with deployment and managed-installer opt-out support
- prepare app v0.16.1 and CLI v0.1.8 in a separate release commit

## Verification

- web lint and typecheck
- 552 web unit tests
- production Chromium desktop and mobile sidebar/settings flow
- CLI lint, typecheck, and 31 tests
- site lint and typecheck
- release version consistency checks