### PR TITLE
feat(agents): add OpenCode support

### DIFF
--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   type HostConnectorEventBatch,
   type HostConnectorEventPayload,
 } from "@overtchat/agent-bridge";
@@ -119,7 +119,7 @@ describe.sequential("connector client compatibility", () => {
     ).toHaveLength(0);
   });
 
-  it("uses the stable v1 compatibility token and advertises its build", async () => {
+  it("uses the protocol compatibility token and advertises its build", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal(
       "fetch",
@@ -134,9 +134,9 @@ describe.sequential("connector client compatibility", () => {
 
     const headers = new Headers(requests[0]!.init?.headers);
     expect(headers.get("x-overtchat-connector-version")).toBe(
-      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+      HOST_CONNECTOR_COMPATIBILITY_RELEASE,
     );
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.7.0");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.8.0");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/connector/src/client.ts
+++ b/apps/connector/src/client.ts
@@ -2,7 +2,7 @@ import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   isHostConnectorCommand,
   MAX_AGENT_IMAGE_BYTES,
   type AgentPromptImage,
@@ -201,7 +201,7 @@ export class ConnectorClient {
         headers: {
           Authorization: `Bearer ${this.config.token}`,
           "X-OvertChat-Connector-Version":
-            HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+            HOST_CONNECTOR_COMPATIBILITY_RELEASE,
           "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
           "X-OvertChat-Connector-Capabilities":
             HOST_CONNECTOR_CAPABILITIES.join(","),
@@ -317,7 +317,7 @@ export class ConnectorClient {
             Authorization: `Bearer ${this.config.token}`,
             "Content-Type": "application/json",
             "X-OvertChat-Connector-Version":
-              HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+              HOST_CONNECTOR_COMPATIBILITY_RELEASE,
             "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
             "X-OvertChat-Connector-Capabilities":
               HOST_CONNECTOR_CAPABILITIES.join(","),

--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -9,6 +9,7 @@ import type {
   HostConnectorCommand,
   HostConnectorEventPayload,
 } from "@overtchat/agent-bridge";
+import { HOST_CONNECTOR_PROTOCOL_VERSION } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
   configureProcessSpawner: vi.fn(),
@@ -504,7 +505,7 @@ describe("connector daemon command identity", () => {
       connectionEpoch: "connection-1",
       activeSessionIds: ["session"],
       serverInfo: {
-        protocolVersion: 1,
+        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
         capabilities: ["session-sync-v1"],
       },
     });
@@ -566,7 +567,7 @@ describe("connector daemon command identity", () => {
       connectionEpoch: "connection-1",
       activeSessionIds: ["session"],
       serverInfo: {
-        protocolVersion: 1,
+        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
         capabilities: [],
       },
     });
@@ -625,7 +626,10 @@ describe("connector daemon command identity", () => {
       type: "sync",
       connectionEpoch: "connection-1",
       activeSessionIds: ["session"],
-      serverInfo: { protocolVersion: 1, capabilities: ["session-sync-v1"] },
+      serverInfo: {
+        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
+        capabilities: ["session-sync-v1"],
+      },
     });
     await daemon.handle({
       type: "request",
@@ -988,7 +992,10 @@ describe("connector daemon command identity", () => {
       type: "sync",
       connectionEpoch: "connection-1",
       activeSessionIds: ["session"],
-      serverInfo: { protocolVersion: 1, capabilities: ["session-sync-v1"] },
+      serverInfo: {
+        protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
+        capabilities: ["session-sync-v1"],
+      },
     });
     await daemon.handle({
       type: "request",

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -16,13 +16,13 @@ import {
 } from "@overtchat/agent-bridge";
 import {
   AgentRuntimeRegistry,
+  AgentProviderSnapshotManager,
   agentProviderAdapter,
   configureProcessSpawner,
-  discoverAgentInstallations,
+  configureTcpTunnelOpener,
   inspectAgentWorkspaceGitStatus,
   listAgentDirectories,
   probeAgentWorkspace,
-  targetForDiscovery,
   type AgentSessionRuntime,
   type HostTarget,
   type ResolvedAgentImage,
@@ -124,6 +124,7 @@ function sessionDescriptor(descriptor: AgentDaemonSessionDescriptor) {
 
 export class ConnectorDaemon {
   private readonly processHost = new ConnectorProcessHost();
+  private readonly providerSnapshots = new AgentProviderSnapshotManager();
   private readonly registry: AgentRuntimeRegistry;
   private readonly subscriptions = new Map<string, SessionSubscription>();
   private readonly captures = new Map<string, TimelineCapture>();
@@ -148,6 +149,7 @@ export class ConnectorDaemon {
     private readonly shutdownGraceMs = SHUTDOWN_GRACE_MS,
   ) {
     configureProcessSpawner(this.processHost.spawn);
+    configureTcpTunnelOpener(this.processHost.openTcpTunnel);
     this.registry = new AgentRuntimeRegistry({
       resolveImages,
       updateSessionMetadata: async (sessionId, patch) => {
@@ -334,8 +336,10 @@ export class ConnectorDaemon {
     switch (request.type) {
       case "list_ssh_hosts":
         return listSshHosts();
-      case "discover":
-        return discoverAgentInstallations(targetForDiscovery(request.target));
+      case "provider_snapshot":
+        return this.providerSnapshots.getSnapshot(request.target, {
+          refresh: request.refresh,
+        });
       case "probe":
         return agentProviderAdapter(request.draft.provider).probeConnection(
           request.draft,

--- a/apps/connector/src/runtime.ts
+++ b/apps/connector/src/runtime.ts
@@ -1,13 +1,81 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import net from "node:net";
 import type {
   ConnectorTarget,
 } from "@overtchat/agent-bridge";
 import type {
   AgentProcess,
   AgentProcessHostLaunch,
+  AgentTcpTunnel,
   HostTarget,
 } from "@overtchat/agent-runtime";
-import { buildSshRemoteCommand, sshSpawnArgs } from "./ssh.js";
+import { buildSshRemoteCommand, sshSpawnArgs, sshTunnelArgs } from "./ssh.js";
+
+const TUNNEL_START_TIMEOUT_MS = 10_000;
+
+function availableLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => {
+        if (error) reject(error);
+        else if (!port) reject(new Error("Unable to allocate a loopback port."));
+        else resolve(port);
+      });
+    });
+  });
+}
+
+function waitForLoopbackPort(
+  port: number,
+  child: ChildProcessWithoutNullStreams,
+): Promise<void> {
+  const deadline = Date.now() + TUNNEL_START_TIMEOUT_MS;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stderr = "";
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      child.removeListener("exit", exited);
+      if (error) reject(error);
+      else resolve();
+    };
+    const exited = (code: number | null) =>
+      finish(
+        new Error(
+          stderr.trim() ||
+            `SSH TCP tunnel exited before it became ready (code ${code ?? "unknown"}).`,
+        ),
+      );
+    child.once("exit", exited);
+    child.stderr.on("data", (chunk) => {
+      if (stderr.length < 8_192) stderr += chunk.toString();
+    });
+    const attempt = () => {
+      if (settled) return;
+      const socket = net.createConnection({ host: "127.0.0.1", port });
+      socket.unref();
+      socket.once("connect", () => {
+        socket.destroy();
+        finish();
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() >= deadline) {
+          finish(new Error("Timed out waiting for the SSH TCP tunnel."));
+          return;
+        }
+        setTimeout(attempt, 50).unref();
+      });
+    };
+    attempt();
+  });
+}
 
 function killProcessTree(
   child: ChildProcessWithoutNullStreams,
@@ -77,6 +145,46 @@ export class ConnectorProcessHost {
       stderr: child.stderr,
       exit,
       kill: (signal = "SIGTERM") => killProcessTree(child, signal),
+    };
+  };
+
+  openTcpTunnel = async (
+    target: Extract<HostTarget, { transport: "ssh" }>,
+    remotePort: number,
+  ): Promise<AgentTcpTunnel> => {
+    const localPort = await availableLoopbackPort();
+    const child = spawn("ssh", sshTunnelArgs(target.alias, localPort, remotePort), {
+      detached: process.platform !== "win32",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.processes.add(child);
+    child.once("exit", () => this.processes.delete(child));
+    child.once("error", () => this.processes.delete(child));
+    try {
+      await waitForLoopbackPort(localPort, child);
+    } catch (error) {
+      killProcessTree(child, "SIGTERM");
+      throw error;
+    }
+    let closePromise: Promise<void> | null = null;
+    return {
+      url: `http://127.0.0.1:${localPort}`,
+      close: () => {
+        if (closePromise) return closePromise;
+        closePromise = new Promise((resolve) => {
+          if (!killProcessTree(child, "SIGTERM")) {
+            resolve();
+            return;
+          }
+          const timer = setTimeout(() => killProcessTree(child, "SIGKILL"), 1_000);
+          timer.unref();
+          child.once("exit", () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+        return closePromise;
+      },
     };
   };
 

--- a/apps/connector/src/ssh.test.ts
+++ b/apps/connector/src/ssh.test.ts
@@ -7,6 +7,7 @@ import {
   listSshHosts,
   parseSshExpansion,
   sshSpawnArgs,
+  sshTunnelArgs,
 } from "./ssh.js";
 
 const temporaryPaths: string[] = [];
@@ -80,6 +81,28 @@ describe("SSH process launching", () => {
         shellMode: "interactive",
       }),
     ).toThrow("Invalid SSH host alias");
+  });
+
+  it("opens a loopback-only TCP forwarding tunnel", () => {
+    expect(sshTunnelArgs("macbook", 41234, 4096)).toEqual([
+      "-N",
+      "-T",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "-o",
+      "ExitOnForwardFailure=yes",
+      "-L",
+      "127.0.0.1:41234:127.0.0.1:4096",
+      "macbook",
+    ]);
+    expect(() => sshTunnelArgs("developer@host", 41234, 4096)).toThrow(
+      "Invalid SSH host alias",
+    );
+    expect(() => sshTunnelArgs("macbook", 0, 4096)).toThrow(
+      "Invalid SSH tunnel port",
+    );
   });
 });
 

--- a/apps/connector/src/ssh.ts
+++ b/apps/connector/src/ssh.ts
@@ -50,6 +50,32 @@ export function sshSpawnArgs(
   ];
 }
 
+export function sshTunnelArgs(
+  alias: string,
+  localPort: number,
+  remotePort: number,
+): string[] {
+  if (!SAFE_ALIAS.test(alias)) throw new Error("Invalid SSH host alias.");
+  for (const port of [localPort, remotePort]) {
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+      throw new Error("Invalid SSH tunnel port.");
+    }
+  }
+  return [
+    "-N",
+    "-T",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ConnectTimeout=10",
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-L",
+    `127.0.0.1:${localPort}:127.0.0.1:${remotePort}`,
+    alias,
+  ];
+}
+
 function stripComment(line: string): string {
   let quote: "'" | '"' | null = null;
   for (let index = 0; index < line.length; index++) {

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -12,6 +12,7 @@
 /install/connector/0.5.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.5.0/install-connector.sh 302
 /install/connector/0.6.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.6.0/install-connector.sh 302
 /install/connector/0.7.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.7.0/install-connector.sh 302
+/install/connector/0.8.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.8.0/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.7.0 302
+/install-connector.sh /install/connector/0.8.0 302

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,8 +1,8 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.16.8",
-  "connectorVersion": "0.7.0",
+  "appVersion": "0.17.0",
+  "connectorVersion": "0.8.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",
   "searxngImage": "docker.io/searxng/searxng@sha256:11a9b34cdc0b1ec2b991470a2762ecb5a1a531898289fb51dcd015260450729e",

--- a/apps/web/app/(app)/settings/connections/AddAgentWorkspaceDialog.tsx
+++ b/apps/web/app/(app)/settings/connections/AddAgentWorkspaceDialog.tsx
@@ -203,6 +203,7 @@ export function AddAgentWorkspaceDialog({
         provider: customProvider,
         executable: customExecutable.trim(),
         version: "configured",
+        shellMode: "interactive",
       };
       const index = installations.findIndex(
         (installation) => installation.provider === customProvider,
@@ -216,7 +217,6 @@ export function AddAgentWorkspaceDialog({
       const result = await createMutation.mutateAsync({
         target,
         path: chosenPath,
-        connections,
         installations,
       });
       const providerCount = result.created + result.refreshed;

--- a/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
+++ b/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
@@ -20,10 +20,6 @@ import {
   Trash2,
   Wifi,
 } from "lucide-react";
-import claudeCodeIcon from "@/assets/agent-providers/claude-code.png";
-import codexIcon from "@/assets/agent-providers/codex.png";
-import ompIcon from "@/assets/agent-providers/omp.svg";
-import piIcon from "@/assets/agent-providers/pi.svg";
 import { BetaBadge } from "@/components/BetaBadge";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/toast";
@@ -32,13 +28,20 @@ import type {
   HostConnectorListItem,
   HostConnectorPairing,
 } from "@overtchat/agent-bridge";
-import { agentProviderMetadata } from "@overtchat/agent-bridge";
 import {
+  AGENT_PROVIDERS,
+  agentProviderMetadata,
+} from "@overtchat/agent-bridge";
+import {
+  agentConnectionTarget,
   groupAgentWorkspaces,
+  projectAgentWorkspaceProviders,
   type AgentWorkspaceGroup,
 } from "@/lib/agents/workspaces";
+import { AGENT_PROVIDER_VISUALS } from "@/lib/agents/providerVisuals";
 import {
   useAgentConnections,
+  useAgentProviderSnapshot,
   useDeleteAgentConnection,
   useDeleteHostConnector,
   useDeleteAgentWorkspace,
@@ -56,7 +59,6 @@ import {
 import { AddAgentWorkspaceDialog } from "./AddAgentWorkspaceDialog";
 
 type PendingDetach =
-  | { type: "connection"; connection: AgentConnectionListItem }
   | { type: "connector"; connector: HostConnectorListItem }
   | { type: "workspace-group"; group: AgentWorkspaceGroup };
 
@@ -71,10 +73,6 @@ export function ConnectionsPanel({
   const connector = connectors[0];
   const workspaceGroups = useMemo(
     () => groupAgentWorkspaces(connections),
-    [connections],
-  );
-  const unassignedConnections = useMemo(
-    () => connections.filter((connection) => connection.workspaces.length === 0),
     [connections],
   );
   const testMutation = useTestAgentConnection();
@@ -116,15 +114,7 @@ export function ConnectionsPanel({
     if (!pendingDetach) return;
     setDetachError("");
     try {
-      if (pendingDetach.type === "connection") {
-        await deleteConnectionMutation.mutateAsync(
-          pendingDetach.connection.id,
-        );
-        toast.success({
-          title: "Agent removed",
-          description: pendingDetach.connection.host.name,
-        });
-      } else if (pendingDetach.type === "connector") {
+      if (pendingDetach.type === "connector") {
         await deleteConnectorMutation.mutateAsync(
           pendingDetach.connector.id,
         );
@@ -202,40 +192,29 @@ export function ConnectionsPanel({
             <span>Run coding agents in project folders on this server or over SSH.</span>
             <span
               className="inline-flex items-center gap-1"
-              aria-label="Supported agents: Pi, Oh My Pi, and Codex. Claude Code coming soon."
+              aria-label={`Supported agents: ${Object.values(AGENT_PROVIDERS)
+                .map((provider) => provider.label)
+                .join(", ")}.`}
             >
-              <span
-                className="flex size-6 items-center justify-center rounded-md border bg-background"
-                title="Pi"
-              >
-                <Image src={piIcon} alt="" className="size-4 object-contain" />
-              </span>
-              <span
-                className="flex size-6 items-center justify-center rounded-md border bg-zinc-950"
-                title="Oh My Pi"
-              >
-                <Image src={ompIcon} alt="" className="size-4 object-contain" />
-              </span>
-              <span
-                className="flex size-6 items-center justify-center rounded-md border bg-background opacity-40 grayscale"
-                title="Claude Code · Coming soon"
-              >
-                <Image
-                  src={claudeCodeIcon}
-                  alt=""
-                  className="size-4 object-contain"
-                />
-              </span>
-              <span
-                className="flex size-6 items-center justify-center rounded-md border bg-zinc-950"
-                title="Codex"
-              >
-                <Image
-                  src={codexIcon}
-                  alt=""
-                  className="size-4 object-contain"
-                />
-              </span>
+              {Object.values(AGENT_PROVIDERS).map((provider) => {
+                const visual = AGENT_PROVIDER_VISUALS[provider.id];
+                return (
+                  <span
+                    key={provider.id}
+                    className={cn(
+                      "flex size-6 items-center justify-center rounded-md border bg-background",
+                      visual.darkSurface && "bg-zinc-950",
+                    )}
+                    title={provider.label}
+                  >
+                    <Image
+                      src={visual.icon}
+                      alt=""
+                      className="size-4 object-contain"
+                    />
+                  </span>
+                );
+              })}
             </span>
           </span>
         }
@@ -440,31 +419,6 @@ export function ConnectionsPanel({
               />
             ))
           )}
-          {unassignedConnections.length > 0 && (
-            <div className="border-t px-4 py-3">
-              <p className="text-xs font-medium text-muted-foreground">
-                Unassigned agent installations
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                These are not shown in the sidebar. Add a workspace to reuse one,
-                or remove it.
-              </p>
-              <div className="mt-2 space-y-1">
-                {unassignedConnections.map((connection) => (
-                  <UnassignedConnectionRow
-                    key={connection.id}
-                    connection={connection}
-                    actionId={actionId}
-                    onTest={() => void testConnection(connection)}
-                    onRemove={() => {
-                      setDetachError("");
-                      setPendingDetach({ type: "connection", connection });
-                    }}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
         </SettingsSection>
       )}
 
@@ -499,9 +453,7 @@ export function ConnectionsPanel({
             <AlertDialog.Title className="text-base font-semibold tracking-tight">
               {pendingDetach?.type === "workspace-group"
                 ? "Remove workspace?"
-                : pendingDetach?.type === "connector"
-                  ? "Remove Host Connector?"
-                  : "Remove agent?"}
+                : "Remove Host Connector?"}
             </AlertDialog.Title>
             <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">
               {pendingDetach?.type === "connector" ? (
@@ -520,18 +472,7 @@ export function ConnectionsPanel({
                   and its agent chats will be removed from OvertChat. Files and
                   native agent sessions remain on the host.
                 </>
-              ) : (
-                <>
-                  <span className="font-medium text-foreground">
-                    {pendingDetach?.connection.host.name}
-                  </span>{" "}
-                  will be removed from OvertChat. Files and native{" "}
-                  {pendingDetach
-                    ? agentProviderMetadata(pendingDetach.connection.provider).label
-                    : "agent"}{" "}
-                  sessions remain on the host.
-                </>
-              )}
+              ) : null}
             </AlertDialog.Description>
             {detachError && (
               <SettingsNotice tone="error" className="mt-3 text-xs">
@@ -635,6 +576,13 @@ function WorkspaceGroupRow({
       ? "This server"
       : `ssh ${group.host.sshAlias}`;
   const sessionCount = group.sessions.length;
+  const providerSnapshot = useAgentProviderSnapshot(
+    agentConnectionTarget(group.targets[0]!.connection),
+  );
+  const providers = projectAgentWorkspaceProviders(
+    group,
+    providerSnapshot.data,
+  );
 
   return (
     <div className="px-4 py-4">
@@ -646,7 +594,7 @@ function WorkspaceGroupRow({
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             <span className="text-sm font-medium">{group.name}</span>
             <span className="text-xs text-muted-foreground">
-              {group.targets.length} agent{group.targets.length === 1 ? "" : "s"}
+              {providers.length} agent{providers.length === 1 ? "" : "s"}
             </span>
           </div>
           <p className="mt-0.5 truncate font-mono text-xs text-muted-foreground" title={group.path}>
@@ -674,11 +622,29 @@ function WorkspaceGroupRow({
       </div>
 
       <div className="mt-4 ml-4 border-l pl-4">
-        {group.targets.map(({ connection, workspace }) => {
-          const provider = agentProviderMetadata(connection.provider);
+        {providers.map(({ provider: providerId }) => {
+          const backing = group.targets.find(
+            ({ connection }) => connection.provider === providerId,
+          );
+          const installation = providerSnapshot.data?.providers.find(
+            (entry) =>
+              entry.provider === providerId && entry.status === "ready",
+          );
+          const provider = agentProviderMetadata(providerId);
+          const executable =
+            installation?.status === "ready"
+              ? installation.executable
+              : backing?.connection.executable;
+          const version =
+            installation?.status === "ready"
+              ? installation.version
+              : backing?.connection.detectedVersion;
+          const providerSessionCount = group.sessions.filter(
+            (session) => session.provider === providerId,
+          ).length;
           return (
             <div
-              key={workspace.id}
+              key={providerId}
               className="flex flex-col gap-2 border-b py-3 first:pt-0 last:border-0 last:pb-0 @xl:flex-row @xl:items-center"
             >
               <TerminalSquare className="size-4 shrink-0 text-muted-foreground" />
@@ -686,18 +652,19 @@ function WorkspaceGroupRow({
                 <div className="flex flex-wrap items-baseline gap-x-2">
                   <p className="text-sm font-medium">{provider.label}</p>
                   <span className="text-xs text-muted-foreground">
-                    {connection.detectedVersion ?? "Not tested"}
+                    {version ?? "Not tested"}
                   </span>
                 </div>
-                <p className="truncate font-mono text-xs text-muted-foreground" title={connection.executable}>
-                  {connection.executable}
+                <p className="truncate font-mono text-xs text-muted-foreground" title={executable}>
+                  {executable}
                 </p>
               </div>
               <span className="text-xs text-muted-foreground">
-                {workspace.sessions.length} session
-                {workspace.sessions.length === 1 ? "" : "s"}
+                {providerSessionCount} session
+                {providerSessionCount === 1 ? "" : "s"}
               </span>
-              <div className="flex items-center gap-1 @xl:justify-end">
+              {backing && (
+                <div className="flex items-center gap-1 @xl:justify-end">
                 <Button
                   type="button"
                   variant="ghost"
@@ -705,74 +672,21 @@ function WorkspaceGroupRow({
                   disabled={actionId !== null}
                   aria-label={`Test ${provider.label} in ${group.name}`}
                   title="Test agent"
-                  onClick={() => onTest(connection)}
+                  onClick={() => onTest(backing.connection)}
                 >
                   <RefreshCw
                     className={cn(
-                      actionId === connection.id &&
+                      actionId === backing.connection.id &&
                         "animate-spin motion-reduce:animate-none",
                     )}
                   />
                 </Button>
               </div>
+              )}
             </div>
           );
         })}
       </div>
-    </div>
-  );
-}
-
-function UnassignedConnectionRow({
-  connection,
-  actionId,
-  onTest,
-  onRemove,
-}: {
-  connection: AgentConnectionListItem;
-  actionId: string | null;
-  onTest: () => void;
-  onRemove: () => void;
-}) {
-  const HostIcon = connection.host.transport === "local" ? Server : Wifi;
-  const provider = agentProviderMetadata(connection.provider);
-  return (
-    <div className="flex min-w-0 items-center gap-2 rounded-md bg-muted/20 px-2 py-2">
-      <HostIcon className="size-4 shrink-0 text-muted-foreground" />
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium">
-          {provider.label} · {connection.host.name}
-        </p>
-        <p className="truncate font-mono text-xs text-muted-foreground">
-          {connection.executable}
-        </p>
-      </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        disabled={actionId !== null}
-        aria-label={`Test ${provider.label}`}
-        title="Test agent"
-        onClick={onTest}
-      >
-        <RefreshCw
-          className={cn(
-            actionId === connection.id &&
-              "animate-spin motion-reduce:animate-none",
-          )}
-        />
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        aria-label={`Remove ${provider.label}`}
-        title={`Remove ${provider.label}`}
-        onClick={onRemove}
-      >
-        <Trash2 />
-      </Button>
     </div>
   );
 }

--- a/apps/web/app/api/agent-connections/[id]/workspaces/route.ts
+++ b/apps/web/app/api/agent-connections/[id]/workspaces/route.ts
@@ -3,13 +3,12 @@ import {
   connectionErrorMessage,
   storedConnectionAccessError,
 } from "@/lib/agents/access";
-import { addAgentWorkspaceSchema } from "@overtchat/agent-bridge";
+import { addAgentWorkspaceSchema, isAgentProviderId } from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
 import {
   daemonTarget,
   parseProviderSessionMetadata,
 } from "@/lib/agents/connector/descriptors";
-import { isAgentProviderId } from "@overtchat/agent-bridge";
 import {
   createAgentWorkspace,
   getOwnedAgentConnection,
@@ -81,10 +80,7 @@ export async function POST(
       workspaceId,
     );
     if (!row) return new Response("Not found", { status: 404 });
-    const sessions = syncAgentWorkspaceSessions(
-      row.id,
-      metadata,
-    );
+    const sessions = syncAgentWorkspaceSessions(row.id, metadata);
     return Response.json(
       {
         workspace: {

--- a/apps/web/app/api/agent-connections/discover/route.test.ts
+++ b/apps/web/app/api/agent-connections/discover/route.test.ts
@@ -37,13 +37,26 @@ describe("Agent Connection discovery route", () => {
       user: { id: "admin", role: "admin" },
     });
     mocks.getOwnedConnector.mockReturnValue({ id: "connector" });
-    mocks.daemonRequest.mockResolvedValue([
-      {
-        provider: "omp",
-        executable: "/home/admin/.bun/bin/omp",
-        version: "17.2.10",
+    mocks.daemonRequest.mockResolvedValue({
+      target: {
+        connectorId: "connector",
+        transport: "ssh",
+        sshAlias: "macbook",
       },
-    ]);
+      providers: [
+        { provider: "pi", status: "unavailable" },
+        {
+          provider: "omp",
+          status: "ready",
+          executable: "/home/admin/.bun/bin/omp",
+          version: "17.2.10",
+          shellMode: "interactive",
+        },
+        { provider: "codex", status: "unavailable" },
+        { provider: "opencode", status: "unavailable" },
+      ],
+      refreshedAt: 123,
+    });
   });
 
   it("discovers agents through an owned connector and exact SSH alias", async () => {
@@ -57,11 +70,32 @@ describe("Agent Connection discovery route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
+      snapshot: {
+        target: {
+          connectorId: "connector",
+          transport: "ssh",
+          sshAlias: "macbook",
+        },
+        providers: [
+          { provider: "pi", status: "unavailable" },
+          {
+            provider: "omp",
+            status: "ready",
+            executable: "/home/admin/.bun/bin/omp",
+            version: "17.2.10",
+            shellMode: "interactive",
+          },
+          { provider: "codex", status: "unavailable" },
+          { provider: "opencode", status: "unavailable" },
+        ],
+        refreshedAt: 123,
+      },
       installations: [
         {
           provider: "omp",
           executable: "/home/admin/.bun/bin/omp",
           version: "17.2.10",
+          shellMode: "interactive",
         },
       ],
     });
@@ -70,12 +104,13 @@ describe("Agent Connection discovery route", () => {
       "admin",
     );
     expect(mocks.daemonRequest).toHaveBeenCalledWith("connector", {
-      type: "discover",
+      type: "provider_snapshot",
       target: {
         connectorId: "connector",
         transport: "ssh",
         sshAlias: "macbook",
       },
+      refresh: true,
     });
   });
 

--- a/apps/web/app/api/agent-connections/discover/route.ts
+++ b/apps/web/app/api/agent-connections/discover/route.ts
@@ -3,7 +3,10 @@ import {
   connectionAccessError,
   connectionErrorMessage,
 } from "@/lib/agents/access";
-import { agentDiscoveryTargetSchema } from "@overtchat/agent-bridge";
+import {
+  agentDiscoveryTargetSchema,
+  agentProviderSnapshotSchema,
+} from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
 import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
 
@@ -31,10 +34,27 @@ export async function POST(request: Request) {
   }
 
   try {
+    const refresh = new URL(request.url).searchParams.get("refresh") !== "0";
+    const snapshot = agentProviderSnapshotSchema.parse(
+      await hostConnectorBroker.request(parsed.data.connectorId, {
+        type: "provider_snapshot",
+        target: parsed.data,
+        refresh,
+      }),
+    );
     return Response.json({
-      installations: await hostConnectorBroker.request(
-        parsed.data.connectorId,
-        { type: "discover", target: parsed.data },
+      snapshot,
+      installations: snapshot.providers.flatMap((entry) =>
+        entry.status === "ready"
+          ? [
+              {
+                provider: entry.provider,
+                executable: entry.executable,
+                version: entry.version,
+                shellMode: entry.shellMode,
+              },
+            ]
+          : [],
       ),
     });
   } catch (error) {

--- a/apps/web/app/api/agent-connections/events/route.test.ts
+++ b/apps/web/app/api/agent-connections/events/route.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   listAgentConnections: vi.fn(),
   subscribeSessionDirectory: vi.fn(),
-  unsubscribe: vi.fn(),
+  unsubscribeDirectory: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -37,6 +37,7 @@ describe("agent connection session-directory stream", () => {
     });
     mocks.listAgentConnections.mockResolvedValue([
       {
+        host: { connectorId: "connector" },
         workspaces: [
           {
             sessions: [{ id: "session" }, { id: "other-session" }],
@@ -57,7 +58,7 @@ describe("agent connection session-directory stream", () => {
             { sessionId: "other-session", runtimeStatus: "exited" },
           ],
         });
-        return mocks.unsubscribe;
+        return mocks.unsubscribeDirectory;
       },
     );
   });
@@ -97,7 +98,7 @@ describe("agent connection session-directory stream", () => {
       JSON.stringify({ sessionId: "session", runtimeStatus: "running" }),
     );
     await reader.cancel();
-    expect(mocks.unsubscribe).toHaveBeenCalledOnce();
+    expect(mocks.unsubscribeDirectory).toHaveBeenCalledOnce();
   });
 
   it("does not expose the directory to non-admin users", async () => {

--- a/apps/web/app/api/agent-connections/route.test.ts
+++ b/apps/web/app/api/agent-connections/route.test.ts
@@ -106,22 +106,23 @@ describe("Agent Connections route", () => {
       host: { id: "host" },
       connection: { id: "connection" },
     });
-    const connection = {
-      id: "connection",
-      provider: "omp",
-      executable: "/Users/yash/.bun/bin/omp",
-      detectedVersion: "17.2.11",
-      lastValidatedAt: Date.now(),
-      host: {
-        id: "host",
-        connectorId: "connector",
-        name: "macbook",
-        transport: "ssh",
-        sshAlias: "macbook",
+    mocks.listAgentConnections.mockResolvedValue([
+      {
+        id: "connection",
+        provider: "omp",
+        executable: "/Users/yash/.bun/bin/omp",
+        detectedVersion: "17.2.11",
+        lastValidatedAt: Date.now(),
+        host: {
+          id: "host",
+          connectorId: "connector",
+          name: "macbook",
+          transport: "ssh",
+          sshAlias: "macbook",
+        },
+        workspaces: [],
       },
-      workspaces: [],
-    };
-    mocks.listAgentConnections.mockResolvedValue([connection]);
+    ]);
 
     const response = await POST(
       request("POST", {
@@ -146,4 +147,5 @@ describe("Agent Connections route", () => {
       }),
     );
   });
+
 });

--- a/apps/web/app/api/agent-workspaces/[id]/catalog/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/catalog/route.test.ts
@@ -4,12 +4,16 @@ const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   getOwnedAgentWorkspace: vi.fn(),
   daemonRequest: vi.fn(),
+  resolveProvider: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/lib/auth/server", () => ({ auth: { api: { getSession: mocks.getSession } } }));
 vi.mock("@/lib/db/agentConnections", () => ({ getOwnedAgentWorkspace: mocks.getOwnedAgentWorkspace }));
 vi.mock("@/lib/agents/connector/broker", () => ({ hostConnectorBroker: { request: mocks.daemonRequest } }));
+vi.mock("@/lib/agents/connector/providerSnapshots", () => ({
+  resolveAgentWorkspaceProvider: mocks.resolveProvider,
+}));
 
 import { GET } from "./route";
 
@@ -30,6 +34,17 @@ describe("agent workspace catalog route", () => {
         detectedVersion: "17.2.15",
       },
       workspace: { id: "workspace", path: "/workspace" },
+    });
+    mocks.resolveProvider.mockResolvedValue({
+      descriptor: {
+        connectionId: "connection",
+        workspaceId: "workspace",
+        provider: "omp",
+        target: { transport: "local", shellMode: "interactive" },
+        executable: "omp",
+        cwd: "/workspace",
+        detectedVersion: "17.2.15",
+      },
     });
     mocks.daemonRequest.mockResolvedValue({
       provider: "omp",
@@ -67,9 +82,61 @@ describe("agent workspace catalog route", () => {
         detectedVersion: "17.2.15",
       },
     });
+    expect(mocks.resolveProvider).toHaveBeenCalledWith({
+      userId: "owner",
+      anchorWorkspaceId: "workspace",
+      provider: "omp",
+    });
     await expect(response.json()).resolves.toMatchObject({
       provider: "omp",
       defaultModeId: "full",
+    });
+  });
+
+  it("resolves a detected provider through an existing workspace anchor", async () => {
+    mocks.resolveProvider.mockResolvedValueOnce({
+      descriptor: {
+        connectionId: "virtual-connection",
+        workspaceId: "virtual-workspace",
+        provider: "opencode",
+        target: { transport: "local", shellMode: "interactive" },
+        executable: "opencode",
+        cwd: "/workspace",
+        detectedVersion: "1.2.3",
+      },
+    });
+    mocks.daemonRequest.mockResolvedValueOnce({
+      provider: "opencode",
+      models: [
+        {
+          id: "openai/gpt-5",
+          label: "GPT-5",
+          provider: "opencode",
+          api: "openai-responses",
+          baseUrl: "",
+          reasoning: true,
+          input: ["text"],
+          contextWindow: null,
+          maxTokens: null,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        },
+      ],
+      modes: [],
+      defaultModeId: null,
+    });
+
+    const response = await GET(
+      new Request(
+        "http://server.test/api/agent-workspaces/workspace/catalog?provider=opencode",
+      ),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.resolveProvider).toHaveBeenCalledWith({
+      userId: "owner",
+      anchorWorkspaceId: "workspace",
+      provider: "opencode",
     });
   });
 

--- a/apps/web/app/api/agent-workspaces/[id]/catalog/route.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/catalog/route.ts
@@ -4,7 +4,7 @@ import {
   storedConnectionAccessError,
 } from "@/lib/agents/access";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import { daemonWorkspace } from "@/lib/agents/connector/descriptors";
+import { resolveAgentWorkspaceProvider } from "@/lib/agents/connector/providerSnapshots";
 import { getOwnedAgentWorkspace } from "@/lib/db/agentConnections";
 import {
   agentProviderCatalogSchema,
@@ -26,26 +26,39 @@ export async function GET(
   const { id } = await params;
   const owned = await getOwnedAgentWorkspace(id, session.user.id);
   if (!owned) return new Response("Not found", { status: 404 });
+  const requestedProvider = new URL(req.url).searchParams.get("provider");
+  const provider =
+    typeof requestedProvider === "string" && isAgentProviderId(requestedProvider)
+    ? requestedProvider
+    : isAgentProviderId(owned.connection.provider)
+      ? owned.connection.provider
+      : null;
+  if (!provider) {
+    return Response.json(
+      { error: "This coding-agent provider is not supported." },
+      { status: 400 },
+    );
+  }
 
   try {
+    const resolved = await resolveAgentWorkspaceProvider({
+      userId: session.user.id,
+      anchorWorkspaceId: id,
+      provider,
+    });
     const response = await hostConnectorBroker.request<unknown>(
       owned.host.connectorId,
-      { type: "get_catalog", workspace: daemonWorkspace(owned) },
+      { type: "get_catalog", workspace: resolved.descriptor },
     );
     const catalog = agentProviderCatalogSchema.parse(response);
-    if (catalog.provider !== owned.connection.provider) {
+    if (catalog.provider !== provider) {
       throw new Error("The connector returned a catalog for another provider.");
     }
     return Response.json(catalog);
   } catch (error) {
     return Response.json(
       {
-        error: connectionErrorMessage(
-          error,
-          isAgentProviderId(owned.connection.provider)
-            ? owned.connection.provider
-            : "pi",
-        ),
+        error: connectionErrorMessage(error, provider),
       },
       { status: 400 },
     );

--- a/apps/web/app/api/agent-workspaces/[id]/sessions/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/sessions/route.test.ts
@@ -3,17 +3,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   getOwnedAgentWorkspace: vi.fn(),
-  daemonRequest: vi.fn(),
-  upsertAgentSession: vi.fn(),
+  createProviderSession: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/lib/auth/server", () => ({ auth: { api: { getSession: mocks.getSession } } }));
 vi.mock("@/lib/db/agentConnections", () => ({
   getOwnedAgentWorkspace: mocks.getOwnedAgentWorkspace,
-  upsertAgentSession: mocks.upsertAgentSession,
 }));
-vi.mock("@/lib/agents/connector/broker", () => ({ hostConnectorBroker: { request: mocks.daemonRequest } }));
+vi.mock("@/lib/agents/connector/providerSnapshots", () => ({
+  createAgentWorkspaceProviderSession: mocks.createProviderSession,
+}));
 
 import { POST } from "./route";
 
@@ -35,16 +35,8 @@ describe("create agent workspace session route", () => {
     vi.clearAllMocks();
     mocks.getSession.mockResolvedValue({ user: { id: "owner", role: "admin" } });
     mocks.getOwnedAgentWorkspace.mockResolvedValue(owned);
-    mocks.daemonRequest.mockResolvedValue({
-      session: {
-        providerSessionId: "native",
-        providerSessionPath: "/sessions/native.jsonl",
-        name: null,
-        firstMessage: null,
-        messageCount: 0,
-        createdAt: null,
-        modifiedAt: null,
-      },
+    mocks.createProviderSession.mockResolvedValue({
+      session: { id: "created" },
       launchConfig: {
         model: "vllm/qwen",
         thinkingOptionId: "high",
@@ -52,7 +44,6 @@ describe("create agent workspace session route", () => {
       },
       snapshot: { sessionId: "created", status: "idle" },
     });
-    mocks.upsertAgentSession.mockResolvedValue({ id: "created" });
   });
 
   it("sends and persists the connector-resolved launch tuple", async () => {
@@ -70,16 +61,34 @@ describe("create agent workspace session route", () => {
       context,
     );
     expect(response.status).toBe(201);
-    expect(mocks.daemonRequest).toHaveBeenCalledWith(
-      "connector",
-      expect.objectContaining({ type: "create_session", launchConfig }),
-    );
-    expect(mocks.upsertAgentSession).toHaveBeenCalledWith(
-      "workspace",
-      expect.objectContaining({ providerSessionId: "native" }),
-      expect.any(String),
+    expect(mocks.createProviderSession).toHaveBeenCalledWith({
+      userId: "owner",
+      anchorWorkspaceId: "workspace",
+      provider: "omp",
       launchConfig,
+    });
+  });
+
+  it("starts a detected provider through an existing workspace anchor", async () => {
+    const response = await POST(
+      new Request("http://server.test/api/agent-workspaces/workspace/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: "opencode",
+          launchConfig: { model: "openai/gpt-5" },
+        }),
+      }),
+      context,
     );
+
+    expect(response.status).toBe(201);
+    expect(mocks.createProviderSession).toHaveBeenCalledWith({
+      userId: "owner",
+      anchorWorkspaceId: "workspace",
+      provider: "opencode",
+      launchConfig: { model: "openai/gpt-5" },
+    });
   });
 
   it("rejects invalid launch configuration before contacting the connector", async () => {
@@ -87,11 +96,11 @@ describe("create agent workspace session route", () => {
       new Request("http://server.test/api/agent-workspaces/workspace/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ thinkingOptionId: "ultra" }),
+        body: JSON.stringify({ thinkingOptionId: "x".repeat(121) }),
       }),
       context,
     );
     expect(response.status).toBe(400);
-    expect(mocks.daemonRequest).not.toHaveBeenCalled();
+    expect(mocks.createProviderSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/agent-workspaces/[id]/sessions/route.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/sessions/route.ts
@@ -3,15 +3,8 @@ import {
   connectionErrorMessage,
   storedConnectionAccessError,
 } from "@/lib/agents/access";
-import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import {
-  daemonWorkspace,
-  parseProviderSessionMetadata,
-} from "@/lib/agents/connector/descriptors";
-import {
-  getOwnedAgentWorkspace,
-  upsertAgentSession,
-} from "@/lib/db/agentConnections";
+import { createAgentWorkspaceProviderSession } from "@/lib/agents/connector/providerSnapshots";
+import { getOwnedAgentWorkspace } from "@/lib/db/agentConnections";
 import {
   agentSessionLaunchConfigSchema,
   isAgentProviderId,
@@ -32,35 +25,38 @@ export async function POST(
   const { id } = await params;
   const owned = await getOwnedAgentWorkspace(id, session.user.id);
   if (!owned) return new Response("Not found", { status: 404 });
+  let errorProvider = isAgentProviderId(owned.connection.provider)
+    ? owned.connection.provider
+    : "pi";
 
   try {
-    const body = await req.json().catch(() => ({}));
-    const launchConfig = agentSessionLaunchConfigSchema.parse(body);
-    const sessionId = crypto.randomUUID();
-    const created = await hostConnectorBroker.request<{
-      session: unknown;
-      launchConfig: unknown;
-      snapshot: unknown;
-    }>(owned.host.connectorId, {
-      type: "create_session",
-      sessionId,
-      workspace: daemonWorkspace(owned),
+    const body = (await req.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const requestedProvider = body.provider;
+    const provider =
+      typeof requestedProvider === "string" && isAgentProviderId(requestedProvider)
+      ? requestedProvider
+      : isAgentProviderId(owned.connection.provider)
+        ? owned.connection.provider
+        : null;
+    if (!provider) throw new Error("This coding-agent provider is not supported.");
+    errorProvider = provider;
+    const launchConfig = agentSessionLaunchConfigSchema.parse(
+      body.launchConfig ?? body,
+    );
+    const created = await createAgentWorkspaceProviderSession({
+      userId: session.user.id,
+      anchorWorkspaceId: id,
+      provider,
       launchConfig,
     });
-    const resolvedLaunchConfig = agentSessionLaunchConfigSchema.parse(
-      created.launchConfig,
-    );
-    const row = await upsertAgentSession(
-      owned.workspace.id,
-      parseProviderSessionMetadata(created.session),
-      sessionId,
-      resolvedLaunchConfig,
-    );
     return Response.json(
       {
         session: {
-          id: row.id,
-          launchConfig: resolvedLaunchConfig,
+          id: created.session.id,
+          launchConfig: created.launchConfig,
           snapshot: created.snapshot,
         },
       },
@@ -69,12 +65,7 @@ export async function POST(
   } catch (error) {
     return Response.json(
       {
-        error: connectionErrorMessage(
-          error,
-          isAgentProviderId(owned.connection.provider)
-            ? owned.connection.provider
-            : "pi",
-        ),
+        error: connectionErrorMessage(error, errorProvider),
       },
       { status: 400 },
     );

--- a/apps/web/app/api/agent-workspaces/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/route.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getConnector: vi.fn(),
+  reconcile: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/hostConnectors", () => ({
+  getOwnedHostConnector: mocks.getConnector,
+}));
+vi.mock("@/lib/agents/connector/providerSnapshots", () => ({
+  provisionAgentWorkspace: mocks.reconcile,
+}));
+
+import { POST } from "./route";
+
+function request(body: unknown) {
+  return new Request("http://server.test/api/agent-workspaces", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("atomic agent workspace route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "admin", role: "admin" },
+    });
+    mocks.getConnector.mockReturnValue({ id: "connector" });
+    mocks.reconcile.mockResolvedValue({
+      providers: 2,
+      created: 2,
+      refreshed: 0,
+      failures: [],
+    });
+  });
+
+  it("reconciles a machine and path as one server operation", async () => {
+    const response = await POST(
+      request({
+        target: { connectorId: "connector", transport: "local" },
+        path: "/srv/overtchat",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.reconcile).toHaveBeenCalledWith({
+      userId: "admin",
+      target: { connectorId: "connector", transport: "local" },
+      path: "/srv/overtchat",
+    });
+  });
+
+  it("does not reconcile another user's connector", async () => {
+    mocks.getConnector.mockReturnValue(null);
+    const response = await POST(
+      request({
+        target: { connectorId: "other", transport: "local" },
+        path: "/srv/overtchat",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+  });
+
+  it("rejects partial success when no provider could be attached", async () => {
+    mocks.reconcile.mockResolvedValue({
+      providers: 1,
+      created: 0,
+      refreshed: 0,
+      failures: [{ provider: "opencode", message: "Session import failed." }],
+    });
+    const response = await POST(
+      request({
+        target: { connectorId: "connector", transport: "local" },
+        path: "/srv/overtchat",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Session import failed.",
+    });
+  });
+});

--- a/apps/web/app/api/agent-workspaces/route.ts
+++ b/apps/web/app/api/agent-workspaces/route.ts
@@ -1,0 +1,58 @@
+import { auth } from "@/lib/auth/server";
+import { connectionAccessError, connectionErrorMessage } from "@/lib/agents/access";
+import { createAgentWorkspaceSchema } from "@overtchat/agent-bridge";
+import { provisionAgentWorkspace } from "@/lib/agents/connector/providerSnapshots";
+import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
+
+export const maxDuration = 150;
+
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  const accessError = connectionAccessError(session.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+  const parsed = createAgentWorkspaceSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return Response.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid workspace." },
+      { status: 400 },
+    );
+  }
+  if (
+    !getOwnedHostConnector(parsed.data.target.connectorId, session.user.id)
+  ) {
+    return new Response("Host Connector not found", { status: 404 });
+  }
+
+  try {
+    const result = await provisionAgentWorkspace({
+      userId: session.user.id,
+      ...parsed.data,
+    });
+    if (
+      result.created + result.refreshed === 0 &&
+      result.failures.length > 0
+    ) {
+      return Response.json(
+        { error: result.failures.map(({ message }) => message).join(" ") },
+        { status: 400 },
+      );
+    }
+    if (result.providers === 0) {
+      return Response.json(
+        { error: "No supported coding agents were detected on this machine." },
+        { status: 400 },
+      );
+    }
+    return Response.json({ result }, { status: 201 });
+  } catch (error) {
+    return Response.json(
+      { error: connectionErrorMessage(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/app/api/agent-workspaces/sync/route.ts
+++ b/apps/web/app/api/agent-workspaces/sync/route.ts
@@ -1,0 +1,22 @@
+import { auth } from "@/lib/auth/server";
+import { connectionAccessError, connectionErrorMessage } from "@/lib/agents/access";
+import { refreshAgentWorkspaces } from "@/lib/agents/connector/providerSnapshots";
+
+export const maxDuration = 300;
+
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  const accessError = connectionAccessError(session.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+  try {
+    return Response.json({ result: await refreshAgentWorkspaces(session.user.id) });
+  } catch (error) {
+    return Response.json(
+      { error: connectionErrorMessage(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/app/api/host-connectors/channel/route.test.ts
+++ b/apps/web/app/api/host-connectors/channel/route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
 } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
@@ -26,11 +26,10 @@ vi.mock("@/lib/db/hostConnectors", () => ({
 vi.mock("@/lib/db/agentConnections", () => ({
   listActiveAgentSessionIds: mocks.listActiveSessions,
 }));
-
 import { GET } from "./route";
 
 function request(
-  version = HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  version = HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   protocol = HOST_CONNECTOR_PROTOCOL_VERSION,
   options: { buildVersion?: string; capabilities?: string } = {},
 ): Request {
@@ -51,7 +50,7 @@ function request(
 describe("Host Connector command channel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.authenticate.mockReturnValue({ id: "connector" });
+    mocks.authenticate.mockReturnValue({ id: "connector", userId: "admin" });
     mocks.register.mockImplementation(
       (
         _connectorId: string,
@@ -69,7 +68,7 @@ describe("Host Connector command channel", () => {
     mocks.listActiveSessions.mockResolvedValue(["session"]);
   });
 
-  it("opens for the protocol-1 compatibility baseline", async () => {
+  it("opens for the current protocol compatibility baseline", async () => {
     const response = await GET(request());
 
     expect(response.status).toBe(200);
@@ -84,7 +83,7 @@ describe("Host Connector command channel", () => {
     );
     expect(mocks.touch).toHaveBeenCalledWith(
       "connector",
-      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+      HOST_CONNECTOR_COMPATIBILITY_RELEASE,
     );
     await reader.cancel();
     expect(mocks.unregister).toHaveBeenCalled();
@@ -93,7 +92,7 @@ describe("Host Connector command channel", () => {
   it("uses the build version for display without gating the wire", async () => {
     const response = await GET(
       request(
-        HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+        HOST_CONNECTOR_COMPATIBILITY_RELEASE,
         HOST_CONNECTOR_PROTOCOL_VERSION,
         {
           buildVersion: "9.9.9",
@@ -119,12 +118,12 @@ describe("Host Connector command channel", () => {
     await expect(wrongRelease.json()).resolves.toMatchObject({
       error: expect.stringContaining("overtchat update"),
       code: "unsupported_connector_protocol",
-      compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+      compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
     });
 
     const wrongProtocol = await GET(
       request(
-        HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+        HOST_CONNECTOR_COMPATIBILITY_RELEASE,
         HOST_CONNECTOR_PROTOCOL_VERSION + 1,
       ),
     );

--- a/apps/web/app/api/host-connectors/channel/route.ts
+++ b/apps/web/app/api/host-connectors/channel/route.ts
@@ -1,6 +1,6 @@
 import {
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   isHostConnectorProtocolVersion,
   parseHostConnectorCapabilities,
   type HostConnectorCommand,
@@ -27,14 +27,14 @@ export async function GET(request: Request) {
     ?.trim();
   if (
     !isHostConnectorProtocolVersion(protocol) ||
-    connectorVersion !== HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE
+    connectorVersion !== HOST_CONNECTOR_COMPATIBILITY_RELEASE
   ) {
     return Response.json(
       {
-        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE}).`,
+        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_COMPATIBILITY_RELEASE}).`,
         code: "unsupported_connector_protocol",
         supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
-        compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+        compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
       },
       { status: 409 },
     );

--- a/apps/web/app/api/host-connectors/events/route.test.ts
+++ b/apps/web/app/api/host-connectors/events/route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
 } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
@@ -39,7 +39,7 @@ function request(
     headers: {
       "Content-Type": "application/json",
       "X-OvertChat-Connector-Version":
-        options.version ?? HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+        options.version ?? HOST_CONNECTOR_COMPATIBILITY_RELEASE,
       "X-OvertChat-Connector-Protocol": String(
         options.protocol ?? HOST_CONNECTOR_PROTOCOL_VERSION,
       ),
@@ -91,7 +91,7 @@ describe("Host Connector event route", () => {
     );
     expect(mocks.touch).toHaveBeenCalledWith(
       "connector",
-      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+      HOST_CONNECTOR_COMPATIBILITY_RELEASE,
     );
   });
 
@@ -223,7 +223,7 @@ describe("Host Connector event route", () => {
     await expect(response.json()).resolves.toMatchObject({
       error: expect.stringContaining("overtchat update"),
       code: "unsupported_connector_protocol",
-      compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+      compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
     });
     expect(mocks.acceptBatch).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/host-connectors/events/route.ts
+++ b/apps/web/app/api/host-connectors/events/route.ts
@@ -1,7 +1,7 @@
 import {
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   isHostConnectorEvent,
   isHostConnectorProtocolVersion,
   type HostConnectorEventBatch,
@@ -18,15 +18,15 @@ export async function POST(request: Request) {
   );
   if (
     request.headers.get("x-overtchat-connector-version") !==
-      HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE ||
+      HOST_CONNECTOR_COMPATIBILITY_RELEASE ||
     !isHostConnectorProtocolVersion(protocol)
   ) {
     return Response.json(
       {
-        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE}).`,
+        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_COMPATIBILITY_RELEASE}).`,
         code: "unsupported_connector_protocol",
         supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
-        compatibilityRelease: HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+        compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
       },
       { status: 409 },
     );
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
       ?.trim();
     touchHostConnector(
       connector.id,
-      connectorBuildVersion || HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+      connectorBuildVersion || HOST_CONNECTOR_COMPATIBILITY_RELEASE,
     );
     return Response.json(ack);
   } catch (error) {

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -80,7 +80,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.7.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -133,9 +133,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.7.0",
+            version: "0.8.0",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.7.0 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.0 | sh -s -- --upgrade",
           },
         },
       ],
@@ -148,14 +148,14 @@ describe("Host Connectors route", () => {
         id: "current",
         name: "Current",
         managed: false,
-        version: "0.7.0",
+        version: "0.8.0",
         lastSeenAt: null,
       },
       {
         id: "newer",
         name: "Newer",
         managed: false,
-        version: "0.7.0",
+        version: "0.8.0",
         lastSeenAt: null,
       },
     ]);

--- a/apps/web/assets/agent-providers/opencode.svg
+++ b/apps/web/assets/agent-providers/opencode.svg
@@ -1,0 +1,4 @@
+<svg width="300" height="300" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M210 240H90V120H210V240Z" fill="#4B4646"/>
+  <path d="M210 60H90V240H210V60ZM270 300H30V0H270V300Z" fill="#F1ECEC"/>
+</svg>

--- a/apps/web/components/SidebarAgentWorkspaces.tsx
+++ b/apps/web/components/SidebarAgentWorkspaces.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image, { type StaticImageData } from "next/image";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -14,9 +14,6 @@ import {
   Plus,
   Wifi,
 } from "lucide-react";
-import codexIcon from "@/assets/agent-providers/codex.png";
-import ompIcon from "@/assets/agent-providers/omp.svg";
-import piIcon from "@/assets/agent-providers/pi.svg";
 import type {
   AgentConnectionListItem,
   AgentProviderId,
@@ -30,24 +27,19 @@ import {
   visibleAgentSessions,
 } from "@/lib/agents/sidebar";
 import {
+  agentConnectionTarget,
   groupAgentWorkspaces,
+  projectAgentWorkspaceProviders,
   type AgentWorkspaceGroup,
   type AgentWorkspaceSession,
 } from "@/lib/agents/workspaces";
 import { useSidebar } from "@/components/sidebar-context";
 import { motionClasses } from "@/lib/motion";
+import { AGENT_PROVIDER_VISUALS } from "@/lib/agents/providerVisuals";
+import { useAgentProviderSnapshot } from "@/lib/queries/agentConnections";
 import { useAgentWorkspaceGitStatus } from "@/lib/queries/agentWorkspaces";
 import { cn } from "@/lib/utils";
 import { NewAgentSessionDialog } from "@/components/agents/NewAgentSessionDialog";
-
-const PROVIDER_ICONS: Record<
-  AgentProviderId,
-  { icon: StaticImageData; darkSurface?: boolean }
-> = {
-  pi: { icon: piIcon },
-  omp: { icon: ompIcon, darkSurface: true },
-  codex: { icon: codexIcon, darkSurface: true },
-};
 
 export function SidebarAgentWorkspaces({
   connections,
@@ -88,7 +80,11 @@ function WorkspaceNode({
   const hasRunningSession = group.sessions.some(({ session }) =>
     agentSessionIsRunning(session),
   );
-  const representativeWorkspace = group.targets[0]!.workspace;
+  const representativeTarget = group.targets[0]!;
+  const representativeWorkspace = representativeTarget.workspace;
+  const providerSnapshot = useAgentProviderSnapshot(
+    agentConnectionTarget(representativeTarget.connection),
+  );
   const gitStatus = useAgentWorkspaceGitStatus(representativeWorkspace.id, {
     active: hasActiveSession,
     running: hasRunningSession,
@@ -110,6 +106,16 @@ function WorkspaceNode({
     visibleIds.has(session.id),
   );
   const hiddenSessionCount = filteredSessions.length - visibleSessions.length;
+  const sessionTargets = projectAgentWorkspaceProviders(
+    group,
+    providerSnapshot.data,
+  ).map(({ provider, workspace }) => {
+    return {
+      workspace,
+      provider,
+      providerLabel: agentProviderMetadata(provider).label,
+    };
+  });
 
   return (
     <li>
@@ -154,8 +160,15 @@ function WorkspaceNode({
         <button
           type="button"
           onClick={() => setCreateOpen(true)}
+          disabled={providerSnapshot.isPending || sessionTargets.length === 0}
           aria-label={`New session in ${group.name}`}
-          title={`New session in ${group.name}`}
+          title={
+            sessionTargets.length > 0
+              ? `New session in ${group.name}`
+              : providerSnapshot.isPending
+                ? "Detecting agents on this machine"
+                : "No agents are currently available on this machine"
+          }
           className={cn(
             "flex min-h-11 w-9 shrink-0 items-center justify-center rounded-r-md text-muted-foreground motion-colors hover:text-foreground focus-visible:text-foreground max-md:w-11",
             motionClasses.hoverReveal,
@@ -197,23 +210,21 @@ function WorkspaceNode({
             )}
         </ul>
       )}
-      <NewAgentSessionDialog
-        open={createOpen}
-        onOpenChange={(next) => {
-          setCreateOpen(next);
-          if (!next) setOpen(true);
-        }}
-        targets={group.targets.map(({ connection, workspace }) => ({
-          workspace,
-          provider: connection.provider,
-          providerLabel: agentProviderMetadata(connection.provider).label,
-        }))}
-        machineLabel={
-          group.host.transport === "local"
-            ? "This server"
-            : `ssh ${group.host.sshAlias}`
-        }
-      />
+      {sessionTargets.length > 0 && (
+        <NewAgentSessionDialog
+          open={createOpen}
+          onOpenChange={(next) => {
+            setCreateOpen(next);
+            if (!next) setOpen(true);
+          }}
+          targets={sessionTargets}
+          machineLabel={
+            group.host.transport === "local"
+              ? "This server"
+              : `ssh ${group.host.sshAlias}`
+          }
+        />
+      )}
     </li>
   );
 }
@@ -288,7 +299,7 @@ function SessionLink({ item }: { item: AgentWorkspaceSession }) {
 }
 
 function ProviderLogo({ provider }: { provider: AgentProviderId }) {
-  const icon = PROVIDER_ICONS[provider];
+  const icon = AGENT_PROVIDER_VISUALS[provider];
   return (
     <span
       className={cn(

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -186,7 +186,7 @@ function AdminAgentWorkspaces() {
 
   async function refreshAllChats() {
     try {
-      const result = await refresh.mutateAsync(connections);
+      const result = await refresh.mutateAsync();
       const synced = result.created + result.refreshed;
       if (synced === 0) {
         toast.error({

--- a/apps/web/components/agents/AgentComposerControls.tsx
+++ b/apps/web/components/agents/AgentComposerControls.tsx
@@ -22,7 +22,6 @@ import type {
   AgentMode,
   AgentModel,
   AgentSelectOption,
-  AgentThinkingLevel,
 } from "@overtchat/agent-bridge";
 import { motionClasses } from "@/lib/motion";
 import { modelIconForModel } from "@/lib/providers/catalog";
@@ -32,7 +31,7 @@ export interface AgentComposerControlsProps {
   providerLabel: string;
   models: AgentModel[];
   currentModel: { provider: string; id: string } | null;
-  thinkingLevel: AgentThinkingLevel | null;
+  thinkingLevel: string | null;
   thinkingOptions: AgentSelectOption[];
   collaborationMode: AgentCollaborationMode;
   collaborationModes: AgentCollaborationMode[];
@@ -42,7 +41,7 @@ export interface AgentComposerControlsProps {
   modes: AgentMode[];
   disabled: boolean;
   onSelectModel: (model: AgentModel) => void;
-  onSelectThinking: (level: AgentThinkingLevel) => void;
+  onSelectThinking: (level: string) => void;
   onSelectCollaborationMode: (mode: AgentCollaborationMode) => void;
   onToggleFastMode: (enabled: boolean) => void;
   onSelectMode: (modeId: string) => void;
@@ -470,10 +469,12 @@ function iconForModel(model: AgentModel | undefined) {
   );
 }
 
-function thinkingLabel(level: AgentThinkingLevel): string {
+function thinkingLabel(level: string): string {
   return level === "off"
     ? "Off"
     : level === "xhigh"
       ? "Extra high"
-      : level[0].toUpperCase() + level.slice(1);
+      : level
+          .replace(/[-_]+/gu, " ")
+          .replace(/\b\w/gu, (letter) => letter.toUpperCase());
 }

--- a/apps/web/components/agents/AgentSessionDialogs.tsx
+++ b/apps/web/components/agents/AgentSessionDialogs.tsx
@@ -463,6 +463,8 @@ function InteractionDialogContent({
     typeof request.approveValue === "string" ? request.approveValue : "Approve";
   const denyValue =
     typeof request.denyValue === "string" ? request.denyValue : "Deny";
+  const alwaysValue =
+    typeof request.alwaysValue === "string" ? request.alwaysValue : null;
   const options = Array.isArray(request.options)
     ? request.options.filter(
         (option): option is string => typeof option === "string",
@@ -617,6 +619,17 @@ function InteractionDialogContent({
                   >
                     Deny
                   </Button>
+                  {alwaysValue && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={pending}
+                      onClick={() => onRespond({ value: alwaysValue })}
+                    >
+                      Allow always
+                    </Button>
+                  )}
                   <Button
                     type="button"
                     size="sm"

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -20,7 +20,6 @@ import type {
   AgentProviderId,
   AgentRuntimeSnapshot,
   AgentSessionCommand,
-  AgentThinkingLevel,
   AgentUsageSnapshot,
 } from "@overtchat/agent-bridge";
 import {
@@ -74,11 +73,11 @@ function currentModel(
 function currentThinking(
   snapshot: AgentRuntimeSnapshot,
   model: AgentRuntimeSnapshot["models"][number] | undefined,
-): AgentThinkingLevel | null {
+): string | null {
   const level = snapshot.state.thinkingLevel;
   return typeof level === "string" &&
     model?.thinkingOptions?.some((option) => option.id === level)
-    ? (level as AgentThinkingLevel)
+    ? level
     : null;
 }
 

--- a/apps/web/components/agents/NewAgentSessionDialog.tsx
+++ b/apps/web/components/agents/NewAgentSessionDialog.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import Image, { type StaticImageData } from "next/image";
+import Image from "next/image";
 import { useMemo, useState } from "react";
 import { Dialog } from "@base-ui/react/dialog";
 import { Check, Loader2 } from "lucide-react";
-import codexIcon from "@/assets/agent-providers/codex.png";
-import ompIcon from "@/assets/agent-providers/omp.svg";
-import piIcon from "@/assets/agent-providers/pi.svg";
 import type {
   AgentModel,
   AgentProviderId,
   AgentSessionLaunchConfig,
-  AgentThinkingLevel,
   AgentWorkspaceListItem,
 } from "@overtchat/agent-bridge";
 import { Button } from "@/components/ui/button";
@@ -26,6 +22,7 @@ import {
 import { toast } from "@/components/ui/toast";
 import { useSidebar } from "@/components/sidebar-context";
 import { motionClasses } from "@/lib/motion";
+import { AGENT_PROVIDER_VISUALS } from "@/lib/agents/providerVisuals";
 import {
   AGENT_CREATE_PREFERENCES_KEY,
   DEFAULT_AGENT_CREATE_PREFERENCES,
@@ -54,15 +51,6 @@ function defaultThinking(model: AgentModel | null): string {
   );
 }
 
-const PROVIDER_ICONS: Record<
-  AgentProviderId,
-  { icon: StaticImageData; darkSurface?: boolean }
-> = {
-  pi: { icon: piIcon },
-  omp: { icon: ompIcon, darkSurface: true },
-  codex: { icon: codexIcon, darkSurface: true },
-};
-
 export function NewAgentSessionDialog({
   open,
   onOpenChange,
@@ -80,16 +68,19 @@ export function NewAgentSessionDialog({
 }) {
   const router = useRouter();
   const { closeMobile } = useSidebar();
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState("");
+  const [selectedProvider, setSelectedProvider] = useState<AgentProviderId | "">(
+    "",
+  );
   const selectedTarget =
     targets.length === 1
       ? targets[0]
-      : targets.find((target) => target.workspace.id === selectedWorkspaceId);
+      : targets.find((target) => target.provider === selectedProvider);
   const workspace = selectedTarget?.workspace ?? targets[0]!.workspace;
   const provider = selectedTarget?.provider;
   const providerLabel = selectedTarget?.providerLabel;
   const catalog = useAgentWorkspaceCatalog(
     selectedTarget?.workspace.id ?? null,
+    selectedTarget?.provider ?? null,
     open && selectedTarget !== undefined,
   );
   const createSession = useCreateAgentSession();
@@ -102,7 +93,7 @@ export function NewAgentSessionDialog({
     [storedPreferences],
   );
   const [modelId, setModelId] = useState("");
-  const [thinkingOptionId, setThinkingOptionId] = useState<AgentThinkingLevel | "">("");
+  const [thinkingOptionId, setThinkingOptionId] = useState("");
   const [modeId, setModeId] = useState("");
   const providerPreferences = provider
     ? preferences.providerPreferences?.[provider]
@@ -128,9 +119,7 @@ export function NewAgentSessionDialog({
       (option) => option.id === thinkingOptionId,
     )
       ? thinkingOptionId
-      : ((preferredThinking ?? defaultThinking(selectedModel)) as
-          | AgentThinkingLevel
-          | "");
+      : (preferredThinking ?? defaultThinking(selectedModel));
   const preferredMode = catalog.data?.modes.find(
     (mode) => mode.id === providerPreferences?.mode,
   )?.id;
@@ -160,7 +149,7 @@ export function NewAgentSessionDialog({
         ? remembered!
         : defaultThinking(model);
     setModelId(model.id);
-    setThinkingOptionId(thinking as AgentThinkingLevel | "");
+    setThinkingOptionId(thinking);
     updateProviderPreferences({ model: model.id });
   }
 
@@ -194,6 +183,7 @@ export function NewAgentSessionDialog({
     try {
       const id = await createSession.mutateAsync({
         workspaceId: selectedTarget.workspace.id,
+        provider,
         launchConfig,
       });
       closeDialog();
@@ -213,15 +203,15 @@ export function NewAgentSessionDialog({
   const loading = catalog.isFetching && !catalog.data;
   const error = catalog.error instanceof Error ? catalog.error.message : null;
 
-  function selectAgent(workspaceId: string) {
-    setSelectedWorkspaceId(workspaceId);
+  function selectAgent(nextProvider: AgentProviderId) {
+    setSelectedProvider(nextProvider);
     setModelId("");
     setThinkingOptionId("");
     setModeId("");
   }
 
   function closeDialog() {
-    setSelectedWorkspaceId("");
+    setSelectedProvider("");
     setModelId("");
     setThinkingOptionId("");
     setModeId("");
@@ -262,15 +252,15 @@ export function NewAgentSessionDialog({
               <Label>{targets.length > 1 ? "Choose an agent" : "Agent"}</Label>
               <div className="grid gap-2 sm:grid-cols-2">
                 {targets.map((target) => {
-                  const selected = target.workspace.id === selectedTarget?.workspace.id;
-                  const icon = PROVIDER_ICONS[target.provider];
+                  const selected = target.provider === selectedTarget?.provider;
+                  const icon = AGENT_PROVIDER_VISUALS[target.provider];
                   return (
                     <button
-                      key={target.workspace.id}
+                      key={target.provider}
                       type="button"
                       aria-pressed={selected}
                       aria-label={`Select ${target.providerLabel}`}
-                      onClick={() => selectAgent(target.workspace.id)}
+                      onClick={() => selectAgent(target.provider)}
                       className={cn(
                         "flex min-h-16 items-center gap-3 rounded-lg border p-3 text-left outline-none motion-colors hover:bg-muted/30 focus-visible:ring-3 focus-visible:ring-ring/50",
                         selected && "border-primary bg-primary/5 ring-1 ring-primary",
@@ -355,7 +345,7 @@ export function NewAgentSessionDialog({
                     value={effectiveThinkingOptionId}
                     onValueChange={(value) => {
                       if (!value || !selectedModel) return;
-                      setThinkingOptionId(value as AgentThinkingLevel);
+                      setThinkingOptionId(value);
                       updateProviderPreferences({
                         thinkingByModel: {
                           ...providerPreferences?.thinkingByModel,

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -50,9 +50,7 @@ async function startHostConnector(
   ).toBeVisible();
   await expect(page.getByTitle("Pi", { exact: true })).toBeVisible();
   await expect(page.getByTitle("Oh My Pi", { exact: true })).toBeVisible();
-  await expect(
-    page.getByTitle("Claude Code · Coming soon", { exact: true }),
-  ).toBeVisible();
+  await expect(page.getByTitle("OpenCode", { exact: true })).toBeVisible();
   await expect(page.getByTitle("Codex", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Agent host" }),
@@ -299,9 +297,7 @@ test("explains agent access before setup", async ({ page }, testInfo) => {
   ).toBeVisible();
   await expect(page.getByTitle("Pi", { exact: true })).toBeVisible();
   await expect(page.getByTitle("Oh My Pi", { exact: true })).toBeVisible();
-  await expect(
-    page.getByTitle("Claude Code · Coming soon", { exact: true }),
-  ).toBeVisible();
+  await expect(page.getByTitle("OpenCode", { exact: true })).toBeVisible();
   await expect(page.getByTitle("Codex", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Agent host" }),
@@ -457,21 +453,63 @@ test("groups providers by directory, filters chats, refreshes globally, and reve
   await startHostConnector(page, testInfo);
   const workspaceIds = seedMixedProviderWorkspace();
   await page.route("**/api/agent-connections/discover", async (route) => {
+    const target = route.request().postDataJSON();
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
+        snapshot: {
+          target,
+          providers: [
+            {
+              provider: "pi",
+              status: "unavailable",
+            },
+            {
+              provider: "omp",
+              status: "ready",
+              executable: "omp",
+              version: "test",
+              shellMode: "interactive",
+            },
+            {
+              provider: "codex",
+              status: "ready",
+              executable: "codex",
+              version: "test",
+              shellMode: "interactive",
+            },
+            {
+              provider: "opencode",
+              status: "unavailable",
+            },
+          ],
+          refreshedAt: Date.now(),
+        },
         installations: [
-          { provider: "codex", executable: "codex", version: "test" },
-          { provider: "omp", executable: "omp", version: "test" },
+          {
+            provider: "codex",
+            executable: "codex",
+            version: "test",
+            shellMode: "interactive",
+          },
+          {
+            provider: "omp",
+            executable: "omp",
+            version: "test",
+            shellMode: "interactive",
+          },
         ],
       }),
     });
   });
   await page.route(
-    /\/api\/agent-workspaces\/[^/]+\/catalog$/u,
+    /\/api\/agent-workspaces\/[^/]+\/catalog(?:\?.*)?$/u,
     async (route) => {
-      const id = new URL(route.request().url()).pathname.split("/").at(-2);
-      const provider = id === workspaceIds.codex ? "codex" : "omp";
+      const url = new URL(route.request().url());
+      const id = url.pathname.split("/").at(-2);
+      const provider =
+        url.searchParams.get("provider") ??
+        (id === workspaceIds.codex ? "codex" : "omp");
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({
@@ -507,7 +545,13 @@ test("groups providers by directory, filters chats, refreshes globally, and reve
     },
   );
   await page.route(/\/api\/agent-workspaces\/[^/]+$/u, async (route) => {
-    if (route.request().method() === "POST") {
+    const workspaceId = new URL(route.request().url()).pathname
+      .split("/")
+      .at(-1);
+    if (
+      route.request().method() === "POST" &&
+      (workspaceId === workspaceIds.codex || workspaceId === workspaceIds.omp)
+    ) {
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({ sessions: [] }),
@@ -515,6 +559,19 @@ test("groups providers by directory, filters chats, refreshes globally, and reve
       return;
     }
     await route.continue();
+  });
+  await page.route("**/api/agent-workspaces/sync", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        result: {
+          providers: 2,
+          created: 0,
+          refreshed: 2,
+          failures: [],
+        },
+      }),
+    });
   });
 
   await page.goto("/");
@@ -645,11 +702,28 @@ test("connect local Pi, attach a workspace, and open a native session", async ({
         await route.fulfill({
           contentType: "application/json",
           body: JSON.stringify({
+            snapshot: {
+              target: route.request().postDataJSON(),
+              providers: [
+                {
+                  provider: "pi",
+                  status: "ready",
+                  executable: "/usr/local/bin/pi",
+                  version: "0.42.3",
+                  shellMode: "interactive",
+                },
+                { provider: "omp", status: "unavailable" },
+                { provider: "codex", status: "unavailable" },
+                { provider: "opencode", status: "unavailable" },
+              ],
+              refreshedAt: Date.now(),
+            },
             installations: [
               {
                 provider: "pi",
                 executable: "/usr/local/bin/pi",
                 version: "0.42.3",
+                shellMode: "interactive",
               },
             ],
           }),

--- a/apps/web/lib/agents/connector/descriptors.ts
+++ b/apps/web/lib/agents/connector/descriptors.ts
@@ -1,12 +1,13 @@
 import "server-only";
-import type {
-  AgentDaemonSessionDescriptor,
-  AgentDaemonTarget,
-  AgentDaemonWorkspaceDescriptor,
-  AgentProviderSessionMetadata,
-  AgentProviderId,
-  AgentSessionLaunchConfig,
-  ConnectorShellMode,
+import {
+  agentSessionLaunchConfigSchema,
+  type AgentDaemonSessionDescriptor,
+  type AgentDaemonTarget,
+  type AgentDaemonWorkspaceDescriptor,
+  type AgentProviderSessionMetadata,
+  type AgentProviderId,
+  type AgentSessionLaunchConfig,
+  type ConnectorShellMode,
 } from "@overtchat/agent-bridge";
 import type {
   AgentHostRow,
@@ -78,6 +79,9 @@ export function parseProviderSessionMetadata(
   const name = Reflect.get(value, "name");
   const firstMessage = Reflect.get(value, "firstMessage");
   const messageCount = Reflect.get(value, "messageCount");
+  const launchConfig = agentSessionLaunchConfigSchema.safeParse(
+    Reflect.get(value, "launchConfig"),
+  );
   if (
     typeof providerSessionId !== "string" ||
     !providerSessionId ||
@@ -98,5 +102,6 @@ export function parseProviderSessionMetadata(
     messageCount: Number(messageCount),
     createdAt: optionalDate(Reflect.get(value, "createdAt")),
     modifiedAt: optionalDate(Reflect.get(value, "modifiedAt")),
+    ...(launchConfig.success ? { launchConfig: launchConfig.data } : {}),
   };
 }

--- a/apps/web/lib/agents/connector/providerSnapshots.test.ts
+++ b/apps/web/lib/agents/connector/providerSnapshots.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  request: vi.fn(),
+  findConnection: vi.fn(),
+  findWorkspace: vi.fn(),
+  getWorkspace: vi.fn(),
+  listConnections: vi.fn(),
+  saveInstallation: vi.fn(),
+  syncSessions: vi.fn(),
+  upsertSession: vi.fn(),
+  updateRuntime: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("./broker", () => ({
+  hostConnectorBroker: { request: mocks.request },
+}));
+vi.mock("@/lib/db/agentConnections", () => ({
+  findOwnedAgentConnectionForTargetProvider: mocks.findConnection,
+  findOwnedAgentWorkspaceForTargetProvider: mocks.findWorkspace,
+  getOwnedAgentWorkspace: mocks.getWorkspace,
+  listAgentConnections: mocks.listConnections,
+  saveAgentWorkspaceInstallation: mocks.saveInstallation,
+  syncAgentWorkspaceSessions: mocks.syncSessions,
+  upsertAgentSession: mocks.upsertSession,
+  updateAgentConnectionRuntime: mocks.updateRuntime,
+}));
+
+import {
+  createAgentWorkspaceProviderSession,
+  getAgentProviderSnapshot,
+  refreshAgentWorkspaces,
+  resolveAgentWorkspaceProvider,
+} from "./providerSnapshots";
+
+const target = { connectorId: "connector", transport: "local" as const };
+const snapshot = {
+  target,
+  providers: [
+    { provider: "pi" as const, status: "unavailable" as const },
+    { provider: "omp" as const, status: "unavailable" as const },
+    { provider: "codex" as const, status: "unavailable" as const },
+    {
+      provider: "opencode" as const,
+      status: "ready" as const,
+      executable: "/usr/local/bin/opencode",
+      version: "1.2.3",
+      shellMode: "interactive" as const,
+    },
+  ],
+  refreshedAt: 123,
+};
+const anchor = {
+  host: {
+    id: "host",
+    userId: "owner",
+    connectorId: "connector",
+    name: "This server",
+    transport: "local" as const,
+    sshAlias: null,
+  },
+  connection: {
+    id: "pi-connection",
+    hostId: "host",
+    provider: "pi",
+    executable: "pi",
+    shellMode: "interactive" as const,
+    detectedVersion: "1.0.0",
+  },
+  workspace: {
+    id: "pi-workspace",
+    connectionId: "pi-connection",
+    path: "/work/project",
+    name: "project",
+  },
+};
+const connectionList = [
+  {
+    id: "pi-connection",
+    provider: "pi" as const,
+    executable: "pi",
+    detectedVersion: "1.0.0",
+    lastValidatedAt: null,
+    host: {
+      id: "host",
+      connectorId: "connector",
+      name: "This server",
+      transport: "local" as const,
+      sshAlias: null,
+    },
+    workspaces: [
+      {
+        id: "pi-workspace",
+        path: "/work/project",
+        name: "project",
+        sessions: [],
+      },
+    ],
+  },
+];
+
+describe("connector provider snapshots", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getWorkspace.mockResolvedValue(anchor);
+    mocks.findConnection.mockResolvedValue(null);
+    mocks.findWorkspace.mockResolvedValue(null);
+    mocks.listConnections.mockResolvedValue(connectionList);
+    mocks.saveInstallation.mockReturnValue({});
+    mocks.syncSessions.mockReturnValue([]);
+    mocks.updateRuntime.mockResolvedValue(true);
+    mocks.upsertSession.mockResolvedValue({});
+  });
+
+  it("reads a connector-owned snapshot without touching persistence", async () => {
+    mocks.request.mockResolvedValue(snapshot);
+
+    await expect(getAgentProviderSnapshot(target)).resolves.toEqual(snapshot);
+
+    expect(mocks.request).toHaveBeenCalledWith("connector", {
+      type: "provider_snapshot",
+      target,
+      refresh: undefined,
+    });
+    expect(mocks.getWorkspace).not.toHaveBeenCalled();
+    expect(mocks.findWorkspace).not.toHaveBeenCalled();
+    expect(mocks.saveInstallation).not.toHaveBeenCalled();
+  });
+
+  it("projects a ready provider onto an existing workspace without a backing row", async () => {
+    mocks.request.mockResolvedValue(snapshot);
+
+    const resolved = await resolveAgentWorkspaceProvider({
+      userId: "owner",
+      anchorWorkspaceId: "pi-workspace",
+      provider: "opencode",
+    });
+
+    expect(resolved.backing).toBeNull();
+    expect(resolved.descriptor).toMatchObject({
+      provider: "opencode",
+      executable: "/usr/local/bin/opencode",
+      cwd: "/work/project",
+      target: { transport: "local", shellMode: "interactive" },
+    });
+    expect(mocks.saveInstallation).not.toHaveBeenCalled();
+  });
+
+  it("does not materialize a newly detected provider with no sessions", async () => {
+    mocks.request
+      .mockResolvedValueOnce(snapshot)
+      .mockResolvedValueOnce([]);
+
+    await expect(refreshAgentWorkspaces("owner")).resolves.toMatchObject({
+      providers: 1,
+      created: 0,
+      refreshed: 0,
+      failures: [],
+    });
+
+    expect(mocks.saveInstallation).not.toHaveBeenCalled();
+  });
+
+  it("materializes a newly detected provider when refresh finds durable sessions", async () => {
+    mocks.request
+      .mockResolvedValueOnce(snapshot)
+      .mockResolvedValueOnce([
+        {
+          providerSessionId: "native",
+          providerSessionPath: "native",
+          name: "Imported session",
+          firstMessage: "Hello",
+          messageCount: 2,
+          createdAt: 1,
+          modifiedAt: 2,
+          launchConfig: { model: "openai/gpt-5" },
+        },
+      ]);
+
+    await expect(refreshAgentWorkspaces("owner")).resolves.toMatchObject({
+      providers: 1,
+      created: 1,
+      refreshed: 0,
+      failures: [],
+    });
+
+    expect(mocks.saveInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connection: expect.objectContaining({ provider: "opencode" }),
+        workspace: { path: "/work/project", name: "project" },
+        sessions: [
+          expect.objectContaining({
+            providerSessionId: "native",
+            launchConfig: { model: "openai/gpt-5" },
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("materializes a virtual provider only after its runtime session exists", async () => {
+    mocks.request
+      .mockResolvedValueOnce(snapshot)
+      .mockResolvedValueOnce({
+        session: {
+          providerSessionId: "native",
+          providerSessionPath: "native",
+          name: null,
+          firstMessage: null,
+          messageCount: 0,
+          createdAt: null,
+          modifiedAt: null,
+        },
+        launchConfig: { model: "openai/gpt-5" },
+        snapshot: { sessionId: "runtime", status: "idle" },
+      });
+
+    await expect(
+      createAgentWorkspaceProviderSession({
+        userId: "owner",
+        anchorWorkspaceId: "pi-workspace",
+        provider: "opencode",
+        launchConfig: { model: "openai/gpt-5" },
+      }),
+    ).resolves.toMatchObject({ session: { id: expect.any(String) } });
+
+    expect(mocks.saveInstallation).toHaveBeenCalledOnce();
+    expect(mocks.request.mock.calls[1]?.[1]).toMatchObject({
+      type: "create_session",
+      workspace: { provider: "opencode", cwd: "/work/project" },
+    });
+  });
+});

--- a/apps/web/lib/agents/connector/providerSnapshots.ts
+++ b/apps/web/lib/agents/connector/providerSnapshots.ts
@@ -1,0 +1,488 @@
+import "server-only";
+import {
+  agentProviderSnapshotSchema,
+  agentSessionLaunchConfigSchema,
+  type AgentDaemonWorkspaceDescriptor,
+  type AgentDiscoveryTarget,
+  type AgentProviderId,
+  type AgentProviderSnapshot,
+  type AgentProviderSnapshotEntry,
+  type AgentSessionLaunchConfig,
+  type DetectedAgentInstallation,
+} from "@overtchat/agent-bridge";
+import { hostConnectorBroker } from "./broker";
+import {
+  daemonTarget,
+  parseProviderSessionMetadata,
+} from "./descriptors";
+import {
+  findOwnedAgentConnectionForTargetProvider,
+  findOwnedAgentWorkspaceForTargetProvider,
+  getOwnedAgentWorkspace,
+  listAgentConnections,
+  saveAgentWorkspaceInstallation,
+  syncAgentWorkspaceSessions,
+  upsertAgentSession,
+  updateAgentConnectionRuntime,
+  type OwnedAgentWorkspace,
+} from "@/lib/db/agentConnections";
+import {
+  agentConnectionTarget,
+  agentTargetKey,
+  groupAgentWorkspaces,
+} from "@/lib/agents/workspaces";
+
+const workspaceProviderLocks = new Map<string, Promise<void>>();
+
+type ReadyProvider = Extract<
+  AgentProviderSnapshotEntry,
+  { status: "ready" }
+>;
+
+export type AgentWorkspaceSyncResult = {
+  providers: number;
+  created: number;
+  refreshed: number;
+  failures: Array<{ provider: string; message: string }>;
+};
+
+function targetFromOwnedWorkspace(
+  owned: OwnedAgentWorkspace,
+): AgentDiscoveryTarget {
+  return owned.host.transport === "local"
+    ? {
+        connectorId: owned.host.connectorId,
+        transport: "local",
+      }
+    : {
+        connectorId: owned.host.connectorId,
+        transport: "ssh",
+        sshAlias: owned.host.sshAlias!,
+      };
+}
+
+function readyProviders(snapshot: AgentProviderSnapshot): ReadyProvider[] {
+  return snapshot.providers.filter(
+    (entry): entry is ReadyProvider => entry.status === "ready",
+  );
+}
+
+export async function getAgentProviderSnapshot(
+  target: AgentDiscoveryTarget,
+  options: { refresh?: boolean } = {},
+): Promise<AgentProviderSnapshot> {
+  return agentProviderSnapshotSchema.parse(
+    await hostConnectorBroker.request(target.connectorId, {
+      type: "provider_snapshot",
+      target,
+      refresh: options.refresh,
+    }),
+  );
+}
+
+export async function resolveAgentWorkspaceProvider(input: {
+  userId: string;
+  anchorWorkspaceId: string;
+  provider: AgentProviderId;
+  refresh?: boolean;
+}): Promise<{
+  anchor: OwnedAgentWorkspace;
+  backing: OwnedAgentWorkspace | null;
+  target: AgentDiscoveryTarget;
+  installation: ReadyProvider;
+  descriptor: AgentDaemonWorkspaceDescriptor;
+}> {
+  const anchor = await getOwnedAgentWorkspace(
+    input.anchorWorkspaceId,
+    input.userId,
+  );
+  if (!anchor) throw new Error("Agent workspace not found.");
+  const target = targetFromOwnedWorkspace(anchor);
+  const snapshot = await getAgentProviderSnapshot(target, {
+    refresh: input.refresh,
+  });
+  const backing = await findOwnedAgentWorkspaceForTargetProvider({
+    userId: input.userId,
+    target,
+    provider: input.provider,
+    path: anchor.workspace.path,
+  });
+  const configured =
+    backing ??
+    (await findOwnedAgentConnectionForTargetProvider({
+      userId: input.userId,
+      target,
+      provider: input.provider,
+    }));
+  const installation =
+    readyProviders(snapshot).find(
+      (entry) => entry.provider === input.provider,
+    ) ??
+    (configured
+      ? {
+          provider: input.provider,
+          status: "ready" as const,
+          executable: configured.connection.executable,
+          version: configured.connection.detectedVersion ?? "configured",
+          shellMode: configured.connection.shellMode,
+        }
+      : undefined);
+  if (!installation) {
+    throw new Error("This coding agent is not available on the selected machine.");
+  }
+  return {
+    anchor,
+    backing,
+    target,
+    installation,
+    descriptor: {
+      connectionId: configured?.connection.id ?? crypto.randomUUID(),
+      workspaceId: backing?.workspace.id ?? crypto.randomUUID(),
+      provider: input.provider,
+      target: daemonTarget(anchor.host, installation.shellMode),
+      executable: installation.executable,
+      cwd: anchor.workspace.path,
+      detectedVersion: installation.version,
+    },
+  };
+}
+
+async function withWorkspaceProviderLock<T>(
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  while (workspaceProviderLocks.has(key)) {
+    await workspaceProviderLocks.get(key);
+  }
+  let release = () => {};
+  const active = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  workspaceProviderLocks.set(key, active);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (workspaceProviderLocks.get(key) === active) {
+      workspaceProviderLocks.delete(key);
+    }
+  }
+}
+
+export async function createAgentWorkspaceProviderSession(input: {
+  userId: string;
+  anchorWorkspaceId: string;
+  provider: AgentProviderId;
+  launchConfig: AgentSessionLaunchConfig;
+}): Promise<{
+  session: { id: string };
+  launchConfig: AgentSessionLaunchConfig;
+  snapshot: unknown;
+}> {
+  const anchor = await getOwnedAgentWorkspace(
+    input.anchorWorkspaceId,
+    input.userId,
+  );
+  if (!anchor) throw new Error("Agent workspace not found.");
+  const target = targetFromOwnedWorkspace(anchor);
+  const key = JSON.stringify([
+    input.userId,
+    agentTargetKey(target),
+    anchor.workspace.path,
+    input.provider,
+  ]);
+  return withWorkspaceProviderLock(key, async () => {
+    const resolved = await resolveAgentWorkspaceProvider(input);
+    const sessionId = crypto.randomUUID();
+    const created = await hostConnectorBroker.request<{
+      session: unknown;
+      launchConfig: unknown;
+      snapshot: unknown;
+    }>(resolved.target.connectorId, {
+      type: "create_session",
+      sessionId,
+      workspace: resolved.descriptor,
+      launchConfig: input.launchConfig,
+    });
+    const launchConfig = agentSessionLaunchConfigSchema.parse(
+      created.launchConfig,
+    );
+    const metadata = parseProviderSessionMetadata(created.session);
+    try {
+      if (resolved.backing) {
+        await updateAgentConnectionRuntime({
+          id: resolved.backing.connection.id,
+          userId: input.userId,
+          executable: resolved.installation.executable,
+          detectedVersion: resolved.installation.version,
+          shellMode: resolved.installation.shellMode,
+        });
+        await upsertAgentSession(
+          resolved.backing.workspace.id,
+          metadata,
+          sessionId,
+          launchConfig,
+        );
+      } else {
+        saveAgentWorkspaceInstallation({
+          userId: input.userId,
+          host:
+            resolved.target.transport === "local"
+              ? {
+                  name: "This server",
+                  transport: "local",
+                  connectorId: resolved.target.connectorId,
+                }
+              : {
+                  name: resolved.target.sshAlias,
+                  transport: "ssh",
+                  connectorId: resolved.target.connectorId,
+                  sshAlias: resolved.target.sshAlias,
+                },
+          connection: {
+            provider: input.provider,
+            executable: resolved.installation.executable,
+            shellMode: resolved.installation.shellMode,
+            detectedVersion: resolved.installation.version,
+          },
+          workspace: {
+            path: resolved.anchor.workspace.path,
+            name: resolved.anchor.workspace.name,
+          },
+          sessions: [{ ...metadata, launchConfig }],
+          ids: {
+            hostId: crypto.randomUUID(),
+            connectionId: resolved.descriptor.connectionId,
+            workspaceId: resolved.descriptor.workspaceId,
+            sessionIds: {
+              [metadata.providerSessionPath]: sessionId,
+            },
+          },
+        });
+      }
+    } catch (error) {
+      await hostConnectorBroker
+        .request(resolved.target.connectorId, {
+          type: "stop_session",
+          sessionId,
+        })
+        .catch(() => {});
+      throw error;
+    }
+    return {
+      session: { id: sessionId },
+      launchConfig,
+      snapshot: created.snapshot,
+    };
+  });
+}
+
+async function syncWorkspaceProvider(input: {
+  userId: string;
+  target: AgentDiscoveryTarget;
+  path: string;
+  name: string;
+  installation: ReadyProvider;
+  materializeEmpty: boolean;
+}): Promise<"created" | "refreshed" | "skipped"> {
+  const backing = await findOwnedAgentWorkspaceForTargetProvider({
+    userId: input.userId,
+    target: input.target,
+    provider: input.installation.provider,
+    path: input.path,
+  });
+  const configured =
+    backing ??
+    (await findOwnedAgentConnectionForTargetProvider({
+      userId: input.userId,
+      target: input.target,
+      provider: input.installation.provider,
+    }));
+  const descriptor: AgentDaemonWorkspaceDescriptor = {
+    connectionId: configured?.connection.id ?? crypto.randomUUID(),
+    workspaceId: backing?.workspace.id ?? crypto.randomUUID(),
+    provider: input.installation.provider,
+    target:
+      input.target.transport === "local"
+        ? { transport: "local", shellMode: input.installation.shellMode }
+        : {
+            transport: "ssh",
+            alias: input.target.sshAlias,
+            shellMode: input.installation.shellMode,
+          },
+    executable: input.installation.executable,
+    cwd: input.path,
+    detectedVersion: input.installation.version,
+  };
+  const sessions = (
+    await hostConnectorBroker.request<unknown[]>(input.target.connectorId, {
+      type: "list_sessions",
+      workspace: descriptor,
+    })
+  ).map(parseProviderSessionMetadata);
+
+  if (backing) {
+    await updateAgentConnectionRuntime({
+      id: backing.connection.id,
+      userId: input.userId,
+      executable: input.installation.executable,
+      detectedVersion: input.installation.version,
+      shellMode: input.installation.shellMode,
+    });
+    syncAgentWorkspaceSessions(backing.workspace.id, sessions);
+    return "refreshed";
+  }
+  if (!input.materializeEmpty && sessions.length === 0) return "skipped";
+
+  saveAgentWorkspaceInstallation({
+    userId: input.userId,
+    host:
+      input.target.transport === "local"
+        ? {
+            name: "This server",
+            transport: "local",
+            connectorId: input.target.connectorId,
+          }
+        : {
+            name: input.target.sshAlias,
+            transport: "ssh",
+            connectorId: input.target.connectorId,
+            sshAlias: input.target.sshAlias,
+          },
+    connection: {
+      provider: input.installation.provider,
+      executable: input.installation.executable,
+      shellMode: input.installation.shellMode,
+      detectedVersion: input.installation.version,
+    },
+    workspace: { path: input.path, name: input.name },
+    sessions,
+    ids: {
+      hostId: crypto.randomUUID(),
+      connectionId: descriptor.connectionId,
+      workspaceId: descriptor.workspaceId,
+    },
+  });
+  return "created";
+}
+
+export async function provisionAgentWorkspace(input: {
+  userId: string;
+  target: AgentDiscoveryTarget;
+  path: string;
+  installations?: DetectedAgentInstallation[];
+}): Promise<AgentWorkspaceSyncResult> {
+  const snapshot = await getAgentProviderSnapshot(input.target);
+  const providersById = new Map(
+    readyProviders(snapshot).map((installation) => [
+      installation.provider,
+      installation,
+    ]),
+  );
+  for (const installation of input.installations ?? []) {
+    providersById.set(installation.provider, {
+      ...installation,
+      status: "ready",
+    });
+  }
+  const providers = [...providersById.values()];
+  if (providers.length === 0) {
+    throw new Error("No supported coding agents were detected on this machine.");
+  }
+  const workspace = await hostConnectorBroker.request<{
+    path: string;
+    name: string;
+  }>(input.target.connectorId, {
+    type: "probe_workspace",
+    target:
+      input.target.transport === "local"
+        ? { transport: "local", shellMode: providers[0]!.shellMode }
+        : {
+            transport: "ssh",
+            alias: input.target.sshAlias,
+            shellMode: providers[0]!.shellMode,
+          },
+    path: input.path,
+  });
+  const result: AgentWorkspaceSyncResult = {
+    providers: providers.length,
+    created: 0,
+    refreshed: 0,
+    failures: [],
+  };
+  for (const installation of providers) {
+    try {
+      const outcome = await syncWorkspaceProvider({
+        userId: input.userId,
+        target: input.target,
+        path: workspace.path,
+        name: workspace.name,
+        installation,
+        materializeEmpty: true,
+      });
+      if (outcome === "created") result.created += 1;
+      else if (outcome === "refreshed") result.refreshed += 1;
+    } catch (error) {
+      result.failures.push({
+        provider: installation.provider,
+        message: error instanceof Error ? error.message : "Agent setup failed.",
+      });
+    }
+  }
+  return result;
+}
+
+export async function refreshAgentWorkspaces(
+  userId: string,
+): Promise<AgentWorkspaceSyncResult> {
+  const connections = await listAgentConnections(userId);
+  const groups = groupAgentWorkspaces(connections);
+  const snapshots = new Map<string, Promise<AgentProviderSnapshot>>();
+  const result: AgentWorkspaceSyncResult = {
+    providers: 0,
+    created: 0,
+    refreshed: 0,
+    failures: [],
+  };
+
+  for (const group of groups) {
+    const target = agentConnectionTarget(group.targets[0]!.connection);
+    const key = agentTargetKey(target);
+    let snapshot = snapshots.get(key);
+    if (!snapshot) {
+      snapshot = getAgentProviderSnapshot(target, { refresh: true });
+      snapshots.set(key, snapshot);
+    }
+    let providers: ReadyProvider[];
+    try {
+      providers = readyProviders(await snapshot);
+    } catch (error) {
+      result.failures.push({
+        provider: "discovery",
+        message: error instanceof Error ? error.message : "Agent refresh failed.",
+      });
+      continue;
+    }
+    result.providers += providers.length;
+    for (const installation of providers) {
+      try {
+        const outcome = await syncWorkspaceProvider({
+          userId,
+          target,
+          path: group.path,
+          name: group.name,
+          installation,
+          materializeEmpty: false,
+        });
+        if (outcome === "created") result.created += 1;
+        else if (outcome === "refreshed") result.refreshed += 1;
+      } catch (error) {
+        result.failures.push({
+          provider: installation.provider,
+          message: error instanceof Error ? error.message : "Refresh failed.",
+        });
+      }
+    }
+  }
+  return result;
+}

--- a/apps/web/lib/agents/createPreferences.test.ts
+++ b/apps/web/lib/agents/createPreferences.test.ts
@@ -45,4 +45,28 @@ describe("agent create preferences", () => {
       }),
     ).toEqual({});
   });
+
+  it("preserves OpenCode model variants", () => {
+    expect(
+      parseAgentCreatePreferences({
+        providerPreferences: {
+          opencode: {
+            model: "anthropic/claude-sonnet-4-5",
+            mode: "build",
+            thinkingByModel: {
+              "anthropic/claude-sonnet-4-5": "max-reasoning",
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      providerPreferences: {
+        opencode: {
+          thinkingByModel: {
+            "anthropic/claude-sonnet-4-5": "max-reasoning",
+          },
+        },
+      },
+    });
+  });
 });

--- a/apps/web/lib/agents/createPreferences.ts
+++ b/apps/web/lib/agents/createPreferences.ts
@@ -21,7 +21,10 @@ const providerPreferencesSchema = z.strictObject({
 
 const preferencesSchema = z.strictObject({
   providerPreferences: z
-    .partialRecord(z.enum(["pi", "omp", "codex"]), providerPreferencesSchema)
+    .partialRecord(
+      z.enum(["pi", "omp", "codex", "opencode"]),
+      providerPreferencesSchema,
+    )
     .optional(),
 });
 

--- a/apps/web/lib/agents/providerVisuals.ts
+++ b/apps/web/lib/agents/providerVisuals.ts
@@ -1,0 +1,21 @@
+import type { StaticImageData } from "next/image";
+import codexIcon from "@/assets/agent-providers/codex.png";
+import ompIcon from "@/assets/agent-providers/omp.svg";
+import openCodeIcon from "@/assets/agent-providers/opencode.svg";
+import piIcon from "@/assets/agent-providers/pi.svg";
+import type { AgentProviderId } from "@overtchat/agent-bridge";
+
+export type AgentProviderVisual = {
+  icon: StaticImageData;
+  darkSurface?: boolean;
+};
+
+export const AGENT_PROVIDER_VISUALS: Record<
+  AgentProviderId,
+  AgentProviderVisual
+> = {
+  pi: { icon: piIcon },
+  omp: { icon: ompIcon, darkSurface: true },
+  codex: { icon: codexIcon, darkSurface: true },
+  opencode: { icon: openCodeIcon, darkSurface: true },
+};

--- a/apps/web/lib/agents/sidebar.test.ts
+++ b/apps/web/lib/agents/sidebar.test.ts
@@ -79,8 +79,8 @@ describe("agent sessions in the sidebar", () => {
       id: "connection",
       provider: "pi",
       executable: "pi",
-      detectedVersion: null,
-      lastValidatedAt: null,
+    detectedVersion: null,
+    lastValidatedAt: null,
       host: {
         id: "host",
         connectorId: "connector",
@@ -110,8 +110,8 @@ describe("agent sessions in the sidebar", () => {
       id: "connection",
       provider: "codex",
       executable: "codex",
-      detectedVersion: null,
-      lastValidatedAt: null,
+    detectedVersion: null,
+    lastValidatedAt: null,
       host: {
         id: "host",
         connectorId: "connector",

--- a/apps/web/lib/agents/workspaces.test.ts
+++ b/apps/web/lib/agents/workspaces.test.ts
@@ -3,6 +3,7 @@ import type { AgentConnectionListItem } from "@overtchat/agent-bridge";
 import {
   agentConnectionMatchesTarget,
   groupAgentWorkspaces,
+  projectAgentWorkspaceProviders,
 } from "./workspaces";
 
 function connection(
@@ -111,5 +112,39 @@ describe("agent workspace projection", () => {
         "omp",
       ),
     ).toBe(false);
+  });
+
+  it("projects a newly detected provider onto an existing workspace", () => {
+    const group = groupAgentWorkspaces([
+      connection("pi", "pi"),
+    ])[0]!;
+
+    const targets = projectAgentWorkspaceProviders(group, {
+      target: { connectorId: "connector", transport: "local" },
+      providers: [
+        {
+          provider: "pi",
+          status: "ready",
+          executable: "pi",
+          version: "1",
+          shellMode: "interactive",
+        },
+        { provider: "omp", status: "unavailable" },
+        { provider: "codex", status: "unavailable" },
+        {
+          provider: "opencode",
+          status: "ready",
+          executable: "opencode",
+          version: "2",
+          shellMode: "interactive",
+        },
+      ],
+      refreshedAt: 1,
+    });
+
+    expect(targets).toEqual([
+      { provider: "pi", workspace: group.targets[0]!.workspace },
+      { provider: "opencode", workspace: group.targets[0]!.workspace },
+    ]);
   });
 });

--- a/apps/web/lib/agents/workspaces.ts
+++ b/apps/web/lib/agents/workspaces.ts
@@ -2,6 +2,7 @@ import type {
   AgentConnectionListItem,
   AgentDiscoveryTarget,
   AgentProviderId,
+  AgentProviderSnapshot,
   AgentSessionListItem,
   AgentWorkspaceListItem,
 } from "@overtchat/agent-bridge";
@@ -24,6 +25,11 @@ export type AgentWorkspaceGroup = {
   host: AgentConnectionListItem["host"];
   targets: AgentWorkspaceTarget[];
   sessions: AgentWorkspaceSession[];
+};
+
+export type AgentWorkspaceProviderTarget = {
+  provider: AgentProviderId;
+  workspace: AgentWorkspaceListItem;
 };
 
 export function agentTargetKey(target: AgentDiscoveryTarget): string {
@@ -119,5 +125,25 @@ export function groupAgentWorkspaces(
         right.session.modifiedAt ?? right.session.createdAt ?? 0;
       return rightTime - leftTime;
     }),
+  }));
+}
+
+export function projectAgentWorkspaceProviders(
+  group: AgentWorkspaceGroup,
+  snapshot: AgentProviderSnapshot | undefined,
+): AgentWorkspaceProviderTarget[] {
+  const representativeWorkspace = group.targets[0]!.workspace;
+  const providers = new Set<AgentProviderId>(
+    snapshot?.providers.flatMap((entry) =>
+      entry.status === "ready" ? [entry.provider] : [],
+    ) ?? [],
+  );
+  for (const { connection } of group.targets) providers.add(connection.provider);
+  return [...providers].map((provider) => ({
+    provider,
+    workspace:
+      group.targets.find(
+        ({ connection }) => connection.provider === provider,
+      )?.workspace ?? representativeWorkspace,
   }));
 }

--- a/apps/web/lib/db/agentConnections.test.ts
+++ b/apps/web/lib/db/agentConnections.test.ts
@@ -130,6 +130,121 @@ function createAliceConnection() {
 }
 
 describe("agent connection persistence", () => {
+  it("reuses an existing configured connection for the same target and provider", () => {
+    const first = createAliceConnection();
+    const updated = repository.createAgentConnection({
+      userId: "alice",
+      host: {
+        name: "This server",
+        transport: "local",
+        connectorId: "alice-connector",
+      },
+      connection: {
+        provider: "pi",
+        executable: "/new/pi",
+        shellMode: "login",
+        detectedVersion: "0.83.0",
+      },
+    });
+    const codex = repository.createAgentConnection({
+      userId: "alice",
+      host: {
+        name: "This server",
+        transport: "local",
+        connectorId: "alice-connector",
+      },
+      connection: {
+        provider: "codex",
+        executable: "codex",
+        shellMode: "interactive",
+        detectedVersion: "1.0.0",
+      },
+    });
+
+    expect(updated.host.id).toBe(first.host.id);
+    expect(updated.connection.id).toBe(first.connection.id);
+    expect(updated.connection.executable).toBe("/new/pi");
+    expect(codex.host.id).not.toBe(first.host.id);
+    expect(raw.prepare("SELECT count(*) AS count FROM agent_hosts").get()).toEqual({
+      count: 2,
+    });
+    expect(
+      raw.prepare("SELECT count(*) AS count FROM agent_connections").get(),
+    ).toEqual({ count: 2 });
+  });
+
+  it("deleting one provider preserves sibling providers on the same target", async () => {
+    const pi = createAliceConnection();
+    const codex = repository.createAgentConnection({
+      userId: "alice",
+      host: {
+        name: "Workstation",
+        transport: "local",
+        connectorId: "alice-connector",
+      },
+      connection: {
+        provider: "codex",
+        executable: "codex",
+        shellMode: "interactive",
+        detectedVersion: "1.0.0",
+      },
+    });
+
+    await expect(
+      repository.deleteAgentConnection(pi.connection.id, "alice"),
+    ).resolves.toBe(true);
+    await expect(
+      repository.getOwnedAgentConnection(codex.connection.id, "alice"),
+    ).resolves.toMatchObject({
+      host: { id: codex.host.id },
+      connection: { provider: "codex" },
+    });
+  });
+
+  it("atomically saves a provider, workspace, and imported sessions", async () => {
+    const saved = repository.saveAgentWorkspaceInstallation({
+      userId: "alice",
+      host: {
+        name: "Workstation",
+        transport: "local",
+        connectorId: "alice-connector",
+      },
+      connection: {
+        provider: "opencode",
+        executable: "opencode",
+        shellMode: "interactive",
+        detectedVersion: "1.18.23",
+      },
+      workspace: { path: "/work/overtchat", name: "overtchat" },
+      sessions: [
+        {
+          providerSessionId: "native",
+          providerSessionPath: "/opencode/native",
+          name: "OpenCode work",
+          firstMessage: "Implement it",
+          messageCount: 2,
+          createdAt: new Date(1_000),
+          modifiedAt: new Date(2_000),
+        },
+      ],
+    });
+
+    expect(saved.connection.provider).toBe("opencode");
+    expect(saved.workspace.path).toBe("/work/overtchat");
+    expect(saved.sessions).toHaveLength(1);
+    await expect(repository.listAgentConnections("alice")).resolves.toEqual([
+      expect.objectContaining({
+        provider: "opencode",
+        workspaces: [
+          expect.objectContaining({
+            path: "/work/overtchat",
+            sessions: [expect.objectContaining({ providerSessionId: "native" })],
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("returns the nested connection, workspace, and session hierarchy", async () => {
     const owned = createAliceConnection();
     const workspace = await repository.createAgentWorkspace(

--- a/apps/web/lib/db/agentConnections.ts
+++ b/apps/web/lib/db/agentConnections.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { and, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, notInArray, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import {
   agentConnections,
@@ -10,6 +10,7 @@ import {
 } from "@/lib/db/schema";
 import type {
   AgentConnectionListItem,
+  AgentDiscoveryTarget,
   AgentProviderSessionMetadata,
   AgentProviderId,
   AgentSessionLaunchConfig,
@@ -50,6 +51,20 @@ export type NewAgentConnection = {
     executable: string;
     shellMode: ConnectorShellMode;
     detectedVersion: string;
+  };
+};
+
+export type AgentWorkspaceInstallation = NewAgentConnection & {
+  workspace: {
+    path: string;
+    name: string;
+  };
+  sessions: ProviderSessionMetadata[];
+  ids?: {
+    hostId: string;
+    connectionId: string;
+    workspaceId: string;
+    sessionIds?: Record<string, string>;
   };
 };
 
@@ -195,6 +210,64 @@ export async function getOwnedAgentWorkspace(
   return row ?? null;
 }
 
+export async function findOwnedAgentWorkspaceForTargetProvider(input: {
+  userId: string;
+  target: AgentDiscoveryTarget;
+  provider: AgentProviderId;
+  path: string;
+}): Promise<OwnedAgentWorkspace | null> {
+  const [row] = await db
+    .select({
+      host: agentHosts,
+      connection: agentConnections,
+      workspace: agentWorkspaces,
+    })
+    .from(agentWorkspaces)
+    .innerJoin(
+      agentConnections,
+      eq(agentWorkspaces.connectionId, agentConnections.id),
+    )
+    .innerJoin(agentHosts, eq(agentConnections.hostId, agentHosts.id))
+    .where(
+      and(
+        eq(agentHosts.userId, input.userId),
+        eq(agentHosts.connectorId, input.target.connectorId),
+        eq(agentHosts.transport, input.target.transport),
+        input.target.transport === "local"
+          ? isNull(agentHosts.sshAlias)
+          : eq(agentHosts.sshAlias, input.target.sshAlias),
+        eq(agentConnections.provider, input.provider),
+        eq(agentWorkspaces.path, input.path),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export async function findOwnedAgentConnectionForTargetProvider(input: {
+  userId: string;
+  target: AgentDiscoveryTarget;
+  provider: AgentProviderId;
+}): Promise<OwnedAgentConnection | null> {
+  const [row] = await db
+    .select({ host: agentHosts, connection: agentConnections })
+    .from(agentConnections)
+    .innerJoin(agentHosts, eq(agentConnections.hostId, agentHosts.id))
+    .where(
+      and(
+        eq(agentHosts.userId, input.userId),
+        eq(agentHosts.connectorId, input.target.connectorId),
+        eq(agentHosts.transport, input.target.transport),
+        input.target.transport === "local"
+          ? isNull(agentHosts.sshAlias)
+          : eq(agentHosts.sshAlias, input.target.sshAlias),
+        eq(agentConnections.provider, input.provider),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
 export async function getOwnedAgentSession(
   id: string,
   userId: string,
@@ -225,34 +298,93 @@ export function createAgentConnection(
   input: NewAgentConnection,
 ): OwnedAgentConnection {
   return db.transaction((tx) => {
-    const hostId = crypto.randomUUID();
-    const [host] = tx
-      .insert(agentHosts)
-      .values({
-        id: hostId,
-        userId: input.userId,
-        ...input.host,
-      })
-      .returning()
-      .all();
-    const [connection] = tx
-      .insert(agentConnections)
-      .values({
-        id: crypto.randomUUID(),
-        hostId,
-        provider: input.connection.provider,
+    return upsertAgentConnectionRecord(tx, input);
+  });
+}
+
+type AgentDbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+function agentHostTargetCondition(input: NewAgentConnection) {
+  return and(
+    eq(agentHosts.userId, input.userId),
+    eq(agentHosts.connectorId, input.host.connectorId),
+    eq(agentHosts.transport, input.host.transport),
+    input.host.transport === "local"
+      ? isNull(agentHosts.sshAlias)
+      : eq(agentHosts.sshAlias, input.host.sshAlias ?? ""),
+  );
+}
+
+function upsertAgentConnectionRecord(
+  tx: AgentDbTransaction,
+  input: NewAgentConnection,
+  ids?: { hostId: string; connectionId: string },
+): OwnedAgentConnection {
+  const existing = tx
+    .select({ host: agentHosts, connection: agentConnections })
+    .from(agentConnections)
+    .innerJoin(agentHosts, eq(agentConnections.hostId, agentHosts.id))
+    .where(
+      and(
+        agentHostTargetCondition(input),
+        eq(agentConnections.provider, input.connection.provider),
+      ),
+    )
+    .limit(1)
+    .get();
+  if (existing) {
+    const host =
+      existing.host.name === input.host.name
+        ? existing.host
+        : tx
+            .update(agentHosts)
+            .set({ name: input.host.name, updatedAt: new Date() })
+            .where(eq(agentHosts.id, existing.host.id))
+            .returning()
+            .get();
+    const connection = tx
+      .update(agentConnections)
+      .set({
         executable: input.connection.executable,
         shellMode: input.connection.shellMode,
         detectedVersion: input.connection.detectedVersion,
         lastValidatedAt: new Date(),
+        updatedAt: new Date(),
       })
+      .where(eq(agentConnections.id, existing.connection.id))
       .returning()
-      .all();
+      .get();
     if (!host || !connection) {
-      throw new Error("Failed to create agent connection.");
+      throw new Error("Failed to update the agent connection backing record.");
     }
     return { host, connection };
-  });
+  }
+
+  const host = tx
+    .insert(agentHosts)
+    .values({
+      id: ids?.hostId ?? crypto.randomUUID(),
+      userId: input.userId,
+      ...input.host,
+    })
+    .returning()
+    .get();
+  if (!host) throw new Error("Failed to save the agent host.");
+  const connection = tx
+    .insert(agentConnections)
+    .values({
+      id: ids?.connectionId ?? crypto.randomUUID(),
+      hostId: host.id,
+      provider: input.connection.provider,
+      executable: input.connection.executable,
+      shellMode: input.connection.shellMode,
+      detectedVersion: input.connection.detectedVersion,
+      lastValidatedAt: new Date(),
+    })
+    .returning()
+    .get();
+  if (!connection) throw new Error("Failed to save the agent connection.");
+  return { host, connection };
 }
 
 export async function touchAgentConnectionValidation(
@@ -263,15 +395,34 @@ export async function touchAgentConnectionValidation(
 ): Promise<boolean> {
   const owned = await getOwnedAgentConnection(id, userId);
   if (!owned) return false;
+  return updateAgentConnectionRuntime({
+    id,
+    userId,
+    executable: owned.connection.executable,
+    detectedVersion,
+    shellMode,
+  });
+}
+
+export async function updateAgentConnectionRuntime(input: {
+  id: string;
+  userId: string;
+  executable: string;
+  detectedVersion: string;
+  shellMode: ConnectorShellMode;
+}): Promise<boolean> {
+  const owned = await getOwnedAgentConnection(input.id, input.userId);
+  if (!owned) return false;
   const updated = await db
     .update(agentConnections)
     .set({
-      detectedVersion,
-      shellMode,
+      executable: input.executable,
+      detectedVersion: input.detectedVersion,
+      shellMode: input.shellMode,
       lastValidatedAt: new Date(),
       updatedAt: new Date(),
     })
-    .where(eq(agentConnections.id, id))
+    .where(eq(agentConnections.id, input.id))
     .returning({ id: agentConnections.id });
   return updated.length > 0;
 }
@@ -311,6 +462,56 @@ export async function createAgentWorkspace(
   return row ?? null;
 }
 
+export function saveAgentWorkspaceInstallation(
+  input: AgentWorkspaceInstallation,
+): OwnedAgentConnection & {
+  workspace: AgentWorkspaceRow;
+  sessions: AgentSessionRow[];
+} {
+  return db.transaction((tx) => {
+    const owned = upsertAgentConnectionRecord(tx, input, input.ids);
+    const existingWorkspace = tx
+      .select()
+      .from(agentWorkspaces)
+      .where(
+        and(
+          eq(agentWorkspaces.connectionId, owned.connection.id),
+          eq(agentWorkspaces.path, input.workspace.path),
+        ),
+      )
+      .limit(1)
+      .get();
+    const workspace = existingWorkspace
+      ? tx
+          .update(agentWorkspaces)
+          .set({ name: input.workspace.name, updatedAt: new Date() })
+          .where(eq(agentWorkspaces.id, existingWorkspace.id))
+          .returning()
+          .get()
+      : tx
+          .insert(agentWorkspaces)
+          .values({
+            id: input.ids?.workspaceId ?? crypto.randomUUID(),
+            connectionId: owned.connection.id,
+            path: input.workspace.path,
+            name: input.workspace.name,
+          })
+          .returning()
+          .get();
+    if (!workspace) throw new Error("Failed to save the agent workspace.");
+    return {
+      ...owned,
+      workspace,
+      sessions: syncAgentWorkspaceSessionsInTransaction(
+        tx,
+        workspace.id,
+        input.sessions,
+        input.ids?.sessionIds,
+      ),
+    };
+  });
+}
+
 export async function deleteAgentWorkspace(
   id: string,
   userId: string,
@@ -328,82 +529,91 @@ export function syncAgentWorkspaceSessions(
   workspaceId: string,
   sessions: ProviderSessionMetadata[],
 ): AgentSessionRow[] {
-  return db.transaction((tx) => {
-    const now = new Date();
-    const paths = sessions.map((session) => session.providerSessionPath);
-    if (paths.length === 0) {
-      tx.delete(agentSessions)
-        .where(eq(agentSessions.workspaceId, workspaceId))
-        .run();
-      return [];
-    }
+  return db.transaction((tx) =>
+    syncAgentWorkspaceSessionsInTransaction(tx, workspaceId, sessions),
+  );
+}
 
-    for (const session of sessions) {
-      const initialTitle = resolveInitialAgentSessionTitle(session);
-      tx.insert(agentSessions)
-        .values({
-          id: crypto.randomUUID(),
-          workspaceId,
+function syncAgentWorkspaceSessionsInTransaction(
+  tx: AgentDbTransaction,
+  workspaceId: string,
+  sessions: ProviderSessionMetadata[],
+  sessionIds: Record<string, string> = {},
+): AgentSessionRow[] {
+  const now = new Date();
+  const paths = sessions.map((session) => session.providerSessionPath);
+  if (paths.length === 0) {
+    tx.delete(agentSessions)
+      .where(eq(agentSessions.workspaceId, workspaceId))
+      .run();
+    return [];
+  }
+
+  for (const session of sessions) {
+    const initialTitle = resolveInitialAgentSessionTitle(session);
+    tx.insert(agentSessions)
+      .values({
+        id: sessionIds[session.providerSessionPath] ?? crypto.randomUUID(),
+        workspaceId,
+        providerSessionId: session.providerSessionId,
+        providerSessionPath: session.providerSessionPath,
+        name: initialTitle,
+        firstMessage: session.firstMessage,
+        messageCount: session.messageCount,
+        providerCreatedAt: session.createdAt,
+        providerModifiedAt: session.modifiedAt,
+        model: session.launchConfig?.model,
+        thinkingOptionId: session.launchConfig?.thinkingOptionId,
+        modeId: session.launchConfig?.modeId,
+        lastSyncedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          agentSessions.workspaceId,
+          agentSessions.providerSessionPath,
+        ],
+        set: {
           providerSessionId: session.providerSessionId,
-          providerSessionPath: session.providerSessionPath,
-          name: initialTitle,
+          ...(initialTitle
+            ? {
+                name: sql`coalesce(nullif(trim(${agentSessions.name}), ''), ${initialTitle})`,
+              }
+            : {}),
           firstMessage: session.firstMessage,
           messageCount: session.messageCount,
           providerCreatedAt: session.createdAt,
           providerModifiedAt: session.modifiedAt,
-          model: session.launchConfig?.model,
-          thinkingOptionId: session.launchConfig?.thinkingOptionId,
-          modeId: session.launchConfig?.modeId,
+          ...(session.launchConfig?.model
+            ? { model: session.launchConfig.model }
+            : {}),
+          ...(session.launchConfig?.thinkingOptionId
+            ? { thinkingOptionId: session.launchConfig.thinkingOptionId }
+            : {}),
+          ...(session.launchConfig?.modeId
+            ? { modeId: session.launchConfig.modeId }
+            : {}),
           lastSyncedAt: now,
-        })
-        .onConflictDoUpdate({
-          target: [
-            agentSessions.workspaceId,
-            agentSessions.providerSessionPath,
-          ],
-          set: {
-            providerSessionId: session.providerSessionId,
-            ...(initialTitle
-              ? {
-                  name: sql`coalesce(nullif(trim(${agentSessions.name}), ''), ${initialTitle})`,
-                }
-              : {}),
-            firstMessage: session.firstMessage,
-            messageCount: session.messageCount,
-            providerCreatedAt: session.createdAt,
-            providerModifiedAt: session.modifiedAt,
-            ...(session.launchConfig?.model
-              ? { model: session.launchConfig.model }
-              : {}),
-            ...(session.launchConfig?.thinkingOptionId
-              ? { thinkingOptionId: session.launchConfig.thinkingOptionId }
-              : {}),
-            ...(session.launchConfig?.modeId
-              ? { modeId: session.launchConfig.modeId }
-              : {}),
-            lastSyncedAt: now,
-            updatedAt: now,
-          },
-        })
-        .run();
-    }
-
-    tx.delete(agentSessions)
-      .where(
-        and(
-          eq(agentSessions.workspaceId, workspaceId),
-          notInArray(agentSessions.providerSessionPath, paths),
-        ),
-      )
+          updatedAt: now,
+        },
+      })
       .run();
+  }
 
-    return tx
-      .select()
-      .from(agentSessions)
-      .where(eq(agentSessions.workspaceId, workspaceId))
-      .orderBy(desc(agentSessions.providerModifiedAt))
-      .all();
-  });
+  tx.delete(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.workspaceId, workspaceId),
+        notInArray(agentSessions.providerSessionPath, paths),
+      ),
+    )
+    .run();
+
+  return tx
+    .select()
+    .from(agentSessions)
+    .where(eq(agentSessions.workspaceId, workspaceId))
+    .orderBy(desc(agentSessions.providerModifiedAt))
+    .all();
 }
 
 export async function upsertAgentSession(

--- a/apps/web/lib/queries/agentConnections.test.tsx
+++ b/apps/web/lib/queries/agentConnections.test.tsx
@@ -187,5 +187,6 @@ describe("agent connection session directory", () => {
         agentConnectionKeys.list(),
       )?.[0]?.workspaces[0]?.sessions[0]?.runtimeStatus,
     ).toBe("running");
+
   });
 });

--- a/apps/web/lib/queries/agentConnections.ts
+++ b/apps/web/lib/queries/agentConnections.ts
@@ -3,28 +3,22 @@
 import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
-  AgentConnectionDraft,
   AgentConnectionListItem,
   AgentDiscoveryTarget,
   AgentDirectoryListing,
   AgentReadyConnectionProbe,
   AgentProviderCatalog,
+  AgentProviderId,
+  AgentProviderSnapshot,
   AgentSessionDirectoryEntry,
   AgentSessionLaunchConfig,
   AgentSshHostCandidate,
-  AgentWorkspaceListItem,
   DetectedAgentInstallation,
   HostConnectorListItem,
   HostConnectorPairing,
 } from "@overtchat/agent-bridge";
 import { isAgentSessionDirectoryEntry } from "@overtchat/agent-bridge";
 import { agentConnectionKeys } from "@/lib/queries/keys";
-import {
-  agentConnectionMatchesTarget,
-  agentConnectionTarget,
-  agentTargetKey,
-  groupAgentWorkspaces,
-} from "@/lib/agents/workspaces";
 import {
   agentConnectionHasRunningSession,
   withAgentSessionDirectory,
@@ -69,7 +63,6 @@ export function useAgentConnectionSessionDirectory(
     )
     .sort()
     .join("\n");
-
   useEffect(() => {
     if (!sessionFingerprint) return;
     const source = new EventSource("/api/agent-connections/events");
@@ -205,18 +198,31 @@ export function useDetectedAgentInstallations(
   });
 }
 
-async function discoverAgentInstallations(
-  target: AgentDiscoveryTarget,
-): Promise<DetectedAgentInstallation[]> {
-  const response = await fetch("/api/agent-connections/discover", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(target),
+export function useAgentProviderSnapshot(
+  target: AgentDiscoveryTarget | null,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: agentConnectionKeys.providerSnapshot(
+      target?.connectorId ?? "",
+      target?.transport ?? "local",
+      target?.transport === "ssh" ? target.sshAlias : "",
+    ),
+    queryFn: async (): Promise<AgentProviderSnapshot> => {
+      if (!target) throw new Error("Choose a machine first.");
+      const response = await fetch("/api/agent-connections/discover?refresh=0", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(target),
+      });
+      if (!response.ok) throw await responseError(response);
+      return ((await response.json()) as {
+        snapshot: AgentProviderSnapshot;
+      }).snapshot;
+    },
+    enabled: enabled && target !== null,
+    retry: false,
   });
-  if (!response.ok) throw await responseError(response);
-  return ((await response.json()) as {
-    installations: DetectedAgentInstallation[];
-  }).installations;
 }
 
 export function useAgentTargetDirectories(
@@ -248,64 +254,9 @@ export function useAgentTargetDirectories(
   });
 }
 
-export type CreateAgentWorkspaceSetupInput = {
-  draft: AgentConnectionDraft;
-  path: string;
-  connection?: AgentConnectionListItem;
-};
-
-export async function createAgentWorkspaceSetup({
-  draft,
-  path,
-  connection: existingConnection,
-}: CreateAgentWorkspaceSetupInput): Promise<{
-  connection: AgentConnectionListItem;
-  workspace: AgentWorkspaceListItem;
-}> {
-  let connection = existingConnection;
-  let createdConnectionId: string | null = null;
-
-  if (!connection) {
-    const response = await fetch("/api/agent-connections", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(draft),
-    });
-    if (!response.ok) throw await responseError(response);
-    connection = ((await response.json()) as {
-      connection: AgentConnectionListItem;
-    }).connection;
-    createdConnectionId = connection.id;
-  }
-
-  try {
-    const response = await fetch(
-      `/api/agent-connections/${connection.id}/workspaces`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ path }),
-      },
-    );
-    if (!response.ok) throw await responseError(response);
-    const workspace = ((await response.json()) as {
-      workspace: AgentWorkspaceListItem;
-    }).workspace;
-    return { connection, workspace };
-  } catch (error) {
-    if (createdConnectionId) {
-      await fetch(`/api/agent-connections/${createdConnectionId}`, {
-        method: "DELETE",
-      }).catch(() => undefined);
-    }
-    throw error;
-  }
-}
-
-type ReconcileAgentWorkspaceInput = {
+export type ReconcileAgentWorkspaceInput = {
   target: AgentDiscoveryTarget;
   path: string;
-  connections: AgentConnectionListItem[];
   installations?: DetectedAgentInstallation[];
 };
 
@@ -316,165 +267,23 @@ export type AgentWorkspaceReconcileResult = {
   failures: Array<{ provider: string; message: string }>;
 };
 
-function draftForInstallation(
-  target: AgentDiscoveryTarget,
-  installation: DetectedAgentInstallation,
-): AgentConnectionDraft {
-  return target.transport === "local"
-    ? {
-        connectorId: target.connectorId,
-        provider: installation.provider,
-        transport: "local",
-        name: "This server",
-        executable: installation.executable,
-      }
-    : {
-        connectorId: target.connectorId,
-        provider: installation.provider,
-        transport: "ssh",
-        name: target.sshAlias.slice(0, 80),
-        executable: installation.executable,
-        sshAlias: target.sshAlias,
-      };
-}
-
-async function refreshStoredWorkspace(id: string): Promise<void> {
-  const response = await fetch(`/api/agent-workspaces/${id}`, {
-    method: "POST",
-  });
-  if (!response.ok) throw await responseError(response);
-}
-
 export async function reconcileAgentWorkspace({
   target,
   path,
-  connections,
   installations,
 }: ReconcileAgentWorkspaceInput): Promise<AgentWorkspaceReconcileResult> {
-  const detected = installations ?? (await discoverAgentInstallations(target));
-  const matchingConnections = connections.filter((connection) =>
-    agentConnectionMatchesTarget(connection, target, connection.provider),
-  );
-  const providers = new Map(
-    detected.map((installation) => [installation.provider, installation]),
-  );
-  for (const connection of matchingConnections) {
-    if (!providers.has(connection.provider)) {
-      providers.set(connection.provider, {
-        provider: connection.provider,
-        executable: connection.executable,
-        version: connection.detectedVersion ?? "configured",
-      });
-    }
-  }
-  if (providers.size === 0) {
-    throw new Error("No supported coding agents were detected on this machine.");
-  }
-
-  const result: AgentWorkspaceReconcileResult = {
-    providers: providers.size,
-    refreshed: 0,
-    created: 0,
-    failures: [],
-  };
-  for (const installation of providers.values()) {
-    const connection = matchingConnections.find(
-      (candidate) => candidate.provider === installation.provider,
-    );
-    const workspace = connection?.workspaces.find(
-      (candidate) => candidate.path === path,
-    );
-    try {
-      if (workspace) {
-        await refreshStoredWorkspace(workspace.id);
-        result.refreshed += 1;
-      } else {
-        await createAgentWorkspaceSetup({
-          draft: draftForInstallation(target, installation),
-          path,
-          connection,
-        });
-        result.created += 1;
-      }
-    } catch (error) {
-      result.failures.push({
-        provider: installation.provider,
-        message: error instanceof Error ? error.message : "Refresh failed.",
-      });
-    }
-  }
-  if (result.refreshed + result.created === 0) {
-    throw new Error(
-      result.failures.map(({ message }) => message).join(" ") ||
-        "The workspace could not be refreshed.",
-    );
-  }
-  return result;
-}
-
-export async function reconcileAllAgentWorkspaces(
-  connections: AgentConnectionListItem[],
-): Promise<AgentWorkspaceReconcileResult> {
-  const groups = groupAgentWorkspaces(connections);
-  const totals: AgentWorkspaceReconcileResult = {
-    providers: 0,
-    refreshed: 0,
-    created: 0,
-    failures: [],
-  };
-  const discoveries = new Map<
-    string,
-    Promise<DetectedAgentInstallation[]>
-  >();
-  const current = [...connections];
-
-  for (const group of groups) {
-    const target = agentConnectionTarget(group.targets[0]!.connection);
-    const key = agentTargetKey(target);
-    let discovery = discoveries.get(key);
-    if (!discovery) {
-      discovery = discoverAgentInstallations(target);
-      discoveries.set(key, discovery);
-    }
-    let installations: DetectedAgentInstallation[] | undefined;
-    try {
-      installations = await discovery;
-    } catch (error) {
-      totals.failures.push({
-        provider: "discovery",
-        message:
-          error instanceof Error ? error.message : "Agent discovery failed.",
-      });
-    }
-    let result: AgentWorkspaceReconcileResult;
-    try {
-      result = await reconcileAgentWorkspace({
-        target,
-        path: group.path,
-        connections: current,
-        installations: installations ?? [],
-      });
-    } catch (error) {
-      totals.failures.push({
-        provider: "workspace",
-        message:
-          error instanceof Error
-            ? `${group.name}: ${error.message}`
-            : `${group.name}: refresh failed.`,
-      });
-      continue;
-    }
-    totals.providers += result.providers;
-    totals.refreshed += result.refreshed;
-    totals.created += result.created;
-    totals.failures.push(...result.failures);
-
-    if (result.created > 0) {
-      const latest = await fetchAgentConnections();
-      current.splice(0, current.length, ...latest);
-    }
-  }
-  return totals;
+  const response = await fetch("/api/agent-workspaces", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      target,
+      path,
+      ...(installations ? { installations } : {}),
+    }),
+  });
+  if (!response.ok) throw await responseError(response);
+  return ((await response.json()) as { result: AgentWorkspaceReconcileResult })
+    .result;
 }
 
 export function useCreateAgentWorkspaceGroup() {
@@ -489,7 +298,15 @@ export function useCreateAgentWorkspaceGroup() {
 export function useRefreshAllAgentWorkspaces() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: reconcileAllAgentWorkspaces,
+    mutationFn: async (): Promise<AgentWorkspaceReconcileResult> => {
+      const response = await fetch("/api/agent-workspaces/sync", {
+        method: "POST",
+      });
+      if (!response.ok) throw await responseError(response);
+      return ((await response.json()) as {
+        result: AgentWorkspaceReconcileResult;
+      }).result;
+    },
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: agentConnectionKeys.list() }),
   });
@@ -545,9 +362,11 @@ export function useCreateAgentSession() {
   return useMutation({
     mutationFn: async ({
       workspaceId,
+      provider,
       launchConfig,
     }: {
       workspaceId: string;
+      provider: AgentProviderId;
       launchConfig: AgentSessionLaunchConfig;
     }): Promise<string> => {
       const response = await fetch(
@@ -555,7 +374,7 @@ export function useCreateAgentSession() {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(launchConfig),
+          body: JSON.stringify({ provider, launchConfig }),
         },
       );
       if (!response.ok) throw await responseError(response);
@@ -569,16 +388,22 @@ export function useCreateAgentSession() {
 
 export function useAgentWorkspaceCatalog(
   workspaceId: string | null,
+  provider: AgentProviderId | null,
   enabled = true,
 ) {
   return useQuery({
-    queryKey: agentConnectionKeys.catalog(workspaceId ?? ""),
+    queryKey: agentConnectionKeys.catalog(
+      workspaceId ?? "",
+      provider ?? "",
+    ),
     queryFn: async (): Promise<AgentProviderCatalog> => {
-      const response = await fetch(`/api/agent-workspaces/${workspaceId}/catalog`);
+      const response = await fetch(
+        `/api/agent-workspaces/${workspaceId}/catalog?provider=${encodeURIComponent(provider ?? "")}`,
+      );
       if (!response.ok) throw await responseError(response);
       return (await response.json()) as AgentProviderCatalog;
     },
-    enabled: enabled && Boolean(workspaceId),
+    enabled: enabled && Boolean(workspaceId) && provider !== null,
     staleTime: 30_000,
   });
 }

--- a/apps/web/lib/queries/agentWorkspaceSetup.test.ts
+++ b/apps/web/lib/queries/agentWorkspaceSetup.test.ts
@@ -1,260 +1,63 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AgentConnectionListItem } from "@overtchat/agent-bridge";
-import {
-  createAgentWorkspaceSetup,
-  reconcileAllAgentWorkspaces,
-  reconcileAgentWorkspace,
-} from "./agentConnections";
+import { reconcileAgentWorkspace } from "./agentConnections";
 
-const draft = {
-  connectorId: "connector",
-  provider: "codex" as const,
-  transport: "local" as const,
-  name: "This server",
-  executable: "/usr/local/bin/codex",
-};
-
-const connection: AgentConnectionListItem = {
-  id: "connection",
-  provider: "codex",
-  executable: "/usr/local/bin/codex",
-  detectedVersion: "1.2.3",
-  lastValidatedAt: 1,
-  host: {
-    id: "host",
-    connectorId: "connector",
-    name: "This server",
-    transport: "local",
-    sshAlias: null,
-  },
-  workspaces: [],
-};
-
-const workspace = {
-  id: "workspace",
-  path: "/srv/overtchat",
-  name: "overtchat",
-  sessions: [],
-};
-
-describe("consolidated agent workspace setup", () => {
+describe("agent workspace setup client", () => {
   afterEach(() => vi.unstubAllGlobals());
 
-  it("reuses an existing agent connection and only attaches the folder", async () => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
-      Response.json({ workspace }, { status: 201 }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      createAgentWorkspaceSetup({
-        draft,
-        path: workspace.path,
-        connection,
-      }),
-    ).resolves.toEqual({ connection, workspace });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/agent-connections/connection/workspaces",
-      expect.objectContaining({ method: "POST" }),
-    );
-  });
-
-  it("creates the agent connection and workspace as one user operation", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(Response.json({ connection }, { status: 201 }))
-      .mockResolvedValueOnce(Response.json({ workspace }, { status: 201 }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      createAgentWorkspaceSetup({ draft, path: workspace.path }),
-    ).resolves.toEqual({ connection, workspace });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("removes a newly-created connection when attaching the folder fails", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(Response.json({ connection }, { status: 201 }))
-      .mockResolvedValueOnce(
-        Response.json({ error: "Folder is unavailable." }, { status: 400 }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      createAgentWorkspaceSetup({ draft, path: workspace.path }),
-    ).rejects.toThrow("Folder is unavailable.");
-    expect(fetchMock).toHaveBeenLastCalledWith(
-      "/api/agent-connections/connection",
-      { method: "DELETE" },
-    );
-  });
-
-  it("creates and imports the directory for every detected provider", async () => {
-    const codexConnection = connection;
-    const ompConnection = {
-      ...connection,
-      id: "omp-connection",
-      provider: "omp" as const,
-      executable: "/usr/local/bin/omp",
+  it("submits one atomic workspace reconciliation request", async () => {
+    const result = {
+      providers: 2,
+      created: 2,
+      refreshed: 0,
+      failures: [],
     };
-    const codexWorkspace = workspace;
-    const ompWorkspace = { ...workspace, id: "omp-workspace" };
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        Response.json({ connection: codexConnection }, { status: 201 }),
-      )
-      .mockResolvedValueOnce(
-        Response.json({ workspace: codexWorkspace }, { status: 201 }),
-      )
-      .mockResolvedValueOnce(
-        Response.json({ connection: ompConnection }, { status: 201 }),
-      )
-      .mockResolvedValueOnce(
-        Response.json({ workspace: ompWorkspace }, { status: 201 }),
-      );
+      .mockResolvedValueOnce(Response.json({ result }, { status: 201 }));
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       reconcileAgentWorkspace({
         target: { connectorId: "connector", transport: "local" },
-        path: workspace.path,
-        connections: [],
+        path: "/srv/overtchat",
         installations: [
           {
             provider: "codex",
             executable: "/usr/local/bin/codex",
             version: "1.2.3",
+            shellMode: "interactive",
           },
           {
-            provider: "omp",
-            executable: "/usr/local/bin/omp",
-            version: "2.0.0",
+            provider: "opencode",
+            executable: "/usr/local/bin/opencode",
+            version: "1.18.23",
+            shellMode: "interactive",
           },
         ],
       }),
-    ).resolves.toEqual({
-      providers: 2,
-      refreshed: 0,
-      created: 2,
-      failures: [],
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
-      "/api/agent-connections",
-      expect.objectContaining({
-        body: JSON.stringify({
-          connectorId: "connector",
-          provider: "codex",
-          transport: "local",
-          name: "This server",
-          executable: "/usr/local/bin/codex",
-        }),
-      }),
+    ).resolves.toEqual(result);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/agent-workspaces",
+      expect.objectContaining({ method: "POST" }),
     );
   });
 
-  it("refreshes every configured provider already attached to the directory", async () => {
-    const attached = {
-      ...connection,
-      workspaces: [workspace],
-    };
-    const ompWorkspace = { ...workspace, id: "omp-workspace" };
-    const ompConnection: AgentConnectionListItem = {
-      ...connection,
-      id: "omp-connection",
-      provider: "omp",
-      executable: "omp",
-      workspaces: [ompWorkspace],
-    };
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValue(new Response(null, { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
+  it("surfaces server reconciliation failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          Response.json({ error: "Workspace probe failed." }, { status: 400 }),
+        ),
+    );
 
     await expect(
       reconcileAgentWorkspace({
         target: { connectorId: "connector", transport: "local" },
-        path: workspace.path,
-        connections: [attached, ompConnection],
-        installations: [],
+        path: "/srv/overtchat",
       }),
-    ).resolves.toEqual({
-      providers: 2,
-      refreshed: 2,
-      created: 0,
-      failures: [],
-    });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/agent-workspaces/workspace",
-      { method: "POST" },
-    );
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/agent-workspaces/omp-workspace",
-      { method: "POST" },
-    );
-  });
-
-  it("global refresh discovers and attaches a newly available provider", async () => {
-    const attached = { ...connection, workspaces: [workspace] };
-    const ompConnection: AgentConnectionListItem = {
-      ...connection,
-      id: "omp-connection",
-      provider: "omp",
-      executable: "omp",
-      workspaces: [],
-    };
-    const ompWorkspace = { ...workspace, id: "omp-workspace" };
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        Response.json({
-          installations: [
-            {
-              provider: "codex",
-              executable: "codex",
-              version: "1.2.3",
-            },
-            { provider: "omp", executable: "omp", version: "2.0.0" },
-          ],
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 200 }))
-      .mockResolvedValueOnce(
-        Response.json({ connection: ompConnection }, { status: 201 }),
-      )
-      .mockResolvedValueOnce(
-        Response.json({ workspace: ompWorkspace }, { status: 201 }),
-      )
-      .mockResolvedValueOnce(
-        Response.json({
-          connections: [
-            attached,
-            { ...ompConnection, workspaces: [ompWorkspace] },
-          ],
-        }),
-      );
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(reconcileAllAgentWorkspaces([attached])).resolves.toEqual({
-      providers: 2,
-      refreshed: 1,
-      created: 1,
-      failures: [],
-    });
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
-      "/api/agent-connections/discover",
-      expect.objectContaining({ method: "POST" }),
-    );
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      3,
-      "/api/agent-connections",
-      expect.objectContaining({ method: "POST" }),
-    );
+    ).rejects.toThrow("Workspace probe failed.");
   });
 });

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -29,6 +29,18 @@ export const agentConnectionKeys = {
       transport,
       sshAlias,
     ] as const,
+  providerSnapshot: (
+    connectorId: string,
+    transport: "local" | "ssh",
+    sshAlias: string,
+  ) =>
+    [
+      ...agentConnectionKeys.all(),
+      "providerSnapshot",
+      connectorId,
+      transport,
+      sshAlias,
+    ] as const,
   targetDirectories: (
     connectorId: string,
     transport: "local" | "ssh",
@@ -43,8 +55,8 @@ export const agentConnectionKeys = {
       sshAlias,
       path,
     ] as const,
-  catalog: (workspaceId: string) =>
-    [...agentConnectionKeys.all(), "catalog", workspaceId] as const,
+  catalog: (workspaceId: string, provider: string) =>
+    [...agentConnectionKeys.all(), "catalog", workspaceId, provider] as const,
 };
 
 export const agentSessionKeys = {

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.16.8}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.17.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,7 +552,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"
@@ -8135,6 +8135,15 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.23.tgz",
+      "integrity": "sha512-VouYbL8O2ynLq0atr5fjzCv8YLtFi/zKLQ/uYkCvTJ4CmUdA01XwPn8om+u3TvxnGEfQsBfmThGU141vt3sg5w==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
@@ -28762,6 +28771,7 @@
       "name": "@overtchat/agent-runtime",
       "version": "0.1.0",
       "dependencies": {
+        "@opencode-ai/sdk": "1.18.23",
         "@overtchat/agent-bridge": "*",
         "zod": "^4.4.3"
       },

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const CONNECTOR_SHELL_MODES = ["interactive", "login"] as const;
 export type ConnectorShellMode = (typeof CONNECTOR_SHELL_MODES)[number];
 
-export const AGENT_PROVIDER_IDS = ["pi", "omp", "codex"] as const;
+export const AGENT_PROVIDER_IDS = ["pi", "omp", "codex", "opencode"] as const;
 export type AgentProviderId = (typeof AGENT_PROVIDER_IDS)[number];
 export type AgentRuntimeStatus = "idle" | "running" | "exited";
 
@@ -83,9 +83,50 @@ export const addAgentWorkspaceSchema = z.object({
   name: z.string().trim().min(1).max(120).optional(),
 });
 
+export const detectedAgentInstallationSchema = z.object({
+  provider: z.enum(AGENT_PROVIDER_IDS),
+  executable: z.string().trim().min(1).max(500),
+  version: z.string().trim().min(1).max(120),
+  shellMode: z.enum(CONNECTOR_SHELL_MODES),
+});
+
+export const agentProviderSnapshotRequestSchema = z.object({
+  target: agentDiscoveryTargetSchema,
+  refresh: z.boolean().optional(),
+});
+
+export const createAgentWorkspaceSchema = z.object({
+  target: agentDiscoveryTargetSchema,
+  path: addAgentWorkspaceSchema.shape.path,
+  installations: z.array(detectedAgentInstallationSchema).optional(),
+});
+
+const agentProviderSnapshotEntrySchema = z.discriminatedUnion("status", [
+  detectedAgentInstallationSchema.extend({ status: z.literal("ready") }),
+  z.object({
+    provider: z.enum(AGENT_PROVIDER_IDS),
+    status: z.literal("unavailable"),
+  }),
+]);
+
+export const agentProviderSnapshotSchema = z.object({
+  target: agentDiscoveryTargetSchema,
+  providers: z.array(agentProviderSnapshotEntrySchema).length(
+    AGENT_PROVIDER_IDS.length,
+  ),
+  refreshedAt: z.number().int().nonnegative(),
+});
+
 export type AddAgentWorkspaceInput = z.infer<
   typeof addAgentWorkspaceSchema
 >;
+export type AgentProviderSnapshotRequest = z.infer<
+  typeof agentProviderSnapshotRequestSchema
+>;
+export type AgentProviderSnapshot = z.infer<
+  typeof agentProviderSnapshotSchema
+>;
+export type AgentProviderSnapshotEntry = AgentProviderSnapshot["providers"][number];
 
 export type AgentSessionListItem = {
   id: string;
@@ -182,7 +223,7 @@ export type AgentModel = {
   contextWindow: number | null;
   maxTokens: number | null;
   thinkingOptions?: AgentSelectOption[];
-  defaultThinkingOptionId?: AgentThinkingLevel;
+  defaultThinkingOptionId?: string;
   cost: {
     input: number;
     output: number;
@@ -192,7 +233,7 @@ export type AgentModel = {
 };
 
 export type AgentSelectOption = {
-  id: AgentThinkingLevel;
+  id: string;
   label: string;
   description?: string;
   isDefault?: boolean;
@@ -201,7 +242,7 @@ export type AgentSelectOption = {
 export const agentSessionLaunchConfigSchema = z
   .object({
     model: z.string().trim().min(1).max(500).optional(),
-    thinkingOptionId: z.enum(AGENT_THINKING_LEVELS).optional(),
+    thinkingOptionId: z.string().trim().min(1).max(120).optional(),
     modeId: z.string().trim().min(1).max(120).optional(),
   })
   .strict();
@@ -238,6 +279,7 @@ export type DetectedAgentInstallation = {
   provider: AgentProviderId;
   executable: string;
   version: string;
+  shellMode: ConnectorShellMode;
 };
 
 export type AgentSshHostCandidate = {
@@ -329,7 +371,7 @@ export type AgentProviderCatalog = {
 };
 
 const agentSelectOptionSchema = z.object({
-  id: z.enum(AGENT_THINKING_LEVELS),
+  id: z.string().trim().min(1).max(120),
   label: z.string().min(1),
   description: z.string().optional(),
   isDefault: z.boolean().optional(),
@@ -354,7 +396,7 @@ const agentModelSchema = z.object({
   contextWindow: z.number().int().positive().nullable(),
   maxTokens: z.number().int().positive().nullable(),
   thinkingOptions: z.array(agentSelectOptionSchema).optional(),
-  defaultThinkingOptionId: z.enum(AGENT_THINKING_LEVELS).optional(),
+  defaultThinkingOptionId: z.string().trim().min(1).max(120).optional(),
   cost: z.object({
     input: z.number().nonnegative(),
     output: z.number().nonnegative(),
@@ -473,7 +515,7 @@ export const agentSessionCommandSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("set_thinking_level"),
-    level: z.enum(AGENT_THINKING_LEVELS),
+    level: z.string().trim().min(1).max(120),
   }),
   z.object({
     type: z.literal("set_collaboration_mode"),

--- a/packages/agent-bridge/src/catalog.ts
+++ b/packages/agent-bridge/src/catalog.ts
@@ -44,6 +44,14 @@ export const AGENT_PROVIDERS: Record<
       forkMessages: true,
     },
   },
+  opencode: {
+    id: "opencode",
+    label: "OpenCode",
+    executable: "opencode",
+    capabilities: {
+      steer: true,
+    },
+  },
 };
 
 export function agentProviderMetadata(

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -19,14 +19,13 @@ import {
   agentSessionLaunchConfigSchema,
 } from "./agents";
 
-export const HOST_CONNECTOR_PROTOCOL_VERSION = 1;
+export const HOST_CONNECTOR_PROTOCOL_VERSION = 2;
 /**
- * Protocol 1 was accidentally reused for two incompatible connector designs.
- * Release 0.7.0 is the compatibility baseline for the current agent-daemon
- * wire shape and remains stable even when the connector build version changes.
+ * Release 0.8.0 is the compatibility baseline for protocol 2 and remains
+ * stable when connector build versions change without changing the wire shape.
  */
-export const HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE = "0.7.0";
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.7.0";
+export const HOST_CONNECTOR_COMPATIBILITY_RELEASE = "0.8.0";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.8.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [
@@ -37,7 +36,7 @@ export type HostConnectorCapability =
   (typeof HOST_CONNECTOR_CAPABILITIES)[number];
 
 export type HostConnectorServerInfo = {
-  protocolVersion: 1;
+  protocolVersion: typeof HOST_CONNECTOR_PROTOCOL_VERSION;
   capabilities: string[];
 };
 
@@ -85,7 +84,11 @@ export type AgentSessionDirectoryEntry = {
 
 export type AgentDaemonRequest =
   | { type: "list_ssh_hosts" }
-  | { type: "discover"; target: AgentDiscoveryTarget }
+  | {
+      type: "provider_snapshot";
+      target: AgentDiscoveryTarget;
+      refresh?: boolean;
+    }
   | { type: "probe"; draft: AgentConnectionDraft }
   | {
       type: "list_sessions";
@@ -180,7 +183,7 @@ export type HostConnectorEvent = {
 };
 
 export type HostConnectorEventBatch = {
-  protocolVersion: 1;
+  protocolVersion: typeof HOST_CONNECTOR_PROTOCOL_VERSION;
   connectorEpoch: string;
   events: HostConnectorEvent[];
 };
@@ -295,8 +298,11 @@ function isAgentDaemonRequest(value: unknown): value is AgentDaemonRequest {
   switch (value.type) {
     case "list_ssh_hosts":
       return true;
-    case "discover":
-      return agentDiscoveryTargetSchema.safeParse(value.target).success;
+    case "provider_snapshot":
+      return (
+        agentDiscoveryTargetSchema.safeParse(value.target).success &&
+        (value.refresh === undefined || typeof value.refresh === "boolean")
+      );
     case "probe":
       return agentConnectionDraftSchema.safeParse(value.draft).success;
     case "list_sessions":

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   HOST_CONNECTOR_CAPABILITIES,
-  HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
+  HOST_CONNECTOR_PROTOCOL_VERSION,
   isHostConnectorCommand,
   isHostConnectorEvent,
   parseHostConnectorCapabilities,
@@ -9,8 +10,9 @@ import {
 import { agentProviderCatalogSchema } from "./agents";
 
 describe("Host Connector protocol compatibility", () => {
-  it("rejects connector builds from the previous v1 wire shape", () => {
-    expect(HOST_CONNECTOR_V1_COMPATIBILITY_RELEASE).toBe("0.7.0");
+  it("identifies the protocol 2 compatibility release", () => {
+    expect(HOST_CONNECTOR_PROTOCOL_VERSION).toBe(2);
+    expect(HOST_CONNECTOR_COMPATIBILITY_RELEASE).toBe("0.8.0");
   });
 
   it("selects known capabilities and ignores unknown additive tokens", () => {
@@ -32,7 +34,7 @@ describe("Host Connector protocol compatibility", () => {
         connectionEpoch: "connection",
         activeSessionIds: [],
         serverInfo: {
-          protocolVersion: 1,
+          protocolVersion: HOST_CONNECTOR_PROTOCOL_VERSION,
           capabilities: [...HOST_CONNECTOR_CAPABILITIES, "future-capability"],
         },
       }),

--- a/packages/agent-bridge/src/state.test.ts
+++ b/packages/agent-bridge/src/state.test.ts
@@ -576,6 +576,23 @@ describe("agent runtime event reducer", () => {
     expect(settled.activeTurn).toBeNull();
   });
 
+  it("preserves multi-question interaction forms", () => {
+    const next = applyAgentRuntimeEnvelope(
+      snapshot(),
+      event({
+        type: "interaction_request",
+        id: "opencode:question:1",
+        method: "form",
+        title: "OpenCode needs your input",
+        fields: [{ id: "0", type: "text", label: "Target" }],
+      }),
+    );
+    expect(next?.pendingInteraction).toMatchObject({
+      id: "opencode:question:1",
+      method: "form",
+    });
+  });
+
   it("tracks OvertChat-owned queues and late prompt errors", () => {
     const queued = applyAgentRuntimeEnvelope(
       snapshot(),

--- a/packages/agent-bridge/src/state.ts
+++ b/packages/agent-bridge/src/state.ts
@@ -542,7 +542,9 @@ export function applyAgentRuntimeEnvelope(
     event.type === "interaction_request" &&
     typeof event.id === "string" &&
     typeof event.method === "string" &&
-    ["select", "confirm", "input", "editor"].includes(event.method)
+    ["select", "confirm", "input", "editor", "form", "external"].includes(
+      event.method,
+    )
   ) {
     return {
       ...current,

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@opencode-ai/sdk": "1.18.23",
     "@overtchat/agent-bridge": "*",
     "zod": "^4.4.3"
   },

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -7,4 +7,5 @@ export {
 export * from "./runtime/filesystem";
 export * from "./runtime/git";
 export * from "./runtime/process";
+export * from "./runtime/provider-snapshots";
 export * from "./runtime/registry";

--- a/packages/agent-runtime/src/opencode/client.test.ts
+++ b/packages/agent-runtime/src/opencode/client.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createOpencodeClient: vi.fn(),
+  acquire: vi.fn(),
+}));
+
+vi.mock("@opencode-ai/sdk/v2/client", () => ({
+  createOpencodeClient: mocks.createOpencodeClient,
+}));
+vi.mock("@overtchat/agent-runtime/opencode/server", () => ({
+  openCodeServerPool: { acquire: mocks.acquire },
+}));
+
+import { listOpenCodeSessions, OpenCodeRuntimeClient } from "./client";
+
+function providerModel(id: string) {
+  return {
+    id,
+    name: id.toUpperCase(),
+    family: "test",
+    api: { id, url: "https://example.test" },
+    capabilities: {
+      reasoning: true,
+      attachment: false,
+      input: { text: true, image: false },
+    },
+    variants: { high: {} },
+    limit: { context: 100_000, output: 10_000 },
+    cost: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+  };
+}
+
+describe("OpenCode runtime client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.acquire.mockResolvedValue({
+      baseUrl: "http://127.0.0.1:4096",
+      exit: new Promise(() => {}),
+      release: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it("pins steering to the active turn while settings change for the next turn", async () => {
+    const promptAsync = vi.fn().mockResolvedValue({ data: undefined });
+    const session = {
+      id: "ses-1",
+      title: "New session",
+      metadata: {},
+      time: { created: 1, updated: 1 },
+      model: { providerID: "provider", id: "model-a", variant: "high" },
+      agent: "build",
+    };
+    const sdk = {
+      global: {
+        event: vi.fn().mockResolvedValue({
+          stream: (async function* () {})(),
+        }),
+      },
+      provider: {
+        list: vi.fn().mockResolvedValue({
+          data: {
+            all: [
+              {
+                id: "provider",
+                name: "Provider",
+                source: "api",
+                models: {
+                  "model-a": providerModel("model-a"),
+                  "model-b": providerModel("model-b"),
+                },
+              },
+            ],
+            connected: ["provider"],
+            default: { provider: "model-a" },
+          },
+        }),
+      },
+      app: {
+        agents: vi.fn().mockResolvedValue({
+          data: [
+            { name: "build", mode: "primary", description: "Build" },
+            { name: "review", mode: "primary", description: "Review" },
+          ],
+        }),
+      },
+      command: { list: vi.fn().mockResolvedValue({ data: [] }) },
+      config: {
+        get: vi.fn().mockResolvedValue({
+          data: { model: "provider/model-a", default_agent: "build" },
+        }),
+      },
+      session: {
+        create: vi.fn().mockResolvedValue({ data: session }),
+        messages: vi.fn().mockResolvedValue({ data: [] }),
+        todo: vi.fn().mockResolvedValue({ data: [] }),
+        status: vi.fn().mockResolvedValue({ data: { "ses-1": { type: "idle" } } }),
+        promptAsync,
+      },
+    };
+    mocks.createOpencodeClient.mockReturnValue(sdk);
+
+    const client = new OpenCodeRuntimeClient(
+      { transport: "local" },
+      {
+        executable: "opencode",
+        cwd: "/workspace",
+        model: "provider/model-a",
+        thinkingOptionId: "high",
+        modeId: "build",
+      },
+    );
+    try {
+      await client.getState();
+      await client.prompt("First");
+      await client.setModel("provider/model-b");
+      await client.setThinkingLevel("default");
+      await client.setMode("review");
+      await client.steer("Steer");
+
+      expect(promptAsync).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          model: { providerID: "provider", modelID: "model-a" },
+          variant: "high",
+          agent: "build",
+        }),
+      );
+      expect(promptAsync).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          model: { providerID: "provider", modelID: "model-a" },
+          variant: "high",
+          agent: "build",
+        }),
+      );
+      await expect(client.getState()).resolves.toMatchObject({
+        model: { provider: "opencode", id: "provider/model-b" },
+        thinkingLevel: "default",
+        modeId: "review",
+      });
+    } finally {
+      await client.stop();
+    }
+  });
+
+  it("keeps listed sessions when one message history cannot be enriched", async () => {
+    const release = vi.fn().mockResolvedValue(undefined);
+    mocks.acquire.mockResolvedValueOnce({
+      baseUrl: "http://127.0.0.1:4096",
+      exit: new Promise(() => {}),
+      release,
+    });
+    const sessions = [
+      { id: "ses-1", title: "First", time: { created: 1, updated: 2 } },
+      { id: "ses-2", title: "Second", time: { created: 3, updated: 4 } },
+    ];
+    const messages = vi
+      .fn()
+      .mockResolvedValueOnce({ error: new Error("fetch failed") })
+      .mockResolvedValueOnce({ data: [{ info: { id: "msg-1" }, parts: [] }] });
+    mocks.createOpencodeClient.mockReturnValue({
+      session: {
+        list: vi.fn().mockResolvedValue({ data: sessions }),
+        messages,
+      },
+    });
+
+    await expect(
+      listOpenCodeSessions({ transport: "local" }, "opencode", "/workspace"),
+    ).resolves.toEqual([
+      { session: sessions[0], messages: [] },
+      {
+        session: sessions[1],
+        messages: [{ info: { id: "msg-1" }, parts: [] }],
+      },
+    ]);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("aborts event recovery and releases the server when initialization fails", async () => {
+    const release = vi.fn().mockResolvedValue(undefined);
+    mocks.acquire.mockResolvedValueOnce({
+      baseUrl: "http://127.0.0.1:4096",
+      exit: new Promise(() => {}),
+      release,
+    });
+    let eventSignal: AbortSignal | undefined;
+    const event = vi.fn().mockImplementation(
+      async ({ signal }: { signal: AbortSignal }) => {
+        eventSignal = signal;
+        return { stream: (async function* () {})() };
+      },
+    );
+    mocks.createOpencodeClient.mockReturnValue({
+      global: { event },
+      provider: {
+        list: vi.fn().mockResolvedValue({
+          data: {
+            all: [
+              {
+                id: "provider",
+                name: "Provider",
+                source: "api",
+                models: { "model-a": providerModel("model-a") },
+              },
+            ],
+            connected: ["provider"],
+            default: { provider: "model-a" },
+          },
+        }),
+      },
+      app: { agents: vi.fn().mockResolvedValue({ data: [] }) },
+      command: { list: vi.fn().mockResolvedValue({ data: [] }) },
+      config: {
+        get: vi.fn().mockResolvedValue({ data: { model: "provider/model-a" } }),
+      },
+    });
+
+    const client = new OpenCodeRuntimeClient(
+      { transport: "local" },
+      {
+        executable: "opencode",
+        cwd: "/workspace",
+        model: "provider/missing",
+      },
+    );
+
+    await expect(client.getState()).rejects.toThrow(
+      "OpenCode did not report configured model provider/missing",
+    );
+    expect(eventSignal?.aborted).toBe(true);
+    expect(event).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent-runtime/src/opencode/client.ts
+++ b/packages/agent-runtime/src/opencode/client.ts
@@ -1,0 +1,1117 @@
+import { randomBytes } from "node:crypto";
+import {
+  createOpencodeClient,
+  type Agent,
+  type Command,
+  type GlobalEvent,
+  type Message,
+  type OpencodeClient,
+  type Part,
+  type Provider,
+  type QuestionInfo,
+  type Session,
+  type Todo,
+} from "@opencode-ai/sdk/v2/client";
+import type {
+  AgentInteractionValue,
+  AgentModel,
+  AgentMode,
+  AgentSessionStats,
+  AgentSlashCommand,
+} from "@overtchat/agent-bridge";
+import type {
+  AgentRuntimeClient,
+  AgentRuntimeEvent,
+  AgentSubmissionOptions,
+  ResolvedAgentImage,
+} from "@overtchat/agent-runtime/providers/types";
+import type { HostTarget } from "@overtchat/agent-runtime/runtime/process";
+import {
+  openCodeErrorText,
+  parseOpenCodeCommands,
+  parseOpenCodeModels,
+  parseOpenCodeModes,
+  parseOpenCodeStats,
+  projectOpenCodeMessage,
+  projectOpenCodeMessages,
+  type OpenCodeMessageWithParts,
+} from "@overtchat/agent-runtime/opencode/protocol";
+import {
+  openCodeServerPool,
+  type OpenCodeServerLease,
+} from "@overtchat/agent-runtime/opencode/server";
+
+const SUBMISSION_METADATA_KEY = "overtchatSubmissionIds";
+const MESSAGE_ID_ALPHABET =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+let lastMessageTimestamp = -1;
+let messageCounter = 0;
+
+type OpenCodeLaunch = {
+  executable: string;
+  cwd: string;
+  model?: string;
+  thinkingOptionId?: string;
+  modeId?: string;
+  resumeSessionId?: string;
+};
+
+type PendingInteraction =
+  | { kind: "permission"; requestId: string }
+  | { kind: "question"; requestId: string; questions: QuestionInfo[] };
+
+type OpenCodeTurnSelection = {
+  model?: string;
+  thinkingOptionId?: string;
+  modeId?: string;
+};
+
+function createMessageId(now = Date.now()): string {
+  if (now !== lastMessageTimestamp) messageCounter = 0;
+  lastMessageTimestamp = now;
+  messageCounter += 1;
+  const ascending = (BigInt(now) * 0x1000n + BigInt(messageCounter))
+    .toString(16)
+    .padStart(12, "0")
+    .slice(-12);
+  const random = Array.from(randomBytes(14), (value) =>
+    MESSAGE_ID_ALPHABET[value % MESSAGE_ID_ALPHABET.length],
+  ).join("");
+  return `msg_${ascending}${random}`;
+}
+
+function modelRef(modelId: string | undefined):
+  | { providerID: string; modelID: string }
+  | undefined {
+  if (!modelId) return undefined;
+  const separator = modelId.indexOf("/");
+  if (separator <= 0 || separator === modelId.length - 1) {
+    throw new Error("OpenCode model id must include its provider.");
+  }
+  return {
+    providerID: modelId.slice(0, separator),
+    modelID: modelId.slice(separator + 1),
+  };
+}
+
+function resultData<T>(result: { data?: T; error?: unknown }, operation: string): T {
+  if (result.error !== undefined) {
+    throw new Error(`${operation}: ${openCodeErrorText(result.error)}`);
+  }
+  if (result.data === undefined) throw new Error(`${operation} returned no data.`);
+  return result.data;
+}
+
+function assertResult(result: { error?: unknown }, operation: string): void {
+  if (result.error !== undefined) {
+    throw new Error(`${operation}: ${openCodeErrorText(result.error)}`);
+  }
+}
+
+function submissionIds(session: Session): Record<string, string> {
+  const value = session.metadata?.[SUBMISSION_METADATA_KEY];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, candidate]) =>
+      typeof candidate === "string" ? [[key, candidate]] : [],
+    ),
+  );
+}
+
+function sessionModel(session: Session): string | undefined {
+  return session.model
+    ? `${session.model.providerID}/${session.model.id}`
+    : undefined;
+}
+
+function partsForPrompt(
+  message: string,
+  images: readonly ResolvedAgentImage[],
+) {
+  return [
+    { type: "text" as const, text: message },
+    ...images.map((image) => ({
+      type: "file" as const,
+      mime: image.mediaType,
+      filename: image.filename,
+      url: `data:${image.mediaType};base64,${image.data}`,
+    })),
+  ];
+}
+
+type OpenCodeEvent = {
+  type: string;
+  properties: Record<string, unknown>;
+};
+
+function sessionIdFromEvent(event: OpenCodeEvent): string | undefined {
+  const properties = event.properties;
+  if (typeof properties.sessionID === "string") return properties.sessionID;
+  const info = properties.info;
+  return info && typeof info === "object" && typeof Reflect.get(info, "sessionID") === "string"
+    ? (Reflect.get(info, "sessionID") as string)
+    : undefined;
+}
+
+function questionFields(questions: QuestionInfo[]) {
+  return questions.map((question, index) => ({
+    id: String(index),
+    label: question.header || `Question ${index + 1}`,
+    description: question.question,
+    type: question.multiple
+      ? ("multiselect" as const)
+      : question.options.length
+        ? ("select" as const)
+        : ("text" as const),
+    required: true,
+    secret: false,
+    options: question.options.map((option) => ({
+      value: option.label,
+      label: option.label,
+      description: option.description,
+    })),
+  }));
+}
+
+function todoPart(todos: Todo[]) {
+  return {
+    type: "taskList",
+    id: "opencode-todos",
+    explanation: "OpenCode task progress",
+    items: todos.map((todo, index) => ({
+      id: `opencode-todo-${index}`,
+      step: todo.content,
+      status: todo.status,
+      priority: todo.priority,
+    })),
+  };
+}
+
+export class OpenCodeRuntimeClient implements AgentRuntimeClient {
+  private readonly subscribers = new Set<(event: AgentRuntimeEvent) => void>();
+  private readonly pendingInteractions = new Map<string, PendingInteraction>();
+  private readonly messageInfo = new Map<string, Message>();
+  private readonly messageParts = new Map<string, Map<string, Part>>();
+  private readonly abortEvents = new AbortController();
+  private readonly readyPromise: Promise<void>;
+  private lease?: OpenCodeServerLease;
+  private client?: OpencodeClient;
+  private session?: Session;
+  private models: AgentModel[] = [];
+  private modes: AgentMode[] = [];
+  private commands: AgentSlashCommand[] = [];
+  private selectedModel?: string;
+  private thinkingOptionId?: string;
+  private modeId?: string;
+  private streaming = false;
+  private compacting = false;
+  private stopped = false;
+  private submissions: Record<string, string> = {};
+  private todos: Todo[] = [];
+  private activeSelection?: OpenCodeTurnSelection;
+
+  constructor(
+    private readonly target: HostTarget,
+    private readonly launch: OpenCodeLaunch,
+  ) {
+    this.selectedModel = launch.model;
+    this.thinkingOptionId = launch.thinkingOptionId;
+    this.modeId = launch.modeId;
+    this.readyPromise = this.initialize().catch(async (error) => {
+      this.stopped = true;
+      this.abortEvents.abort();
+      const lease = this.lease;
+      this.lease = undefined;
+      await lease?.release().catch(() => {});
+      throw error;
+    });
+  }
+
+  onEvent(subscriber: (event: AgentRuntimeEvent) => void): () => void {
+    this.subscribers.add(subscriber);
+    return () => this.subscribers.delete(subscriber);
+  }
+
+  async getState(): Promise<Record<string, unknown>> {
+    await this.readyPromise;
+    return {
+      sessionId: this.session!.id,
+      sessionFile: this.session!.id,
+      sessionName: this.session!.title.trim() || null,
+      model: this.selectedModel
+        ? { provider: "opencode", id: this.selectedModel }
+        : null,
+      thinkingLevel: this.thinkingOptionId ?? "default",
+      modeId: this.modeId ?? null,
+      modes: this.modes,
+      isStreaming: this.streaming,
+      isCompacting: this.compacting,
+    };
+  }
+
+  async getMessages(): Promise<{ messages: unknown[] }> {
+    await this.readyPromise;
+    const messages = await this.fetchMessages();
+    const projected = projectOpenCodeMessages(messages, this.submissions);
+    this.addTodos(projected);
+    return { messages: projected };
+  }
+
+  async getAvailableModels(): Promise<AgentModel[]> {
+    await this.readyPromise;
+    return this.models;
+  }
+
+  async getSessionStats(): Promise<AgentSessionStats> {
+    await this.readyPromise;
+    const messages = await this.fetchMessages();
+    const contextWindow = this.models.find((model) => model.id === this.selectedModel)
+      ?.contextWindow;
+    return {
+      ...parseOpenCodeStats(messages, contextWindow ?? undefined),
+      sessionFile: this.session!.id,
+      sessionId: this.session!.id,
+    };
+  }
+
+  async getCommands(): Promise<AgentSlashCommand[]> {
+    await this.readyPromise;
+    return this.commands;
+  }
+
+  prompt(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+    options: AgentSubmissionOptions = {},
+  ): Promise<unknown> {
+    return this.submit(message, images, options, false);
+  }
+
+  steer(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+    options: AgentSubmissionOptions = {},
+  ): Promise<unknown> {
+    return this.submit(message, images, options, true);
+  }
+
+  async abort(): Promise<unknown> {
+    await this.readyPromise;
+    const result = await this.client!.session.abort({
+      sessionID: this.session!.id,
+      directory: this.launch.cwd,
+    });
+    assertResult(result, "OpenCode abort");
+    return result.data;
+  }
+
+  async setModel(modelId: string): Promise<unknown> {
+    await this.readyPromise;
+    modelRef(modelId);
+    if (!this.models.some((model) => model.id === modelId)) {
+      throw new Error(`OpenCode did not report model ${modelId}.`);
+    }
+    this.selectedModel = modelId;
+    this.thinkingOptionId =
+      this.models.find((model) => model.id === modelId)?.defaultThinkingOptionId ??
+      "default";
+    this.emitConfig();
+    return undefined;
+  }
+
+  async setThinkingLevel(level: string): Promise<unknown> {
+    await this.readyPromise;
+    const selected = this.models.find((model) => model.id === this.selectedModel);
+    if (
+      level !== "default" &&
+      !selected?.thinkingOptions?.some((option) => option.id === level)
+    ) {
+      throw new Error(`OpenCode model ${this.selectedModel ?? "selection"} does not provide variant ${level}.`);
+    }
+    this.thinkingOptionId = level;
+    this.emitConfig();
+    return undefined;
+  }
+
+  async setMode(modeId: string): Promise<unknown> {
+    await this.readyPromise;
+    if (!this.modes.some((mode) => mode.id === modeId)) {
+      throw new Error(`OpenCode did not report agent ${modeId}.`);
+    }
+    this.modeId = modeId;
+    this.emitConfig();
+    return undefined;
+  }
+
+  async compact(customInstructions?: string): Promise<unknown> {
+    await this.readyPromise;
+    if (customInstructions) {
+      throw new Error("OpenCode does not accept custom compaction instructions.");
+    }
+    const model = modelRef(this.selectedModel);
+    const result = await this.client!.session.summarize({
+      sessionID: this.session!.id,
+      directory: this.launch.cwd,
+      ...(model ? { providerID: model.providerID, modelID: model.modelID } : {}),
+    });
+    assertResult(result, "OpenCode compaction");
+    return result.data;
+  }
+
+  setAutoCompaction(): Promise<unknown> {
+    return Promise.reject(new Error("OpenCode manages context compaction automatically."));
+  }
+
+  async setSessionName(name: string): Promise<unknown> {
+    await this.readyPromise;
+    const result = await this.client!.session.update({
+      sessionID: this.session!.id,
+      directory: this.launch.cwd,
+      title: name,
+    });
+    this.session = resultData(result, "OpenCode session rename");
+    this.emit({ type: "session_info_update", title: name });
+    return this.session;
+  }
+
+  respondToInteraction(
+    id: string,
+    response: {
+      value?: string;
+      values?: Record<string, AgentInteractionValue>;
+      confirmed?: boolean;
+      cancelled?: boolean;
+    },
+  ): void {
+    const pending = this.pendingInteractions.get(id);
+    if (!pending || !this.client) return;
+    this.pendingInteractions.delete(id);
+    const action = async () => {
+      if (pending.kind === "permission") {
+        const reply = response.cancelled
+          ? "reject"
+          : response.value === "Allow always"
+            ? "always"
+            : response.value === "Allow once" || response.confirmed
+              ? "once"
+              : "reject";
+        assertResult(
+          await this.client!.permission.reply({
+            requestID: pending.requestId,
+            directory: this.launch.cwd,
+            reply,
+          }),
+          "OpenCode permission response",
+        );
+        return;
+      }
+      if (response.cancelled) {
+        assertResult(
+          await this.client!.question.reject({
+            requestID: pending.requestId,
+            directory: this.launch.cwd,
+          }),
+          "OpenCode question rejection",
+        );
+        return;
+      }
+      const answers = pending.questions.map((question, index) => {
+        const value = response.values?.[String(index)] ??
+          (pending.questions.length === 1 ? response.value : undefined);
+        if (Array.isArray(value)) return value;
+        if (value === undefined) return [];
+        return [String(value)];
+      });
+      assertResult(
+        await this.client!.question.reply({
+          requestID: pending.requestId,
+          directory: this.launch.cwd,
+          answers,
+        }),
+        "OpenCode question response",
+      );
+    };
+    void action().catch((error) => {
+      this.emit({ type: "rpc_error", command: "interaction_response", error: openCodeErrorText(error) });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.abortEvents.abort();
+    await this.readyPromise.catch(() => {});
+    await this.lease?.release().catch(() => {});
+  }
+
+  private async initialize(): Promise<void> {
+    this.lease = await openCodeServerPool.acquire(this.target, this.launch.executable);
+    this.client = createOpencodeClient({
+      baseUrl: this.lease.baseUrl,
+      directory: this.launch.cwd,
+    });
+    const stream = await this.client.global.event({ signal: this.abortEvents.signal });
+    void this.runEventLoop(stream.stream);
+
+    const [providerResult, agentResult, commandResult, configResult] = await Promise.all([
+      this.client.provider.list({ directory: this.launch.cwd }),
+      this.client.app.agents({ directory: this.launch.cwd }),
+      this.client.command.list({ directory: this.launch.cwd }),
+      this.client.config.get({ directory: this.launch.cwd }),
+    ]);
+    const config = resultData(configResult, "OpenCode configuration");
+    this.models = parseOpenCodeModels(
+      resultData(providerResult, "OpenCode provider catalog"),
+      config.model,
+    );
+    this.modes = parseOpenCodeModes(resultData(agentResult, "OpenCode agent catalog") as Agent[]);
+    this.commands = parseOpenCodeCommands(resultData(commandResult, "OpenCode command catalog") as Command[]);
+    const requestedModel = this.selectedModel;
+    if (requestedModel && !this.models.some((model) => model.id === requestedModel)) {
+      throw new Error(`OpenCode did not report configured model ${requestedModel}.`);
+    }
+    const selectedModel = requestedModel ?? this.models.find((model) => model.isDefault)?.id ?? this.models[0]?.id;
+    const selectedRef = modelRef(selectedModel);
+    if (this.launch.resumeSessionId) {
+      this.session = resultData(
+        await this.client.session.get({
+          sessionID: this.launch.resumeSessionId,
+          directory: this.launch.cwd,
+        }),
+        "OpenCode session resume",
+      );
+    } else {
+      this.session = resultData(
+        await this.client.session.create({
+          directory: this.launch.cwd,
+          ...(this.modeId ? { agent: this.modeId } : {}),
+          ...(selectedRef
+            ? {
+                model: {
+                  id: selectedRef.modelID,
+                  providerID: selectedRef.providerID,
+                  ...(this.thinkingOptionId && this.thinkingOptionId !== "default"
+                    ? { variant: this.thinkingOptionId }
+                    : {}),
+                },
+              }
+            : {}),
+        }),
+        "OpenCode session create",
+      );
+    }
+    this.selectedModel = requestedModel ?? sessionModel(this.session) ?? selectedModel;
+    this.thinkingOptionId = this.launch.thinkingOptionId ?? this.session.model?.variant ?? "default";
+    this.modeId =
+      this.launch.modeId ??
+      this.session.agent ??
+      config.default_agent ??
+      this.modes.find((mode) => mode.id === "build")?.id ??
+      this.modes[0]?.id;
+    this.submissions = submissionIds(this.session);
+    const messages = await this.fetchMessages();
+    for (const message of messages) this.rememberMessage(message);
+    const todoResult = await this.client.session.todo({
+      sessionID: this.session.id,
+      directory: this.launch.cwd,
+    });
+    if (!todoResult.error && todoResult.data) this.todos = todoResult.data;
+    const statusResult = await this.client.session.status({ directory: this.launch.cwd });
+    if (!statusResult.error) {
+      this.streaming = statusResult.data?.[this.session.id]?.type === "busy";
+    }
+    void this.lease.exit.then((error) => {
+      if (!this.stopped) this.emit({ type: "process_exit", error: error.message });
+    });
+  }
+
+  private async submit(
+    message: string,
+    images: readonly ResolvedAgentImage[],
+    options: AgentSubmissionOptions,
+    steering: boolean,
+  ): Promise<unknown> {
+    await this.readyPromise;
+    const selection = steering
+      ? (this.activeSelection ?? this.currentSelection())
+      : this.currentSelection();
+    if (!steering) this.activeSelection = selection;
+    const command = /^\/([^\s]+)(?:\s+([\s\S]*))?$/u.exec(message.trim());
+    const discovered =
+      !steering &&
+      command &&
+      this.commands.some((item) => item.name === command[1]);
+    const id = createMessageId();
+    try {
+      if (options.clientMessageId) {
+        await this.rememberSubmission(id, options.clientMessageId);
+      }
+    } catch (error) {
+      if (!steering) this.activeSelection = undefined;
+      throw error;
+    }
+    if (discovered) {
+      try {
+        const result = await this.client!.session.command({
+          sessionID: this.session!.id,
+          directory: this.launch.cwd,
+          messageID: id,
+          command: command![1],
+          arguments: command![2] ?? "",
+          ...(selection.model ? { model: selection.model } : {}),
+          ...(selection.modeId ? { agent: selection.modeId } : {}),
+          ...(selection.thinkingOptionId &&
+          selection.thinkingOptionId !== "default"
+            ? { variant: selection.thinkingOptionId }
+            : {}),
+          parts: images.map((image) => ({
+            type: "file" as const,
+            mime: image.mediaType,
+            filename: image.filename,
+            url: `data:${image.mediaType};base64,${image.data}`,
+          })),
+        });
+        assertResult(result, `OpenCode /${command![1]} command`);
+        return result.data;
+      } catch (error) {
+        if (!steering) this.activeSelection = undefined;
+        throw error;
+      }
+    }
+    try {
+      const selectedModel = modelRef(selection.model);
+      const result = await this.client!.session.promptAsync({
+        sessionID: this.session!.id,
+        directory: this.launch.cwd,
+        messageID: id,
+        parts: partsForPrompt(message, images),
+        ...(selectedModel ? { model: selectedModel } : {}),
+        ...(selection.modeId ? { agent: selection.modeId } : {}),
+        ...(selection.thinkingOptionId && selection.thinkingOptionId !== "default"
+          ? { variant: selection.thinkingOptionId }
+          : {}),
+      });
+      assertResult(result, "OpenCode prompt");
+      return result.data;
+    } catch (error) {
+      if (!steering) this.activeSelection = undefined;
+      throw error;
+    }
+  }
+
+  private currentSelection(): OpenCodeTurnSelection {
+    return {
+      model: this.selectedModel,
+      thinkingOptionId: this.thinkingOptionId,
+      modeId: this.modeId,
+    };
+  }
+
+  private async rememberSubmission(providerMessageId: string, clientMessageId: string) {
+    this.submissions[providerMessageId] = clientMessageId;
+    const entries = Object.entries(this.submissions).slice(-256);
+    this.submissions = Object.fromEntries(entries);
+    const result = await this.client!.session.update({
+      sessionID: this.session!.id,
+      directory: this.launch.cwd,
+      metadata: {
+        ...(this.session!.metadata ?? {}),
+        [SUBMISSION_METADATA_KEY]: this.submissions,
+      },
+    });
+    this.session = resultData(result, "OpenCode submission checkpoint");
+  }
+
+  private async fetchMessages(): Promise<OpenCodeMessageWithParts[]> {
+    const result = await this.client!.session.messages({
+      sessionID: this.session!.id,
+      directory: this.launch.cwd,
+    });
+    return resultData(result, "OpenCode messages");
+  }
+
+  private rememberMessage(message: OpenCodeMessageWithParts): void {
+    this.messageInfo.set(message.info.id, message.info);
+    this.messageParts.set(message.info.id, new Map(message.parts.map((part) => [part.id, part])));
+  }
+
+  private message(messageId: string): OpenCodeMessageWithParts | null {
+    const info = this.messageInfo.get(messageId);
+    if (!info) return null;
+    return { info, parts: [...(this.messageParts.get(messageId)?.values() ?? [])] };
+  }
+
+  private emitProjected(messageId: string): void {
+    const message = this.message(messageId);
+    if (!message) return;
+    const projected = projectOpenCodeMessage(message, this.submissions);
+    this.addTodos(projected);
+    for (const item of projected) this.emit({ type: "message_update", message: item });
+  }
+
+  private addTodos(projected: unknown[]): void {
+    if (!this.todos.length) return;
+    const assistant = [...projected].reverse().find((item) =>
+      item && typeof item === "object" && Reflect.get(item, "role") === "assistant",
+    );
+    if (!assistant || typeof assistant !== "object") return;
+    const content = Reflect.get(assistant, "content");
+    if (Array.isArray(content) && !content.some((part) => part && typeof part === "object" && Reflect.get(part, "type") === "taskList")) {
+      content.push(todoPart(this.todos));
+    }
+  }
+
+  private async consumeEvents(stream: AsyncIterable<GlobalEvent>): Promise<void> {
+    for await (const envelope of stream) {
+      if (this.stopped) continue;
+      const payload = envelope.payload as unknown as Record<string, unknown>;
+      if (
+        typeof payload.type !== "string" ||
+        !payload.properties ||
+        typeof payload.properties !== "object" ||
+        Array.isArray(payload.properties)
+      ) {
+        continue;
+      }
+      const event: OpenCodeEvent = {
+        type: payload.type,
+        properties: payload.properties as Record<string, unknown>,
+      };
+      const sessionId = sessionIdFromEvent(event);
+      if (this.session && sessionId && sessionId !== this.session.id) continue;
+      if (
+        this.session &&
+        !sessionId &&
+        envelope.directory !== this.session.directory
+      ) {
+        continue;
+      }
+      this.handleEvent(event);
+    }
+  }
+
+  private async runEventLoop(initialStream: AsyncIterable<GlobalEvent>): Promise<void> {
+    let stream = initialStream;
+    let failures = 0;
+    while (!this.stopped && !this.abortEvents.signal.aborted) {
+      try {
+        await this.consumeEvents(stream);
+      } catch (error) {
+        if (this.stopped || this.abortEvents.signal.aborted) return;
+        failures += 1;
+        if (failures === 3) {
+          this.emit({
+            type: "rpc_error",
+            command: "events",
+            error: `OpenCode event stream is reconnecting: ${openCodeErrorText(error)}`,
+          });
+        }
+      }
+      while (!this.stopped && !this.abortEvents.signal.aborted) {
+        await this.waitForEventReconnect(
+          Math.min(2_000, 100 * 2 ** Math.min(failures, 5)),
+        );
+        if (this.stopped || this.abortEvents.signal.aborted) return;
+        try {
+          const next = await this.client!.global.event({
+            signal: this.abortEvents.signal,
+          });
+          stream = next.stream;
+          failures = 0;
+          await this.reconcileAfterReconnect().catch((error) => {
+            this.emit({
+              type: "rpc_error",
+              command: "events",
+              error: `OpenCode reconnected but could not reconcile: ${openCodeErrorText(error)}`,
+            });
+          });
+          break;
+        } catch (error) {
+          if (this.stopped || this.abortEvents.signal.aborted) return;
+          failures += 1;
+          if (failures === 3) {
+            this.emit({
+              type: "rpc_error",
+              command: "events",
+              error: `OpenCode event stream is reconnecting: ${openCodeErrorText(error)}`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  private waitForEventReconnect(delayMs: number): Promise<void> {
+    if (this.abortEvents.signal.aborted) return Promise.resolve();
+    return new Promise((resolve) => {
+      const finish = () => {
+        clearTimeout(timeout);
+        this.abortEvents.signal.removeEventListener("abort", finish);
+        resolve();
+      };
+      const timeout = setTimeout(finish, delayMs);
+      timeout.unref();
+      this.abortEvents.signal.addEventListener("abort", finish, { once: true });
+    });
+  }
+
+  private async reconcileAfterReconnect(): Promise<void> {
+    if (!this.session) return;
+    const [sessionResult, messages, todoResult, statusResult] = await Promise.all([
+      this.client!.session.get({
+        sessionID: this.session.id,
+        directory: this.launch.cwd,
+      }),
+      this.fetchMessages(),
+      this.client!.session.todo({
+        sessionID: this.session.id,
+        directory: this.launch.cwd,
+      }),
+      this.client!.session.status({ directory: this.launch.cwd }),
+    ]);
+    this.session = resultData(sessionResult, "OpenCode session reconciliation");
+    this.submissions = submissionIds(this.session);
+    this.messageInfo.clear();
+    this.messageParts.clear();
+    for (const message of messages) this.rememberMessage(message);
+    if (!todoResult.error && todoResult.data) this.todos = todoResult.data;
+    for (const message of messages) this.emitProjected(message.info.id);
+    if (!statusResult.error) {
+      this.handleEvent({
+        type: "session.status",
+        properties: {
+          sessionID: this.session.id,
+          status: statusResult.data?.[this.session.id] ?? { type: "idle" },
+        },
+      });
+    }
+  }
+
+  private handleEvent(event: OpenCodeEvent): void {
+    if (!this.session) return;
+    const properties = event.properties as Record<string, unknown>;
+    switch (event.type) {
+      case "session.status": {
+        const status = properties.status as
+          | { type?: string; message?: string }
+          | undefined;
+        if (status?.type === "busy" && !this.streaming) {
+          this.streaming = true;
+          this.emit({ type: "turn_start" });
+        } else if (status?.type === "idle" && this.streaming) {
+          this.streaming = false;
+          this.compacting = false;
+          this.activeSelection = undefined;
+          this.emit({ type: "turn_end", status: "completed" });
+        } else if (status?.type === "retry") {
+          this.emit({ type: "rpc_error", command: "prompt", error: String(status.message ?? "OpenCode is retrying the turn.") });
+        }
+        break;
+      }
+      case "session.idle":
+        if (this.streaming) {
+          this.streaming = false;
+          this.compacting = false;
+          this.activeSelection = undefined;
+          this.emit({ type: "turn_end", status: "completed" });
+        }
+        break;
+      case "session.error":
+        this.streaming = false;
+        this.activeSelection = undefined;
+        this.emit({ type: "rpc_error", command: "prompt", error: openCodeErrorText(properties.error) });
+        this.emit({ type: "turn_end", status: "failed" });
+        break;
+      case "session.updated": {
+        const info = properties.info as Session | undefined;
+        if (info) {
+          this.session = info;
+          this.emit({ type: "session_info_update", title: info.title });
+        }
+        break;
+      }
+      case "message.updated": {
+        const info = properties.info as Message | undefined;
+        if (info) {
+          this.messageInfo.set(info.id, info);
+          this.messageParts.set(info.id, this.messageParts.get(info.id) ?? new Map());
+          this.emitProjected(info.id);
+        }
+        break;
+      }
+      case "message.part.updated": {
+        const part = properties.part as Part | undefined;
+        if (part) {
+          const parts = this.messageParts.get(part.messageID) ?? new Map<string, Part>();
+          parts.set(part.id, part);
+          this.messageParts.set(part.messageID, parts);
+          this.emitProjected(part.messageID);
+          if (part.type === "tool") this.emitTool(part);
+        }
+        break;
+      }
+      case "message.part.delta": {
+        const messageId = properties.messageID;
+        const partId = properties.partID;
+        const field = properties.field;
+        const delta = properties.delta;
+        if (typeof messageId === "string" && typeof partId === "string" && typeof field === "string" && typeof delta === "string") {
+          const part = this.messageParts.get(messageId)?.get(partId);
+          if (part && (part.type === "text" || part.type === "reasoning") && field === "text") {
+            part.text += delta;
+            this.emitProjected(messageId);
+          }
+        }
+        break;
+      }
+      case "todo.updated":
+        if (Array.isArray(properties.todos)) {
+          this.todos = properties.todos as Todo[];
+          const lastAssistant = [...this.messageInfo.values()].reverse().find((message) => message.role === "assistant");
+          if (lastAssistant) this.emitProjected(lastAssistant.id);
+        }
+        break;
+      case "permission.v2.asked":
+      case "permission.asked": {
+        const requestId = String(properties.id ?? "");
+        if (!requestId) break;
+        const id = `opencode:permission:${requestId}`;
+        this.pendingInteractions.set(id, { kind: "permission", requestId });
+        const patterns = Array.isArray(properties.patterns)
+          ? properties.patterns.join("\n")
+          : Array.isArray(properties.resources)
+            ? properties.resources.join("\n")
+            : "";
+        this.emit({
+          type: "interaction_request",
+          id,
+          method: "select",
+          title: `Allow ${String(properties.permission ?? properties.action ?? "OpenCode action")}?`,
+          message: patterns || "OpenCode needs permission to continue.",
+          options: ["Allow once", "Allow always", "Deny"],
+          approvalKind: "tool",
+          toolName: String(properties.permission ?? properties.action ?? "OpenCode"),
+          toolDetail: { type: "shell", command: patterns },
+          approveValue: "Allow once",
+          alwaysValue: "Allow always",
+          denyValue: "Deny",
+        });
+        break;
+      }
+      case "permission.v2.replied":
+      case "permission.replied": {
+        const id = `opencode:permission:${String(properties.requestID ?? "")}`;
+        this.pendingInteractions.delete(id);
+        this.emit({ type: "interaction_resolved", id });
+        break;
+      }
+      case "question.v2.asked":
+      case "question.asked": {
+        const requestId = String(properties.id ?? "");
+        const questions = Array.isArray(properties.questions)
+          ? (properties.questions as QuestionInfo[])
+          : [];
+        if (!requestId || !questions.length) break;
+        const id = `opencode:question:${requestId}`;
+        this.pendingInteractions.set(id, { kind: "question", requestId, questions });
+        this.emit({
+          type: "interaction_request",
+          id,
+          method: "form",
+          title: questions.length === 1 ? questions[0].header : "OpenCode needs your input",
+          message: questions.length === 1 ? questions[0].question : "Answer the following questions to continue.",
+          fields: questionFields(questions),
+        });
+        break;
+      }
+      case "question.v2.replied":
+      case "question.v2.rejected":
+      case "question.replied":
+      case "question.rejected": {
+        const id = `opencode:question:${String(properties.requestID ?? "")}`;
+        this.pendingInteractions.delete(id);
+        this.emit({ type: "interaction_resolved", id });
+        break;
+      }
+      case "session.compacted":
+        this.compacting = false;
+        this.emit({ type: "compaction_end" });
+        break;
+      case "session.next.compaction.started":
+        this.compacting = true;
+        this.emit({ type: "compaction_start", reason: properties.reason });
+        break;
+      case "session.next.compaction.ended":
+        this.compacting = false;
+        this.emit({ type: "compaction_end" });
+        break;
+    }
+  }
+
+  private emitTool(part: Extract<Part, { type: "tool" }>): void {
+    const base = {
+      toolCallId: part.callID,
+      toolName: part.tool,
+    };
+    if (part.state.status === "completed") {
+      this.emit({
+        type: "tool_execution_end",
+        ...base,
+        result: { content: [{ type: "text", text: part.state.output }] },
+        isError: false,
+      });
+    } else if (part.state.status === "error") {
+      this.emit({
+        type: "tool_execution_end",
+        ...base,
+        result: { content: [{ type: "text", text: part.state.error }] },
+        isError: true,
+      });
+    } else {
+      this.emit({
+        type: "tool_execution_update",
+        ...base,
+        partialResult: {
+          content: [{ type: "text", text: JSON.stringify(part.state.input ?? {}) }],
+        },
+      });
+    }
+  }
+
+  private emitConfig(): void {
+    this.emit({
+      type: "config_update",
+      model: this.selectedModel ? { provider: "opencode", id: this.selectedModel } : null,
+      thinkingLevel: this.thinkingOptionId ?? "default",
+      modeId: this.modeId ?? null,
+      modes: this.modes,
+    });
+  }
+
+  private emit(event: AgentRuntimeEvent): void {
+    for (const subscriber of this.subscribers) subscriber(event);
+  }
+}
+
+export function startOpenCodeRuntime(
+  target: HostTarget,
+  launch: OpenCodeLaunch,
+): OpenCodeRuntimeClient {
+  return new OpenCodeRuntimeClient(target, launch);
+}
+
+export async function fetchOpenCodeCatalog(
+  target: HostTarget,
+  executable: string,
+  cwd?: string,
+): Promise<{ models: AgentModel[]; modes: AgentMode[]; defaultModeId: string | null }> {
+  const lease = await openCodeServerPool.acquire(target, executable);
+  try {
+    const client = createOpencodeClient({
+      baseUrl: lease.baseUrl,
+      ...(cwd ? { directory: cwd } : {}),
+    });
+    const directory = cwd ? { directory: cwd } : {};
+    const [providers, agents, config] = await Promise.all([
+      client.provider.list(directory),
+      client.app.agents(directory),
+      client.config.get(directory),
+    ]);
+    const resolvedConfig = resultData(config, "OpenCode configuration");
+    const modes = parseOpenCodeModes(
+      resultData(agents, "OpenCode agent catalog") as Agent[],
+    );
+    return {
+      models: parseOpenCodeModels(
+        resultData(providers, "OpenCode provider catalog") as {
+          all: Provider[];
+          connected: string[];
+          default: Record<string, string>;
+        },
+        resolvedConfig.model,
+      ),
+      modes,
+      defaultModeId:
+        (resolvedConfig.default_agent &&
+        modes.some((mode) => mode.id === resolvedConfig.default_agent)
+          ? resolvedConfig.default_agent
+          : modes.find((mode) => mode.id === "build")?.id) ??
+        modes[0]?.id ??
+        null,
+    };
+  } finally {
+    await lease.release();
+  }
+}
+
+export async function listOpenCodeSessions(
+  target: HostTarget,
+  executable: string,
+  cwd: string,
+): Promise<Array<{ session: Session; messages: OpenCodeMessageWithParts[] }>> {
+  const lease = await openCodeServerPool.acquire(target, executable);
+  try {
+    const client = createOpencodeClient({ baseUrl: lease.baseUrl, directory: cwd });
+    const sessions = resultData(
+      await client.session.list({
+        directory: cwd,
+        scope: "project",
+        roots: true,
+        limit: 200,
+      }),
+      "OpenCode session list",
+    );
+    const results: Array<{
+      session: Session;
+      messages: OpenCodeMessageWithParts[];
+    }> = new Array(sessions.length);
+    let nextIndex = 0;
+    await Promise.all(
+      Array.from({ length: Math.min(8, sessions.length) }, async () => {
+        while (nextIndex < sessions.length) {
+          const index = nextIndex++;
+          const session = sessions[index]!;
+          let messages: OpenCodeMessageWithParts[] = [];
+          try {
+            messages = resultData(
+              await client.session.messages({
+                sessionID: session.id,
+                directory: cwd,
+              }),
+              `OpenCode messages for ${session.id}`,
+            );
+          } catch {
+            // Session identity and timestamps come from the authoritative list.
+            // Message-derived metadata is optional enrichment and one corrupt or
+            // transiently unavailable history must not hide every other session.
+          }
+          results[index] = { session, messages };
+        }
+      }),
+    );
+    return results;
+  } finally {
+    await lease.release();
+  }
+}
+
+export async function deleteOpenCodeSession(
+  target: HostTarget,
+  executable: string,
+  cwd: string,
+  sessionId: string,
+): Promise<void> {
+  const lease = await openCodeServerPool.acquire(target, executable);
+  try {
+    const client = createOpencodeClient({ baseUrl: lease.baseUrl, directory: cwd });
+    assertResult(
+      await client.session.delete({
+        sessionID: sessionId,
+        directory: cwd,
+      }),
+      `OpenCode delete session ${sessionId}`,
+    );
+  } finally {
+    await lease.release();
+  }
+}

--- a/packages/agent-runtime/src/opencode/integration.test.ts
+++ b/packages/agent-runtime/src/opencode/integration.test.ts
@@ -1,0 +1,181 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  deleteOpenCodeSession,
+  startOpenCodeRuntime,
+} from "./client";
+import { probeOpenCodeTarget } from "./probe";
+import { configureLocalTestProcessSpawner } from "../runtime/local-process.test-helper";
+
+const runIntegration = process.env.RUN_OPENCODE_INTEGRATION === "1";
+const executable = process.env.OPENCODE_COMMAND ?? "opencode";
+
+beforeAll(configureLocalTestProcessSpawner);
+
+function waitUntil(
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 120_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const check = async () => {
+      try {
+        if (await condition()) {
+          resolve();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          reject(new Error("Timed out waiting for OpenCode integration state."));
+          return;
+        }
+        setTimeout(check, 100).unref();
+      } catch (error) {
+        reject(error);
+      }
+    };
+    void check();
+  });
+}
+
+function messageText(value: unknown): string {
+  if (!value || typeof value !== "object") return "";
+  const content = Reflect.get(value, "content");
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .flatMap((part) =>
+      part && typeof part === "object" && typeof Reflect.get(part, "text") === "string"
+        ? [Reflect.get(part, "text") as string]
+        : [],
+    )
+    .join("\n");
+}
+
+describe.runIf(runIntegration)("installed OpenCode integration", () => {
+  it(
+    "streams, steers, aborts, and resumes a disposable native session",
+    async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "overtchat-opencode-"));
+      const target = { transport: "local" as const };
+      let sessionId: string | undefined;
+      const probe = await probeOpenCodeTarget(target, executable);
+      expect(probe).toMatchObject({
+        status: "ready",
+        version: expect.stringMatching(/^\d+\.\d+\.\d+/u),
+      });
+      expect(probe.models).not.toHaveLength(0);
+      let client = startOpenCodeRuntime(target, {
+        executable,
+        cwd: root,
+      });
+      const events: Array<Record<string, unknown>> = [];
+      client.onEvent((event) => {
+        events.push(event);
+        if (event.type === "interaction_request" && typeof event.id === "string") {
+          client.respondToInteraction(event.id, { value: "Allow once" });
+        }
+      });
+
+      try {
+        const state = await client.getState();
+        sessionId = state.sessionId as string;
+        expect(sessionId).toMatch(/^ses_/u);
+        const models = await client.getAvailableModels();
+        expect(models).not.toHaveLength(0);
+        expect(await client.getCommands()).toEqual(expect.any(Array));
+        const selectedModel =
+          models.find((model) => model.id === (state.model as { id?: string } | null)?.id) ??
+          models[0];
+        await client.setModel(selectedModel!.id);
+        const selectedVariant =
+          selectedModel!.thinkingOptions?.find((option) => option.id !== "default")?.id ??
+          selectedModel!.defaultThinkingOptionId ??
+          "default";
+        await client.setThinkingLevel(selectedVariant);
+        const modes = Array.isArray(state.modes) ? state.modes : [];
+        const selectedMode = modes.find(
+          (mode) => mode && typeof mode === "object" && typeof Reflect.get(mode, "id") === "string",
+        );
+        if (selectedMode) await client.setMode(Reflect.get(selectedMode, "id") as string);
+        await expect(client.getState()).resolves.toMatchObject({
+          model: { provider: "opencode", id: selectedModel!.id },
+          thinkingLevel: selectedVariant,
+        });
+        await client.setSessionName("OvertChat OpenCode integration");
+
+        await client.prompt(
+          "Use the shell to run `sleep 3`, then reply with the exact text FIRST_RESPONSE.",
+          [],
+          { clientMessageId: "integration-first" },
+        );
+        await waitUntil(() => events.some((event) => event.type === "turn_start"));
+        await client.steer(
+          "Change course: reply with the exact text OPENCODE_STEER_OK instead.",
+          [],
+          { clientMessageId: "integration-steer" },
+        );
+        await waitUntil(async () => {
+          const current = await client.getState();
+          const history = await client.getMessages();
+          return (
+            current.isStreaming === false &&
+            history.messages.some((message) =>
+              messageText(message).includes("OPENCODE_STEER_OK"),
+            )
+          );
+        });
+
+        const streamed = await client.getMessages();
+        expect(streamed.messages).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              role: "user",
+              overtchatSubmissionId: "integration-first",
+            }),
+            expect.objectContaining({
+              role: "user",
+              overtchatSubmissionId: "integration-steer",
+            }),
+          ]),
+        );
+        expect(events).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: "message_update" }),
+            expect.objectContaining({ type: "tool_execution_end" }),
+            expect.objectContaining({ type: "turn_end" }),
+          ]),
+        );
+
+        const startedCount = events.filter((event) => event.type === "turn_start").length;
+        await client.prompt("Use the shell to run `sleep 10`, then say TOO_LATE.");
+        await waitUntil(
+          () => events.filter((event) => event.type === "turn_start").length > startedCount,
+        );
+        await client.abort();
+        await waitUntil(async () => (await client.getState()).isStreaming === false);
+
+        await client.stop();
+        client = startOpenCodeRuntime(target, {
+          executable,
+          cwd: root,
+          resumeSessionId: sessionId,
+        });
+        await expect(client.getState()).resolves.toMatchObject({
+          sessionId,
+          sessionName: "OvertChat OpenCode integration",
+        });
+        const resumed = await client.getMessages();
+        expect(resumed.messages.some((message) => messageText(message).includes("OPENCODE_STEER_OK"))).toBe(true);
+      } finally {
+        await client.stop();
+        if (sessionId) {
+          await deleteOpenCodeSession(target, executable, root, sessionId).catch(() => {});
+        }
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+    240_000,
+  );
+});

--- a/packages/agent-runtime/src/opencode/probe.ts
+++ b/packages/agent-runtime/src/opencode/probe.ts
@@ -1,0 +1,70 @@
+import type {
+  AgentConnectionDraft,
+  AgentReadyConnectionProbe,
+  ConnectorShellMode,
+} from "@overtchat/agent-bridge";
+import { fetchOpenCodeCatalog } from "@overtchat/agent-runtime/opencode/client";
+import {
+  parseAgentVersion,
+  shellModesForTarget,
+  targetForConnectionDraft,
+  targetWithShellMode,
+} from "@overtchat/agent-runtime/runtime/discovery";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@overtchat/agent-runtime/runtime/process";
+
+export async function probeOpenCodeTarget(
+  target: HostTarget,
+  executable: string,
+): Promise<AgentReadyConnectionProbe> {
+  let resolved:
+    | { target: HostTarget; shellMode: ConnectorShellMode; version: string }
+    | undefined;
+  const failures: string[] = [];
+  for (const shellMode of shellModesForTarget(target)) {
+    try {
+      const resolvedTarget = targetWithShellMode(target, shellMode);
+      const result = await executeOnHost(resolvedTarget, {
+        command: executable,
+        args: ["--version"],
+      });
+      const version = parseAgentVersion(result.stdout);
+      if (!version) throw new Error("OpenCode returned an invalid version.");
+      resolved = { target: resolvedTarget, shellMode, version };
+      break;
+    } catch (error) {
+      failures.push(
+        `${shellMode === "interactive" ? "Interactive login" : "Login"}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  if (!resolved) {
+    throw new Error(`OpenCode could not be started. ${failures.join(" ")}`);
+  }
+  const catalog = await fetchOpenCodeCatalog(
+    resolved.target,
+    executable,
+  );
+  if (!catalog.models.length) {
+    throw new Error("OpenCode is installed, but it did not report any usable models.");
+  }
+  return {
+    status: "ready",
+    version: resolved.version,
+    models: catalog.models,
+    shellMode: resolved.shellMode,
+  };
+}
+
+export function probeOpenCodeConnection(
+  draft: AgentConnectionDraft,
+): Promise<AgentReadyConnectionProbe> {
+  return probeOpenCodeTarget(
+    targetForConnectionDraft(draft),
+    draft.executable,
+  );
+}

--- a/packages/agent-runtime/src/opencode/protocol.test.ts
+++ b/packages/agent-runtime/src/opencode/protocol.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import type { Message, Part, Provider, Session } from "@opencode-ai/sdk/v2/client";
+import {
+  openCodeSessionMetadata,
+  parseOpenCodeModels,
+  parseOpenCodeModes,
+  parseOpenCodeStats,
+  projectOpenCodeMessages,
+  type OpenCodeMessageWithParts,
+} from "./protocol";
+
+const provider = {
+  id: "openai",
+  name: "OpenAI",
+  source: "api",
+  models: {
+    "gpt-test": {
+      id: "gpt-test",
+      name: "GPT Test",
+      family: "gpt",
+      api: { id: "gpt-test", url: "https://example.test" },
+      capabilities: {
+        reasoning: true,
+        attachment: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+      },
+      variants: { high: {} },
+      limit: { context: 128_000, output: 16_000 },
+      cost: { input: 1, output: 2, cache: { read: 0.1, write: 0.2 } },
+    },
+  },
+} as unknown as Provider;
+
+const user = {
+  id: "msg-user",
+  sessionID: "ses-1",
+  role: "user",
+  time: { created: 100 },
+  agent: "build",
+  model: { providerID: "openai", modelID: "gpt-test" },
+} as Message;
+
+const assistant = {
+  id: "msg-assistant",
+  sessionID: "ses-1",
+  role: "assistant",
+  time: { created: 200, completed: 300 },
+  parentID: "msg-user",
+  modelID: "gpt-test",
+  providerID: "openai",
+  mode: "build",
+  agent: "build",
+  path: { cwd: "/workspace", root: "/workspace" },
+  cost: 0.25,
+  tokens: {
+    input: 10,
+    output: 5,
+    reasoning: 2,
+    cache: { read: 3, write: 1 },
+  },
+} as Message;
+
+const messages: OpenCodeMessageWithParts[] = [
+  {
+    info: user,
+    parts: [
+      {
+        id: "part-user",
+        sessionID: "ses-1",
+        messageID: "msg-user",
+        type: "text",
+        text: "Fix the test",
+      } as Part,
+    ],
+  },
+  {
+    info: assistant,
+    parts: [
+      {
+        id: "part-reasoning",
+        sessionID: "ses-1",
+        messageID: "msg-assistant",
+        type: "reasoning",
+        text: "Inspecting",
+        time: { start: 201, end: 210 },
+      } as Part,
+      {
+        id: "part-text",
+        sessionID: "ses-1",
+        messageID: "msg-assistant",
+        type: "text",
+        text: "Done",
+      } as Part,
+      {
+        id: "part-tool",
+        sessionID: "ses-1",
+        messageID: "msg-assistant",
+        type: "tool",
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: { command: "npm test" },
+          output: "passed",
+          title: "Run tests",
+          metadata: {},
+          time: { start: 220, end: 250 },
+          attachments: [],
+        },
+      } as Part,
+    ],
+  },
+];
+
+describe("OpenCode protocol projection", () => {
+  it("maps connected models and arbitrary variants", () => {
+    expect(
+      parseOpenCodeModels(
+        {
+          all: [provider],
+          connected: ["openai"],
+          default: { openai: "gpt-test" },
+        },
+        "openai/gpt-test",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        provider: "opencode",
+        id: "openai/gpt-test",
+        isDefault: true,
+        input: ["text", "image"],
+        contextWindow: 128_000,
+        defaultThinkingOptionId: "default",
+        thinkingOptions: [
+          { id: "default", label: "Default", isDefault: true },
+          { id: "high", label: "high" },
+        ],
+      }),
+    ]);
+  });
+
+  it("projects streaming content, tools, and durable submission identity", () => {
+    const projected = projectOpenCodeMessages(messages, {
+      "msg-user": "client-message-1",
+    });
+    expect(projected).toEqual([
+      expect.objectContaining({
+        id: "msg-user",
+        role: "user",
+        overtchatSubmissionId: "client-message-1",
+      }),
+      expect.objectContaining({
+        id: "msg-assistant",
+        role: "assistant",
+        content: [
+          expect.objectContaining({ type: "thinking", thinking: "Inspecting" }),
+          expect.objectContaining({ type: "text", text: "Done" }),
+          expect.objectContaining({ type: "toolCall", id: "call-1", name: "bash" }),
+        ],
+      }),
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId: "call-1",
+        isError: false,
+      }),
+    ]);
+    expect(parseOpenCodeStats(messages, 128_000)).toMatchObject({
+      sessionId: "ses-1",
+      userMessages: 1,
+      assistantMessages: 1,
+      toolCalls: 1,
+      tokens: { input: 10, output: 7, cacheRead: 3, cacheWrite: 1, total: 21 },
+      cost: 0.25,
+    });
+  });
+
+  it("maps agents and persisted sessions", () => {
+    expect(
+      parseOpenCodeModes([
+        { name: "build", mode: "primary", description: "Build things" },
+        { name: "helper", mode: "subagent", description: "Hidden helper" },
+      ] as never),
+    ).toEqual([
+      { id: "build", label: "Build", description: "Build things" },
+    ]);
+    const session = {
+      id: "ses-1",
+      title: "Repair",
+      time: { created: 100, updated: 300 },
+      model: { providerID: "openai", id: "gpt-test", variant: "high" },
+      agent: "build",
+    } as Session;
+    expect(openCodeSessionMetadata(session, messages)).toEqual({
+      providerSessionId: "ses-1",
+      providerSessionPath: "ses-1",
+      name: "Repair",
+      firstMessage: "Fix the test",
+      messageCount: 2,
+      createdAt: new Date(100),
+      modifiedAt: new Date(300),
+      launchConfig: {
+        model: "openai/gpt-test",
+        thinkingOptionId: "high",
+        modeId: "build",
+      },
+    });
+  });
+});

--- a/packages/agent-runtime/src/opencode/protocol.ts
+++ b/packages/agent-runtime/src/opencode/protocol.ts
@@ -1,0 +1,321 @@
+import type {
+  AgentModel,
+  AgentMode,
+  AgentProviderSessionMetadata,
+  AgentSessionStats,
+  AgentSlashCommand,
+} from "@overtchat/agent-bridge";
+import type {
+  Agent,
+  Command,
+  Message,
+  Part,
+  Provider,
+  Session,
+} from "@opencode-ai/sdk/v2/client";
+
+export type OpenCodeMessageWithParts = {
+  info: Message;
+  parts: Part[];
+};
+
+export function openCodeErrorText(value: unknown): string {
+  if (!value) return "OpenCode returned an unknown error.";
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  if (typeof value === "object") {
+    const data = Reflect.get(value, "data");
+    if (data && typeof data === "object") {
+      const message = Reflect.get(data, "message");
+      if (typeof message === "string" && message) return message;
+    }
+    const message = Reflect.get(value, "message");
+    if (typeof message === "string" && message) return message;
+    const name = Reflect.get(value, "name");
+    if (typeof name === "string" && name) return name;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function parseOpenCodeModels(data: {
+  all: Provider[];
+  connected: string[];
+  default: Record<string, string>;
+}, configuredModel?: string): AgentModel[] {
+  const connected = new Set(data.connected);
+  return data.all.flatMap((provider) => {
+    if (!connected.has(provider.id) && provider.source !== "api") return [];
+    return Object.entries(provider.models).map(([modelId, model]) => {
+      const variantIds = Object.keys(model.variants ?? {}).filter(
+        (id) => id !== "default",
+      );
+      const thinkingOptions = variantIds.length
+        ? [
+            { id: "default", label: "Default", isDefault: true },
+            ...variantIds.map((id) => ({ id, label: id })),
+          ]
+        : undefined;
+      const input: Array<"text" | "image"> = ["text"];
+      if (model.capabilities.input.image || model.capabilities.attachment) {
+        input.push("image");
+      }
+      return {
+        provider: "opencode" as const,
+        id: `${provider.id}/${modelId}`,
+        label: model.name,
+        description: [provider.name, model.family].filter(Boolean).join(" · "),
+        isDefault: configuredModel
+          ? configuredModel === `${provider.id}/${modelId}`
+          : data.default[provider.id] === modelId,
+        metadata: { provider: provider.id, modelId },
+        api: model.api.id,
+        baseUrl: model.api.url,
+        reasoning: model.capabilities.reasoning,
+        input,
+        contextWindow: model.limit.context || null,
+        maxTokens: model.limit.output || null,
+        ...(thinkingOptions ? { thinkingOptions, defaultThinkingOptionId: "default" } : {}),
+        cost: {
+          input: model.cost.input,
+          output: model.cost.output,
+          cacheRead: model.cost.cache.read,
+          cacheWrite: model.cost.cache.write,
+        },
+      };
+    });
+  });
+}
+
+export function parseOpenCodeModes(agents: Agent[]): AgentMode[] {
+  return agents
+    .filter((agent) => !agent.hidden && agent.mode !== "subagent")
+    .map((agent) => ({
+      id: agent.name,
+      label: agent.name
+        .replace(/[-_]+/gu, " ")
+        .replace(/\b\w/gu, (letter) => letter.toUpperCase()),
+      description: agent.description ?? `Use the ${agent.name} OpenCode agent.`,
+    }));
+}
+
+export function parseOpenCodeCommands(commands: Command[]): AgentSlashCommand[] {
+  return commands.map((command) => ({
+    name: command.name,
+    ...(command.description ? { description: command.description } : {}),
+    source:
+      command.source === "skill"
+        ? "skill"
+        : command.source === "mcp"
+          ? "mcp_prompt"
+          : "custom",
+    ...(command.hints.length ? { argumentHint: command.hints.join(" ") } : {}),
+  }));
+}
+
+function textContent(part: Part): string | null {
+  if (part.type === "text") return part.text;
+  if (part.type === "file") {
+    return part.mime.startsWith("image/") ? null : part.filename ?? part.url;
+  }
+  return null;
+}
+
+function projectedContent(parts: Part[]): unknown[] {
+  const content: unknown[] = [];
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (!part.ignored) content.push({ type: "text", text: part.text, id: part.id });
+      continue;
+    }
+    if (part.type === "reasoning") {
+      content.push({ type: "thinking", thinking: part.text, id: part.id });
+      continue;
+    }
+    if (part.type === "file" && part.mime.startsWith("image/")) {
+      content.push({
+        type: "image",
+        url: part.url,
+        mimeType: part.mime,
+        filename: part.filename ?? "image",
+        id: part.id,
+      });
+      continue;
+    }
+    if (part.type === "file") {
+      content.push({ type: "text", text: part.filename ?? part.url, id: part.id });
+      continue;
+    }
+    if (part.type === "tool") {
+      content.push({
+        type: "toolCall",
+        id: part.callID,
+        name: part.tool,
+        arguments: part.state.input,
+      });
+    }
+  }
+  return content;
+}
+
+export function projectOpenCodeMessage(
+  message: OpenCodeMessageWithParts,
+  submissionIds: Readonly<Record<string, string>> = {},
+): unknown[] {
+  const { info, parts } = message;
+  if (info.role === "user") {
+    const content = projectedContent(parts);
+    return [
+      {
+        id: info.id,
+        role: "user",
+        content: content.length ? content : parts.map(textContent).filter(Boolean).join("\n"),
+        timestamp: info.time.created,
+        ...(submissionIds[info.id]
+          ? { overtchatSubmissionId: submissionIds[info.id] }
+          : {}),
+      },
+    ];
+  }
+  const content = projectedContent(parts);
+  if (info.structured !== undefined && !content.length) {
+    content.push({
+      type: "text",
+      text:
+        typeof info.structured === "string"
+          ? info.structured
+          : JSON.stringify(info.structured, null, 2),
+    });
+  }
+  const messages: unknown[] = [
+    {
+      id: info.id,
+      role: "assistant",
+      content,
+      timestamp: info.time.created,
+      ...(info.error ? { errorMessage: openCodeErrorText(info.error) } : {}),
+    },
+  ];
+  for (const part of parts) {
+    if (part.type !== "tool") continue;
+    const state = part.state;
+    if (state.status !== "completed" && state.status !== "error") continue;
+    messages.push({
+      id: `result:${part.callID}`,
+      role: "toolResult",
+      toolCallId: part.callID,
+      toolName: part.tool,
+      content: [
+        {
+          type: "text",
+          text: state.status === "completed" ? state.output : state.error,
+        },
+      ],
+      isError: state.status === "error",
+      timestamp: state.time.end,
+    });
+  }
+  return messages;
+}
+
+export function projectOpenCodeMessages(
+  messages: OpenCodeMessageWithParts[],
+  submissionIds: Readonly<Record<string, string>> = {},
+): unknown[] {
+  return messages.flatMap((message) => projectOpenCodeMessage(message, submissionIds));
+}
+
+export function parseOpenCodeStats(
+  messages: OpenCodeMessageWithParts[],
+  contextWindow?: number,
+): AgentSessionStats {
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolCalls = 0;
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheWrite = 0;
+  let cost = 0;
+  let contextTokens: number | null = null;
+  for (const message of messages) {
+    if (message.info.role === "user") userMessages += 1;
+    else {
+      assistantMessages += 1;
+      input += message.info.tokens.input;
+      output += message.info.tokens.output + message.info.tokens.reasoning;
+      cacheRead += message.info.tokens.cache.read;
+      cacheWrite += message.info.tokens.cache.write;
+      cost += message.info.cost;
+      contextTokens =
+        message.info.tokens.input +
+        message.info.tokens.output +
+        message.info.tokens.reasoning +
+        message.info.tokens.cache.read +
+        message.info.tokens.cache.write;
+    }
+    toolCalls += message.parts.filter((part) => part.type === "tool").length;
+  }
+  const total = input + output + cacheRead + cacheWrite;
+  return {
+    sessionFile: null,
+    sessionId: messages[0]?.info.sessionID ?? null,
+    userMessages,
+    assistantMessages,
+    toolCalls,
+    toolResults: toolCalls,
+    totalMessages: messages.length,
+    tokens: { input, output, cacheRead, cacheWrite, total },
+    cost,
+    ...(contextWindow
+      ? {
+          contextUsage: {
+            tokens: contextTokens,
+            contextWindow,
+            percent:
+              contextTokens === null
+                ? null
+                : Math.min(100, (contextTokens / contextWindow) * 100),
+          },
+        }
+      : {}),
+  };
+}
+
+function firstUserText(messages: OpenCodeMessageWithParts[]): string | null {
+  for (const message of messages) {
+    if (message.info.role !== "user") continue;
+    const text = message.parts
+      .map(textContent)
+      .filter((value): value is string => Boolean(value))
+      .join("\n")
+      .trim();
+    if (text) return text;
+  }
+  return null;
+}
+
+export function openCodeSessionMetadata(
+  session: Session,
+  messages: OpenCodeMessageWithParts[],
+): AgentProviderSessionMetadata {
+  return {
+    providerSessionId: session.id,
+    providerSessionPath: session.id,
+    name: session.title.trim() || null,
+    firstMessage: firstUserText(messages),
+    messageCount: messages.length,
+    createdAt: new Date(session.time.created),
+    modifiedAt: new Date(session.time.updated),
+    launchConfig: {
+      ...(session.model
+        ? { model: `${session.model.providerID}/${session.model.id}` }
+        : {}),
+      ...(session.model?.variant ? { thinkingOptionId: session.model.variant } : {}),
+      ...(session.agent ? { modeId: session.agent } : {}),
+    },
+  };
+}

--- a/packages/agent-runtime/src/opencode/server.test.ts
+++ b/packages/agent-runtime/src/opencode/server.test.ts
@@ -1,0 +1,85 @@
+import { PassThrough, Writable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentProcess } from "../runtime/process";
+
+const mocks = vi.hoisted(() => ({
+  executeOnHost: vi.fn(),
+  openTcpTunnel: vi.fn(),
+  spawnOnHost: vi.fn(),
+}));
+
+vi.mock("@overtchat/agent-runtime/runtime/process", () => mocks);
+
+import { OpenCodeServerPool } from "./server";
+
+function serverProcess(): AgentProcess {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let resolveExit: (value: Awaited<AgentProcess["exit"]>) => void = () => {};
+  const exit = new Promise<Awaited<AgentProcess["exit"]>>((resolve) => {
+    resolveExit = resolve;
+  });
+  const kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
+    resolveExit({ code: null, signal });
+    return true;
+  });
+  return {
+    stdin: new Writable({ write: (_chunk, _encoding, callback) => callback() }),
+    stdout,
+    stderr,
+    exit,
+    kill,
+  };
+}
+
+describe("OpenCode server pool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts from a private neutral host directory and releases its tunnel", async () => {
+    const process = serverProcess();
+    const close = vi.fn().mockResolvedValue(undefined);
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: "/home/dev/.local/state/overtchat/opencode-home\n",
+      stderr: "",
+    });
+    mocks.spawnOnHost.mockImplementation(() => {
+      queueMicrotask(() => {
+        process.stdout.emit(
+          "data",
+          Buffer.from("opencode server listening on http://127.0.0.1:4096\n"),
+        );
+      });
+      return process;
+    });
+    mocks.openTcpTunnel.mockResolvedValue({
+      url: "http://127.0.0.1:51234",
+      close,
+    });
+    const target = {
+      transport: "ssh" as const,
+      alias: "workstation",
+      shellMode: "login" as const,
+    };
+
+    const lease = await new OpenCodeServerPool().acquire(target, "opencode");
+
+    expect(mocks.executeOnHost).toHaveBeenCalledWith(
+      target,
+      expect.objectContaining({ command: "/bin/sh" }),
+    );
+    expect(mocks.spawnOnHost).toHaveBeenCalledWith(
+      target,
+      expect.objectContaining({
+        command: "opencode",
+        cwd: "/home/dev/.local/state/overtchat/opencode-home",
+      }),
+    );
+    expect(lease.baseUrl).toBe("http://127.0.0.1:51234");
+
+    await lease.release();
+    expect(close).toHaveBeenCalled();
+    expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});

--- a/packages/agent-runtime/src/opencode/server.ts
+++ b/packages/agent-runtime/src/opencode/server.ts
@@ -1,0 +1,210 @@
+import {
+  executeOnHost,
+  openTcpTunnel,
+  spawnOnHost,
+  type AgentProcess,
+  type AgentTcpTunnel,
+  type HostTarget,
+} from "@overtchat/agent-runtime/runtime/process";
+
+const STARTUP_TIMEOUT_MS = 30_000;
+const LISTENING_URL = /opencode server listening on http:\/\/127\.0\.0\.1:(\d{1,5})/iu;
+const PREPARE_SERVER_DIRECTORY = `
+set -eu
+base="\${XDG_STATE_HOME:-\${HOME}/.local/state}"
+directory="\${base}/overtchat/opencode-home"
+umask 077
+mkdir -p -- "\${directory}"
+cd -- "\${directory}"
+pwd -P
+`.trim();
+
+export type OpenCodeServerLease = {
+  baseUrl: string;
+  exit: Promise<Error>;
+  release(): Promise<void>;
+};
+
+type StartedServer = {
+  process: AgentProcess;
+  tunnel: AgentTcpTunnel;
+  baseUrl: string;
+  exit: Promise<Error>;
+};
+
+type PoolEntry = {
+  references: number;
+  start: Promise<StartedServer>;
+};
+
+function targetKey(target: HostTarget, executable: string): string {
+  return JSON.stringify({
+    transport: target.transport,
+    alias: target.transport === "ssh" ? target.alias : null,
+    shellMode: target.shellMode ?? "interactive",
+    executable,
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function prepareServerDirectory(target: HostTarget): Promise<string> {
+  const result = await executeOnHost(target, {
+    command: "/bin/sh",
+    args: ["-c", PREPARE_SERVER_DIRECTORY],
+  });
+  const directory = result.stdout.trim();
+  if (!directory.startsWith("/")) {
+    throw new Error("Unable to prepare a neutral OpenCode server directory.");
+  }
+  return directory;
+}
+
+async function startServer(
+  target: HostTarget,
+  executable: string,
+): Promise<StartedServer> {
+  const cwd = await prepareServerDirectory(target);
+  const process = spawnOnHost(target, {
+    command: executable,
+    args: [
+      "serve",
+      "--hostname",
+      "127.0.0.1",
+      "--port",
+      "0",
+      "--print-logs",
+      "--log-level",
+      "INFO",
+    ],
+    cwd,
+    env: { OPENCODE_SERVER_PASSWORD: "" },
+  });
+  process.stdin.end();
+  let stdout = "";
+  let stderr = "";
+  const append = (current: string, chunk: Buffer | string) =>
+    (current + chunk.toString()).slice(-16_384);
+  process.stdout.on("data", (chunk) => {
+    stdout = append(stdout, chunk);
+  });
+  process.stderr.on("data", (chunk) => {
+    stderr = append(stderr, chunk);
+  });
+
+  const remotePort = await new Promise<number>((resolve, reject) => {
+    let settled = false;
+    const finish = (value: number | Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      process.stdout.removeListener("data", inspect);
+      process.stderr.removeListener("data", inspect);
+      if (value instanceof Error) reject(value);
+      else resolve(value);
+    };
+    const inspect = () => {
+      const match = LISTENING_URL.exec(`${stdout}\n${stderr}`);
+      const port = Number(match?.[1]);
+      if (Number.isInteger(port) && port > 0 && port <= 65_535) finish(port);
+    };
+    process.stdout.on("data", inspect);
+    process.stderr.on("data", inspect);
+    void process.exit.then((result) => {
+      finish(
+        new Error(
+          result.error?.message ||
+            stderr.trim() ||
+            stdout.trim() ||
+            `OpenCode server exited before becoming ready (code ${result.code ?? "unknown"}).`,
+        ),
+      );
+    });
+    const timeout = setTimeout(() => {
+      finish(
+        new Error(
+          `OpenCode server did not become ready within ${STARTUP_TIMEOUT_MS / 1_000} seconds.${
+            stderr.trim() ? ` ${stderr.trim()}` : ""
+          }`,
+        ),
+      );
+      process.kill("SIGTERM");
+    }, STARTUP_TIMEOUT_MS);
+  });
+
+  let tunnel: AgentTcpTunnel;
+  try {
+    tunnel = await openTcpTunnel(target, remotePort);
+  } catch (error) {
+    process.kill("SIGTERM");
+    throw new Error(`Unable to connect to the OpenCode server: ${errorMessage(error)}`);
+  }
+  const exit = process.exit.then((result) =>
+    result.error ??
+    new Error(
+      stderr.trim() ||
+        `OpenCode server exited (code ${result.code ?? "unknown"}, signal ${result.signal ?? "none"}).`,
+    ),
+  );
+  return { process, tunnel, baseUrl: tunnel.url, exit };
+}
+
+export class OpenCodeServerPool {
+  private readonly entries = new Map<string, PoolEntry>();
+
+  async acquire(target: HostTarget, executable: string): Promise<OpenCodeServerLease> {
+    const key = targetKey(target, executable);
+    let entry = this.entries.get(key);
+    if (!entry) {
+      entry = { references: 0, start: startServer(target, executable) };
+      this.entries.set(key, entry);
+      void entry.start
+        .then((server) => server.exit)
+        .then(async () => {
+          if (this.entries.get(key) === entry) this.entries.delete(key);
+          const server = await entry!.start.catch(() => null);
+          await server?.tunnel.close().catch(() => {});
+        })
+        .catch(() => {});
+    }
+    entry.references += 1;
+    let server: StartedServer;
+    try {
+      server = await entry.start;
+    } catch (error) {
+      entry.references -= 1;
+      if (this.entries.get(key) === entry) this.entries.delete(key);
+      throw error;
+    }
+    let releasePromise: Promise<void> | null = null;
+    return {
+      baseUrl: server.baseUrl,
+      exit: server.exit,
+      release: () => {
+        if (releasePromise) return releasePromise;
+        releasePromise = this.release(key, entry!, server);
+        return releasePromise;
+      },
+    };
+  }
+
+  private async release(
+    key: string,
+    entry: PoolEntry,
+    server: StartedServer,
+  ): Promise<void> {
+    entry.references = Math.max(0, entry.references - 1);
+    if (entry.references > 0 || this.entries.get(key) !== entry) return;
+    this.entries.delete(key);
+    await server.tunnel.close().catch(() => {});
+    server.process.kill("SIGTERM");
+    const timeout = setTimeout(() => server.process.kill("SIGKILL"), 1_000);
+    timeout.unref();
+    await server.process.exit.catch(() => {});
+    clearTimeout(timeout);
+  }
+}
+
+export const openCodeServerPool = new OpenCodeServerPool();

--- a/packages/agent-runtime/src/providers/opencode.test.ts
+++ b/packages/agent-runtime/src/providers/opencode.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  startOpenCodeRuntime: vi.fn(),
+  fetchOpenCodeCatalog: vi.fn(),
+  listOpenCodeSessions: vi.fn(),
+}));
+
+vi.mock("@overtchat/agent-runtime/opencode/client", () => mocks);
+
+import { openCodeProviderAdapter } from "./opencode";
+
+describe("OpenCode provider adapter", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("launches and resumes with model, variant, and agent selection", () => {
+    const client = {};
+    mocks.startOpenCodeRuntime.mockReturnValue(client);
+    const target = { transport: "local" as const };
+    expect(
+      openCodeProviderAdapter.startSession(target, {
+        executable: "opencode",
+        cwd: "/workspace",
+        model: "openai/gpt-test",
+        thinkingOptionId: "high",
+        modeId: "build",
+        resume: {
+          providerSessionId: "ses-1",
+          providerSessionPath: "ses-1",
+        },
+      }),
+    ).toBe(client);
+    expect(mocks.startOpenCodeRuntime).toHaveBeenCalledWith(target, {
+      executable: "opencode",
+      cwd: "/workspace",
+      model: "openai/gpt-test",
+      thinkingOptionId: "high",
+      modeId: "build",
+      resumeSessionId: "ses-1",
+    });
+  });
+
+  it("classifies turns and compaction", () => {
+    const classifier = openCodeProviderAdapter.createEventClassifier();
+    expect(classifier.classify({ type: "turn_start" })).toEqual({
+      started: true,
+      terminal: false,
+    });
+    expect(classifier.classify({ type: "turn_end" })).toEqual({
+      started: false,
+      terminal: true,
+    });
+    expect(classifier.classify({ type: "compaction_start" })).toEqual({
+      started: true,
+      terminal: false,
+    });
+  });
+
+  it("owns OpenCode session identity and generic slash normalization", () => {
+    expect(
+      openCodeProviderAdapter.sessionIdentity({
+        sessionId: "ses-1",
+        sessionFile: "ses-1",
+        sessionName: "Repair",
+      }),
+    ).toEqual({
+      providerSessionId: "ses-1",
+      providerSessionPath: "ses-1",
+      sessionName: "Repair",
+    });
+    expect(
+      openCodeProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/compact" },
+        {},
+      ),
+    ).toEqual({ type: "compact" });
+  });
+});

--- a/packages/agent-runtime/src/providers/opencode.ts
+++ b/packages/agent-runtime/src/providers/opencode.ts
@@ -1,0 +1,117 @@
+import type {
+  AgentProviderCatalog,
+  AgentSlashCommand,
+} from "@overtchat/agent-bridge";
+import {
+  mergeAgentSlashCommands,
+  normalizeAgentSessionCommand,
+} from "@overtchat/agent-bridge";
+import {
+  fetchOpenCodeCatalog,
+  listOpenCodeSessions,
+  startOpenCodeRuntime,
+} from "@overtchat/agent-runtime/opencode/client";
+import { openCodeSessionMetadata } from "@overtchat/agent-runtime/opencode/protocol";
+import {
+  probeOpenCodeConnection,
+  probeOpenCodeTarget,
+} from "@overtchat/agent-runtime/opencode/probe";
+import type {
+  AgentProviderAdapter,
+  AgentRuntimeEvent,
+  AgentRuntimeEventClassifier,
+  AgentSessionIdentity,
+  AgentSessionLaunch,
+} from "@overtchat/agent-runtime/providers/types";
+import type { HostTarget } from "@overtchat/agent-runtime/runtime/process";
+
+const COMMANDS: readonly AgentSlashCommand[] = [
+  { name: "new", description: "Start a new session", source: "builtin" },
+  {
+    name: "compact",
+    description: "Compact conversation context",
+    source: "builtin",
+  },
+  {
+    name: "name",
+    description: "Set the session name",
+    source: "builtin",
+    argumentHint: "<name>",
+  },
+];
+
+class OpenCodeEventClassifier implements AgentRuntimeEventClassifier {
+  reset(): void {}
+
+  classify(event: AgentRuntimeEvent) {
+    return {
+      started: event.type === "turn_start" || event.type === "compaction_start",
+      terminal: event.type === "turn_end" || event.type === "compaction_end",
+    };
+  }
+}
+
+function sessionIdentity(state: Record<string, unknown>): AgentSessionIdentity {
+  if (typeof state.sessionId !== "string" || !state.sessionId) {
+    throw new Error("OpenCode did not return a session ID.");
+  }
+  return {
+    providerSessionId: state.sessionId,
+    providerSessionPath:
+      typeof state.sessionFile === "string" && state.sessionFile
+        ? state.sessionFile
+        : state.sessionId,
+    sessionName:
+      typeof state.sessionName === "string" && state.sessionName.trim()
+        ? state.sessionName.trim()
+        : null,
+  };
+}
+
+async function fetchCatalog(
+  target: HostTarget,
+  launch: Omit<AgentSessionLaunch, "resume">,
+): Promise<AgentProviderCatalog> {
+  const catalog = await fetchOpenCodeCatalog(
+    target,
+    launch.executable,
+    launch.cwd,
+  );
+  return {
+    provider: "opencode",
+    ...catalog,
+  };
+}
+
+export const openCodeProviderAdapter: AgentProviderAdapter = {
+  provider: "opencode",
+  startSession(target, launch) {
+    return startOpenCodeRuntime(target, {
+      executable: launch.executable,
+      cwd: launch.cwd,
+      model: launch.model,
+      thinkingOptionId: launch.thinkingOptionId,
+      modeId: launch.modeId,
+      resumeSessionId: launch.resume?.providerSessionId,
+    });
+  },
+  probeConnection: probeOpenCodeConnection,
+  probeTarget: probeOpenCodeTarget,
+  async listWorkspaceSessions(target, executable, workspacePath) {
+    const sessions = await listOpenCodeSessions(
+      target,
+      executable,
+      workspacePath,
+    );
+    return sessions.map(({ session, messages }) =>
+      openCodeSessionMetadata(session, messages),
+    );
+  },
+  fetchCatalog,
+  sessionIdentity,
+  createEventClassifier: () => new OpenCodeEventClassifier(),
+  commandsFromEvent: () => null,
+  mergeCommands: (discovered) => mergeAgentSlashCommands(COMMANDS, discovered),
+  normalizeCommand: (command, state) =>
+    normalizeAgentSessionCommand(command, state),
+};

--- a/packages/agent-runtime/src/providers/registry.ts
+++ b/packages/agent-runtime/src/providers/registry.ts
@@ -2,12 +2,14 @@ import type { AgentProviderAdapter } from "@overtchat/agent-runtime/providers/ty
 import { piProviderAdapter } from "@overtchat/agent-runtime/providers/pi";
 import { ompProviderAdapter } from "@overtchat/agent-runtime/providers/omp";
 import { codexProviderAdapter } from "@overtchat/agent-runtime/providers/codex";
+import { openCodeProviderAdapter } from "@overtchat/agent-runtime/providers/opencode";
 import type { AgentProviderId } from "@overtchat/agent-bridge";
 
 const adapters = {
   pi: piProviderAdapter,
   omp: ompProviderAdapter,
   codex: codexProviderAdapter,
+  opencode: openCodeProviderAdapter,
 } satisfies Record<AgentProviderId, AgentProviderAdapter>;
 
 export function agentProviderAdapter(

--- a/packages/agent-runtime/src/runtime/discovery.ts
+++ b/packages/agent-runtime/src/runtime/discovery.ts
@@ -104,7 +104,9 @@ async function discoverAgentInstallationsInMode(
           args: ["--version"],
         });
         const version = parseAgentVersion(versionResult.stdout);
-        return version ? { provider: id, executable, version } : null;
+        return version
+          ? { provider: id, executable, version, shellMode }
+          : null;
       } catch {
         return null;
       }

--- a/packages/agent-runtime/src/runtime/process.test.ts
+++ b/packages/agent-runtime/src/runtime/process.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  configureTcpTunnelOpener,
+  openTcpTunnel,
+} from "./process";
+
+describe("agent TCP tunnels", () => {
+  it("uses a direct loopback URL for local agents", async () => {
+    const tunnel = await openTcpTunnel({ transport: "local" }, 4096);
+    expect(tunnel.url).toBe("http://127.0.0.1:4096");
+    await expect(tunnel.close()).resolves.toBeUndefined();
+  });
+
+  it("delegates SSH forwarding to the connector process host", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const opener = vi.fn().mockResolvedValue({
+      url: "http://127.0.0.1:41234",
+      close,
+    });
+    configureTcpTunnelOpener(opener);
+    const target = { transport: "ssh" as const, alias: "macbook" };
+    const tunnel = await openTcpTunnel(target, 4096);
+    expect(opener).toHaveBeenCalledWith(target, 4096);
+    expect(tunnel.url).toBe("http://127.0.0.1:41234");
+  });
+
+  it("rejects invalid remote ports before opening a tunnel", async () => {
+    await expect(
+      openTcpTunnel({ transport: "local" }, 0),
+    ).rejects.toThrow("Invalid remote TCP port");
+  });
+});

--- a/packages/agent-runtime/src/runtime/process.ts
+++ b/packages/agent-runtime/src/runtime/process.ts
@@ -39,8 +39,43 @@ export type ProcessSpawner = (
 
 let configuredSpawner: ProcessSpawner | undefined;
 
+export type AgentTcpTunnel = {
+  url: string;
+  close(): Promise<void>;
+};
+
+export type TcpTunnelOpener = (
+  target: Extract<HostTarget, { transport: "ssh" }>,
+  remotePort: number,
+) => Promise<AgentTcpTunnel>;
+
+let configuredTcpTunnelOpener: TcpTunnelOpener | undefined;
+
 export function configureProcessSpawner(spawner: ProcessSpawner): void {
   configuredSpawner = spawner;
+}
+
+export function configureTcpTunnelOpener(opener: TcpTunnelOpener): void {
+  configuredTcpTunnelOpener = opener;
+}
+
+export function openTcpTunnel(
+  target: HostTarget,
+  remotePort: number,
+): Promise<AgentTcpTunnel> {
+  if (!Number.isInteger(remotePort) || remotePort < 1 || remotePort > 65_535) {
+    return Promise.reject(new Error("Invalid remote TCP port."));
+  }
+  if (target.transport === "local") {
+    return Promise.resolve({
+      url: `http://127.0.0.1:${remotePort}`,
+      close: async () => {},
+    });
+  }
+  if (!configuredTcpTunnelOpener) {
+    return Promise.reject(new Error("The agent TCP tunnel opener is not configured."));
+  }
+  return configuredTcpTunnelOpener(target, remotePort);
 }
 
 export function spawnOnHost(

--- a/packages/agent-runtime/src/runtime/provider-snapshots.test.ts
+++ b/packages/agent-runtime/src/runtime/provider-snapshots.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentProviderSnapshotManager } from "./provider-snapshots";
+
+describe("AgentProviderSnapshotManager", () => {
+  it("warms lazily, caches per target, and refreshes explicitly", async () => {
+    const discover = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          provider: "opencode",
+          executable: "/usr/bin/opencode",
+          version: "1.2.3",
+          shellMode: "interactive",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const manager = new AgentProviderSnapshotManager(discover, () => 123);
+    const target = { connectorId: "connector", transport: "local" as const };
+
+    const first = await manager.getSnapshot(target);
+    const cached = await manager.getSnapshot(target);
+    const refreshed = await manager.getSnapshot(target, { refresh: true });
+
+    expect(first.providers).toContainEqual({
+      provider: "opencode",
+      status: "ready",
+      executable: "/usr/bin/opencode",
+      version: "1.2.3",
+      shellMode: "interactive",
+    });
+    expect(cached).toBe(first);
+    expect(refreshed.providers).toContainEqual({
+      provider: "opencode",
+      status: "unavailable",
+    });
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent warm-up and keeps the last good snapshot on error", async () => {
+    let finish: ((value: []) => void) | undefined;
+    const discover = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise<[]>((resolve) => {
+          finish = resolve;
+        }),
+      )
+      .mockRejectedValueOnce(new Error("offline"));
+    const manager = new AgentProviderSnapshotManager(discover);
+    const target = {
+      connectorId: "connector",
+      transport: "ssh" as const,
+      sshAlias: "server",
+    };
+
+    const left = manager.getSnapshot(target);
+    const right = manager.getSnapshot(target);
+    expect(discover).toHaveBeenCalledOnce();
+    finish?.([]);
+    const first = await left;
+    await expect(right).resolves.toBe(first);
+    await expect(
+      manager.getSnapshot(target, { refresh: true }),
+    ).rejects.toThrow("offline");
+    await expect(manager.getSnapshot(target)).resolves.toBe(first);
+  });
+});

--- a/packages/agent-runtime/src/runtime/provider-snapshots.ts
+++ b/packages/agent-runtime/src/runtime/provider-snapshots.ts
@@ -1,0 +1,73 @@
+import {
+  AGENT_PROVIDERS,
+  type AgentDiscoveryTarget,
+  type AgentProviderSnapshot,
+  type DetectedAgentInstallation,
+} from "@overtchat/agent-bridge";
+import {
+  discoverAgentInstallations,
+  targetForDiscovery,
+} from "./discovery";
+import type { HostTarget } from "./process";
+
+type DiscoverProviders = (
+  target: HostTarget,
+) => Promise<DetectedAgentInstallation[]>;
+
+function snapshotKey(target: AgentDiscoveryTarget): string {
+  return JSON.stringify([
+    target.transport,
+    target.transport === "ssh" ? target.sshAlias : "",
+  ]);
+}
+
+export class AgentProviderSnapshotManager {
+  private readonly snapshots = new Map<string, AgentProviderSnapshot>();
+  private readonly loads = new Map<string, Promise<AgentProviderSnapshot>>();
+
+  constructor(
+    private readonly discover: DiscoverProviders = discoverAgentInstallations,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  getSnapshot(
+    target: AgentDiscoveryTarget,
+    options: { refresh?: boolean } = {},
+  ): Promise<AgentProviderSnapshot> {
+    const key = snapshotKey(target);
+    const active = this.loads.get(key);
+    if (active) return active;
+    const current = this.snapshots.get(key);
+    if (current && !options.refresh) return Promise.resolve(current);
+
+    const load = this.load(target).finally(() => {
+      if (this.loads.get(key) === load) this.loads.delete(key);
+    });
+    this.loads.set(key, load);
+    return load;
+  }
+
+  private async load(
+    target: AgentDiscoveryTarget,
+  ): Promise<AgentProviderSnapshot> {
+    const installations = await this.discover(targetForDiscovery(target));
+    const ready = new Map(
+      installations.map((installation) => [
+        installation.provider,
+        installation,
+      ]),
+    );
+    const snapshot: AgentProviderSnapshot = {
+      target,
+      providers: Object.values(AGENT_PROVIDERS).map(({ id }) => {
+        const installation = ready.get(id);
+        return installation
+          ? { ...installation, status: "ready" as const }
+          : { provider: id, status: "unavailable" as const };
+      }),
+      refreshedAt: this.now(),
+    };
+    this.snapshots.set(snapshotKey(target), snapshot);
+    return snapshot;
+  }
+}

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -398,7 +398,9 @@ export class AgentSessionRuntime {
         event.type === "interaction_request" &&
         typeof event.id === "string" &&
         typeof event.method === "string" &&
-        ["select", "confirm", "input", "editor"].includes(event.method)
+        ["select", "confirm", "input", "editor", "form", "external"].includes(
+          event.method,
+        )
       ) {
         this.clearPendingInteraction();
         this.pendingInteraction = event as NonNullable<

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.7.0"
+connector_version="0.8.0"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

- add OpenCode discovery, catalogs, session creation/resumption, streaming, queue/steer behavior, permissions, model variants, and usage events
- project connector-owned provider snapshots onto existing workspaces so newly installed providers appear without deleting and re-adding a workspace
- keep provider availability ephemeral and connector-owned; persist only materialized connections, workspaces, and sessions
- centralize provider metadata/visuals and show OpenCode in Agent Connections
- bump the atomic web/connector wire protocol to 2
- prepare app v0.17.0 and Host Connector v0.8.0 release metadata

## Architecture

Provider registration is static. Per-target availability is an in-memory connector snapshot, refreshed through the existing authenticated relay. Existing workspace paths are projected across ready providers, and a provider is only materialized in SQLite when setup is explicit or a durable native session exists. This avoids a provider-lifecycle persistence subsystem and keeps the web app from reconstructing runtime state.

The protocol bump intentionally rejects stale partial deployments. This PR does not add backward-compatibility or independent component-update support; OvertChat updates remain atomic.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run deps:check`
- `npm run build`
- `npm run test:e2e` (12 passed, 5 opt-in real-agent tests skipped; stale fixture then corrected and affected scenario rerun: 1 passed)
- `node apps/connector/dist/overtchat-connector.mjs version` -> `0.8.0`
- `git diff --check`