### PR TITLE
fix(agents): share managed connector across admins

### DIFF
--- a/apps/web/app/api/agent-connections/directories/route.test.ts
+++ b/apps/web/app/api/agent-connections/directories/route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   daemonRequest: vi.fn(),
-  getOwnedConnector: vi.fn(),
+  getAvailableConnector: vi.fn(),
   getSession: vi.fn(),
 }));
 
@@ -14,7 +14,7 @@ vi.mock("@/lib/agents/connector/broker", () => ({
   hostConnectorBroker: { request: mocks.daemonRequest },
 }));
 vi.mock("@/lib/db/hostConnectors", () => ({
-  getOwnedHostConnector: mocks.getOwnedConnector,
+  getAvailableHostConnector: mocks.getAvailableConnector,
 }));
 
 import { POST } from "./route";
@@ -33,7 +33,7 @@ describe("Agent target directory route", () => {
     mocks.getSession.mockResolvedValue({
       user: { id: "admin", role: "admin" },
     });
-    mocks.getOwnedConnector.mockReturnValue({ id: "connector" });
+    mocks.getAvailableConnector.mockReturnValue({ id: "connector" });
     mocks.daemonRequest.mockResolvedValue({
       path: "/srv",
       parent: "/",
@@ -108,8 +108,8 @@ describe("Agent target directory route", () => {
     expect(mocks.daemonRequest).not.toHaveBeenCalled();
   });
 
-  it("keeps browsing restricted to owned connectors", async () => {
-    mocks.getOwnedConnector.mockReturnValue(null);
+  it("keeps browsing restricted to available connectors", async () => {
+    mocks.getAvailableConnector.mockReturnValue(null);
 
     const response = await POST(
       request({

--- a/apps/web/app/api/agent-connections/directories/route.ts
+++ b/apps/web/app/api/agent-connections/directories/route.ts
@@ -7,7 +7,7 @@ import {
 import { agentDiscoveryTargetSchema } from "@overtchat/agent-bridge";
 import type { ConnectorShellMode } from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
+import { getAvailableHostConnector } from "@/lib/db/hostConnectors";
 
 export const maxDuration = 30;
 
@@ -41,7 +41,7 @@ export async function POST(request: Request) {
     );
   }
   const { target, path } = parsed.data;
-  if (!getOwnedHostConnector(target.connectorId, session.user.id)) {
+  if (!getAvailableHostConnector(target.connectorId, session.user.id)) {
     return new Response("Host Connector not found", { status: 404 });
   }
 

--- a/apps/web/app/api/agent-connections/discover/route.test.ts
+++ b/apps/web/app/api/agent-connections/discover/route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   daemonRequest: vi.fn(),
-  getOwnedConnector: vi.fn(),
+  getAvailableConnector: vi.fn(),
   getSession: vi.fn(),
 }));
 
@@ -14,7 +14,7 @@ vi.mock("@/lib/agents/connector/broker", () => ({
   hostConnectorBroker: { request: mocks.daemonRequest },
 }));
 vi.mock("@/lib/db/hostConnectors", () => ({
-  getOwnedHostConnector: mocks.getOwnedConnector,
+  getAvailableHostConnector: mocks.getAvailableConnector,
 }));
 
 import { POST } from "./route";
@@ -36,7 +36,7 @@ describe("Agent Connection discovery route", () => {
     mocks.getSession.mockResolvedValue({
       user: { id: "admin", role: "admin" },
     });
-    mocks.getOwnedConnector.mockReturnValue({ id: "connector" });
+    mocks.getAvailableConnector.mockReturnValue({ id: "connector" });
     mocks.daemonRequest.mockResolvedValue({
       target: {
         connectorId: "connector",
@@ -59,7 +59,7 @@ describe("Agent Connection discovery route", () => {
     });
   });
 
-  it("discovers agents through an owned connector and exact SSH alias", async () => {
+  it("discovers agents through an available connector and exact SSH alias", async () => {
     const response = await POST(
       request({
         connectorId: "connector",
@@ -99,7 +99,7 @@ describe("Agent Connection discovery route", () => {
         },
       ],
     });
-    expect(mocks.getOwnedConnector).toHaveBeenCalledWith(
+    expect(mocks.getAvailableConnector).toHaveBeenCalledWith(
       "connector",
       "admin",
     );
@@ -114,8 +114,8 @@ describe("Agent Connection discovery route", () => {
     });
   });
 
-  it("rejects connectors owned by another user", async () => {
-    mocks.getOwnedConnector.mockReturnValue(null);
+  it("rejects connectors unavailable to the current administrator", async () => {
+    mocks.getAvailableConnector.mockReturnValue(null);
 
     const response = await POST(
       request({ connectorId: "other", transport: "local" }),
@@ -135,7 +135,7 @@ describe("Agent Connection discovery route", () => {
     );
 
     expect(response.status).toBe(403);
-    expect(mocks.getOwnedConnector).not.toHaveBeenCalled();
+    expect(mocks.getAvailableConnector).not.toHaveBeenCalled();
     expect(mocks.daemonRequest).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/agent-connections/discover/route.ts
+++ b/apps/web/app/api/agent-connections/discover/route.ts
@@ -8,7 +8,7 @@ import {
   agentProviderSnapshotSchema,
 } from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
+import { getAvailableHostConnector } from "@/lib/db/hostConnectors";
 
 export const maxDuration = 30;
 
@@ -29,7 +29,7 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
-  if (!getOwnedHostConnector(parsed.data.connectorId, session.user.id)) {
+  if (!getAvailableHostConnector(parsed.data.connectorId, session.user.id)) {
     return new Response("Host Connector not found", { status: 404 });
   }
 

--- a/apps/web/app/api/agent-connections/probe/route.ts
+++ b/apps/web/app/api/agent-connections/probe/route.ts
@@ -5,7 +5,7 @@ import {
 } from "@/lib/agents/access";
 import { agentConnectionDraftSchema } from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
+import { getAvailableHostConnector } from "@/lib/db/hostConnectors";
 
 export const maxDuration = 150;
 
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
-  if (!getOwnedHostConnector(parsed.data.connectorId, session.user.id)) {
+  if (!getAvailableHostConnector(parsed.data.connectorId, session.user.id)) {
     return new Response("Host Connector not found", { status: 404 });
   }
 

--- a/apps/web/app/api/agent-connections/route.test.ts
+++ b/apps/web/app/api/agent-connections/route.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   listAgentConnections: vi.fn(),
   createAgentConnection: vi.fn(),
   daemonRequest: vi.fn(),
-  getOwnedHostConnector: vi.fn(),
+  getAvailableHostConnector: vi.fn(),
   withConnectorSessionDirectory: vi.fn(),
 }));
 
@@ -21,7 +21,7 @@ vi.mock("@/lib/agents/connector/broker", () => ({
   hostConnectorBroker: { request: mocks.daemonRequest },
 }));
 vi.mock("@/lib/db/hostConnectors", () => ({
-  getOwnedHostConnector: mocks.getOwnedHostConnector,
+  getAvailableHostConnector: mocks.getAvailableHostConnector,
 }));
 vi.mock("@/lib/agents/connector/directory", () => ({
   withConnectorSessionDirectory: mocks.withConnectorSessionDirectory,
@@ -48,7 +48,7 @@ describe("Agent Connections route", () => {
       user: { id: "admin", role: "admin" },
     });
     mocks.listAgentConnections.mockResolvedValue([]);
-    mocks.getOwnedHostConnector.mockReturnValue({ id: "connector" });
+    mocks.getAvailableHostConnector.mockReturnValue({ id: "connector" });
     mocks.withConnectorSessionDirectory.mockImplementation(
       (connections) => connections,
     );

--- a/apps/web/app/api/agent-connections/route.ts
+++ b/apps/web/app/api/agent-connections/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@overtchat/agent-bridge";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
 import { withConnectorSessionDirectory } from "@/lib/agents/connector/directory";
-import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
+import { getAvailableHostConnector } from "@/lib/db/hostConnectors";
 import {
   createAgentConnection,
   listAgentConnections,
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
     );
   }
   const draft = parsed.data;
-  if (!getOwnedHostConnector(draft.connectorId, session.user.id)) {
+  if (!getAvailableHostConnector(draft.connectorId, session.user.id)) {
     return new Response("Host Connector not found", { status: 404 });
   }
 

--- a/apps/web/app/api/agent-connections/ssh-hosts/route.ts
+++ b/apps/web/app/api/agent-connections/ssh-hosts/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/lib/auth/server";
 import { hostConnectorBroker } from "@/lib/agents/connector/broker";
-import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
+import { getAvailableHostConnector } from "@/lib/db/hostConnectors";
 
 export async function GET(req: Request) {
   const session = await auth.api.getSession({ headers: req.headers });
@@ -12,7 +12,7 @@ export async function GET(req: Request) {
   if (!connectorId) {
     return Response.json({ error: "Choose a Host Connector." }, { status: 400 });
   }
-  if (!getOwnedHostConnector(connectorId, session.user.id)) {
+  if (!getAvailableHostConnector(connectorId, session.user.id)) {
     return new Response("Not found", { status: 404 });
   }
   try {

--- a/apps/web/app/api/agent-workspaces/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/route.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/auth/server", () => ({
   auth: { api: { getSession: mocks.getSession } },
 }));
 vi.mock("@/lib/db/hostConnectors", () => ({
-  getOwnedHostConnector: mocks.getConnector,
+  getAvailableHostConnector: mocks.getConnector,
 }));
 vi.mock("@/lib/agents/connector/providerSnapshots", () => ({
   provisionAgentWorkspace: mocks.reconcile,
@@ -58,7 +58,7 @@ describe("atomic agent workspace route", () => {
     });
   });
 
-  it("does not reconcile another user's connector", async () => {
+  it("does not reconcile an unavailable connector", async () => {
     mocks.getConnector.mockReturnValue(null);
     const response = await POST(
       request({

--- a/apps/web/app/api/agent-workspaces/route.ts
+++ b/apps/web/app/api/agent-workspaces/route.ts
@@ -2,7 +2,7 @@ import { auth } from "@/lib/auth/server";
 import { connectionAccessError, connectionErrorMessage } from "@/lib/agents/access";
 import { createAgentWorkspaceSchema } from "@overtchat/agent-bridge";
 import { provisionAgentWorkspace } from "@/lib/agents/connector/providerSnapshots";
-import { getOwnedHostConnector } from "@/lib/db/hostConnectors";
+import { getAvailableHostConnector } from "@/lib/db/hostConnectors";
 
 export const maxDuration = 150;
 
@@ -23,7 +23,7 @@ export async function POST(request: Request) {
     );
   }
   if (
-    !getOwnedHostConnector(parsed.data.target.connectorId, session.user.id)
+    !getAvailableHostConnector(parsed.data.target.connectorId, session.user.id)
   ) {
     return new Response("Host Connector not found", { status: 404 });
   }

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   daemonRequest: vi.fn(),
   createPairing: vi.fn(),
   deleteConnector: vi.fn(),
+  getManagedConnector: vi.fn(),
   getOwnedConnector: vi.fn(),
   listConnectors: vi.fn(),
 }));
@@ -23,8 +24,9 @@ vi.mock("@/lib/agents/connector/broker", () => ({
 vi.mock("@/lib/db/hostConnectors", () => ({
   createHostConnectorPairing: mocks.createPairing,
   deleteHostConnector: mocks.deleteConnector,
+  getManagedHostConnector: mocks.getManagedConnector,
   getOwnedHostConnector: mocks.getOwnedConnector,
-  listHostConnectors: mocks.listConnectors,
+  listAvailableHostConnectors: mocks.listConnectors,
 }));
 
 import { DELETE, GET, POST } from "./route";
@@ -47,6 +49,7 @@ describe("Host Connectors route", () => {
       user: { id: "admin", role: "admin" },
     });
     mocks.listConnectors.mockReturnValue([]);
+    mocks.getManagedConnector.mockReturnValue(null);
     mocks.isOnline.mockReturnValue(false);
     mocks.createPairing.mockReturnValue({
       pairCode: "ocp_pair.secret",
@@ -85,6 +88,26 @@ describe("Host Connectors route", () => {
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
 
+  it("lists connectors available to the current administrator", async () => {
+    mocks.listConnectors.mockReturnValue([
+      {
+        id: "managed",
+        name: "Managed host",
+        managed: true,
+        version: "0.8.0",
+        lastSeenAt: new Date(12_000),
+      },
+    ]);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.listConnectors).toHaveBeenCalledWith("admin");
+    await expect(response.json()).resolves.toMatchObject({
+      connectors: [{ id: "managed", managed: true }],
+    });
+  });
+
   it("keeps managed connectors under overtchat setup", async () => {
     const managed = {
       id: "managed",
@@ -94,6 +117,7 @@ describe("Host Connectors route", () => {
       lastSeenAt: null,
     };
     mocks.listConnectors.mockReturnValue([managed]);
+    mocks.getManagedConnector.mockReturnValue(managed);
     mocks.getOwnedConnector.mockReturnValue(managed);
 
     const pairResponse = await POST(request("POST"));

--- a/apps/web/app/api/host-connectors/route.ts
+++ b/apps/web/app/api/host-connectors/route.ts
@@ -7,8 +7,9 @@ import { hostConnectorBroker } from "@/lib/agents/connector/broker";
 import {
   createHostConnectorPairing,
   deleteHostConnector,
+  getManagedHostConnector,
   getOwnedHostConnector,
-  listHostConnectors,
+  listAvailableHostConnectors,
 } from "@/lib/db/hostConnectors";
 
 function shellQuote(value: string): string {
@@ -78,7 +79,7 @@ async function adminUser(request: Request) {
 export async function GET(request: Request) {
   const result = await adminUser(request);
   if (!result.ok) return result.error;
-  const connectors = listHostConnectors(result.user.id).map((connector) => {
+  const connectors = listAvailableHostConnectors(result.user.id).map((connector) => {
     const needsUpgrade = connectorNeedsUpgrade(connector.version);
     return {
       id: connector.id,
@@ -101,7 +102,7 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const result = await adminUser(request);
   if (!result.ok) return result.error;
-  if (listHostConnectors(result.user.id).some((connector) => connector.managed)) {
+  if (getManagedHostConnector()) {
     return Response.json(
       {
         error: "Agent Connections are managed by overtchat setup.",

--- a/apps/web/lib/db/agentConnections.test.ts
+++ b/apps/web/lib/db/agentConnections.test.ts
@@ -130,6 +130,63 @@ function createAliceConnection() {
 }
 
 describe("agent connection persistence", () => {
+  it("keeps configured directories personal when two admins use the same connector", async () => {
+    repository.saveAgentWorkspaceInstallation({
+      userId: "alice",
+      host: {
+        name: "This server",
+        transport: "local",
+        connectorId: "alice-connector",
+      },
+      connection: {
+        provider: "pi",
+        executable: "pi",
+        shellMode: "interactive",
+        detectedVersion: "0.82.1",
+      },
+      workspace: { path: "/work/shared", name: "shared" },
+      sessions: [],
+    });
+
+    await expect(repository.listAgentConnections("bob")).resolves.toEqual([]);
+
+    repository.saveAgentWorkspaceInstallation({
+      userId: "bob",
+      host: {
+        name: "This server",
+        transport: "local",
+        connectorId: "alice-connector",
+      },
+      connection: {
+        provider: "pi",
+        executable: "pi",
+        shellMode: "interactive",
+        detectedVersion: "0.82.1",
+      },
+      workspace: { path: "/work/shared", name: "shared" },
+      sessions: [],
+    });
+
+    const [aliceConnections, bobConnections] = await Promise.all([
+      repository.listAgentConnections("alice"),
+      repository.listAgentConnections("bob"),
+    ]);
+    expect(aliceConnections).toEqual([
+      expect.objectContaining({
+        workspaces: [expect.objectContaining({ path: "/work/shared" })],
+      }),
+    ]);
+    expect(bobConnections).toEqual([
+      expect.objectContaining({
+        workspaces: [expect.objectContaining({ path: "/work/shared" })],
+      }),
+    ]);
+    expect(bobConnections[0]!.id).not.toBe(aliceConnections[0]!.id);
+    expect(bobConnections[0]!.workspaces[0]!.id).not.toBe(
+      aliceConnections[0]!.workspaces[0]!.id,
+    );
+  });
+
   it("reuses an existing configured connection for the same target and provider", () => {
     const first = createAliceConnection();
     const updated = repository.createAgentConnection({

--- a/apps/web/lib/db/hostConnectors.test.ts
+++ b/apps/web/lib/db/hostConnectors.test.ts
@@ -133,6 +133,20 @@ describe("Host Connector pairing", () => {
     expect(repository.listHostConnectors("alice")).toHaveLength(1);
   });
 
+  it("keeps an unmanaged connector private to the administrator who paired it", () => {
+    const pairing = repository.createHostConnectorPairing("alice");
+    const paired = repository.consumeHostConnectorPairing({
+      pairCode: pairing.pairCode,
+      name: "Alice host",
+      version: "0.2.0",
+    })!;
+
+    expect(
+      repository.getAvailableHostConnector(paired.connector.id, "bob"),
+    ).toBeNull();
+    expect(repository.listAvailableHostConnectors("bob")).toEqual([]);
+  });
+
   it("rejects expired pairings", () => {
     const pairing = repository.createHostConnectorPairing("alice");
     raw.prepare("UPDATE host_connector_pairings SET expires_at = 0").run();
@@ -197,5 +211,23 @@ describe("managed Host Connector", () => {
     expect(repository.authenticateHostConnectorToken(managed.token))
       .toMatchObject({ id: legacy.connector.id });
     expect(repository.listHostConnectors("alice")).toHaveLength(1);
+  });
+
+  it("is available to another administrator without transferring ownership", () => {
+    raw.prepare("UPDATE user SET role = 'admin' WHERE id = 'bob'").run();
+    const managed = repository.provisionManagedHostConnector({
+      name: "Managed host",
+      version: "0.4.0",
+    }).connector;
+
+    expect(repository.getOwnedHostConnector(managed.id, "bob")).toBeNull();
+    expect(repository.getAvailableHostConnector(managed.id, "bob")).toMatchObject({
+      id: managed.id,
+      userId: "alice",
+      managed: true,
+    });
+    expect(repository.listAvailableHostConnectors("bob")).toEqual([
+      expect.objectContaining({ id: managed.id, userId: "alice", managed: true }),
+    ]);
   });
 });

--- a/apps/web/lib/db/hostConnectors.ts
+++ b/apps/web/lib/db/hostConnectors.ts
@@ -4,7 +4,7 @@ import {
   randomBytes,
   timingSafeEqual,
 } from "node:crypto";
-import { and, asc, eq, gt, isNull, lt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, isNull, lt, or } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import {
   hostConnectorPairings,
@@ -268,6 +268,43 @@ export function listHostConnectors(userId: string): HostConnectorRow[] {
     .from(hostConnectors)
     .where(eq(hostConnectors.userId, userId))
     .all();
+}
+
+export function listAvailableHostConnectors(
+  userId: string,
+): HostConnectorRow[] {
+  return db
+    .select()
+    .from(hostConnectors)
+    .where(
+      or(
+        eq(hostConnectors.managed, true),
+        eq(hostConnectors.userId, userId),
+      ),
+    )
+    .orderBy(desc(hostConnectors.managed), asc(hostConnectors.createdAt))
+    .all();
+}
+
+export function getAvailableHostConnector(
+  id: string,
+  userId: string,
+): HostConnectorRow | null {
+  return (
+    db
+      .select()
+      .from(hostConnectors)
+      .where(
+        and(
+          eq(hostConnectors.id, id),
+          or(
+            eq(hostConnectors.managed, true),
+            eq(hostConnectors.userId, userId),
+          ),
+        ),
+      )
+      .get() ?? null
+  );
 }
 
 export function getOwnedHostConnector(


### PR DESCRIPTION
## Summary

- make the installation-managed Host Connector available to every administrator
- allow secondary admins to discover agents, browse directories, and create their own workspaces through the shared runner
- keep unmanaged connectors, saved Agent Connections, configured directories, and agent sessions user-scoped
- detect the managed connector installation-wide so secondary admins are not offered a second pairing flow
- require no database migration

## Validation

- 599 web tests pass
- web typecheck passes
- web production build passes
- changed-file and tracked-source lint pass
- regression coverage verifies that a second admin initially sees none of the first admin configured directories, but can independently configure the same directory