### PR TITLE
refactor(connector): simplify protocol compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,8 @@ body:
     attributes:
       label: App version
       description: |
-        Run `docker compose images app` and paste the tag (e.g. `0.7.0`). If you're running from source, paste the short commit hash from `git rev-parse --short HEAD`.
-      placeholder: "0.7.0"
+        Run `overtchat status` and paste the reported version. If you're running from source, paste the short commit hash from `git rev-parse --short HEAD`.
+      placeholder: "0.17.0"
     validations:
       required: true
 
@@ -51,5 +51,5 @@ body:
     attributes:
       label: Relevant logs (optional)
       description: |
-        Output of `docker compose logs app --tail=100` around the time of the bug, if it's a server-side issue. Browser DevTools console errors are great for UI bugs.
+        Output of `docker logs overtchat-app --tail=100` around the time of the bug, if it's a server-side issue. Browser DevTools console errors are great for UI bugs.
       render: shell

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ you a URL to open. The first signup becomes the admin.
 - `overtchat status` — check the installation
 - `overtchat update` — update the app and everything it manages
 
-Prefer to manage Compose yourself or deploy from source? See the
-[deployment guide](docs/deploy.md#manual-compose-installation).
+The guided manager is the supported production installation and update path.
+Existing standard Compose installations can be adopted in place with
+`overtchat setup`.
 
 ## Built for your stack
 

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   type HostConnectorEventBatch,
   type HostConnectorEventPayload,
 } from "@overtchat/agent-bridge";
@@ -119,7 +118,7 @@ describe.sequential("connector client compatibility", () => {
     ).toHaveLength(0);
   });
 
-  it("uses the protocol compatibility token and advertises its build", async () => {
+  it("advertises its wire protocol and build version", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal(
       "fetch",
@@ -133,9 +132,7 @@ describe.sequential("connector client compatibility", () => {
     await vi.waitFor(() => expect(requests.length).toBeGreaterThan(0));
 
     const headers = new Headers(requests[0]!.init?.headers);
-    expect(headers.get("x-overtchat-connector-version")).toBe(
-      HOST_CONNECTOR_COMPATIBILITY_RELEASE,
-    );
+    expect(headers.get("x-overtchat-connector-version")).toBeNull();
     expect(headers.get("x-overtchat-connector-build-version")).toBe("0.8.0");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),

--- a/apps/connector/src/client.ts
+++ b/apps/connector/src/client.ts
@@ -2,7 +2,6 @@ import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   isHostConnectorCommand,
   MAX_AGENT_IMAGE_BYTES,
   type AgentPromptImage,
@@ -200,8 +199,6 @@ export class ConnectorClient {
         signal: abort.signal,
         headers: {
           Authorization: `Bearer ${this.config.token}`,
-          "X-OvertChat-Connector-Version":
-            HOST_CONNECTOR_COMPATIBILITY_RELEASE,
           "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
           "X-OvertChat-Connector-Capabilities":
             HOST_CONNECTOR_CAPABILITIES.join(","),
@@ -316,8 +313,6 @@ export class ConnectorClient {
           headers: {
             Authorization: `Bearer ${this.config.token}`,
             "Content-Type": "application/json",
-            "X-OvertChat-Connector-Version":
-              HOST_CONNECTOR_COMPATIBILITY_RELEASE,
             "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
             "X-OvertChat-Connector-Capabilities":
               HOST_CONNECTOR_CAPABILITIES.join(","),

--- a/apps/web/app/api/host-connectors/channel/route.test.ts
+++ b/apps/web/app/api/host-connectors/channel/route.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
 } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
@@ -29,14 +28,19 @@ vi.mock("@/lib/db/agentConnections", () => ({
 import { GET } from "./route";
 
 function request(
-  version = HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   protocol = HOST_CONNECTOR_PROTOCOL_VERSION,
-  options: { buildVersion?: string; capabilities?: string } = {},
+  options: {
+    buildVersion?: string;
+    capabilities?: string;
+    legacyVersion?: string;
+  } = {},
 ): Request {
   return new Request("http://server.test/api/host-connectors/channel", {
     headers: {
-      "X-OvertChat-Connector-Version": version,
       "X-OvertChat-Connector-Protocol": String(protocol),
+      ...(options.legacyVersion
+        ? { "X-OvertChat-Connector-Version": options.legacyVersion }
+        : {}),
       ...(options.buildVersion
         ? { "X-OvertChat-Connector-Build-Version": options.buildVersion }
         : {}),
@@ -68,7 +72,7 @@ describe("Host Connector command channel", () => {
     mocks.listActiveSessions.mockResolvedValue(["session"]);
   });
 
-  it("opens for the current protocol compatibility baseline", async () => {
+  it("opens for the current wire protocol", async () => {
     const response = await GET(request());
 
     expect(response.status).toBe(200);
@@ -81,24 +85,17 @@ describe("Host Connector command channel", () => {
       expect.any(Function),
       [],
     );
-    expect(mocks.touch).toHaveBeenCalledWith(
-      "connector",
-      HOST_CONNECTOR_COMPATIBILITY_RELEASE,
-    );
+    expect(mocks.touch).toHaveBeenCalledWith("connector", undefined);
     await reader.cancel();
     expect(mocks.unregister).toHaveBeenCalled();
   });
 
   it("uses the build version for display without gating the wire", async () => {
     const response = await GET(
-      request(
-        HOST_CONNECTOR_COMPATIBILITY_RELEASE,
-        HOST_CONNECTOR_PROTOCOL_VERSION,
-        {
-          buildVersion: "9.9.9",
-          capabilities: `${HOST_CONNECTOR_CAPABILITIES[0]},future-capability`,
-        },
-      ),
+      request(HOST_CONNECTOR_PROTOCOL_VERSION, {
+        buildVersion: "9.9.9",
+        capabilities: `${HOST_CONNECTOR_CAPABILITIES[0]},future-capability`,
+      }),
     );
 
     expect(response.status).toBe(200);
@@ -112,22 +109,25 @@ describe("Host Connector command channel", () => {
     await response.body!.cancel();
   });
 
-  it("rejects an incompatible wire shape or protocol", async () => {
-    const wrongRelease = await GET(request("0.1.0"));
-    expect(wrongRelease.status).toBe(409);
-    await expect(wrongRelease.json()).resolves.toMatchObject({
-      error: expect.stringContaining("overtchat update"),
-      code: "unsupported_connector_protocol",
-      compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
-    });
+  it("ignores the retired compatibility-release header", async () => {
+    const response = await GET(
+      request(HOST_CONNECTOR_PROTOCOL_VERSION, { legacyVersion: "0.1.0" }),
+    );
 
+    expect(response.status).toBe(200);
+    await response.body!.cancel();
+  });
+
+  it("rejects an incompatible wire protocol", async () => {
     const wrongProtocol = await GET(
-      request(
-        HOST_CONNECTOR_COMPATIBILITY_RELEASE,
-        HOST_CONNECTOR_PROTOCOL_VERSION + 1,
-      ),
+      request(HOST_CONNECTOR_PROTOCOL_VERSION + 1),
     );
     expect(wrongProtocol.status).toBe(409);
+    await expect(wrongProtocol.json()).resolves.toMatchObject({
+      error: expect.stringContaining("overtchat update"),
+      code: "unsupported_connector_protocol",
+      supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
+    });
     expect(mocks.register).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/api/host-connectors/channel/route.ts
+++ b/apps/web/app/api/host-connectors/channel/route.ts
@@ -1,6 +1,5 @@
 import {
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   isHostConnectorProtocolVersion,
   parseHostConnectorCapabilities,
   type HostConnectorCommand,
@@ -19,22 +18,16 @@ export async function GET(request: Request) {
   const protocol = Number(
     request.headers.get("x-overtchat-connector-protocol"),
   );
-  const connectorVersion = request.headers.get(
-    "x-overtchat-connector-version",
-  );
   const connectorBuildVersion = request.headers
     .get("x-overtchat-connector-build-version")
     ?.trim();
-  if (
-    !isHostConnectorProtocolVersion(protocol) ||
-    connectorVersion !== HOST_CONNECTOR_COMPATIBILITY_RELEASE
-  ) {
+  if (!isHostConnectorProtocolVersion(protocol)) {
     return Response.json(
       {
-        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_COMPATIBILITY_RELEASE}).`,
+        error:
+          "The OvertChat app and Host Connector use incompatible protocols. Run `overtchat update` on the OvertChat host.",
         code: "unsupported_connector_protocol",
         supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
-        compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
       },
       { status: 409 },
     );
@@ -42,7 +35,7 @@ export async function GET(request: Request) {
   const capabilities = parseHostConnectorCapabilities(
     request.headers.get("x-overtchat-connector-capabilities"),
   );
-  touchHostConnector(connector.id, connectorBuildVersion || connectorVersion);
+  touchHostConnector(connector.id, connectorBuildVersion || undefined);
   const activeSessionIds = await listActiveAgentSessionIds(connector.id);
 
   let close = () => {};

--- a/apps/web/app/api/host-connectors/events/route.test.ts
+++ b/apps/web/app/api/host-connectors/events/route.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
 } from "@overtchat/agent-bridge";
 
 const mocks = vi.hoisted(() => ({
@@ -29,20 +28,21 @@ import { POST } from "./route";
 function request(
   body: unknown,
   options: {
-    version?: string;
     protocol?: number;
     buildVersion?: string;
+    legacyVersion?: string;
   } = {},
 ): Request {
   return new Request("http://server.test/api/host-connectors/events", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-OvertChat-Connector-Version":
-        options.version ?? HOST_CONNECTOR_COMPATIBILITY_RELEASE,
       "X-OvertChat-Connector-Protocol": String(
         options.protocol ?? HOST_CONNECTOR_PROTOCOL_VERSION,
       ),
+      ...(options.legacyVersion
+        ? { "X-OvertChat-Connector-Version": options.legacyVersion }
+        : {}),
       ...(options.buildVersion
         ? { "X-OvertChat-Connector-Build-Version": options.buildVersion }
         : {}),
@@ -89,10 +89,7 @@ describe("Host Connector event route", () => {
       "daemon",
       [event],
     );
-    expect(mocks.touch).toHaveBeenCalledWith(
-      "connector",
-      HOST_CONNECTOR_COMPATIBILITY_RELEASE,
-    );
+    expect(mocks.touch).toHaveBeenCalledWith("connector", undefined);
   });
 
   it("records a newer build without requiring its release to match", async () => {
@@ -197,7 +194,7 @@ describe("Host Connector event route", () => {
     expect(mocks.acceptBatch).not.toHaveBeenCalled();
   });
 
-  it("rejects an outdated connector release with an update instruction", async () => {
+  it("ignores the retired compatibility-release header", async () => {
     const response = await POST(
       request(
         {
@@ -215,17 +212,12 @@ describe("Host Connector event route", () => {
             },
           ],
         },
-        { version: "0.1.0" },
+        { legacyVersion: "0.1.0" },
       ),
     );
 
-    expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toMatchObject({
-      error: expect.stringContaining("overtchat update"),
-      code: "unsupported_connector_protocol",
-      compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
-    });
-    expect(mocks.acceptBatch).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(mocks.acceptBatch).toHaveBeenCalledOnce();
   });
 
   it("returns a client error when the broker rejects a noncontiguous batch", async () => {

--- a/apps/web/app/api/host-connectors/events/route.ts
+++ b/apps/web/app/api/host-connectors/events/route.ts
@@ -1,7 +1,6 @@
 import {
   HOST_CONNECTOR_EVENT_BATCH_LIMIT,
   HOST_CONNECTOR_PROTOCOL_VERSION,
-  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   isHostConnectorEvent,
   isHostConnectorProtocolVersion,
   type HostConnectorEventBatch,
@@ -16,17 +15,13 @@ export async function POST(request: Request) {
   const protocol = Number(
     request.headers.get("x-overtchat-connector-protocol"),
   );
-  if (
-    request.headers.get("x-overtchat-connector-version") !==
-      HOST_CONNECTOR_COMPATIBILITY_RELEASE ||
-    !isHostConnectorProtocolVersion(protocol)
-  ) {
+  if (!isHostConnectorProtocolVersion(protocol)) {
     return Response.json(
       {
-        error: `The OvertChat app and Host Connector are out of date with each other. Run \`overtchat update\` on the OvertChat host (or reinstall connector ${HOST_CONNECTOR_COMPATIBILITY_RELEASE}).`,
+        error:
+          "The OvertChat app and Host Connector use incompatible protocols. Run `overtchat update` on the OvertChat host.",
         code: "unsupported_connector_protocol",
         supportedProtocolVersions: [HOST_CONNECTOR_PROTOCOL_VERSION],
-        compatibilityRelease: HOST_CONNECTOR_COMPATIBILITY_RELEASE,
       },
       { status: 409 },
     );
@@ -57,7 +52,7 @@ export async function POST(request: Request) {
       ?.trim();
     touchHostConnector(
       connector.id,
-      connectorBuildVersion || HOST_CONNECTOR_COMPATIBILITY_RELEASE,
+      connectorBuildVersion || undefined,
     );
     return Response.json(ack);
   } catch (error) {

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,195 +1,71 @@
 # Deploy
 
-The managed installer runs OvertChat on the current Linux machine with Docker
-Compose. It supports x86-64 and arm64.
+The guided manager is the supported production installation and update path.
+It runs OvertChat with Docker Compose on x86-64 or arm64 Linux.
 
-## One-time setup
+## Install and configure
 
 ```bash
 curl -fsSL https://overtchat.com/install | sh
 ```
 
-The terminal wizard configures web search, TTS, STT, and optional Agent
-Connections. Docker is detected automatically and can be installed when it is
-missing. For local STT, the wizard detects NVIDIA GPUs by stable UUID and lets
-you select Auto, a specific device, or CPU.
+The wizard installs Docker when needed and configures the app, optional local
+services, and Agent Connections. Open the printed URL; the first signup becomes
+the administrator.
 
-Open the printed URL. The first user to sign up becomes the admin. Model setup
-continues in the web app.
-
-The managed files live under `~/.config/overtchat` and
-`~/.local/share/overtchat`. Re-run setup whenever you want to install an
-optional bundled service that was skipped initially:
+Use the manager for later changes:
 
 ```bash
-overtchat setup
+overtchat setup     # reconfigure services or Agent Connections
+overtchat status    # show the installed version, URL, and service status
 ```
 
-Provider selection can also be changed later in **Admin Settings → Services**.
-Bundled services must first be installed with `overtchat setup`.
+Model endpoints and product settings remain in the web app. Bundled services
+must first be installed with `overtchat setup`.
 
-Web search uses the selected provider as its primary. When Brave is selected,
-an installed or configured SearXNG service is used automatically if Brave
-fails or returns no useful results. OvertChat then tries Firecrawl, Exa, and
-DuckDuckGo in order, stopping after the first useful response. Those public
-backup providers receive the query only when the providers before them cannot
-answer. Search activity records which provider ultimately served the results.
+Managed configuration lives under `~/.config/overtchat`; generated stack files
+and service data live under `~/.local/share/overtchat`. Manual edits to generated
+files may be replaced by the next setup or update.
 
-## Adopting an existing Compose installation
+## Adopt an existing installation
 
-Running `overtchat setup` on a machine that already has the standard
-`overtchat-app` container adopts it in place. The installer preserves the
-current `/app/data` Docker volume or bind mount, public port, auth secret, and
-standard SearXNG configuration. If the containers were removed with
-`docker compose down`, it can recover a single standard Compose data volume by
-its Docker labels. After adoption, use `overtchat setup`, `overtchat status`,
-and `overtchat update` instead of the old Compose workflow.
+Run `overtchat setup` on a machine with a standard `overtchat-app` container to
+adopt it. The manager preserves its `/app/data` volume or bind mount, public
+port, auth secret, and standard SearXNG configuration. It creates and verifies
+a SQLite snapshot before replacing the app or running migrations.
 
-If more than one candidate data volume exists, start the specific old stack
-before running setup so the manager can identify it. Custom layouts and source
-deployments are not part of the supported production update path; back up their
-data and migrate it into a standard installation instead of expecting the
-manager to modify an ambiguous deployment.
+If the old containers are stopped, setup can recover one standard Compose data
+volume by its Docker labels. If it finds multiple candidates, start the stack
+you want to adopt and run setup again. Setup also converts an existing manually
+paired connector into a managed connector.
 
-## Development
+Custom layouts and source deployments are outside the supported production
+update path. Back up their data before migrating to a standard installation.
 
-Install dependencies, then start the local web app, Redis, and Host Connector:
-
-```bash
-npm install
-npm run dev
-```
-
-Open [http://localhost:4717](http://localhost:4717). The development command
-starts an isolated `overtchat-dev` Redis container, waits for Next.js, provisions
-a development connector through the internal management API, and runs the
-connector directly from TypeScript. Stop the web app and connector with
-Ctrl-C. Next.js and the connector run directly on the host; Docker supplies
-Redis only. Redis stays available between runs; stop it with
-`npm run dev:down`.
-
-Generated credentials, journals, timelines, and locks live under the ignored
-`.overtchat-dev/` directory. Development never reads or changes the installed
-connector in `~/.config/overtchat`, its binary, or its systemd service. When a
-development database creates a different connector identity, the old runtime
-state is moved to a timestamped backup instead of being reused.
-
-Safe localhost defaults are tracked in `apps/web/.env.development`.
-Machine-specific URLs and trusted origins still belong in the ignored
-`apps/web/.env.local` file. The tracked development environment also clears a
-container-only `REDIS_URL`; the full root command supplies its local Redis URL
-explicitly.
-
-The root `.env` is source-development configuration. Managed production
-settings live under `~/.config/overtchat` and must be changed through
-`overtchat setup` or the product settings. `apps/web/.env` must remain a
-symlink to `../../.env` so direct Next.js commands see the development file;
-do not replace it with a copy. Next loads `.env.development` and then the
-gitignored `.env.local` overrides during development. Mobile has no environment
-file because its server URL is selected per device.
-
-For a phone or browser on another development origin, update both mechanisms:
-`EXTRA_TRUSTED_ORIGINS` controls Better Auth and CORS, while
-`allowedDevOrigins` in `apps/web/next.config.ts` controls Next.js development
-assets. Neither setting replaces the other.
-
-Use the narrower commands when the complete stack is not needed:
-
-```bash
-npm run dev:web       # Next.js only, without Redis or Agent Connections
-npm run dev:mobile    # Expo in its own terminal
-npm run dev:site      # marketing site on port 4719
-```
-
-Production always includes Redis so the root development command does too.
-Running the web workspace alone intentionally exercises the supported fallback
-where ordinary streaming works but disconnected streams cannot be resumed.
-
-To use non-default local ports, set `OVERTCHAT_DEV_PORT` or
-`OVERTCHAT_DEV_REDIS_PORT`. Search, text-to-speech, and speech-to-text remain
-explicit integrations rather than processes hidden inside the default command.
-
-If an incompatible source change makes the disposable connector journal
-unreadable, `npm run dev:reset-connector` moves the connector directory to a
-timestamped backup. The next `npm run dev` provisions fresh local state.
-
-For a complete managed build from the current worktree, including the Host
-Connector and user systemd service, run:
-
-```bash
-npm run dev:managed
-```
-
-This uses the same managed provisioning path as `overtchat setup`: the CLI
-requests connector credentials through the app's internal management endpoint
-and installs the user service. This command is for testing the production
-installer from source, not for the normal hot-reload development loop. It does
-not create or consume a pairing code in Settings.
-
-To debug an installed connector specifically, stop its service so two
-processes do not compete for the same production identity, then run the source
-process:
-
-```bash
-systemctl --user stop overtchat-connector.service
-npm run dev -w apps/connector
-```
-
-The source process reads `~/.config/overtchat/connector.json`; its `run`
-command does not accept `--server`. Restart the installed service when done.
-
-## Deploying updates
+## Update
 
 ```bash
 overtchat update
 ```
 
-This updates the management CLI, app image, selected local sidecars, and managed
-Agent Connector as one coordinated release. Database migrations run
-automatically when the app starts; the existing data mount is not replaced.
+This updates the management CLI, app image, selected sidecars, and managed Host
+Connector as one coordinated release. Database migrations run when the app
+starts without replacing its data mount. If an update stops partway through,
+run the command again to reconcile every managed component.
 
-When an administrator loads the authenticated web app, OvertChat checks the
-public release manifest at `overtchat.com` and shows an update indicator on the
-account button when a newer app image is available. The account menu includes
-the available version. The browser may recheck after reconnecting, returning
-to the tab, or reopening a stale account menu; the server does not retain a
-process-wide update result. The check does not send an instance identifier,
-account data, configuration, or the installed version. Run
-`DISABLE_UPDATE_CHECK=true overtchat setup` once to persist an opt-out.
+The web app reports newer releases from the public OvertChat manifest. To
+disable that check, run `DISABLE_UPDATE_CHECK=true overtchat setup` once.
 
-Running `overtchat setup` adopts an older manually paired connector, rotates
-its credentials, and brings it under managed updates.
+## Connect other services
 
-## Pointing at your LLM
+Addresses configured in OvertChat must be reachable from the app container:
 
-The app container makes the upstream LLM calls, so the base URL you set in **Settings → API endpoint** needs to be reachable **from inside the container**, not from your browser.
-
-- **LLM running on the host:** use `http://host.docker.internal:<port>/v1`.
-  The managed stack provides this hostname on Linux.
-- **Public provider (OpenAI / Groq / etc.):** use the provider's base URL + API key.
-
-## MCP servers
-
-Admins can add STDIO or Streamable HTTP MCP servers under **Settings → Tools**.
-STDIO commands run inside the app container, which includes Node.js, npm, and
-npx:
-
-```text
-Command: npx
-Arguments: -y, @example/mcp-server@1.0.0
-```
-
-MCP addresses are resolved from inside the container. Use
-`host.docker.internal` for the Docker host or a Compose service name for a
-container on the same network. Downloads launched through npm use the separate
-`overtchat-npm-cache` volume.
-
-## Using existing search and speech services
-
-Run `overtchat setup` and select **Existing SearXNG** or an
-**OpenAI-compatible API** for speech. Enter a URL reachable from the app
-container. Use `host.docker.internal` for a service running on the OvertChat
-host, or use a LAN URL for another machine.
+- For an LLM or another service on the OvertChat host, use
+  `http://host.docker.internal:<port>`.
+- For existing SearXNG or speech services, run `overtchat setup` and select the
+  existing or OpenAI-compatible option. Use a LAN URL for another machine.
+- Configure MCP servers under **Settings → Tools**. STDIO commands run inside
+  the app container; HTTP servers need a container-reachable URL.
 
 ## Status, logs, and backup
 
@@ -200,20 +76,48 @@ overtchat status
 # App logs
 docker logs -f overtchat-app
 
-# Backup the DB (safe while running)
+# Backup the SQLite database while the app is running
 docker exec overtchat-app sqlite3 /app/data/chat.db ".backup /app/data/backup.db"
 docker cp overtchat-app:/app/data/backup.db ./backup.db
 ```
 
-The manager owns the generated Compose and environment files. Manual edits to
-those files may be replaced by the next `overtchat setup` or `overtchat update`.
+Common checks:
 
-## Troubleshooting
+- An HTTP `307` from `http://localhost:4718` is the healthy login redirect.
+- If login redirects back to itself, run `overtchat setup` and correct the
+  public URL.
+- If the port is occupied, run `overtchat setup` and select another port.
 
-- **`curl -I http://localhost:4718` returns `307`** — healthy (redirect to `/login`).
-- **Login succeeds, next page redirects back to login** — the configured public
-  URL does not match what the browser sees. Run `overtchat setup` and correct
-  the URL.
-- **Port already in use** — run `overtchat setup` and choose another port.
-- **An update stops partway through** — run `overtchat update` again. It
-  reconciles every managed component against the current release manifest.
+## Development
+
+Install dependencies and start the web app, isolated Redis container, and
+source Host Connector:
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:4717](http://localhost:4717). Stop the web app and
+connector with Ctrl-C; stop the retained development Redis container with
+`npm run dev:down`. Disposable connector state lives under `.overtchat-dev/`
+and never uses the installed production connector.
+
+Safe defaults are tracked in `apps/web/.env.development`; machine-specific
+values belong in `apps/web/.env.local`. The root `.env` is source-development
+configuration, and `apps/web/.env` must remain a symlink to `../../.env`. For
+another development origin, configure both `EXTRA_TRUSTED_ORIGINS` and Next.js
+`allowedDevOrigins`.
+
+Use a narrower process when the full stack is unnecessary:
+
+```bash
+npm run dev:web
+npm run dev:mobile
+npm run dev:site
+```
+
+Set `OVERTCHAT_DEV_PORT` or `OVERTCHAT_DEV_REDIS_PORT` for custom ports. Run
+`npm run dev:reset-connector` after an incompatible disposable journal change.
+To exercise the production provisioning path from the current worktree, run
+`npm run dev:managed`.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,18 +35,21 @@ DuckDuckGo in order, stopping after the first useful response. Those public
 backup providers receive the query only when the providers before them cannot
 answer. Search activity records which provider ultimately served the results.
 
-## Existing Compose installations
+## Adopting an existing Compose installation
 
 Running `overtchat setup` on a machine that already has the standard
 `overtchat-app` container adopts it in place. The installer preserves the
 current `/app/data` Docker volume or bind mount, public port, auth secret, and
 standard SearXNG configuration. If the containers were removed with
 `docker compose down`, it can recover a single standard Compose data volume by
-its Docker labels.
+its Docker labels. After adoption, use `overtchat setup`, `overtchat status`,
+and `overtchat update` instead of the old Compose workflow.
 
-The old Compose commands remain supported. If more than one candidate data
-volume exists or the installation uses unrelated container names, start the
-specific old stack first or continue managing that custom layout manually.
+If more than one candidate data volume exists, start the specific old stack
+before running setup so the manager can identify it. Custom layouts and source
+deployments are not part of the supported production update path; back up their
+data and migrate it into a standard installation instead of expecting the
+manager to modify an ambiguous deployment.
 
 ## Development
 
@@ -77,8 +80,10 @@ Machine-specific URLs and trusted origins still belong in the ignored
 container-only `REDIS_URL`; the full root command supplies its local Redis URL
 explicitly.
 
-The root `.env` is the Compose/production configuration. `apps/web/.env` must
-remain a symlink to `../../.env` so direct Next.js commands see the same file;
+The root `.env` is source-development configuration. Managed production
+settings live under `~/.config/overtchat` and must be changed through
+`overtchat setup` or the product settings. `apps/web/.env` must remain a
+symlink to `../../.env` so direct Next.js commands see the development file;
 do not replace it with a copy. Next loads `.env.development` and then the
 gitignored `.env.local` overrides during development. Mobile has no environment
 file because its server URL is selected per device.
@@ -149,37 +154,18 @@ account button when a newer app image is available. The account menu includes
 the available version. The browser may recheck after reconnecting, returning
 to the tab, or reopening a stale account menu; the server does not retain a
 process-wide update result. The check does not send an instance identifier,
-account data, configuration, or the installed version. For a manual Compose
-installation, set
-`DISABLE_UPDATE_CHECK=true` in the root `.env` file. For an installation made
-with the guided manager, run `DISABLE_UPDATE_CHECK=true overtchat setup` once
-to persist the same opt-out.
+account data, configuration, or the installed version. Run
+`DISABLE_UPDATE_CHECK=true overtchat setup` once to persist an opt-out.
 
 Running `overtchat setup` adopts an older manually paired connector, rotates
 its credentials, and brings it under managed updates.
-
-## Manual Compose installation
-
-For source development, custom orchestration, or non-Linux hosts, clone the
-repository and use the original Compose flow:
-
-```bash
-git clone https://github.com/yoloyash/overtchat
-cd overtchat
-cp .env.example .env
-echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)" >> .env
-echo "SEARXNG_SECRET=$(openssl rand -hex 32)" >> .env
-docker compose up -d --build
-```
-
-Set `BETTER_AUTH_URL` in `.env` to the URL browsers will use. Manual installs
-update with `git pull && docker compose up -d --build`.
 
 ## Pointing at your LLM
 
 The app container makes the upstream LLM calls, so the base URL you set in **Settings → API endpoint** needs to be reachable **from inside the container**, not from your browser.
 
-- **LLM running on the host (not in docker):** use `http://host.docker.internal:<port>/v1`. Baked into `compose.yml` via `extra_hosts`, works on Linux / macOS / Windows.
+- **LLM running on the host:** use `http://host.docker.internal:<port>/v1`.
+  The managed stack provides this hostname on Linux.
 - **Public provider (OpenAI / Groq / etc.):** use the provider's base URL + API key.
 
 ## MCP servers
@@ -198,53 +184,36 @@ MCP addresses are resolved from inside the container. Use
 container on the same network. Downloads launched through npm use the separate
 `overtchat-npm-cache` volume.
 
-## Reusing sidecars
+## Using existing search and speech services
 
-SearXNG and Kokoro are bundled by default. To point the app at existing services, set container-reachable URLs in `.env`:
+Run `overtchat setup` and select **Existing SearXNG** or an
+**OpenAI-compatible API** for speech. Enter a URL reachable from the app
+container. Use `host.docker.internal` for a service running on the OvertChat
+host, or use a LAN URL for another machine.
 
-```env
-OVERTCHAT_SEARXNG_URL=http://host.docker.internal:8088
-OVERTCHAT_KOKORO_URL=http://host.docker.internal:8880
-OVERTCHAT_STT_URL=http://host.docker.internal:5092
-```
-
-This changes where the app connects. To also stop the bundled containers from starting, add this to your local `compose.override.yml`:
-
-```yaml
-services:
-  searxng:
-    profiles: ["disabled"]
-  kokoro:
-    profiles: ["disabled"]
-```
-
-Docker Compose loads `compose.override.yml` automatically; this repo ignores it. If you already use that file for local networks or other overrides, merge these service entries into it.
-
-Then run the usual command:
+## Status, logs, and backup
 
 ```bash
-docker compose up -d
-```
+# Installation status
+overtchat status
 
-Use `host.docker.internal` for services running on the Docker host, or a LAN/container URL for services running elsewhere.
-
-## Common ops
-
-```bash
-# Tail logs
-docker compose logs -f app
-
-# Stop everything
-docker compose down
+# App logs
+docker logs -f overtchat-app
 
 # Backup the DB (safe while running)
-docker compose exec app sqlite3 /app/data/chat.db ".backup /app/data/backup.db"
-docker compose cp app:/app/data/backup.db ./backup.db
+docker exec overtchat-app sqlite3 /app/data/chat.db ".backup /app/data/backup.db"
+docker cp overtchat-app:/app/data/backup.db ./backup.db
 ```
+
+The manager owns the generated Compose and environment files. Manual edits to
+those files may be replaced by the next `overtchat setup` or `overtchat update`.
 
 ## Troubleshooting
 
 - **`curl -I http://localhost:4718` returns `307`** — healthy (redirect to `/login`).
-- **Login succeeds, next page redirects back to login** — `BETTER_AUTH_URL` mismatch with what the browser sees. Fix in `.env`, then `docker compose up -d`.
-- **Port already in use** — change `APP_PORT` in `.env`.
-- **Schema errors after pull** — you didn't rebuild. `docker compose up -d --build`.
+- **Login succeeds, next page redirects back to login** — the configured public
+  URL does not match what the browser sees. Run `overtchat setup` and correct
+  the URL.
+- **Port already in use** — run `overtchat setup` and choose another port.
+- **An update stops partway through** — run `overtchat update` again. It
+  reconciles every managed component against the current release manifest.

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,7 +19,7 @@ stable channel used by both `overtchat setup` and `overtchat update`.
 | --- | --- | --- |
 | App | Manifest `appVersion`; `compose.yml` default | `vX.Y.Z` |
 | CLI | `apps/cli/package.json`; lockfile; `CLI_VERSION`; site installer; manifest `cliVersion` | `cli-vX.Y.Z` |
-| Connector | Package and lockfile; bridge release constants; connector installer; site redirects; manifest `connectorVersion` | `connector-vX.Y.Z` |
+| Connector | Package and lockfile; bridge release version; connector installer; site redirects; manifest `connectorVersion` | `connector-vX.Y.Z` |
 | STT | Manifest `sttVersion`; `compose.yml` default | `stt-vX.Y.Z` |
 | Bundled images | Manifest `redisImage`, `searxngImage`, or `kokoroImage` digest | None |
 | Mobile | See [Mobile release](#mobile-release) | `mobile-vX.Y.Z` |
@@ -42,7 +42,9 @@ Do not change unrelated manifest fields.
 - **CLI:** The CLI workflow verifies both binaries, publishes the GitHub
   release, and dispatches promotion.
 - **Connector:** The connector workflow verifies both binaries, publishes the
-  GitHub release, and dispatches promotion.
+  GitHub release, and dispatches promotion. Increment the bridge protocol only
+  for a breaking web-to-connector contract change; ordinary connector releases
+  retain the current protocol.
 - **STT:** The STT workflow publishes both images and dispatches promotion.
 - **Bundled images:** Promotion verifies amd64 and arm64 for every selected
   digest. A digest-only change does not require a CLI release.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -19,8 +19,9 @@ state model used by the web app, connector, and runtime.
 - Keep this package transport-neutral and free of filesystem, network, process,
   database, UI, or provider implementations.
 - Wire types, Zod schemas, runtime guards, reducers, and tests must evolve
-  together. Protocol v1 is exact; coordinate wire changes across the web and
-  connector consumers rather than adding parallel protocol shapes.
+  together. The current protocol is exact; increment it only for a breaking
+  web-to-connector contract change and coordinate the web and connector
+  consumers rather than adding parallel protocol shapes.
 
 ## Agent runtime
 

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -19,12 +19,9 @@ import {
   agentSessionLaunchConfigSchema,
 } from "./agents";
 
+/** Increment only for a breaking web-to-connector wire contract change. */
 export const HOST_CONNECTOR_PROTOCOL_VERSION = 2;
-/**
- * Release 0.8.0 is the compatibility baseline for protocol 2 and remains
- * stable when connector build versions change without changing the wire shape.
- */
-export const HOST_CONNECTOR_COMPATIBILITY_RELEASE = "0.8.0";
+/** Published connector artifact version; independent of wire compatibility. */
 export const HOST_CONNECTOR_RELEASE_VERSION = "0.8.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   HOST_CONNECTOR_CAPABILITIES,
-  HOST_CONNECTOR_COMPATIBILITY_RELEASE,
   HOST_CONNECTOR_PROTOCOL_VERSION,
   isHostConnectorCommand,
   isHostConnectorEvent,
@@ -10,9 +9,8 @@ import {
 import { agentProviderCatalogSchema } from "./agents";
 
 describe("Host Connector protocol compatibility", () => {
-  it("identifies the protocol 2 compatibility release", () => {
+  it("identifies the current wire protocol", () => {
     expect(HOST_CONNECTOR_PROTOCOL_VERSION).toBe(2);
-    expect(HOST_CONNECTOR_COMPATIBILITY_RELEASE).toBe("0.8.0");
   });
 
   it("selects known capabilities and ignores unknown additive tokens", () => {


### PR DESCRIPTION
## Summary

- make protocol `2` the sole web-to-connector compatibility signal
- keep connector build/release versions only for artifact identity, display, and upgrades
- retire the compatibility-release header, constant, response field, and exact release gate
- document the guided manager as the only supported production installation and update path
- retain existing Compose adoption as a migration into managed ownership

## Why

The connector handshake currently checks both protocol `2` and a synthetic compatibility release (`0.8.0`). Those values answer the same compatibility question and make routine connector releases harder to reason about.

The managed updater starts the new app before replacing the connector. With this change, the new app accepts any connector speaking protocol `2`, including the currently released connector with its now-ignored legacy header. It still rejects an incompatible protocol before commands or events are exchanged.

The deployment documentation also advertised a separate source-Compose production lifecycle even though managed setup is already the normal product path. This PR removes that supported-path ambiguity while preserving adoption for existing standard Compose installations.

## Rollout

- no protocol bump
- no database migration
- no provider or runtime behavior change
- no updater transaction redesign
- no removal of legacy pairing APIs, installer assets, redirects, or historical releases

App-first managed updates remain compatible: the updated app accepts the existing protocol-2 connector, then the updated connector stops sending the retired header.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run deps:check`
- `npm run build`