### PR TITLE
fix(web): keep update notices fresh

### DIFF
--- a/apps/web/app/api/app-update/route.test.ts
+++ b/apps/web/app/api/app-update/route.test.ts
@@ -40,7 +40,7 @@ describe("GET /api/app-update", () => {
     expect(mocks.getAppUpdateStatus).not.toHaveBeenCalled();
   });
 
-  it("returns the cached update status without HTTP caching", async () => {
+  it("returns the current update status without HTTP caching", async () => {
     const response = await GET(request());
 
     expect(response.status).toBe(200);

--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { Menu } from "@base-ui/react/menu";
 import {
   ChevronUp,
@@ -29,10 +28,9 @@ import { useSidebar } from "@/components/sidebar-context";
 
 export function AccountMenu() {
   const router = useRouter();
-  const [menuOpen, setMenuOpen] = useState(false);
   const { data: session, isPending } = authClient.useSession();
   const isAdmin = session?.user.role === "admin";
-  const { data: update } = useAppUpdate(menuOpen && isAdmin);
+  const { data: update, isStale, refetch } = useAppUpdate(isAdmin);
   const availableVersion = update?.updateAvailable
     ? update.latestVersion
     : null;
@@ -42,6 +40,10 @@ export function AccountMenu() {
   // the drawer isn't mounted, ref.current is null, and base-ui falls back to
   // portaling into <body>. See sidebar-context.tsx for the full explanation.
   const { closeMobile, drawerRef } = useSidebar();
+
+  function handleOpenChange(open: boolean) {
+    if (open && isAdmin && isStale) void refetch();
+  }
 
   async function logOut() {
     try {
@@ -64,7 +66,7 @@ export function AccountMenu() {
   }
 
   return (
-    <Menu.Root onOpenChange={setMenuOpen}>
+    <Menu.Root onOpenChange={handleOpenChange}>
       <Menu.Trigger
         render={
           <Button
@@ -97,6 +99,17 @@ export function AccountMenu() {
             </span>
           )}
         </span>
+        {updateAvailable && (
+          <span
+            className="shrink-0 text-ring"
+            title={`Update available v${availableVersion}`}
+          >
+            <CircleArrowUp className="size-4" aria-hidden="true" />
+            <span className="sr-only">
+              Update available v{availableVersion}
+            </span>
+          </span>
+        )}
         <ChevronUp className="size-3.5 shrink-0 text-muted-foreground" />
       </Menu.Trigger>
       <Menu.Portal container={drawerRef}>

--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -2,10 +2,14 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Dialog } from "@base-ui/react/dialog";
 import { Menu } from "@base-ui/react/menu";
 import {
+  Check,
   ChevronUp,
   CircleArrowUp,
+  Clipboard,
   ExternalLink,
   FileText,
   LogOut,
@@ -15,7 +19,7 @@ import {
   User,
   UserRound,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
 import { toast } from "@/components/ui/toast";
 import { authClient } from "@/lib/auth/client";
@@ -26,8 +30,11 @@ import { APP_VERSION } from "@/lib/version";
 import { useAppUpdate } from "@/lib/queries/appUpdate";
 import { useSidebar } from "@/components/sidebar-context";
 
+const UPDATE_COMMAND = "overtchat update";
+
 export function AccountMenu() {
   const router = useRouter();
+  const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
   const { data: session, isPending } = authClient.useSession();
   const isAdmin = session?.user.role === "admin";
   const { data: update, isStale, refetch } = useAppUpdate(isAdmin);
@@ -175,33 +182,36 @@ export function AccountMenu() {
               </Menu.Item>
             )}
             <Menu.Separator className="mx-1 my-1 h-px bg-border" />
-            <Menu.Item
-              render={
-                <a
-                  href="https://overtchat.com/releases/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={closeMobile}
-                />
-              }
-              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
-            >
-              {updateAvailable ? (
+            {updateAvailable ? (
+              <Menu.Item
+                onClick={() => {
+                  setUpdateDialogOpen(true);
+                }}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              >
                 <CircleArrowUp className="size-3.5 shrink-0 text-ring" />
-              ) : (
-                <FileText className="size-3.5 shrink-0 text-muted-foreground" />
-              )}
-              <span className={cn("flex-1", updateAvailable && "font-medium")}>
-                {updateAvailable ? "Update available" : "Release notes"}
-              </span>
-              {updateAvailable ? (
+                <span className="flex-1 font-medium">Update available</span>
                 <span className="text-xs font-medium text-ring">
                   v{availableVersion}
                 </span>
-              ) : (
+              </Menu.Item>
+            ) : (
+              <Menu.Item
+                render={
+                  <a
+                    href="https://overtchat.com/releases/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={closeMobile}
+                  />
+                }
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              >
+                <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="flex-1">Release notes</span>
                 <ExternalLink className="size-3 shrink-0 text-muted-foreground" />
-              )}
-            </Menu.Item>
+              </Menu.Item>
+            )}
             <Menu.Item
               render={
                 <a
@@ -231,6 +241,98 @@ export function AccountMenu() {
           </Menu.Popup>
         </Menu.Positioner>
       </Menu.Portal>
+      {availableVersion && (
+        <AppUpdateDialog
+          open={updateDialogOpen}
+          version={availableVersion}
+          onOpenChange={setUpdateDialogOpen}
+        />
+      )}
     </Menu.Root>
+  );
+}
+
+function AppUpdateDialog({
+  open,
+  version,
+  onOpenChange,
+}: {
+  open: boolean;
+  version: string;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) setCopied(false);
+    onOpenChange(next);
+  }
+
+  async function copyUpdateCommand() {
+    try {
+      await navigator.clipboard.writeText(UPDATE_COMMAND);
+      setCopied(true);
+    } catch (error) {
+      toast.error({
+        title: "Could not copy update command",
+        description: getErrorMessage(error, "Copy the command manually."),
+      });
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop
+          className={cn("fixed inset-0 z-40 bg-black/40", motionClasses.overlay)}
+        />
+        <Dialog.Popup
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl border bg-card p-6 text-card-foreground shadow-lg outline-none",
+            motionClasses.dialog,
+          )}
+        >
+          <Dialog.Title className="text-lg font-semibold tracking-tight">
+            Update available
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+            OvertChat v{version} is ready. Run this on the OvertChat host.
+          </Dialog.Description>
+
+          <div className="mt-4 flex items-center gap-2">
+            <code
+              aria-label="OvertChat update command"
+              className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded-md bg-muted px-3 py-2 text-sm"
+            >
+              {UPDATE_COMMAND}
+            </code>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => void copyUpdateCommand()}
+              aria-label={
+                copied ? "Update command copied" : "Copy update command"
+              }
+              title={copied ? "Copied" : "Copy update command"}
+            >
+              {copied ? <Check /> : <Clipboard />}
+            </Button>
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center justify-end gap-2 border-t pt-4">
+            <a
+              href="https://overtchat.com/releases/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              View release notes
+              <ExternalLink />
+            </a>
+            <Dialog.Close render={<Button size="sm" />}>Close</Dialog.Close>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/apps/web/e2e/sidebar.spec.ts
+++ b/apps/web/e2e/sidebar.spec.ts
@@ -41,7 +41,11 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
   await page.getByRole("button", { name: "Create account" }).click();
   await page.waitForURL("**/");
 
-  await page.getByText("Sidebar Admin", { exact: true }).click();
+  const accountButton = page.getByRole("button", {
+    name: "Sidebar Admin Update available v99.0.0",
+  });
+  await expect(accountButton).toBeVisible();
+  await accountButton.click();
   await expect(page.getByRole("menuitem", { name: "Profile" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Settings" })).toBeVisible();
   await expect(
@@ -115,6 +119,16 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
     "transition-property",
     "transform, translate, scale, rotate",
   );
+  const mobileAccountButton = drawer.getByRole("button", {
+    name: "Sidebar Admin Update available v99.0.0",
+  });
+  await expect(mobileAccountButton).toBeVisible();
+  await mobileAccountButton.click();
+  await expect(
+    page.getByRole("menuitem", { name: "Update available v99.0.0" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(drawer).toBeVisible();
 
   await drawer.getByRole("link", { name: "Sidebar Project", exact: true }).click();
   await expect(drawer).toBeHidden();

--- a/apps/web/e2e/sidebar.spec.ts
+++ b/apps/web/e2e/sidebar.spec.ts
@@ -22,6 +22,7 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
   page,
 }) => {
   test.setTimeout(60_000);
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.emulateMedia({ reducedMotion: "no-preference" });
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.route("**/api/app-update", async (route) => {
@@ -51,9 +52,32 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
   await expect(
     page.getByRole("menuitem", { name: "Administration" }),
   ).toBeVisible();
+  await page
+    .getByRole("menuitem", { name: "Update available v99.0.0" })
+    .click();
+  const updateDialog = page.getByRole("dialog", { name: "Update available" });
+  await expect(updateDialog).toBeVisible();
+  await expect(updateDialog).toContainText(
+    "OvertChat v99.0.0 is ready. Run this on the OvertChat host.",
+  );
   await expect(
-    page.getByRole("menuitem", { name: "Update available v99.0.0" }),
+    updateDialog.getByLabel("OvertChat update command"),
+  ).toHaveText("overtchat update");
+  await updateDialog
+    .getByRole("button", { name: "Copy update command" })
+    .click();
+  await expect(
+    updateDialog.getByRole("button", { name: "Update command copied" }),
+  ).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe("overtchat update");
+  await expect(
+    updateDialog.getByRole("link", { name: "View release notes" }),
   ).toHaveAttribute("href", "https://overtchat.com/releases/");
+  await updateDialog.getByRole("button", { name: "Close" }).click();
+
+  await accountButton.click();
   await expect(page.getByRole("menuitem", { name: "Privacy" })).toHaveAttribute(
     "href",
     "https://overtchat.com/privacy/",
@@ -124,10 +148,14 @@ test("sidebar behavior stays consistent across desktop and mobile", async ({
   });
   await expect(mobileAccountButton).toBeVisible();
   await mobileAccountButton.click();
+  await page
+    .getByRole("menuitem", { name: "Update available v99.0.0" })
+    .click();
+  await expect(updateDialog).toBeVisible();
   await expect(
-    page.getByRole("menuitem", { name: "Update available v99.0.0" }),
-  ).toBeVisible();
-  await page.keyboard.press("Escape");
+    updateDialog.getByLabel("OvertChat update command"),
+  ).toHaveText("overtchat update");
+  await updateDialog.getByRole("button", { name: "Close" }).click();
   await expect(drawer).toBeVisible();
 
   await drawer.getByRole("link", { name: "Sidebar Project", exact: true }).click();

--- a/apps/web/lib/queries/appUpdate.ts
+++ b/apps/web/lib/queries/appUpdate.ts
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { appUpdateKeys } from "@/lib/queries/keys";
 
-const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1_000;
+const UPDATE_STALE_TIME_MS = 60_000;
 
 export type AppUpdateStatus = {
   currentVersion: string;
@@ -20,7 +20,9 @@ export function useAppUpdate(enabled: boolean) {
       return response.json() as Promise<AppUpdateStatus>;
     },
     enabled,
-    retry: false,
-    staleTime: CHECK_INTERVAL_MS,
+    retry: 1,
+    staleTime: UPDATE_STALE_TIME_MS,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
   });
 }

--- a/apps/web/lib/update-check.test.ts
+++ b/apps/web/lib/update-check.test.ts
@@ -24,7 +24,7 @@ describe("app update check", () => {
     expect(isNewerVersion("0.16.0", "not-a-version")).toBe(false);
   });
 
-  it("caches the public manifest result across checks", async () => {
+  it("fetches the current public manifest for every check", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValue(
@@ -39,17 +39,23 @@ describe("app update check", () => {
     });
     await getAppUpdateStatus();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://overtchat.com/install-manifest.json",
-      expect.objectContaining({ headers: { Accept: "application/json" } }),
+      expect.objectContaining({
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      }),
     );
   });
 
-  it("fails silently and caches an unavailable result", async () => {
+  it("does not retain an unavailable manifest result", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockResolvedValue(new Response(null, { status: 503 }));
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(
+        Response.json({ format: 1, appVersion: "99.0.0" }),
+      );
     vi.stubGlobal("fetch", fetchMock);
     const { getAppUpdateStatus } = await import("./update-check");
 
@@ -57,9 +63,12 @@ describe("app update check", () => {
       latestVersion: null,
       updateAvailable: false,
     });
-    await getAppUpdateStatus();
+    await expect(getAppUpdateStatus()).resolves.toMatchObject({
+      latestVersion: "99.0.0",
+      updateAvailable: true,
+    });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not make a request when checks are disabled", async () => {

--- a/apps/web/lib/update-check.ts
+++ b/apps/web/lib/update-check.ts
@@ -2,7 +2,6 @@ import "server-only";
 import { APP_VERSION } from "@/lib/version";
 
 const RELEASE_MANIFEST_URL = "https://overtchat.com/install-manifest.json";
-const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1_000;
 const REQUEST_TIMEOUT_MS = 5_000;
 const SEMVER_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/u;
 
@@ -11,14 +10,6 @@ export type AppUpdateStatus = {
   latestVersion: string | null;
   updateAvailable: boolean;
 };
-
-type CacheEntry = {
-  checkedAt: number;
-  latestVersion: string | null;
-};
-
-let cached: CacheEntry | null = null;
-let pending: Promise<string | null> | null = null;
 
 function updateCheckDisabled(): boolean {
   return /^(1|true|yes)$/iu.test(
@@ -58,6 +49,7 @@ function manifestVersion(value: unknown): string | null {
 async function fetchLatestVersion(): Promise<string | null> {
   try {
     const response = await fetch(RELEASE_MANIFEST_URL, {
+      cache: "no-store",
       headers: { Accept: "application/json" },
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
@@ -68,26 +60,8 @@ async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
-async function latestVersion(): Promise<string | null> {
-  const now = Date.now();
-  if (cached && now - cached.checkedAt < CHECK_INTERVAL_MS) {
-    return cached.latestVersion;
-  }
-  if (pending) return pending;
-
-  pending = fetchLatestVersion()
-    .then((version) => {
-      cached = { checkedAt: Date.now(), latestVersion: version };
-      return version;
-    })
-    .finally(() => {
-      pending = null;
-    });
-  return pending;
-}
-
 export async function getAppUpdateStatus(): Promise<AppUpdateStatus> {
-  const latest = updateCheckDisabled() ? null : await latestVersion();
+  const latest = updateCheckDisabled() ? null : await fetchLatestVersion();
   return {
     currentVersion: APP_VERSION,
     latestVersion: latest,

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -136,11 +136,14 @@ This updates the management CLI, app image, selected local sidecars, and managed
 Agent Connector as one coordinated release. Database migrations run
 automatically when the app starts; the existing data mount is not replaced.
 
-When an administrator opens the account menu, OvertChat checks the public
-release manifest at `overtchat.com` and shows an update notice when a newer app
-image is available. The result is cached by the server for 12 hours; the check
-does not send an instance identifier, account data, configuration, or the
-installed version. For a manual Compose installation, set
+When an administrator loads the authenticated web app, OvertChat checks the
+public release manifest at `overtchat.com` and shows an update indicator on the
+account button when a newer app image is available. The account menu includes
+the available version. The browser may recheck after reconnecting, returning
+to the tab, or reopening a stale account menu; the server does not retain a
+process-wide update result. The check does not send an instance identifier,
+account data, configuration, or the installed version. For a manual Compose
+installation, set
 `DISABLE_UPDATE_CHECK=true` in the root `.env` file. For an installation made
 with the guided manager, run `DISABLE_UPDATE_CHECK=true overtchat setup` once
 to persist the same opt-out.


### PR DESCRIPTION
## Summary

- check the stable release manifest when an administrator loads the authenticated web app
- remove the 12-hour process cache that could keep serving an outdated release
- recheck through the normal browser query lifecycle and when a stale account menu is opened
- show a persistent update icon on the account button plus the versioned menu row on desktop and responsive web
- open a compact modal with the copyable `overtchat update` command and release-notes link
- leave the Expo mobile app unchanged

## Production diagnosis

The running v0.16.3 instance returned v0.16.3 from `/api/app-update` while the same container fetched v0.16.4 from the stable manifest. The server process had retained the pre-promotion result in its 12-hour cache.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test:e2e -w apps/web -- --grep "sidebar behavior stays consistent"`