### PR TITLE
Release app v0.16.4 with llama.cpp inference progress

### DIFF
--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.16.3",
+  "appVersion": "0.16.4",
   "connectorVersion": "0.7.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -42,10 +42,14 @@ const mocks = vi.hoisted(() => {
     agentStream: vi.fn(),
     isStepCount: vi.fn(),
     toUIMessageStream: vi.fn(),
+    createUIMessageStream: vi.fn(),
     createUIMessageStreamResponse: vi.fn(),
     agentSettings: [] as Array<Record<string, unknown>>,
     agentStreamArgs: [] as Array<Record<string, unknown>>,
     uiStreamOptions: undefined as Record<string, unknown> | undefined,
+    outerUiStreamOptions: undefined as Record<string, unknown> | undefined,
+    uiChunks: [] as Array<Record<string, unknown>>,
+    mergedUiStream: undefined as ReadableStream<unknown> | undefined,
     responseOptions: undefined as Record<string, unknown> | undefined,
     responseStream: undefined as ReadableStream<string> | undefined,
     chatTools,
@@ -58,6 +62,7 @@ const mocks = vi.hoisted(() => {
 vi.mock("server-only", () => ({}));
 vi.mock("ai", () => ({
   convertToModelMessages: mocks.convertToModelMessages,
+  createUIMessageStream: mocks.createUIMessageStream,
   createUIMessageStreamResponse: mocks.createUIMessageStreamResponse,
   isStepCount: mocks.isStepCount,
   ToolLoopAgent: class MockToolLoopAgent {
@@ -216,6 +221,9 @@ describe("chat route setup boundary", () => {
     mocks.agentSettings.length = 0;
     mocks.agentStreamArgs.length = 0;
     mocks.uiStreamOptions = undefined;
+    mocks.outerUiStreamOptions = undefined;
+    mocks.uiChunks.length = 0;
+    mocks.mergedUiStream = undefined;
     mocks.responseOptions = undefined;
     mocks.responseStream = undefined;
 
@@ -263,6 +271,28 @@ describe("chat route setup boundary", () => {
       (options: Record<string, unknown>) => {
         mocks.uiStreamOptions = options;
         return options.stream;
+      },
+    );
+    mocks.createUIMessageStream.mockImplementation(
+      (options: Record<string, unknown>) => {
+        mocks.outerUiStreamOptions = options;
+        const execute = options.execute as (event: {
+          writer: {
+            write(part: Record<string, unknown>): void;
+            merge(stream: ReadableStream<unknown>): void;
+          };
+        }) => void;
+        execute({
+          writer: {
+            write(part) {
+              mocks.uiChunks.push(part);
+            },
+            merge(stream) {
+              mocks.mergedUiStream = stream;
+            },
+          },
+        });
+        return new ReadableStream();
       },
     );
     mocks.createUIMessageStreamResponse.mockImplementation(
@@ -697,6 +727,61 @@ describe("chat route setup boundary", () => {
     expect(mocks.toUIMessageStream).toHaveBeenCalledWith(
       expect.objectContaining({ tools: undefined }),
     );
+  });
+
+  it("forwards llama.cpp prompt progress as transient UI data", async () => {
+    mocks.getModelConfig.mockResolvedValue({
+      ...modelConfig,
+      providerId: "llamacpp",
+      apiFormat: "auto",
+    });
+    mocks.getProvider.mockReturnValue({ label: "llama.cpp", iconId: null });
+    mocks.agentStream.mockResolvedValue({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            type: "raw",
+            rawValue: {
+              choices: [{ delta: { content: null }, finish_reason: null }],
+              prompt_progress: {
+                total: 2_048,
+                cache: 0,
+                processed: 1_536,
+                time_ms: 3_200,
+              },
+            },
+          });
+          controller.close();
+        },
+      }),
+    });
+
+    await POST(request());
+
+    expect(mocks.agentSettings[0]).toMatchObject({
+      include: { rawChunks: true },
+    });
+    expect(mocks.outerUiStreamOptions).toBeDefined();
+    expect(mocks.mergedUiStream).toBeDefined();
+
+    const observed = mocks.uiStreamOptions?.stream as ReadableStream<unknown>;
+    await observed.pipeTo(new WritableStream());
+
+    expect(mocks.uiChunks).toEqual([
+      {
+        type: "data-inference-activity",
+        transient: true,
+        data: {
+          phase: "prompt",
+          completedTokens: 1_536,
+          totalTokens: 2_048,
+          cachedTokens: 0,
+          elapsedMs: 3_200,
+          progress: 0.75,
+          tokensPerSecond: 480,
+        },
+      },
+    ]);
   });
 
   it("uses persistent MCP tools without web tools", async () => {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   isStepCount,
   ToolLoopAgent,
@@ -9,6 +10,10 @@ import {
   type ToolSet,
 } from "ai";
 import type { MessageStats } from "@/lib/chat/stats";
+import {
+  INFERENCE_ACTIVITY_DATA_TYPE,
+  type InferenceActivity,
+} from "@/lib/chat/inference-activity";
 import { currentDateSystemPrompt } from "@/lib/chat/current-date";
 import {
   markAnthropicConversationCacheBoundary,
@@ -55,6 +60,7 @@ import {
   resolveModelContextWindow,
 } from "@/lib/providers/server/model-catalog";
 import { createConfiguredLanguageModel } from "@/lib/providers/server/registry";
+import { readLlamaCppInferenceActivity } from "@/lib/providers/server/llamacpp-activity";
 import * as cancelRegistry from "@/lib/streams/cancel-registry";
 import { getStreamContext } from "@/lib/streams/context";
 
@@ -315,6 +321,10 @@ async function handlePost(req: Request): Promise<Response> {
         (name) => !(CHAT_TOOL_ORDER as readonly string[]).includes(name),
       ),
     ];
+    const includeProviderActivity = modelConfig.providerId === "llamacpp";
+    const streamInclude = includeProviderActivity
+      ? { rawChunks: true as const }
+      : undefined;
     const result = toolsEnabled
       ? await new ToolLoopAgent<never, ToolSet>({
           model,
@@ -333,11 +343,13 @@ async function handlePost(req: Request): Promise<Response> {
                   : undefined
             : undefined,
           providerOptions: requestProviderOptions,
+          ...(streamInclude ? { include: streamInclude } : {}),
         }).stream({ messages: modelMessages, abortSignal })
       : await new ToolLoopAgent<never, Record<string, never>>({
           model,
           instructions,
           providerOptions: requestProviderOptions,
+          ...(streamInclude ? { include: streamInclude } : {}),
         }).stream({ messages: modelMessages, abortSignal });
 
     if (
@@ -358,6 +370,9 @@ async function handlePost(req: Request): Promise<Response> {
     const streamContext = temporary ? null : getStreamContext();
     const streamHeaders = corsHeaders(req);
     streamHeaders.set("Content-Encoding", "none");
+    let emitInferenceActivity:
+      | ((activity: InferenceActivity) => void)
+      | undefined;
     const observedStream = observeChatStream(
       result.stream as ReadableStream<TextStreamPart<ToolSet>>,
       {
@@ -382,6 +397,9 @@ async function handlePost(req: Request): Promise<Response> {
             hasUnpricedStep = true;
           }
         },
+        onInferenceActivity(activity) {
+          emitInferenceActivity?.(activity);
+        },
         onError(error) {
           if (streamError === null) {
             streamError = error;
@@ -393,7 +411,7 @@ async function handlePost(req: Request): Promise<Response> {
         },
       },
     );
-    const uiStream = toUIMessageStream({
+    const convertedUiStream = toUIMessageStream({
       stream: observedStream,
       tools: toolsEnabled ? agentTools : undefined,
       sendReasoning: true,
@@ -525,6 +543,20 @@ async function handlePost(req: Request): Promise<Response> {
         }
       },
     });
+    const uiStream = includeProviderActivity
+      ? createUIMessageStream({
+          execute({ writer }) {
+            emitInferenceActivity = (activity) => {
+              writer.write({
+                type: INFERENCE_ACTIVITY_DATA_TYPE,
+                data: activity,
+                transient: true,
+              });
+            };
+            writer.merge(convertedUiStream);
+          },
+        })
+      : convertedUiStream;
     let resumableSetup: Promise<void> | undefined;
     const response = createUIMessageStreamResponse({
       stream: uiStream,
@@ -574,11 +606,14 @@ function observeChatStream(
   callbacks: {
     onFirstToken(): void;
     onFinishStep(usage: LanguageModelUsage): void;
+    onInferenceActivity(activity: InferenceActivity): void;
     onError(error: unknown): void;
     onDone(): void;
   },
 ): ReadableStream<TextStreamPart<ToolSet>> {
   const reader = stream.getReader();
+  let lastActivityPhase: InferenceActivity["phase"] | undefined;
+  let lastGenerationActivityAt = 0;
 
   return new ReadableStream<TextStreamPart<ToolSet>>({
     async pull(controller) {
@@ -597,6 +632,23 @@ function observeChatStream(
           callbacks.onFirstToken();
         } else if (part.type === "finish-step") {
           callbacks.onFinishStep(part.usage);
+        } else if (part.type === "raw") {
+          const activity = readLlamaCppInferenceActivity(part.rawValue);
+          if (activity) {
+            const now = Date.now();
+            const phaseChanged = activity.phase !== lastActivityPhase;
+            if (
+              activity.phase === "prompt" ||
+              phaseChanged ||
+              now - lastGenerationActivityAt >= 1_000
+            ) {
+              callbacks.onInferenceActivity(activity);
+              lastActivityPhase = activity.phase;
+              if (activity.phase === "generation") {
+                lastGenerationActivityAt = now;
+              }
+            }
+          }
         } else if (part.type === "error") {
           callbacks.onError(part.error);
         }

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -41,6 +41,11 @@ import {
   getDataTransferFiles,
   hasDataTransferFiles,
 } from "@/lib/chat/attachments";
+import {
+  INFERENCE_ACTIVITY_DATA_TYPE,
+  isInferenceActivity,
+  type InferenceActivity,
+} from "@/lib/chat/inference-activity";
 import { AdminOnboardingCard } from "@/components/AdminOnboardingCard";
 import { useSidebar } from "@/components/sidebar-context";
 import { ChatHeader } from "./ChatHeader";
@@ -130,6 +135,8 @@ export function ChatArea({
   const [storedStats, setStoredStats] = useState<StoredMessageStats>(() =>
     readStoredMessageStats(),
   );
+  const [inferenceActivity, setInferenceActivity] =
+    useState<InferenceActivity | null>(null);
   const [dragDepth, setDragDepth] = useState(0);
 
   const isNewRef = useRef(isNew ?? false);
@@ -168,7 +175,17 @@ export function ChatArea({
     resume: !temporary && !isNew,
     transport,
     messages: initialMessages,
+    onData: (part) => {
+      if (
+        part.type === INFERENCE_ACTIVITY_DATA_TYPE &&
+        isInferenceActivity(part.data)
+      ) {
+        setInferenceActivity(part.data);
+      }
+    },
+    onError: () => setInferenceActivity(null),
     onFinish: ({ message, isError }) => {
+      setInferenceActivity(null);
       const stats = readMessageStats(message);
       if (stats && !temporaryRef.current) {
         setStoredStats((current) => {
@@ -244,6 +261,7 @@ export function ChatArea({
   }
 
   function handleStop() {
+    setInferenceActivity(null);
     stop();
     if (!temporary) {
       void fetch(`/api/chat/${chatId}/stream/cancel`, { method: "POST" }).catch(
@@ -253,6 +271,7 @@ export function ChatArea({
   }
 
   function handleSubmit(text: string, attachments: FileUIPart[]) {
+    setInferenceActivity(null);
     const wasNew = isNewRef.current && !temporary;
     if (wasNew) {
       isNewRef.current = false;
@@ -290,16 +309,19 @@ export function ChatArea({
 
   function handleRegenerate(messageId: string) {
     if (streaming || !configured) return;
+    setInferenceActivity(null);
     regenerate({ messageId, body: requestBody() });
   }
 
   function handleRetry() {
     if (streaming || !configured) return;
+    setInferenceActivity(null);
     regenerate({ body: requestBody() });
   }
 
   function handleEdit(messageId: string, text: string, files: FileUIPart[]) {
     if (streaming || !configured) return;
+    setInferenceActivity(null);
     sendMessage({ text, files, messageId }, { body: requestBody() });
   }
 
@@ -435,6 +457,7 @@ export function ChatArea({
             messages={messages}
             streaming={streaming}
             status={status}
+            inferenceActivity={inferenceActivity}
             error={error}
             configured={configured}
             speech={speech}

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -5,7 +5,13 @@ import { AlertTriangle, ChevronDown, RotateCcw } from "lucide-react";
 import { useStickToBottom } from "use-stick-to-bottom";
 import { Button } from "@/components/ui/button";
 import { chatErrorMessage } from "@/lib/chat/message";
-import { readMessageStats, type StoredMessageStats } from "@/lib/chat/stats";
+import type { InferenceActivity } from "@/lib/chat/inference-activity";
+import {
+  formatInteger,
+  formatTps,
+  readMessageStats,
+  type StoredMessageStats,
+} from "@/lib/chat/stats";
 import { motionClasses } from "@/lib/motion";
 import type { useSpeech } from "@/lib/useSpeech";
 import { MessageBubble } from "./MessageBubble";
@@ -14,6 +20,7 @@ export function MessageList({
   messages,
   streaming,
   status,
+  inferenceActivity,
   error,
   configured,
   speech,
@@ -26,6 +33,7 @@ export function MessageList({
   messages: UIMessage[];
   streaming: boolean;
   status: ChatStatus;
+  inferenceActivity: InferenceActivity | null;
   error: Error | undefined;
   configured: boolean;
   speech: ReturnType<typeof useSpeech>;
@@ -65,7 +73,11 @@ export function MessageList({
             />
           ))}
           {error && <ChatErrorBubble error={error} onRetry={onRetry} />}
+          {!error && streaming && inferenceActivity && (
+            <InferenceActivityIndicator activity={inferenceActivity} />
+          )}
           {!error &&
+            !inferenceActivity &&
             status === "submitted" &&
             messages.at(-1)?.role === "user" && <PendingIndicator />}
         </div>
@@ -89,6 +101,54 @@ export function MessageList({
   );
 }
 
+function InferenceActivityIndicator({
+  activity,
+}: {
+  activity: InferenceActivity;
+}) {
+  const details: string[] = [];
+  let label: string;
+
+  if (activity.phase === "prompt") {
+    const cachedTokens = activity.cachedTokens ?? 0;
+    label =
+      activity.progress === undefined
+        ? "Processing prompt"
+        : `Processing prompt ${Math.round(activity.progress * 100)}%`;
+    if (activity.totalTokens !== undefined) {
+      details.push(
+        `${formatInteger(activity.completedTokens)} / ${formatInteger(activity.totalTokens)} ${cachedTokens > 0 ? "new" : "tokens"}`,
+      );
+    }
+    if (cachedTokens > 0) {
+      details.push(`${formatInteger(cachedTokens)} cached`);
+    }
+  } else {
+    label = "Generating";
+    details.push(`${formatInteger(activity.completedTokens)} tokens`);
+  }
+
+  if (activity.tokensPerSecond !== undefined) {
+    details.push(formatTps(activity.tokensPerSecond));
+  }
+
+  const description = [label, ...details].join(" · ");
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-2 gap-y-1 py-2 text-xs text-muted-foreground"
+      role="status"
+      aria-label={description}
+      aria-live="polite"
+    >
+      <PendingDots />
+      <span className="font-medium text-foreground/80">{label}</span>
+      {details.length > 0 && (
+        <span className="tabular-nums">{details.join(" · ")}</span>
+      )}
+    </div>
+  );
+}
+
 function PendingIndicator() {
   return (
     <div
@@ -96,10 +156,18 @@ function PendingIndicator() {
       role="status"
       aria-label="Assistant is responding"
     >
+      <PendingDots />
+    </div>
+  );
+}
+
+function PendingDots() {
+  return (
+    <span className="flex items-center gap-1.5" aria-hidden="true">
       <span className={`size-1.5 rounded-full bg-muted-foreground/70 [animation-delay:-0.3s] ${motionClasses.pendingDot}`} />
       <span className={`size-1.5 rounded-full bg-muted-foreground/70 [animation-delay:-0.15s] ${motionClasses.pendingDot}`} />
       <span className={`size-1.5 rounded-full bg-muted-foreground/70 ${motionClasses.pendingDot}`} />
-    </div>
+    </span>
   );
 }
 

--- a/apps/web/lib/chat/inference-activity.test.ts
+++ b/apps/web/lib/chat/inference-activity.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isInferenceActivity } from "./inference-activity";
+
+describe("inference activity", () => {
+  it("accepts a valid provider-neutral activity snapshot", () => {
+    expect(
+      isInferenceActivity({
+        phase: "prompt",
+        completedTokens: 1_536,
+        totalTokens: 2_048,
+        cachedTokens: 0,
+        elapsedMs: 3_200,
+        progress: 0.75,
+        tokensPerSecond: 480,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects invalid activity data", () => {
+    expect(
+      isInferenceActivity({
+        phase: "prompt",
+        completedTokens: -1,
+        progress: 2,
+      }),
+    ).toBe(false);
+    expect(isInferenceActivity({ phase: "waiting" })).toBe(false);
+  });
+});

--- a/apps/web/lib/chat/inference-activity.ts
+++ b/apps/web/lib/chat/inference-activity.ts
@@ -1,0 +1,40 @@
+export const INFERENCE_ACTIVITY_DATA_TYPE = "data-inference-activity";
+
+export interface InferenceActivity {
+  phase: "prompt" | "generation";
+  completedTokens: number;
+  totalTokens?: number;
+  cachedTokens?: number;
+  elapsedMs?: number;
+  progress?: number;
+  tokensPerSecond?: number;
+}
+
+export function isInferenceActivity(value: unknown): value is InferenceActivity {
+  if (!isRecord(value)) return false;
+  if (value.phase !== "prompt" && value.phase !== "generation") return false;
+  if (!isNonNegativeNumber(value.completedTokens)) return false;
+  if (!isOptionalNonNegativeNumber(value.totalTokens)) return false;
+  if (!isOptionalNonNegativeNumber(value.cachedTokens)) return false;
+  if (!isOptionalNonNegativeNumber(value.elapsedMs)) return false;
+  if (!isOptionalNonNegativeNumber(value.tokensPerSecond)) return false;
+  if (
+    value.progress !== undefined &&
+    (!isNonNegativeNumber(value.progress) || value.progress > 1)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isOptionalNonNegativeNumber(value: unknown): boolean {
+  return value === undefined || isNonNegativeNumber(value);
+}

--- a/apps/web/lib/providers/server/adapters/llamacpp.ts
+++ b/apps/web/lib/providers/server/adapters/llamacpp.ts
@@ -5,4 +5,14 @@ import { listLlamaCppModels } from "@/lib/providers/server/http";
 export const llamaCppAdapter = createOpenAICompatibleAdapter(
   "llamacpp",
   (connection) => listLlamaCppModels(connection.baseUrl, connection.apiKey),
+  (body) =>
+    body.stream === true
+      ? {
+          ...body,
+          // llama.cpp extensions that emit progress and timings in the same
+          // SSE stream as the OpenAI-compatible response.
+          return_progress: true,
+          timings_per_token: true,
+        }
+      : body,
 );

--- a/apps/web/lib/providers/server/adapters/openai-compatible.ts
+++ b/apps/web/lib/providers/server/adapters/openai-compatible.ts
@@ -12,10 +12,15 @@ type ListModels = (
   connection: ProviderConnection,
 ) => Promise<DiscoveredModel[]>;
 
+type TransformRequestBody = (
+  body: Record<string, unknown>,
+) => Record<string, unknown>;
+
 export function createOpenAICompatibleAdapter(
   id: ProviderId,
   listModels: ListModels = (connection) =>
     listOpenAIModels(connection.baseUrl, connection.apiKey),
+  transformRequestBody?: TransformRequestBody,
 ): ProviderAdapter {
   return {
     id,
@@ -27,6 +32,7 @@ export function createOpenAICompatibleAdapter(
           apiKey: config.apiKey,
           model: config.model,
           supportsImageInput: config.supportsImageInput,
+          transformRequestBody,
         }),
         providerOptionsKey: id,
       };

--- a/apps/web/lib/providers/server/llamacpp-activity.test.ts
+++ b/apps/web/lib/providers/server/llamacpp-activity.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { readLlamaCppInferenceActivity } from "./llamacpp-activity";
+
+describe("llama.cpp inference activity", () => {
+  it("reports uncached prompt progress and throughput", () => {
+    expect(
+      readLlamaCppInferenceActivity({
+        choices: [{ delta: { content: null }, finish_reason: null }],
+        prompt_progress: {
+          total: 2_048,
+          cache: 512,
+          processed: 1_664,
+          time_ms: 2_400,
+        },
+      }),
+    ).toEqual({
+      phase: "prompt",
+      completedTokens: 1_152,
+      totalTokens: 1_536,
+      cachedTokens: 512,
+      elapsedMs: 2_400,
+      progress: 0.75,
+      tokensPerSecond: 480,
+    });
+  });
+
+  it("prefers generation timings once output tokens exist", () => {
+    expect(
+      readLlamaCppInferenceActivity({
+        timings: {
+          prompt_n: 2_048,
+          prompt_ms: 3_874,
+          predicted_n: 125,
+          predicted_ms: 3_055,
+          predicted_per_second: 40.9165,
+          cache_n: 0,
+        },
+        prompt_progress: {
+          total: 2_048,
+          cache: 0,
+          processed: 2_048,
+          time_ms: 3_874,
+        },
+      }),
+    ).toEqual({
+      phase: "generation",
+      completedTokens: 125,
+      elapsedMs: 3_055,
+      tokensPerSecond: expect.closeTo(40.9165, 3),
+    });
+  });
+
+  it("omits the unstable rate from the first generated token", () => {
+    expect(
+      readLlamaCppInferenceActivity({
+        timings: {
+          prompt_n: 11,
+          prompt_ms: 274.508,
+          predicted_n: 1,
+          predicted_ms: 0.001,
+          predicted_per_second: 0,
+          cache_n: 0,
+        },
+      }),
+    ).toEqual({
+      phase: "generation",
+      completedTokens: 1,
+      elapsedMs: 0.001,
+    });
+  });
+
+  it("ignores unrelated or malformed provider chunks", () => {
+    expect(readLlamaCppInferenceActivity({ choices: [] })).toBeNull();
+    expect(
+      readLlamaCppInferenceActivity({
+        prompt_progress: {
+          total: 100,
+          cache: 101,
+          processed: 50,
+          time_ms: 10,
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/providers/server/llamacpp-activity.ts
+++ b/apps/web/lib/providers/server/llamacpp-activity.ts
@@ -1,0 +1,73 @@
+import "server-only";
+import type { InferenceActivity } from "@/lib/chat/inference-activity";
+
+export function readLlamaCppInferenceActivity(
+  value: unknown,
+): InferenceActivity | null {
+  if (!isRecord(value)) return null;
+
+  const timings = isRecord(value.timings) ? value.timings : null;
+  const generatedTokens = nonNegativeNumber(timings?.predicted_n);
+  if (generatedTokens !== undefined && generatedTokens > 0) {
+    const elapsedMs = nonNegativeNumber(timings?.predicted_ms);
+    const tokensPerSecond = nonNegativeNumber(timings?.predicted_per_second);
+    return {
+      phase: "generation",
+      completedTokens: generatedTokens,
+      ...(elapsedMs !== undefined ? { elapsedMs } : {}),
+      ...(tokensPerSecond !== undefined && tokensPerSecond > 0
+        ? { tokensPerSecond }
+        : {}),
+    };
+  }
+
+  const prompt = isRecord(value.prompt_progress)
+    ? value.prompt_progress
+    : null;
+  if (!prompt) return null;
+
+  const total = nonNegativeNumber(prompt.total);
+  const cached = nonNegativeNumber(prompt.cache);
+  const processed = nonNegativeNumber(prompt.processed);
+  const elapsedMs = nonNegativeNumber(prompt.time_ms);
+  if (
+    total === undefined ||
+    total <= 0 ||
+    cached === undefined ||
+    processed === undefined ||
+    cached > total
+  ) {
+    return null;
+  }
+
+  // Cached prefix tokens do not perform prompt evaluation work. Match the
+  // llama.cpp UI by reporting progress over only the uncached portion.
+  const totalTokens = total - cached;
+  const completedTokens = Math.min(
+    Math.max(processed - cached, 0),
+    totalTokens,
+  );
+  const progress = totalTokens === 0 ? 1 : completedTokens / totalTokens;
+
+  return {
+    phase: "prompt",
+    completedTokens,
+    totalTokens,
+    cachedTokens: cached,
+    ...(elapsedMs !== undefined ? { elapsedMs } : {}),
+    progress,
+    ...(elapsedMs !== undefined && elapsedMs > 0 && completedTokens > 0
+      ? { tokensPerSecond: (completedTokens / elapsedMs) * 1_000 }
+      : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}

--- a/apps/web/lib/providers/server/registry.test.ts
+++ b/apps/web/lib/providers/server/registry.test.ts
@@ -261,6 +261,74 @@ describe("provider registry", () => {
     },
   );
 
+  it("requests and preserves live activity fields from llama.cpp", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const progressChunk = {
+      id: "chatcmpl-test",
+      choices: [
+        { delta: { role: "assistant", content: null }, finish_reason: null },
+      ],
+      timings: {
+        cache_n: 0,
+        prompt_n: 7,
+        prompt_ms: 167.085,
+        predicted_n: 0,
+        predicted_ms: 0,
+      },
+      prompt_progress: {
+        total: 11,
+        cache: 0,
+        processed: 7,
+        time_ms: 168,
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(
+          [
+            `data: ${JSON.stringify(progressChunk)}`,
+            'data: {"id":"chatcmpl-test","choices":[{"delta":{"content":"ok"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-test","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}',
+            "data: [DONE]",
+            "",
+          ].join("\n\n"),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const configured = createConfiguredLanguageModel({
+      ...baseConfig,
+      providerId: "llamacpp",
+    });
+
+    const result = await configured.model.doStream({
+      includeRawChunks: true,
+      prompt: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    });
+    const rawChunks: unknown[] = [];
+    await result.stream.pipeTo(
+      new WritableStream({
+        write(part) {
+          if (part.type === "raw") rawChunks.push(part.rawValue);
+        },
+      }),
+    );
+
+    expect(requestBody).toMatchObject({
+      stream: true,
+      return_progress: true,
+      timings_per_token: true,
+    });
+    expect(rawChunks).toContainEqual(progressChunk);
+  });
+
   it("uses the shared OpenAI-compatible transport for DeepSeek", () => {
     const configured = createConfiguredLanguageModel({
       ...baseConfig,

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.3}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.4}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- show live llama.cpp prompt-processing progress, cache reuse, token counts, and generation throughput in the web chat UI
- translate llama.cpp raw SSE extensions into provider-neutral transient activity events without persisting them in message history
- preserve the existing pending indicator for providers that do not expose inference telemetry
- promote the app release candidate to 0.16.4 while keeping CLI, connector, STT, mobile, and bundled image selections unchanged

## Live verification

Verified against llama.cpp `b10615-f280b2698` on `/v1/chat/completions`:

- `return_progress: true` emitted incremental `prompt_progress` chunks
- `timings_per_token: true` emitted generation timing data on each token
- first-token zero-rate timing is omitted until llama.cpp reports a valid `predicted_per_second`

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- 91 web test files / 573 web tests passed

## Release

After review, mark ready and squash-merge into `main`. Tag the exact merged `main` commit as `v0.16.4`. The app image workflow will publish amd64 and arm64 images, create the GitHub Release, and dispatch serialized stable promotion. Verify `https://overtchat.com/install-manifest.json` reports app version `0.16.4` after promotion.