### PR TITLE
release: app 0.17.1 and connector 0.8.1

### DIFF
--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -133,7 +133,7 @@ describe.sequential("connector client compatibility", () => {
 
     const headers = new Headers(requests[0]!.init?.headers);
     expect(headers.get("x-overtchat-connector-version")).toBeNull();
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.8.0");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.8.1");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -13,6 +13,7 @@
 /install/connector/0.6.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.6.0/install-connector.sh 302
 /install/connector/0.7.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.7.0/install-connector.sh 302
 /install/connector/0.8.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.8.0/install-connector.sh 302
+/install/connector/0.8.1 https://github.com/yoloyash/overtchat/releases/download/connector-v0.8.1/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.8.0 302
+/install-connector.sh /install/connector/0.8.1 302

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,8 +1,8 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.17.0",
-  "connectorVersion": "0.8.0",
+  "appVersion": "0.17.1",
+  "connectorVersion": "0.8.1",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",
   "searxngImage": "docker.io/searxng/searxng@sha256:11a9b34cdc0b1ec2b991470a2762ecb5a1a531898289fb51dcd015260450729e",

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -83,7 +83,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.1 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -94,7 +94,7 @@ describe("Host Connectors route", () => {
         id: "managed",
         name: "Managed host",
         managed: true,
-        version: "0.8.0",
+        version: "0.8.1",
         lastSeenAt: new Date(12_000),
       },
     ]);
@@ -157,9 +157,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.8.0",
+            version: "0.8.1",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.0 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.1 | sh -s -- --upgrade",
           },
         },
       ],
@@ -172,14 +172,14 @@ describe("Host Connectors route", () => {
         id: "current",
         name: "Current",
         managed: false,
-        version: "0.8.0",
+        version: "0.8.1",
         lastSeenAt: null,
       },
       {
         id: "newer",
         name: "Newer",
         managed: false,
-        version: "0.8.0",
+        version: "0.8.1",
         lastSeenAt: null,
       },
     ]);

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.17.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.17.1}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,7 +552,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -22,7 +22,7 @@ import {
 /** Increment only for a breaking web-to-connector wire contract change. */
 export const HOST_CONNECTOR_PROTOCOL_VERSION = 2;
 /** Published connector artifact version; independent of wire compatibility. */
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.8.0";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.8.1";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.8.0"
+connector_version="0.8.1"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

- release the connector protocol compatibility simplification from #206
- release shared managed Host Connector access with personal Agent Connections and directories from #209
- bump the app from 0.17.0 to 0.17.1
- bump the Host Connector from 0.8.0 to 0.8.1 without changing protocol 2
- preserve historical connector installer routes and advance the current installer alias
- leave CLI, STT, and bundled image selections unchanged

## Rollout

The updated app remains compatible with the released 0.8.0 connector because both use protocol 2. Managed updates install the app before replacing the connector. Stable promotion remains atomic and will complete only after both the app 0.17.1 image and connector 0.8.1 artifacts are public.

## Validation

- npm run deps:check
- tracked-source repository lint
- npm run typecheck
- npm test
- npm run build
- connector bundled version check
- connector installer redirect tests
- CI workspace validation
- CI web E2E smoke
- CI project site validation
- CI connector artifact build
- CI CLI guard build