### PR TITLE
release: app v0.16.8

### DIFF
--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.16.7",
+  "appVersion": "0.16.8",
   "connectorVersion": "0.7.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.7}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.8}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- promote the app release version from 0.16.7 to 0.16.8
- select the v0.16.8 image in the stable install manifest and Compose default

This patch release contains #203, which restores the legacy first-message title fallback for existing agent sessions while retaining persisted titles for new sessions. CLI, connector, STT, and mobile versions remain unchanged.

## Validation

- npm run lint
- npm run typecheck
- npm run test
- git diff --check