### PR TITLE
Release app v0.16.3

### DIFF
--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.16.2",
+  "appVersion": "0.16.3",
   "connectorVersion": "0.7.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.2}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.3}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- promote the app release candidate to 0.16.3
- keep CLI, connector, STT, and bundled image selections unchanged

## Validation

- npm run lint
- npm run typecheck
- npm run test

## Release

After squash merge, tag the exact merged main commit as `v0.16.3`. The app image workflow will publish both platforms, create the GitHub Release, and dispatch serialized stable promotion.