### PR TITLE
fix(agents): improve Codex goal and task progress UI

### DIFF
--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -39,6 +39,7 @@ import {
   formatAgentElapsed,
   type AgentRunActivity,
 } from "./AgentActivity";
+import { AgentTaskProgressCard } from "./AgentTaskList";
 
 export type { AgentRunActivity } from "./AgentActivity";
 
@@ -280,6 +281,9 @@ function AgentTranscriptRow({
       />
     );
   }
+  if (item.type === "task_list") {
+    return <AgentTaskProgressCard snapshot={item.snapshot} />;
+  }
   return (
     <AgentActivityGroup
       entries={item.entries}
@@ -397,17 +401,19 @@ function AgentPlanCard({
             ))}
           </ol>
         ) : null}
-        <div className="flex justify-end border-t pt-3">
-          <Button
-            type="button"
-            size="sm"
-            disabled={disabled}
-            onClick={onImplement}
-          >
-            <Play />
-            Implement plan
-          </Button>
-        </div>
+        {item.actionable && (
+          <div className="flex justify-end border-t pt-3">
+            <Button
+              type="button"
+              size="sm"
+              disabled={disabled}
+              onClick={onImplement}
+            >
+              <Play />
+              Implement plan
+            </Button>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/web/components/agents/AgentSessionContext.tsx
+++ b/apps/web/components/agents/AgentSessionContext.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { Popover } from "@base-ui/react/popover";
+import { ListChecks, Pause, Play, Target, X } from "lucide-react";
+import type { AgentGoal } from "@overtchat/agent-bridge";
+import { Button } from "@/components/ui/button";
+import type { AgentTaskListSnapshot } from "@/lib/agents/presentation";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+import { AgentTaskListRows } from "./AgentTaskList";
+
+export function AgentSessionContext({
+  goal,
+  tasks,
+  goalActionsDisabled,
+  onPauseGoal,
+  onResumeGoal,
+  onClearGoal,
+}: {
+  goal: AgentGoal | null;
+  tasks: AgentTaskListSnapshot | null;
+  goalActionsDisabled: boolean;
+  onPauseGoal: () => void;
+  onResumeGoal: () => void;
+  onClearGoal: () => void;
+}) {
+  if (!goal && !tasks?.tasks.length) return null;
+
+  return (
+    <div
+      className="mb-2 flex min-h-7 flex-wrap items-center gap-2"
+      data-testid="agent-session-context"
+    >
+      {goal && (
+        <GoalContext
+          goal={goal}
+          disabled={goalActionsDisabled}
+          onPause={onPauseGoal}
+          onResume={onResumeGoal}
+          onClear={onClearGoal}
+        />
+      )}
+      {tasks && tasks.tasks.length > 0 && <TaskContext snapshot={tasks} />}
+    </div>
+  );
+}
+
+function GoalContext({
+  goal,
+  disabled,
+  onPause,
+  onResume,
+  onClear,
+}: {
+  goal: AgentGoal;
+  disabled: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onClear: () => void;
+}) {
+  const paused = goal.status === "paused";
+  const status = humanizeGoalStatus(goal.status);
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-label={`Goal, ${status}`}
+          />
+        }
+      >
+        <Target />
+        Goal
+        <span className="font-normal text-muted-foreground">{status}</span>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner side="top" align="start" sideOffset={8}>
+          <Popover.Popup
+            className={cn(
+              "z-50 w-96 max-w-[calc(100vw-2rem)] rounded-lg border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+              motionClasses.popup,
+            )}
+            data-testid="agent-goal-panel"
+          >
+            <div className="flex items-center gap-2">
+              <Target className="size-4 text-muted-foreground" />
+              <Popover.Title className="text-sm font-medium">
+                Goal
+              </Popover.Title>
+              <span className="ml-auto text-xs text-muted-foreground">
+                {status}
+              </span>
+            </div>
+            <p className="mt-3 break-words whitespace-pre-wrap text-sm leading-relaxed">
+              {goal.objective}
+            </p>
+            <GoalUsage goal={goal} />
+            <div className="mt-4 flex items-center justify-end gap-2 border-t pt-3">
+              {paused ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  aria-label="Resume goal"
+                  disabled={disabled}
+                  onClick={onResume}
+                >
+                  <Play />
+                  Resume
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  aria-label="Pause goal"
+                  disabled={disabled}
+                  onClick={onPause}
+                >
+                  <Pause />
+                  Pause
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label="Clear goal"
+                disabled={disabled}
+                onClick={onClear}
+              >
+                <X />
+                Clear
+              </Button>
+            </div>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+function TaskContext({ snapshot }: { snapshot: AgentTaskListSnapshot }) {
+  const completed = snapshot.tasks.filter(
+    (task) => task.status === "completed",
+  ).length;
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-label={`${completed} of ${snapshot.tasks.length} tasks complete`}
+          />
+        }
+      >
+        <ListChecks />
+        Tasks
+        <span className="font-normal tabular-nums text-muted-foreground">
+          {completed}/{snapshot.tasks.length}
+        </span>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner side="top" align="start" sideOffset={8}>
+          <Popover.Popup
+            className={cn(
+              "z-50 w-96 max-w-[calc(100vw-2rem)] rounded-lg border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+              motionClasses.popup,
+            )}
+            data-testid="agent-task-panel"
+          >
+            <div className="flex items-center gap-2">
+              <ListChecks className="size-4 text-muted-foreground" />
+              <Popover.Title className="text-sm font-medium">
+                Tasks
+              </Popover.Title>
+              <span className="ml-auto text-xs tabular-nums text-muted-foreground">
+                {completed}/{snapshot.tasks.length} complete
+              </span>
+            </div>
+            {snapshot.explanation && (
+              <p className="mt-3 text-sm text-muted-foreground">
+                {snapshot.explanation}
+              </p>
+            )}
+            <div className="mt-3 border-t pt-3">
+              <AgentTaskListRows tasks={snapshot.tasks} />
+            </div>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+function GoalUsage({ goal }: { goal: AgentGoal }) {
+  const usage =
+    goal.tokenBudget !== null
+      ? `${goal.tokensUsed.toLocaleString()} / ${goal.tokenBudget.toLocaleString()} tokens`
+      : goal.tokensUsed > 0
+        ? `${goal.tokensUsed.toLocaleString()} tokens`
+        : null;
+  const elapsed = formatGoalElapsed(goal.timeUsedSeconds);
+  if (!usage && !elapsed) return null;
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+      {usage && <span>{usage}</span>}
+      {elapsed && <span>{elapsed}</span>}
+    </div>
+  );
+}
+
+function humanizeGoalStatus(value: AgentGoal["status"]): string {
+  return value.replace(/([a-z])([A-Z])/gu, "$1 $2").toLowerCase();
+}
+
+function formatGoalElapsed(seconds: number): string | null {
+  if (seconds <= 0) return null;
+  if (seconds < 60) return `${Math.floor(seconds)}s elapsed`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m elapsed`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m elapsed`;
+}

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -6,11 +6,7 @@ import {
   AlertTriangle,
   Loader2,
   LockKeyhole,
-  Pause,
-  Play,
   RefreshCw,
-  Target,
-  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SidebarToggle } from "@/components/SidebarToggle";
@@ -36,6 +32,7 @@ import {
   useAgentSessionUsage,
 } from "@/lib/queries/agentSessions";
 import { commandForAgentSessionSubmit } from "@/lib/agents/sessionCommands";
+import { latestAgentTaskList } from "@/lib/agents/presentation";
 import {
   AGENT_CREATE_PREFERENCES_KEY,
   DEFAULT_AGENT_CREATE_PREFERENCES,
@@ -53,6 +50,7 @@ import {
 } from "./AgentSessionDialogs";
 import { AgentMessageList } from "./AgentMessageList";
 import type { AgentRunActivity } from "./AgentActivity";
+import { AgentSessionContext } from "./AgentSessionContext";
 import { AgentSessionHeader } from "./AgentSessionHeader";
 
 type UnknownRecord = Record<string, unknown>;
@@ -363,6 +361,7 @@ export function AgentSessionView({
   const availableModes = agentModes(snapshot);
   const modeId = currentModeId(snapshot);
   const goal = currentGoal(snapshot);
+  const tasks = latestAgentTaskList(snapshot.messages);
   const runtimeError =
     snapshot.error ??
     (session.error instanceof Error ? session.error.message : undefined);
@@ -407,31 +406,6 @@ export function AgentSessionView({
           setCompactOpen(true);
         }}
       />
-
-      {goal && (
-        <AgentGoalBar
-          goal={goal}
-          disabled={Boolean(readOnly) || command.isPending}
-          onPause={() =>
-            void run(
-              { type: "update_goal", action: "pause" },
-              { toastTitle: "Goal paused" },
-            )
-          }
-          onResume={() =>
-            void run(
-              { type: "update_goal", action: "resume" },
-              { toastTitle: "Goal resumed" },
-            )
-          }
-          onClear={() =>
-            void run(
-              { type: "update_goal", action: "clear" },
-              { toastTitle: "Goal cleared" },
-            )
-          }
-        />
-      )}
 
       {readOnly && (
         <section
@@ -497,6 +471,29 @@ export function AgentSessionView({
 
       <div className="px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
         <div className="mx-auto max-w-3xl">
+          <AgentSessionContext
+            goal={goal}
+            tasks={tasks}
+            goalActionsDisabled={Boolean(readOnly) || command.isPending}
+            onPauseGoal={() =>
+              void run(
+                { type: "update_goal", action: "pause" },
+                { toastTitle: "Goal paused" },
+              )
+            }
+            onResumeGoal={() =>
+              void run(
+                { type: "update_goal", action: "resume" },
+                { toastTitle: "Goal resumed" },
+              )
+            }
+            onClearGoal={() =>
+              void run(
+                { type: "update_goal", action: "clear" },
+                { toastTitle: "Goal cleared" },
+              )
+            }
+          />
           <AgentComposer
             key={sessionId}
             providerLabel={providerLabel}
@@ -654,84 +651,6 @@ export function AgentSessionView({
         }}
       />
     </div>
-  );
-}
-
-function AgentGoalBar({
-  goal,
-  disabled,
-  onPause,
-  onResume,
-  onClear,
-}: {
-  goal: AgentGoal;
-  disabled: boolean;
-  onPause: () => void;
-  onResume: () => void;
-  onClear: () => void;
-}) {
-  const paused = goal.status === "paused";
-  const status = goal.status.replace(/([a-z])([A-Z])/gu, "$1 $2");
-  const budget =
-    goal.tokenBudget !== null
-      ? `${goal.tokensUsed.toLocaleString()} / ${goal.tokenBudget.toLocaleString()} tokens`
-      : goal.tokensUsed > 0
-        ? `${goal.tokensUsed.toLocaleString()} tokens`
-        : null;
-
-  return (
-    <section
-      aria-label={`Goal: ${goal.objective}`}
-      className="border-b bg-muted/20 px-4 py-2"
-      data-testid="agent-goal-bar"
-    >
-      <div className="mx-auto flex max-w-3xl items-center gap-2">
-        <Target className="size-4 shrink-0 text-muted-foreground" />
-        <span className="min-w-0 flex-1 truncate text-sm font-medium">
-          {goal.objective}
-        </span>
-        <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
-          {status}
-          {budget ? ` · ${budget}` : ""}
-        </span>
-        {paused ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            title="Resume goal"
-            aria-label="Resume goal"
-            disabled={disabled}
-            onClick={onResume}
-          >
-            <Play />
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            title="Pause goal"
-            aria-label="Pause goal"
-            disabled={disabled}
-            onClick={onPause}
-          >
-            <Pause />
-          </Button>
-        )}
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          title="Clear goal"
-          aria-label="Clear goal"
-          disabled={disabled}
-          onClick={onClear}
-        >
-          <X />
-        </Button>
-      </div>
-    </section>
   );
 }
 

--- a/apps/web/components/agents/AgentTaskList.tsx
+++ b/apps/web/components/agents/AgentTaskList.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { CheckCircle2, Circle, Loader2, ListChecks } from "lucide-react";
+import type {
+  AgentTask,
+  AgentTaskListSnapshot,
+} from "@/lib/agents/presentation";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export function AgentTaskListRows({ tasks }: { tasks: readonly AgentTask[] }) {
+  return (
+    <ol className="space-y-2" data-testid="agent-task-list">
+      {tasks.map((task) => (
+        <li
+          key={task.id}
+          className="flex min-w-0 items-start gap-2 text-sm"
+          data-task-status={task.status}
+        >
+          <TaskStatusIcon task={task} />
+          <span
+            className={cn(
+              "min-w-0 flex-1 break-words",
+              task.status === "completed" &&
+                "text-muted-foreground line-through decoration-border",
+              task.status === "in_progress" && "font-medium",
+            )}
+          >
+            {task.step}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function AgentTaskProgressCard({
+  snapshot,
+}: {
+  snapshot: AgentTaskListSnapshot;
+}) {
+  const completed = snapshot.tasks.filter(
+    (task) => task.status === "completed",
+  ).length;
+
+  return (
+    <section
+      className="overflow-hidden rounded-lg border bg-muted/15"
+      data-testid="agent-task-progress-card"
+    >
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <ListChecks className="size-4 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Tasks</h3>
+        <span className="ml-auto text-xs tabular-nums text-muted-foreground">
+          {completed}/{snapshot.tasks.length}
+        </span>
+      </div>
+      <div className="space-y-3 px-3 py-3">
+        {snapshot.explanation && (
+          <p className="text-sm text-muted-foreground">
+            {snapshot.explanation}
+          </p>
+        )}
+        <AgentTaskListRows tasks={snapshot.tasks} />
+      </div>
+    </section>
+  );
+}
+
+function TaskStatusIcon({ task }: { task: AgentTask }) {
+  if (task.status === "completed") {
+    return (
+      <CheckCircle2
+        className="mt-0.5 size-4 shrink-0 text-emerald-600 dark:text-emerald-400"
+        aria-label="Completed"
+      />
+    );
+  }
+  if (task.status === "in_progress") {
+    return (
+      <Loader2
+        className={cn(
+          "mt-0.5 size-4 shrink-0 text-foreground",
+          motionClasses.spinner,
+        )}
+        aria-label="In progress"
+      />
+    );
+  }
+  return (
+    <Circle
+      className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+      aria-label="Pending"
+    />
+  );
+}

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -128,7 +128,8 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
       ],
       goalsSupported: true,
       goal: {
-        objective: "Finish Codex parity",
+        objective:
+          "Finish Codex parity across the connector, runtime, and web interface without losing live goal updates",
         status: "active",
         tokenBudget: 20_000,
         tokensUsed: 4_200,
@@ -204,6 +205,7 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
             id: "plan",
             text: "- [x] Audit the runtime\n- [ ] Finish parity",
             explanation: "Two focused steps.",
+            actionable: true,
             steps: [
               { step: "Audit the runtime", status: "completed" },
               { step: "Finish parity", status: "inProgress" },
@@ -211,6 +213,21 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
           },
         ],
         timestamp: 2.5,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "taskList",
+            id: "tasks",
+            explanation: "Live execution progress.",
+            items: [
+              { step: "Audit the runtime", status: "completed" },
+              { step: "Finish parity", status: "inProgress" },
+            ],
+          },
+        ],
+        timestamp: 2.6,
       },
       {
         role: "assistant",
@@ -871,9 +888,32 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(page.getByTestId("agent-plan-card")).toContainText(
     "Finish parity",
   );
-  await expect(page.getByTestId("agent-goal-bar")).toContainText(
-    "Finish Codex parity",
+  const taskProgress = page.getByTestId("agent-task-progress-card");
+  await expect(taskProgress).toContainText("1/2");
+  await expect(
+    taskProgress.getByRole("button", { name: "Implement plan" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Goal, active" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Goal, active" }).click();
+  await expect(page.getByTestId("agent-goal-panel")).toContainText(
+    "Finish Codex parity across the connector, runtime, and web interface without losing live goal updates",
   );
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByRole("button", { name: "1 of 2 tasks complete" }),
+  ).toBeVisible();
+  await page
+    .getByRole("button", { name: "1 of 2 tasks complete" })
+    .click();
+  await expect(page.getByTestId("agent-task-panel")).toContainText(
+    "Finish parity",
+  );
+  await expect(
+    page.getByTestId("agent-task-panel").getByLabel("In progress"),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
   const toolSummaries = page.locator('[data-agent-tool-summary="true"]');
   await expect(toolSummaries).toHaveCount(2);
   const completedCommandSummary = page.getByRole("button", {
@@ -1367,17 +1407,18 @@ test("shows durable turn activity without changing completed tool status", async
     enabled: false,
   });
   await expect(fastModeControl).toHaveCount(0);
+  await page.getByRole("button", { name: "Goal, active" }).click();
   await page.getByRole("button", { name: "Pause goal" }).click();
   await expect(page.getByRole("button", { name: "Resume goal" })).toBeVisible();
   await page.getByRole("button", { name: "Resume goal" }).click();
   await expect(page.getByRole("button", { name: "Pause goal" })).toBeVisible();
+  await page.getByRole("button", { name: "Clear goal" }).click();
+  await expect(page.getByRole("button", { name: /^Goal,/u })).toHaveCount(0);
   await page.getByRole("button", { name: "Implement plan" }).click();
   await expect.poll(() => submittedCommands.at(-1)).toMatchObject({
     type: "implement_plan",
     plan: expect.stringContaining("Finish parity"),
   });
-  await page.getByRole("button", { name: "Clear goal" }).click();
-  await expect(page.getByTestId("agent-goal-bar")).toHaveCount(0);
   await page.screenshot({
     path: testInfo.outputPath("runtime-codex-parity-desktop.png"),
     fullPage: true,

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -5,6 +5,7 @@ import {
   describeAgentActivity,
   describeAgentTool,
   formatAgentToolDetail,
+  latestAgentTaskList,
   presentAgentError,
   projectAgentTranscript,
   type AgentToolActivity,
@@ -381,9 +382,71 @@ describe("projectAgentTranscript", () => {
     expect(projected[1]).toMatchObject({
       type: "plan",
       explanation: "A focused plan.",
+      actionable: false,
       steps: [
         { step: "Inspect", status: "completed" },
         { step: "Implement", status: "pending" },
+      ],
+    });
+  });
+
+  it("projects task progress separately and exposes the latest snapshot", () => {
+    const messages = [
+      assistant(
+        [
+          {
+            type: "taskList",
+            id: "tasks-1",
+            explanation: "Live execution progress.",
+            items: [
+              { step: "Inspect", status: "completed" },
+              { step: "Implement", status: "inProgress" },
+            ],
+          },
+        ],
+        1,
+      ),
+      assistant([{ type: "text", text: "Still working." }], 2),
+      assistant(
+        [
+          {
+            type: "taskList",
+            id: "tasks-1",
+            explanation: "Live execution progress.",
+            items: [
+              { step: "Inspect", status: "completed" },
+              { step: "Implement", status: "completed" },
+            ],
+          },
+        ],
+        3,
+      ),
+    ];
+
+    expect(projectAgentTranscript(messages)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "task_list",
+          snapshot: expect.objectContaining({
+            tasks: [
+              expect.objectContaining({
+                step: "Inspect",
+                status: "completed",
+              }),
+              expect.objectContaining({
+                step: "Implement",
+                status: "completed",
+              }),
+            ],
+          }),
+        }),
+      ]),
+    );
+    expect(latestAgentTaskList(messages)).toMatchObject({
+      id: "tasks-1",
+      tasks: [
+        { id: "tasks-1:0", step: "Inspect", status: "completed" },
+        { id: "tasks-1:1", step: "Implement", status: "completed" },
       ],
     });
   });

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -60,6 +60,20 @@ export type AgentErrorPresentation = {
   details: string | null;
 };
 
+export type AgentTaskStatus = "pending" | "in_progress" | "completed";
+
+export type AgentTask = {
+  id: string;
+  step: string;
+  status: AgentTaskStatus;
+};
+
+export type AgentTaskListSnapshot = {
+  id: string;
+  explanation: string | null;
+  tasks: AgentTask[];
+};
+
 export type AgentTranscriptItem =
   | {
       type: "message";
@@ -95,10 +109,16 @@ export type AgentTranscriptItem =
       key: string;
       text: string;
       explanation: string | null;
+      actionable: boolean;
       steps: Array<{
         step: string;
         status: string;
       }>;
+    }
+  | {
+      type: "task_list";
+      key: string;
+      snapshot: AgentTaskListSnapshot;
     };
 
 export type AgentToolStatus =
@@ -196,6 +216,71 @@ function recordOf(value: unknown): UnknownRecord | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as UnknownRecord)
     : null;
+}
+
+function normalizeTaskStatus(value: unknown): AgentTaskStatus {
+  if (value === "completed") return "completed";
+  if (value === "inProgress" || value === "in_progress") {
+    return "in_progress";
+  }
+  return "pending";
+}
+
+function taskListSnapshot(
+  value: unknown,
+  fallbackId: string,
+): AgentTaskListSnapshot | null {
+  const part = recordOf(value);
+  if (part?.type !== "taskList" || !Array.isArray(part.items)) return null;
+  const id = typeof part.id === "string" ? part.id : fallbackId;
+  return {
+    id,
+    explanation:
+      typeof part.explanation === "string" ? part.explanation : null,
+    tasks: part.items.flatMap((value, index) => {
+      const task = recordOf(value);
+      const step =
+        typeof task?.step === "string"
+          ? task.step
+          : typeof task?.text === "string"
+            ? task.text
+            : null;
+      return step
+        ? [{
+            id: typeof task?.id === "string" ? task.id : `${id}:${index}`,
+            step,
+            status: normalizeTaskStatus(task?.status),
+          }]
+        : [];
+    }),
+  };
+}
+
+export function latestAgentTaskList(
+  messages: readonly unknown[],
+): AgentTaskListSnapshot | null {
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex -= 1
+  ) {
+    const message = recordOf(messages[messageIndex]);
+    if (message?.role !== "assistant" || !Array.isArray(message.content)) {
+      continue;
+    }
+    for (
+      let partIndex = message.content.length - 1;
+      partIndex >= 0;
+      partIndex -= 1
+    ) {
+      const snapshot = taskListSnapshot(
+        message.content[partIndex],
+        `task-list:${messageIndex}:${partIndex}`,
+      );
+      if (snapshot) return snapshot;
+    }
+  }
+  return null;
 }
 
 function roleOf(message: unknown): string {
@@ -427,6 +512,7 @@ export function projectAgentTranscript(
               typeof partRecord.explanation === "string"
                 ? partRecord.explanation
                 : null,
+            actionable: partRecord.actionable === true,
             steps: Array.isArray(partRecord.steps)
               ? partRecord.steps.flatMap((value) => {
                   const step = recordOf(value);
@@ -444,6 +530,18 @@ export function projectAgentTranscript(
                 })
               : [],
           });
+          return;
+        }
+
+        const tasks = taskListSnapshot(partRecord, partIdentity);
+        if (tasks) {
+          if (tasks.tasks.length > 0) {
+            items.push({
+              type: "task_list",
+              key: `task-list:${tasks.id}`,
+              snapshot: tasks,
+            });
+          }
           return;
         }
 

--- a/packages/agent-runtime/src/codex/client.test.ts
+++ b/packages/agent-runtime/src/codex/client.test.ts
@@ -895,7 +895,7 @@ describe("CodexRuntimeClient", () => {
     });
   });
 
-  it("keeps plans, terminal input, and child activity after sparse completion", async () => {
+  it("keeps task progress, terminal input, and child activity after sparse completion", async () => {
     const client = new CodexRuntimeClient(
       { transport: "local" },
       { executable: "codex", cwd: "/workspace" },
@@ -971,6 +971,15 @@ describe("CodexRuntimeClient", () => {
         { step: "Implement parity", status: "inProgress" },
       ],
     });
+    server.emit("turn/plan/updated", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      explanation: "Two focused steps.",
+      plan: [
+        { step: "Inspect the runtime", status: "completed" },
+        { step: "Implement parity", status: "completed" },
+      ],
+    });
     server.emit("turn/completed", {
       threadId: "child-1",
       turn: {
@@ -1011,8 +1020,18 @@ describe("CodexRuntimeClient", () => {
           terminalInputs: ["y\n"],
         }),
         expect.objectContaining({
-          type: "plan",
+          type: "taskList",
           explanation: "Two focused steps.",
+          items: [
+            expect.objectContaining({
+              step: "Inspect the runtime",
+              status: "completed",
+            }),
+            expect.objectContaining({
+              step: "Implement parity",
+              status: "completed",
+            }),
+          ],
         }),
         expect.objectContaining({ type: "text", text: "Ready." }),
       ]),
@@ -1020,6 +1039,63 @@ describe("CodexRuntimeClient", () => {
     await expect(client.getState()).resolves.toMatchObject({
       isStreaming: false,
     });
+  });
+
+  it("keeps Plan-mode proposals actionable and separate from task progress", async () => {
+    server.collaborationModes = [
+      {
+        name: "Code",
+        mode: "default",
+        model: null,
+        reasoning_effort: null,
+      },
+      {
+        name: "Plan",
+        mode: "plan",
+        model: null,
+        reasoning_effort: null,
+      },
+    ];
+    const client = new CodexRuntimeClient(
+      { transport: "local" },
+      { executable: "codex", cwd: "/workspace" },
+    );
+    await client.getState();
+    await client.setCollaborationMode("plan");
+    await client.prompt("Design the change");
+    server.emit("turn/started", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-plan",
+        status: "inProgress",
+        startedAt: 10,
+        items: [],
+      },
+    });
+    server.emit("turn/plan/updated", {
+      threadId: "thread-1",
+      turnId: "turn-plan",
+      explanation: "Ready for review.",
+      plan: [
+        { step: "Inspect the runtime", status: "completed" },
+        { step: "Implement parity", status: "pending" },
+      ],
+    });
+
+    expect(assistantParts((await client.getMessages()).messages)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "plan",
+          explanation: "Ready for review.",
+          actionable: true,
+        }),
+      ]),
+    );
+    expect(assistantParts((await client.getMessages()).messages)).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "taskList" }),
+      ]),
+    );
   });
 
   it("ignores aggregate diff telemetry and keeps concrete file changes", async () => {

--- a/packages/agent-runtime/src/codex/client.ts
+++ b/packages/agent-runtime/src/codex/client.ts
@@ -552,7 +552,19 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
   const assistantContent: UnknownRecord[] = [];
   const assistantOrders: number[] = [];
   const results: unknown[] = [];
-  const planItems = turn.items.filter((item) => item.type === "plan");
+  const taskPlanItems = turn.items.filter(
+    (item) =>
+      item.type === "plan" &&
+      stringOf(item, "overtchatPlanKind") === "taskProgress",
+  );
+  const selectedTaskPlan = taskPlanItems.findLast((item) =>
+    Array.isArray(item.steps),
+  );
+  const planItems = turn.items.filter(
+    (item) =>
+      item.type === "plan" &&
+      stringOf(item, "overtchatPlanKind") !== "taskProgress",
+  );
   const structuredPlan = planItems.findLast((item) =>
     Array.isArray(item.steps),
   );
@@ -561,6 +573,7 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
     structuredPlan ??
     null;
   let planAdded = false;
+  let taskPlanAdded = false;
   const pushAssistantContent = (content: UnknownRecord, order: number) => {
     assistantContent.push(content);
     assistantOrders.push(order);
@@ -624,6 +637,20 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
       continue;
     }
     if (item.type === "plan") {
+      if (
+        !taskPlanAdded &&
+        item.id === selectedTaskPlan?.id &&
+        Array.isArray(selectedTaskPlan.steps)
+      ) {
+        pushAssistantContent({
+          type: "taskList",
+          id: selectedTaskPlan.id,
+          explanation: stringOf(selectedTaskPlan, "explanation"),
+          items: selectedTaskPlan.steps,
+        }, itemIndex);
+        taskPlanAdded = true;
+        continue;
+      }
       if (!planAdded && item.id === selectedPlan?.id) {
         const structured = structuredPlan ?? selectedPlan;
         pushAssistantContent({
@@ -632,6 +659,8 @@ function canonicalTurnMessages(turn: CodexTurn): unknown[] {
           text: stringOf(selectedPlan, "text") ?? "",
           explanation: stringOf(structured, "explanation"),
           steps: Array.isArray(structured?.steps) ? structured.steps : [],
+          actionable:
+            stringOf(selectedPlan, "overtchatPlanKind") === "proposal",
         }, itemIndex);
         planAdded = true;
       }
@@ -1981,6 +2010,9 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
     if (method === "turn/plan/updated") {
       const turnId = stringOf(data, "turnId");
       if (turnId) {
+        // Codex uses this notification for both an execution checklist and a
+        // Plan-mode proposal. Capture the meaning now because the completed
+        // turn projection no longer has the mode that produced the item.
         const steps = Array.isArray(data?.plan)
           ? data.plan.flatMap((value) => {
               const step = recordOf(value);
@@ -2000,6 +2032,10 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         this.upsertItem(turnId, {
           id: `overtchat:turn-plan:${turnId}`,
           type: "plan",
+          overtchatPlanKind:
+            this.selectedCollaborationMode === "plan"
+              ? "proposal"
+              : "taskProgress",
           text,
           explanation: stringOf(data, "explanation"),
           steps,
@@ -2612,7 +2648,19 @@ export class CodexRuntimeClient implements AgentRuntimeClient {
         items: [],
         startedAt: Date.now() / 1_000,
       });
-    const item = { ...value, id, type };
+    const item = {
+      ...value,
+      id,
+      type,
+      ...(type === "plan" && !stringOf(value, "overtchatPlanKind")
+        ? {
+            overtchatPlanKind:
+              this.selectedCollaborationMode === "plan"
+                ? "proposal"
+                : "informational",
+          }
+        : {}),
+    };
     const index = turn.items.findIndex((candidate) => candidate.id === id);
     if (index >= 0) turn.items[index] = item;
     else turn.items.push(item);


### PR DESCRIPTION
## Summary

- move the full Codex goal into a composer-adjacent popover while preserving live goal controls
- distinguish ongoing Codex task progress from actionable Plan-mode proposals
- keep the latest task checklist visible and updated throughout a turn
- add presentation, runtime, and browser coverage for goal/task behavior

## Validation

- `npm run test -w packages/agent-runtime -- src/codex/client.test.ts`
- `npm run test -w apps/web -- lib/agents/presentation.test.ts`
- `npm run typecheck -w packages/agent-runtime --`
- `npm run typecheck -w apps/web --`
- `npm run lint -w apps/web -- --quiet`
- `npm run typecheck -w apps/connector --`
- `npm run lint -w apps/connector --`
- `npm run test -w apps/connector --`
- `npm run build -w apps/connector --`
- `npm run test:e2e -w apps/web -- agent-runtime.spec.ts --grep "shows durable turn activity"`
- `git diff --check`