### PR TITLE
fix(agents): preserve legacy session titles

### DIFF
--- a/apps/web/app/(app)/agents/[id]/page.tsx
+++ b/apps/web/app/(app)/agents/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { AgentSessionView } from "@/components/agents/AgentSessionView";
+import { agentSessionDisplayTitle } from "@/lib/agents/sidebar";
 import { auth } from "@/lib/auth/server";
 import { getOwnedAgentSession } from "@/lib/db/agentConnections";
 import { isAgentProviderId } from "@overtchat/agent-bridge";
@@ -25,7 +26,7 @@ export default async function AgentSessionPage({
       workspaceId={owned.workspace.id}
       workspaceName={owned.workspace.name}
       workspacePath={owned.workspace.path}
-      initialSessionName={owned.agentSession.name ?? ""}
+      initialSessionName={agentSessionDisplayTitle(owned.agentSession) ?? ""}
     />
   );
 }

--- a/apps/web/components/SidebarAgentWorkspaces.tsx
+++ b/apps/web/components/SidebarAgentWorkspaces.tsx
@@ -25,6 +25,7 @@ import type {
 import { agentProviderMetadata } from "@overtchat/agent-bridge";
 import {
   AGENT_SESSION_PREVIEW_COUNT,
+  agentSessionDisplayTitle,
   agentSessionIsRunning,
   visibleAgentSessions,
 } from "@/lib/agents/sidebar";
@@ -262,7 +263,7 @@ function SessionLink({ item }: { item: AgentWorkspaceSession }) {
   const pathname = usePathname();
   const { closeMobile } = useSidebar();
   const { session, provider } = item;
-  const title = session.name || "New session";
+  const title = agentSessionDisplayTitle(session) || "New session";
   return (
     <li>
       <Link

--- a/apps/web/lib/agents/sidebar.test.ts
+++ b/apps/web/lib/agents/sidebar.test.ts
@@ -6,6 +6,7 @@ import type {
 import {
   AGENT_SESSION_PREVIEW_COUNT,
   agentConnectionHasRunningSession,
+  agentSessionDisplayTitle,
   agentWorkspaceHasRunningSession,
   visibleAgentSessions,
   withAgentSessionDirectory,
@@ -25,6 +26,24 @@ function sessions(count: number): AgentSessionListItem[] {
 }
 
 describe("agent sessions in the sidebar", () => {
+  it("preserves legacy first-message titles while preferring persisted names", () => {
+    expect(
+      agentSessionDisplayTitle({
+        name: "Persisted title",
+        firstMessage: "Original prompt",
+      }),
+    ).toBe("Persisted title");
+    expect(
+      agentSessionDisplayTitle({
+        name: null,
+        firstMessage: "Legacy prompt title",
+      }),
+    ).toBe("Legacy prompt title");
+    expect(
+      agentSessionDisplayTitle({ name: null, firstMessage: null }),
+    ).toBeNull();
+  });
+
   it("shows only the recent preview until expanded", () => {
     const all = sessions(20);
     expect(visibleAgentSessions(all, false, null)).toHaveLength(

--- a/apps/web/lib/agents/sidebar.ts
+++ b/apps/web/lib/agents/sidebar.ts
@@ -7,6 +7,12 @@ import type {
 
 export const AGENT_SESSION_PREVIEW_COUNT = 8;
 
+export function agentSessionDisplayTitle(
+  session: Pick<AgentSessionListItem, "name" | "firstMessage">,
+): string | null {
+  return session.name || session.firstMessage || null;
+}
+
 export function agentSessionIsRunning(
   session: AgentSessionListItem,
 ): boolean {


### PR DESCRIPTION
## Summary

- restore the first-message display fallback for existing agent sessions that do not have a persisted title
- continue preferring the new persisted title for new sessions
- show New session only when neither source exists
- apply the same compatibility behavior to the sidebar and agent session page

This is a read-time compatibility fix. It does not rewrite session data or change the v0.16.7 persisted-title policy.

## Validation

- npm run test -w apps/web -- (92 files, 582 tests)
- npm run typecheck -w apps/web --
- npm run lint -w apps/web --
- npm run build -w apps/web --
- git diff --check