### PR TITLE
fix(agents): persist prompt-derived session titles

### DIFF
--- a/apps/web/app/(app)/agents/[id]/page.tsx
+++ b/apps/web/app/(app)/agents/[id]/page.tsx
@@ -25,11 +25,7 @@ export default async function AgentSessionPage({
       workspaceId={owned.workspace.id}
       workspaceName={owned.workspace.name}
       workspacePath={owned.workspace.path}
-      initialSessionName={
-        owned.agentSession.name ??
-        owned.agentSession.firstMessage ??
-        ""
-      }
+      initialSessionName={owned.agentSession.name ?? ""}
     />
   );
 }

--- a/apps/web/app/api/agent-sessions/[id]/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   getOwnedAgentSession: vi.fn(),
+  renameAgentSession: vi.fn(),
   replaceAgentSessionProviderSession: vi.fn(),
   updateAgentSessionMetadata: vi.fn(),
   upsertAgentSession: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock("@/lib/auth/server", () => ({
 }));
 vi.mock("@/lib/db/agentConnections", () => ({
   getOwnedAgentSession: mocks.getOwnedAgentSession,
+  renameAgentSession: mocks.renameAgentSession,
   replaceAgentSessionProviderSession: mocks.replaceAgentSessionProviderSession,
   updateAgentSessionMetadata: mocks.updateAgentSessionMetadata,
   upsertAgentSession: mocks.upsertAgentSession,
@@ -223,6 +225,23 @@ describe("agent session route", () => {
       "session",
       expect.objectContaining({ firstMessage: "screen.png" }),
     );
+  });
+
+  it("persists an explicit rename as the authoritative session title", async () => {
+    const response = await POST(
+      request("POST", {
+        type: "set_session_name",
+        name: "Release prep",
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.renameAgentSession).toHaveBeenCalledWith(
+      "session",
+      "Release prep",
+    );
+    expect(mocks.updateAgentSessionMetadata).not.toHaveBeenCalled();
   });
 
   it("forwards provider-neutral queue commands", async () => {

--- a/apps/web/app/api/agent-sessions/[id]/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/route.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/agents/connector/descriptors";
 import {
   getOwnedAgentSession,
+  renameAgentSession,
   replaceAgentSessionProviderSession,
   type OwnedAgentSession,
   updateAgentSessionMetadata,
@@ -219,7 +220,7 @@ export async function POST(
         providerModifiedAt: new Date(),
       });
     } else if (command.type === "set_session_name") {
-      await updateAgentSessionMetadata(id, { name: command.name });
+      await renameAgentSession(id, command.name);
     }
     return Response.json({
       accepted: true,

--- a/apps/web/components/SidebarAgentWorkspaces.tsx
+++ b/apps/web/components/SidebarAgentWorkspaces.tsx
@@ -262,7 +262,7 @@ function SessionLink({ item }: { item: AgentWorkspaceSession }) {
   const pathname = usePathname();
   const { closeMobile } = useSidebar();
   const { session, provider } = item;
-  const title = session.name || session.firstMessage || "Untitled session";
+  const title = session.name || "New session";
   return (
     <li>
       <Link

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -196,7 +196,9 @@ export function AgentSessionView({
   const snapshot = session.data;
 
   useEffect(() => {
-    const title = snapshot ? sessionName(snapshot) : initialSessionName;
+    const title = snapshot
+      ? sessionName(snapshot) || initialSessionName
+      : initialSessionName;
     document.title = `${title.trim() || workspaceName} · ${providerLabel}`;
   }, [initialSessionName, providerLabel, snapshot, workspaceName]);
 

--- a/apps/web/lib/agents/sessionTitle.test.ts
+++ b/apps/web/lib/agents/sessionTitle.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveInitialAgentSessionTitle,
+  resolveInitialAgentSessionTitle,
+} from "./sessionTitle";
+
+describe("agent session titles", () => {
+  it("uses the first non-empty prompt line and normalizes whitespace", () => {
+    expect(
+      deriveInitialAgentSessionTitle(
+        "\n  Investigate   the\tbroken session titles  \nMore context",
+      ),
+    ).toBe("Investigate the broken session titles");
+  });
+
+  it("caps prompt-derived titles at 60 characters", () => {
+    expect(deriveInitialAgentSessionTitle("a".repeat(80))).toBe(
+      "a".repeat(60),
+    );
+  });
+
+  it("returns null for a prompt without content", () => {
+    expect(deriveInitialAgentSessionTitle(" \n\t\n ")).toBeNull();
+  });
+
+  it("prefers an explicit or provider-supplied initial name", () => {
+    expect(
+      resolveInitialAgentSessionTitle({
+        name: "  Release prep  ",
+        firstMessage: "Inspect the release",
+      }),
+    ).toBe("Release prep");
+  });
+
+  it("falls back to the first message when no name exists", () => {
+    expect(
+      resolveInitialAgentSessionTitle({
+        name: null,
+        firstMessage: "Review this repository\nBe thorough",
+      }),
+    ).toBe("Review this repository");
+  });
+});

--- a/apps/web/lib/agents/sessionTitle.ts
+++ b/apps/web/lib/agents/sessionTitle.ts
@@ -1,0 +1,31 @@
+const MAX_INITIAL_AGENT_TITLE_CHARS = 60;
+
+export function deriveInitialAgentSessionTitle(prompt: string): string | null {
+  const firstContentLine = prompt
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstContentLine) return null;
+
+  const normalized = firstContentLine.replace(/\s+/g, " ").trim();
+  if (!normalized) return null;
+
+  const clamped = normalized.slice(0, MAX_INITIAL_AGENT_TITLE_CHARS).trim();
+  return clamped.length > 0 ? clamped : null;
+}
+
+export function resolveInitialAgentSessionTitle({
+  name,
+  firstMessage,
+}: {
+  name?: string | null;
+  firstMessage?: string | null;
+}): string | null {
+  const explicitTitle = typeof name === "string" ? name.trim() : "";
+  return (
+    explicitTitle ||
+    (typeof firstMessage === "string"
+      ? deriveInitialAgentSessionTitle(firstMessage)
+      : null)
+  );
+}

--- a/apps/web/lib/db/agentConnections.test.ts
+++ b/apps/web/lib/db/agentConnections.test.ts
@@ -179,6 +179,7 @@ describe("agent connection persistence", () => {
               }),
               expect.objectContaining({
                 providerSessionId: "older",
+                name: "Review this repository",
               }),
             ],
           }),
@@ -187,7 +188,7 @@ describe("agent connection persistence", () => {
     ]);
   });
 
-  it("updates and prunes only cached session metadata on a full sync", async () => {
+  it("updates cached metadata without replacing an established title", async () => {
     const owned = createAliceConnection();
     const workspace = await repository.createAgentWorkspace(
       owned.connection.id,
@@ -240,7 +241,7 @@ describe("agent connection persistence", () => {
     expect(rows[0]).toMatchObject({
       providerSessionId: "keep",
       providerSessionPath: "/remote/keep.jsonl",
-      name: "New name",
+      name: "Old name",
       messageCount: 3,
       model: "openai/new-model",
       thinkingOptionId: "high",
@@ -282,10 +283,56 @@ describe("agent connection persistence", () => {
         id: original.id,
         providerSessionId: "edited-thread",
         providerSessionPath: "/codex/edited-thread.jsonl",
-        name: null,
+        name: "Original thread",
         firstMessage: null,
         messageCount: 0,
       },
+    });
+  });
+
+  it("fills a missing title once and preserves explicit renames", async () => {
+    const owned = createAliceConnection();
+    const workspace = await repository.createAgentWorkspace(
+      owned.connection.id,
+      "alice",
+      { path: "/work/overtchat", name: "overtchat" },
+    );
+    const session = await repository.upsertAgentSession(workspace!.id, {
+      providerSessionId: "session",
+      providerSessionPath: "/remote/session.jsonl",
+      name: null,
+      firstMessage: null,
+      messageCount: 0,
+      createdAt: null,
+      modifiedAt: null,
+    });
+
+    await repository.updateAgentSessionMetadata(session.id, {
+      firstMessage:
+        "\n  Diagnose   inconsistent\tchat titles\nKeep this focused",
+    });
+    await expect(
+      repository.getOwnedAgentSession(session.id, "alice"),
+    ).resolves.toMatchObject({
+      agentSession: {
+        name: "Diagnose inconsistent chat titles",
+        firstMessage:
+          "\n  Diagnose   inconsistent\tchat titles\nKeep this focused",
+      },
+    });
+
+    await repository.updateAgentSessionMetadata(session.id, {
+      name: "Late provider name",
+    });
+    await repository.renameAgentSession(session.id, "  My title  ");
+    await repository.updateAgentSessionMetadata(session.id, {
+      name: "Another provider name",
+    });
+
+    await expect(
+      repository.getOwnedAgentSession(session.id, "alice"),
+    ).resolves.toMatchObject({
+      agentSession: { name: "My title" },
     });
   });
 

--- a/apps/web/lib/db/agentConnections.ts
+++ b/apps/web/lib/db/agentConnections.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { and, desc, eq, inArray, notInArray } from "drizzle-orm";
+import { and, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import {
   agentConnections,
@@ -17,6 +17,7 @@ import type {
   AgentTransportId,
 } from "@overtchat/agent-bridge";
 import type { ConnectorShellMode } from "@overtchat/agent-bridge";
+import { resolveInitialAgentSessionTitle } from "@/lib/agents/sessionTitle";
 
 export type AgentHostRow = typeof agentHosts.$inferSelect;
 export type AgentConnectionRow = typeof agentConnections.$inferSelect;
@@ -338,13 +339,14 @@ export function syncAgentWorkspaceSessions(
     }
 
     for (const session of sessions) {
+      const initialTitle = resolveInitialAgentSessionTitle(session);
       tx.insert(agentSessions)
         .values({
           id: crypto.randomUUID(),
           workspaceId,
           providerSessionId: session.providerSessionId,
           providerSessionPath: session.providerSessionPath,
-          name: session.name,
+          name: initialTitle,
           firstMessage: session.firstMessage,
           messageCount: session.messageCount,
           providerCreatedAt: session.createdAt,
@@ -361,7 +363,11 @@ export function syncAgentWorkspaceSessions(
           ],
           set: {
             providerSessionId: session.providerSessionId,
-            name: session.name,
+            ...(initialTitle
+              ? {
+                  name: sql`coalesce(nullif(trim(${agentSessions.name}), ''), ${initialTitle})`,
+                }
+              : {}),
             firstMessage: session.firstMessage,
             messageCount: session.messageCount,
             providerCreatedAt: session.createdAt,
@@ -407,6 +413,7 @@ export async function upsertAgentSession(
   launchConfig: AgentSessionLaunchConfig = {},
 ): Promise<AgentSessionRow> {
   const now = new Date();
+  const initialTitle = resolveInitialAgentSessionTitle(session);
   const [row] = await db
     .insert(agentSessions)
     .values({
@@ -417,7 +424,7 @@ export async function upsertAgentSession(
       model: launchConfig.model,
       thinkingOptionId: launchConfig.thinkingOptionId,
       modeId: launchConfig.modeId,
-      name: session.name,
+      name: initialTitle,
       firstMessage: session.firstMessage,
       messageCount: session.messageCount,
       providerCreatedAt: session.createdAt,
@@ -434,7 +441,11 @@ export async function upsertAgentSession(
         model: launchConfig.model,
         thinkingOptionId: launchConfig.thinkingOptionId,
         modeId: launchConfig.modeId,
-        name: session.name,
+        ...(initialTitle
+          ? {
+              name: sql`coalesce(nullif(trim(${agentSessions.name}), ''), ${initialTitle})`,
+            }
+          : {}),
         firstMessage: session.firstMessage,
         messageCount: session.messageCount,
         providerCreatedAt: session.createdAt,
@@ -466,7 +477,6 @@ export async function replaceAgentSessionProviderSession(
             modeId: launchConfig.modeId ?? null,
           }
         : {}),
-      name: session.name,
       firstMessage: session.firstMessage,
       messageCount: session.messageCount,
       providerCreatedAt: session.createdAt,
@@ -487,11 +497,20 @@ export async function updateAgentSessionMetadata(
     launchConfig?: AgentSessionLaunchConfig;
   },
 ): Promise<void> {
-  const { launchConfig, ...metadata } = patch;
+  const { launchConfig, name: providerName, ...metadata } = patch;
+  const initialTitle = resolveInitialAgentSessionTitle({
+    name: providerName,
+    firstMessage: patch.firstMessage,
+  });
   await db
     .update(agentSessions)
     .set({
       ...metadata,
+      ...(initialTitle
+        ? {
+            name: sql`coalesce(nullif(trim(${agentSessions.name}), ''), ${initialTitle})`,
+          }
+        : {}),
       ...(launchConfig
         ? {
             model: launchConfig.model ?? null,
@@ -499,6 +518,20 @@ export async function updateAgentSessionMetadata(
             modeId: launchConfig.modeId ?? null,
           }
         : {}),
+      updatedAt: new Date(),
+      lastSyncedAt: new Date(),
+    })
+    .where(eq(agentSessions.id, id));
+}
+
+export async function renameAgentSession(
+  id: string,
+  name: string,
+): Promise<void> {
+  await db
+    .update(agentSessions)
+    .set({
+      name: name.trim(),
       updatedAt: new Date(),
       lastSyncedAt: new Date(),
     })


### PR DESCRIPTION
## Summary

- derive a stable session title from the first non-empty prompt line, normalize whitespace, and cap it at 60 characters
- seed imported sessions from their native name or first prompt, then keep the persisted OvertChat title stable across provider refreshes and thread replacement
- preserve explicit renames as the only operation that replaces an established title
- render the persisted title directly, with New session reserved for sessions that have not received a prompt

This follows the same prompt-derived title policy as Paseo. It does not invoke an LLM and does not add provider-specific title generation.

No database migration is included. Existing cached unnamed sessions receive a title the next time their workspace metadata is refreshed.

## Validation

- npm run test -w apps/web -- (92 files, 581 tests)
- npm run typecheck -w apps/web --
- npm run lint -w apps/web --
- npm run build -w apps/web --