### PR TITLE
Release app v0.16.5

### DIFF
--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.16.4",
+  "appVersion": "0.16.5",
   "connectorVersion": "0.7.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.4}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.5}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- release the fresh web update-notice lifecycle from #195
- add the update instructions modal with copyable `overtchat update` command
- advance the app candidate manifest and Compose default to v0.16.5
- leave CLI, connector, STT, bundled images, and mobile versions unchanged

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`