### PR TITLE
Refresh repository guidance and release promotion

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -277,3 +278,37 @@ jobs:
           test -n "$CLOUDFLARE_ACCOUNT_ID"
           test -n "$CLOUDFLARE_API_TOKEN"
           npm run site:deploy
+
+      - name: Log in to GHCR after stable deployment
+        if: steps.readiness.outputs.ready == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update the app latest alias
+        if: steps.readiness.outputs.ready == 'true'
+        env:
+          APP_VERSION: ${{ steps.manifest.outputs.app }}
+        run: |
+          versioned_image="ghcr.io/yoloyash/overtchat-app:$APP_VERSION"
+          latest_image="ghcr.io/yoloyash/overtchat-app:latest"
+          versioned_digest=$(docker buildx imagetools inspect \
+            "$versioned_image" --format '{{.Manifest.Digest}}')
+
+          docker buildx imagetools create \
+            --tag "$latest_image" \
+            "$versioned_image@$versioned_digest"
+
+          for _ in {1..10}; do
+            latest_digest=$(docker buildx imagetools inspect \
+              "$latest_image" --format '{{.Manifest.Digest}}')
+            if [ "$latest_digest" = "$versioned_digest" ]; then
+              exit 0
+            fi
+            sleep 3
+          done
+
+          echo "$latest_image does not match $versioned_image." >&2
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ ROADMAP.md
 ROADMAP_MOBILE.md
 GEMINI.md
 CLAUDE.md
-AGENTS.md
 /scripts/*
 !/scripts/install-connector.sh
 !/scripts/dev.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# Repository guidance
+
+OvertChat is a self-hosted chat application for local and hosted LLMs, with
+web/mobile clients and optional coding-agent control. Users own the server and
+data; a host-native connector runs Codex, Pi, and Oh My Pi sessions locally or
+over SSH.
+
+## Sources of truth
+
+- `docs/deploy.md` owns development setup, environment loading, managed
+  installation, deployment, and operator procedures.
+- `docs/release.md` owns version, tag, artifact, promotion, and release-specific
+  validation procedures.
+- `docs/android.md` is the end-user Android installation guide.
+
+Update a runbook when its process changes. In `AGENTS.md`, link to the owning
+runbook instead of copying its instructions.
+
+## Repository map and ownership
+
+| Path | Responsibility |
+| --- | --- |
+| `apps/web` | Self-hosted Next.js product: UI, auth, SQLite persistence, chat APIs, and the authenticated Host Connector relay |
+| `apps/mobile` | Expo client for an operator-supplied OvertChat server |
+| `apps/site` | Static `overtchat.com` export, installer assets, and release manifest |
+| `apps/cli` | Linux management CLI for setup, adoption, updates, and managed Compose state |
+| `apps/connector` | Host-native daemon that owns live coding-agent sessions and process execution |
+| `packages/agent-bridge` | Exact web-to-connector protocol and shared agent data contracts |
+| `packages/agent-runtime` | Codex, Pi, and OMP provider adapters plus host runtime primitives |
+| `packages/shared` | Cross-client chat/tool/model contracts and generated web/native theme outputs |
+| `scripts/dev.mjs` | Root development-stack orchestration |
+| `compose.yml`, `searxng/`, `stt/` | Self-hosted application and bundled sidecars |
+| `.github/` | Validation, artifact publication, and release promotion automation |
+
+Keep these boundaries strict:
+
+- The connector is the only product process that spawns coding agents or uses
+  the user's SSH configuration. The web app authorizes and relays; it does not
+  import `@overtchat/agent-runtime` or reconstruct live runtime state.
+- `agent-bridge` defines transport-neutral contracts and validation.
+  `agent-runtime` implements providers against those contracts. Product UI and
+  durable database models stay out of both packages.
+- `packages/shared` must remain usable by every target that imports a given
+  export. Platform-specific theme representations use the existing export
+  paths rather than runtime platform branching.
+
+## Commands
+
+Use Node 22 and npm 10.9.8. The npm version is repeated in `package.json`,
+`Dockerfile`, and CI workflows; update those pins and regenerate
+`package-lock.json` together.
+
+Run commands from the repository root unless a scoped file says otherwise:
+
+- `package.json` is the command registry; use an existing package script when
+  one covers the task.
+- `npm run <script> -w <workspace> --` targets one workspace.
+
+Run the narrowest relevant checks while iterating, then widen validation for
+cross-workspace or release-sensitive changes.
+
+## Repository conventions
+
+- Workspace packages export TypeScript source directly. Do not introduce a
+  package build step unless all consumers and Turbo dependencies are updated
+  together.
+- Add a scoped `AGENTS.md` only when a subtree has distinct ownership,
+  invariants, or validation.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -1,0 +1,24 @@
+# Management CLI guidance
+
+This workspace is the Linux installer and updater for managed OvertChat
+installations. It turns a validated release manifest, detected Docker state,
+and operator choices into a managed Compose stack and optional Host Connector.
+
+## Architecture
+
+- `src/setup.ts` is the main provisioning flow: detect or adopt an installation,
+  collect configuration, render managed files, start the stack, wait for the
+  app, sync service capabilities, and install the connector.
+- `src/update.ts` applies newer manifest versions through the same rendering,
+  Compose, readiness, and connector paths.
+- `src/config.ts`, `src/paths.ts`, and `src/compose.ts` own persisted
+  installation state, managed locations, secrets/environment output, and
+  Compose rendering.
+- `src/docker.ts` owns Docker discovery, existing-install detection, GPU
+  support, and bundled-sidecar reconciliation.
+- `src/release.ts` validates the published manifest and handles CLI
+  self-updates; `src/connector.ts` installs and verifies the managed connector.
+
+Setup and update can modify the host installation. Keep ordinary iteration in
+unit tests and reserve end-to-end runs for a disposable installation. Run the
+workspace test, typecheck, and build scripts before finishing.

--- a/apps/connector/AGENTS.md
+++ b/apps/connector/AGENTS.md
@@ -1,0 +1,31 @@
+# Host Connector guidance
+
+This workspace is the host-native bridge between an OvertChat server and local
+or SSH-hosted coding agents. It maintains an authenticated outbound connection,
+runs provider sessions through `@overtchat/agent-runtime`, and sends their state
+back using contracts from `@overtchat/agent-bridge`.
+
+## Architecture
+
+- `src/cli.ts`, `src/config.ts`, and `src/service.ts` own pairing, persisted
+  credentials, command routing, and systemd user-service installation.
+- `src/client.ts` owns the server connection, reconnect behavior, command
+  stream, event delivery, acknowledgements, and connector instance lock.
+- `src/daemon.ts` dispatches bridge requests, manages live agent sessions, and
+  coordinates command execution with durable state.
+- `src/state.ts` persists command deduplication, durable outbound events,
+  session descriptors, and queued messages across reconnects and restarts.
+- `src/timeline.ts` is the canonical per-session event history used for replay
+  and synchronization. Live session events are recoverable hints derived from
+  this timeline.
+- `src/runtime.ts` and `src/ssh.ts` adapt local or SSH process execution to the
+  runtime package. SSH targets remain OpenSSH aliases; the connector does not
+  manage private keys.
+
+The connector is outbound-only and does not expose a shell or listening server.
+Changes to command handling or event delivery must preserve journal-before-ack
+ordering, command deduplication, and timeline recovery across restarts.
+
+Run the workspace tests, typecheck, and build before finishing. Changes to
+transport or persistence require the corresponding client, daemon, state, and
+timeline tests.

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -1,0 +1,46 @@
+# Mobile app guidance
+
+This workspace is the Expo/React Native client for an operator-selected
+OvertChat server. Run Expo interactively from `apps/mobile`; native module
+changes require rebuilding the development client.
+
+## Product boundary
+
+The server URL is selected at runtime and stored on the device. Mobile does not
+implement server setup, first-user signup, or administration; those flows remain
+in the web app.
+
+## Architecture
+
+- `src/app/_layout.tsx` owns root providers and protected routing between server
+  selection, login, and authenticated routes.
+- `src/app/(authed)/_layout.tsx` owns the active chat session and authenticated
+  navigation stack. The drawer selects chats and projects through
+  `src/lib/chat/session.ts`.
+- `src/lib/server-url.ts` owns the selected server. `src/lib/auth/client.ts`
+  creates the Better Auth client for that server, and `src/lib/api.ts` is the
+  authenticated HTTP boundary.
+- The chat screen first hydrates persisted messages through React Query, then
+  runs the AI SDK `useChat` transport for streaming. Chat completion invalidates
+  the shared chat and message query keys.
+- Server-state hooks live under `src/lib/queries`; reusable keys are defined
+  only in `src/lib/queries/keys.ts`.
+- Chat rendering and input behavior live under `src/components/chat`; the
+  drawer and its project/chat mutations live under `src/components/drawer`.
+
+## Platform constraints
+
+Better Auth stores the mobile cookie in SecureStore. Use `authFetch` for
+authenticated requests; uploads must attach `getAuthCookie()` to the
+`expo/fetch` multipart request explicitly. Changing servers must also reset the
+cached auth client.
+
+`src/polyfills.js` must load before the AI SDK streaming stack. Test streaming
+on both Android and iOS after changing the transport or its polyfills.
+
+Navigation headers and safe-area behavior are owned by Expo Router. Android
+drawer behavior currently relies on `predictiveBackGestureEnabled: false` in
+`app.json`; test gestures and system-bar insets before changing navigation.
+
+Use `@/*` for `src` imports and `@overtchat/shared/theme.rn` for shared theme
+tokens. Run the mobile typecheck before finishing.

--- a/apps/site/AGENTS.md
+++ b/apps/site/AGENTS.md
@@ -1,0 +1,49 @@
+# Marketing site guidance
+
+This workspace produces the fully static `overtchat.com` project site, release
+log, and public installer files. `next build` writes the export to `apps/site/out`;
+there is no production Next.js server.
+
+The releases page reads GitHub during the build. Set `GITHUB_TOKEN` locally to
+avoid unauthenticated API rate limits.
+
+## Architecture
+
+- `app/page.tsx` is the marketing homepage. `lib/home-sections.ts` defines its
+  section IDs and ordering for both the page and `components/SectionRail.tsx`.
+- `app/releases/page.tsx` renders the build-time release log.
+  `lib/releases.server.ts` fetches GitHub Releases, while `lib/releases.ts`
+  validates, classifies, and orders the returned data.
+- `lib/site.ts` owns base-path and origin handling. `lib/metadata.ts` uses it
+  for canonical, Open Graph, and other absolute page URLs.
+- `public/` contains files copied directly into the export, including the
+  installer, release manifest, redirects, and response headers.
+- `app/layout.tsx` and `components/ThemeProvider.tsx` own fonts and theme
+  hydration. Shared theme tokens come from `@overtchat/shared/theme.css`.
+
+## Static export constraints
+
+Every route must remain build-time renderable. Do not add server actions,
+runtime API routes, ISR, or runtime-only environment dependencies.
+
+Next.js applies `basePath` to its own `Link` components. Use normal root-relative
+route hrefs there; use `sitePath()` for emitted asset or manifest paths and
+`absoluteSiteUrl()` when a complete URL is required.
+
+A failed GitHub request or a feed with no stable web/mobile releases must fail
+the build. Release Markdown is external content: keep raw HTML disabled,
+preserve `target="_blank"` and `rel="noopener noreferrer"` on external links,
+and keep headings below the page-level heading.
+
+Run the site tests, typecheck, and static build before finishing. Release-data,
+installer, or redirect changes require their focused tests as well.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,136 @@
+# Web app guidance
+
+This workspace is the self-hosted OvertChat product: a Next.js App Router
+server, browser client, mobile API, and SQLite persistence layer. SQLite is the
+application source of truth. Redis is optional infrastructure for reconnectable
+chat delivery.
+
+## Architecture
+
+- `app/(app)` contains authenticated product routes, `app/(auth)` contains
+  login and bootstrap signup, and `app/api` serves browser and mobile clients.
+- `components/AppShell.tsx`, `components/Sidebar.tsx`, and
+  `components/chat/ChatArea.tsx` form the main browser application.
+- `lib/db` owns schema, queries, transactions, migrations, and search indexing.
+- `lib/providers` owns provider definitions, model discovery, generated model
+  metadata, protocol adapters, and AI SDK model construction.
+- `lib/chat` owns chat request validation and message helpers; `lib/streams`
+  owns cancellation and optional reconnectable-stream integration.
+- `lib/capabilities` validates search and speech configuration;
+  `lib/db/serverCapabilities.ts` persists it.
+- `lib/agents` owns Agent Connections projections and access rules.
+  `lib/agents/connector` owns the authorized web-side connector relay.
+- `lib/mcp` owns MCP configuration, connections, tool bindings, and lifecycle.
+- `lib/queries` owns client-side React Query keys, queries, and mutations.
+
+## Authentication boundaries
+
+Better Auth sessions authorize browser and mobile APIs. Database operations
+must also scope resources by the authenticated user; checking only that a
+session exists is insufficient.
+
+Host Connector routes authenticate connector tokens. Internal management routes
+authenticate `OVERTCHAT_MANAGEMENT_SECRET`. Keep both separate from user
+sessions, and never expose connector tokens, management secrets, provider keys,
+or executable MCP configuration through user APIs.
+
+The first created user becomes the administrator. Public signup closes after
+that; administrators create subsequent users through Better Auth's admin path.
+
+## Chat and persistence
+
+`app/api/chat/route.ts` is the streaming orchestration boundary. Validate and
+authorize the complete request, resolve the provider and project, inline
+uploads, and convert messages before mutating persistent state.
+
+Saved turns use `commitChatTurn()` and `completeChatStream()` from
+`lib/db/chatTurns.ts`. Preserve their transaction boundaries, stream-ID
+ownership, edit/regenerate truncation, message and FTS consistency, usage
+recording, and partial-response behavior.
+
+Temporary chats do not claim streams or persist chats, messages, titles, search
+records, or usage. Redis-backed resumability changes stream delivery only; it
+does not replace SQLite persistence.
+
+Messages persist AI SDK `UIMessage` identity, role, parts, and metadata.
+Rendering, attachments, export, and search extraction consume that
+representation; do not introduce a parallel plain-text message model.
+
+## Providers and tools
+
+Provider identity comes from `model_configs.provider_id`, never from endpoint
+URLs. Adding a provider requires its catalog definition, one adapter under
+`lib/providers/server/adapters`, registry wiring, discovery behavior, and
+contract tests. Chat routes must remain provider-neutral.
+
+`lib/providers/server/model-catalog.json` and its manifest are generated,
+committed inputs for offline capability and pricing defaults. Update and
+validate them through the catalog scripts; commit both artifacts.
+
+Web search and URL retrieval go through `@yoloyash/web-basics`, which owns
+redirect, extraction, size, and SSRF policy.
+
+MCP input is validated in `lib/mcp/schema.ts`. STDIO configuration remains
+structured as command, arguments, environment, passthrough, and working
+directory. `lib/mcp/manager.ts` scopes runtimes by user and chat; release
+bindings after generation and preserve invalidation, idle-close, and
+chat-deletion cleanup.
+
+## Agent Connections
+
+`lib/agents/connector/broker.ts` owns live connector channels, request dispatch,
+reconnect handling, and subscriptions. It is process-local; durable connection,
+workspace, and session metadata belongs in `lib/db`.
+
+`lib/agents/sessionReplica.ts` projects connector snapshots and ordered events
+for the browser UI. It is not an independent runtime or persistence layer.
+Preserve cursor, epoch, and sequence reconciliation when changing the
+agent-session APIs or SSE client.
+
+A command can have an unknown outcome when the connector disconnects. Do not
+automatically replay it unless the connector command journal makes that
+operation replay-safe.
+
+Protocol payloads come from `@overtchat/agent-bridge`. Provider transcript
+normalization remains in the runtime/connector; web-specific presentation
+belongs in `lib/agents/presentation.ts`.
+
+## Database and startup
+
+`lib/db/schema.ts` is authoritative. Generate and review a Drizzle migration
+after schema changes and commit both. Published migrations are immutable.
+
+Changes to searchable message data must update `lib/search/extract.ts` together
+with the FTS schema, triggers, migrations, and focused tests.
+
+`npm run auth:generate` replaces `lib/db/schema.ts` with Better Auth's fragment.
+Use the result as an update source, restore the application tables, and only
+then generate a migration.
+
+`instrumentation.ts` is the Node.js startup boundary for migrations, capability
+defaults, and maintenance. The production build uses standalone output; add
+runtime files that imports cannot trace to `next.config.ts`.
+
+## Client conventions
+
+React Query owns remote client state. Define reusable keys in
+`lib/queries/keys.ts` and update or invalidate affected caches after mutations
+and stream completion.
+
+Shared theme values come from `@overtchat/shared/theme.css`; web-specific tokens
+remain in `app/globals.css`.
+
+Use `@/*` for workspace imports. Run focused tests while iterating, then the web
+typecheck, lint, and build. Auth, chat persistence, migrations, connector
+transport, and import/export changes require their relevant integration or E2E
+coverage.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -70,6 +70,17 @@ Machine-specific URLs and trusted origins still belong in the ignored
 container-only `REDIS_URL`; the full root command supplies its local Redis URL
 explicitly.
 
+The root `.env` is the Compose/production configuration. `apps/web/.env` must
+remain a symlink to `../../.env` so direct Next.js commands see the same file;
+do not replace it with a copy. Next loads `.env.development` and then the
+gitignored `.env.local` overrides during development. Mobile has no environment
+file because its server URL is selected per device.
+
+For a phone or browser on another development origin, update both mechanisms:
+`EXTRA_TRUSTED_ORIGINS` controls Better Auth and CORS, while
+`allowedDevOrigins` in `apps/web/next.config.ts` controls Next.js development
+assets. Neither setting replaces the other.
+
 Use the narrower commands when the complete stack is not needed:
 
 ```bash

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,15 +1,16 @@
 # Releases
 
-Agent runbook. `apps/site/public/install-manifest.json` is the candidate stable
-channel used by both `overtchat setup` and `overtchat update`.
+Maintainer runbook. `apps/site/public/install-manifest.json` is the candidate
+stable channel used by both `overtchat setup` and `overtchat update`.
 
 ## Rules
 
-- Version the CLI, app, connector, and STT independently.
+- Version the CLI, app, connector, STT, and mobile app independently.
 - Publish and verify all selected artifacts before deploying the manifest.
 - Use strict `X.Y.Z` versions. Never reuse a published tag or artifact.
 - Managed installs do not downgrade. Roll back with a higher patch version.
-- App migrations are automatic and forward-only.
+- Released database changes must support forward-only upgrades; never publish
+  a rollback that assumes a migration can be reversed.
 - Pin bundled third-party images by digest in the manifest.
 
 ## Version map
@@ -18,10 +19,10 @@ channel used by both `overtchat setup` and `overtchat update`.
 | --- | --- | --- |
 | App | Manifest `appVersion`; `compose.yml` default | `vX.Y.Z` |
 | CLI | `apps/cli/package.json`; lockfile; `CLI_VERSION`; site installer; manifest `cliVersion` | `cli-vX.Y.Z` |
-| Connector | Package and lockfile; connector installer; site redirects; manifest `connectorVersion` | `connector-vX.Y.Z` |
+| Connector | Package and lockfile; bridge release constants; connector installer; site redirects; manifest `connectorVersion` | `connector-vX.Y.Z` |
 | STT | Manifest `sttVersion`; `compose.yml` default | `stt-vX.Y.Z` |
 | Bundled images | Manifest `redisImage`, `searxngImage`, or `kokoroImage` digest | None |
-| Mobile | Mobile package and Expo native versions | `mobile-vX.Y.Z` |
+| Mobile | See [Mobile release](#mobile-release) | `mobile-vX.Y.Z` |
 
 Do not change unrelated manifest fields.
 
@@ -36,7 +37,8 @@ Do not change unrelated manifest fields.
 ## Component notes
 
 - **App:** `.github/workflows/app-image.yml` publishes amd64 and arm64, creates
-  the GitHub release, and dispatches promotion.
+  the GitHub release, and dispatches promotion. Successful stable promotion
+  then moves the mutable app `latest` alias to the verified versioned image.
 - **CLI:** The CLI workflow verifies both binaries, publishes the GitHub
   release, and dispatches promotion.
 - **Connector:** The connector workflow verifies both binaries, publishes the
@@ -46,18 +48,46 @@ Do not change unrelated manifest fields.
   digest. A digest-only change does not require a CLI release.
 - **Combined:** Artifacts may publish in any order; promotion succeeds only
   after every selected component is public.
-- **Mobile:** Follow `apps/mobile/AGENTS.md` and `docs/android.md`. Do not change
-  the server manifest for a mobile-only release.
+
+## Mobile release
+
+`apps/mobile/app.json` is authoritative: `expo.version` is the public version,
+`android.versionCode` is the committed Play build number, and
+`ios.buildNumber` mirrors it as a string. The mobile package version must match
+`expo.version`. `eas.json` uses local app versions; keep remote versioning and
+automatic increments disabled unless this release model is deliberately
+replaced.
+
+Android signing files are local and gitignored at
+`apps/mobile/credentials.json` and
+`apps/mobile/credentials/android/keystore.jks`. A self-hosted runner may supply
+them from `$HOME/.overtchat/mobile-credentials`. Retrieve a missing local copy
+through EAS credentials rather than committing it.
+
+`.github/workflows/mobile-eas.yml` owns the Android release pipeline:
+
+1. A manual dispatch builds the production AAB and APK and smoke-tests the APK
+   on a clean hosted emulator. It uploads short-lived workflow artifacts but
+   does not submit to Play or create a GitHub release.
+2. A tagged release performs the same build and emulator gate, submits the
+   verified AAB to Play production with `releaseStatus: completed`, and
+   attaches the APK to the matching GitHub release.
+3. Submission therefore goes live after Google review; there is no Play draft
+   gate. The service account needs the separate **Release to production** app
+   permission.
+
+Local EAS builds cannot read secret-visibility variables.
+`EXPO_PUBLIC_SENTRY_DSN` must have plain-text visibility so crash reporting is
+enabled in the binary; `SENTRY_AUTH_TOKEN` remains a credential but must be
+readable by the local build. Keep each EAS build profile's environment explicit
+and run the workflow preflight before spending time on a release build.
 
 ## Validation
 
-```bash
-npm run lint
-npm run typecheck
-npm run test
-```
+Run the standard repository lint, typecheck, and test scripts, followed by the
+release-specific checks below.
 
-For CLI changes:
+For a CLI release, build the CLI workspace and then verify the bundled version:
 
 ```bash
 npm run build -w apps/cli --
@@ -66,4 +96,6 @@ node apps/cli/dist/overtchat.mjs version
 
 `promote-release.yml` is the only CI production deploy path. It verifies CLI
 and connector checksums plus the required app/STT platforms before atomically
-deploying the site and manifest. Versioned container tags are immutable.
+deploying the site and manifest. After deployment, it updates the app `latest`
+alias to the same digest selected by `appVersion`; the manifest remains the
+stable source of truth. Versioned container tags are immutable.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,64 @@
+# Shared package guidance
+
+These workspaces are source-level libraries consumed directly by the apps.
+Keep their public exports small and preserve the dependency direction:
+`agent-runtime` may depend on `agent-bridge`, while `agent-bridge` and
+`shared` remain independent of application and runtime implementations.
+
+## Agent bridge
+
+`agent-bridge` defines the Host Connector wire protocol and the shared agent
+state model used by the web app, connector, and runtime.
+
+- `src/index.ts` owns connector commands, event batches, acknowledgements,
+  protocol validation, and release compatibility constants.
+- `src/agents.ts` owns connection, workspace, session, command, catalog,
+  snapshot, cursor, and synchronization contracts.
+- `src/state.ts` owns the pure reducers that apply runtime envelopes and
+  reconcile snapshots; `src/commands.ts` owns shared command normalization.
+- Keep this package transport-neutral and free of filesystem, network, process,
+  database, UI, or provider implementations.
+- Wire types, Zod schemas, runtime guards, reducers, and tests must evolve
+  together. Protocol v1 is exact; coordinate wire changes across the web and
+  connector consumers rather than adding parallel protocol shapes.
+
+## Agent runtime
+
+`agent-runtime` adapts Codex, Pi, and Oh My Pi into the bridge contracts and
+provides host-runtime primitives used by the connector.
+
+- `src/providers/types.ts` defines the provider adapter and runtime-client
+  interfaces; `src/providers/registry.ts` registers the provider adapters.
+- Provider-specific clients, probes, protocol parsing, commands, and session
+  discovery remain under their `src/codex`, `src/pi`, or `src/omp` directory.
+- `src/runtime/registry.ts` owns live session orchestration, normalized state,
+  event sequencing, queued submissions, and runtime shutdown.
+- Local and SSH execution goes through the spawner configured in
+  `src/runtime/process.ts`. Provider implementations do not create child
+  processes directly.
+- Normalize provider messages and behavior inside the provider adapter before
+  emitting bridge events. Keep timeouts, output bounds, and deterministic
+  process cleanup in the shared runtime path.
+
+## Shared
+
+`shared` contains cross-client chat, model, tool, citation, MCP-name, search,
+and theme contracts used by web, mobile, and the static site.
+
+- Keep exports platform-neutral and free of authorization, persistence,
+  network clients, and application UI.
+- `src/index.ts` is the public TypeScript surface. The export map in
+  `package.json` additionally exposes the generated web and React Native theme
+  representations.
+- `src/theme/tokens.ts` is the theme source of truth. Do not edit
+  `src/theme.css` or `src/theme.rn.ts` manually; regenerate and commit both with
+  `npm run theme:generate -w packages/shared --`.
+- Shared contracts must remain valid for every consumer. Put app-specific
+  extensions in the consuming workspace rather than weakening a shared type.
+
+## Validation
+
+Run the changed package's typecheck and tests where available. Bridge changes
+require its web, connector, and runtime consumers; runtime changes require the
+connector; shared contract or theme changes require the affected web, mobile,
+and site checks.


### PR DESCRIPTION
## Summary

- add concise root and workspace-scoped `AGENTS.md` files that document OvertChat's actual architecture, ownership boundaries, and high-cost invariants
- centralize development environment and release procedures in the deployment and release runbooks
- promote the verified versioned app image to the GHCR `latest` alias only after the stable site deployment succeeds
- track repository agent guidance instead of globally ignoring `AGENTS.md`

## Validation

- `git diff --check`
- `npm run test:dev`
- `actionlint .github/workflows/promote-release.yml`
- parsed `.github/workflows/promote-release.yml` as YAML
- verified the installed Docker Buildx supports the `imagetools inspect --format` and `imagetools create --tag` flags

## Release impact

No component versions or install-manifest versions change in this PR. Merging updates the stable promotion workflow and documentation; it does not publish a new app, CLI, connector, STT, or mobile release by itself.
