### PR TITLE
fix(release): publish self-contained app image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,10 @@ npm-debug.log*
 apps/web/data
 apps/connector
 apps/mobile
-apps/site
+apps/site/*
+!apps/site/public
+apps/site/public/*
+!apps/site/public/install-manifest.json
 scripts
 **/test-results
 **/playwright-report

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,5 +1,5 @@
-export const CLI_VERSION = "0.1.8";
-export const APP_VERSION = "0.16.1";
+export const CLI_VERSION = "0.1.9";
+export const APP_VERSION = "0.16.2";
 export const CONNECTOR_VERSION = "0.7.0";
 export const STT_VERSION = "0.1.1";
 

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.8"
+cli_version="0.1.9"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
-  "cliVersion": "0.1.8",
-  "appVersion": "0.16.1",
+  "cliVersion": "0.1.9",
+  "appVersion": "0.16.2",
   "connectorVersion": "0.7.0",
   "sttVersion": "0.1.1"
 }

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.1}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.2}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },


### PR DESCRIPTION
## Summary

- include the public app-version manifest in the Docker build context
- fix the tagged image build failure caused by the marketing-site workspace exclusion
- prepare replacement app v0.16.2 and CLI v0.1.9 releases

## Verification

- full local Docker builder stage succeeds
- release version consistency checks pass
- CLI: 31 tests pass
- version-sensitive web tests pass

The existing v0.16.1 image workflow failed before publishing an image. Public tags remain immutable, so v0.16.2 replaces that failed app release.