### PR TITLE
feat(agents): add Claude Code support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 OvertChat is a self-hosted chat application for local and hosted LLMs, with
 web/mobile clients and optional coding-agent control. Users own the server and
-data; a host-native connector runs Codex, Pi, and Oh My Pi sessions locally or
-over SSH.
+data; a host-native connector runs Codex, Claude Code, Pi, Oh My Pi, and
+OpenCode sessions locally or over SSH.
 
 ## Sources of truth
 
@@ -26,7 +26,7 @@ runbook instead of copying its instructions.
 | `apps/cli` | Linux management CLI for setup, adoption, updates, and managed Compose state |
 | `apps/connector` | Host-native daemon that owns live coding-agent sessions and process execution |
 | `packages/agent-bridge` | Exact web-to-connector protocol and shared agent data contracts |
-| `packages/agent-runtime` | Codex, Pi, and OMP provider adapters plus host runtime primitives |
+| `packages/agent-runtime` | Coding-agent provider adapters plus host runtime primitives |
 | `packages/shared` | Cross-client chat/tool/model contracts and generated web/native theme outputs |
 | `scripts/dev.mjs` | Root development-stack orchestration |
 | `compose.yml`, `searxng/`, `stt/` | Self-hosted application and bundled sidecars |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Existing standard Compose installations can be adopted in place with
 
 | Local inference | Included locally | Coding agents |
 | --- | --- | --- |
-| vLLM · llama.cpp · SGLang | SearXNG · Kokoro TTS · Parakeet STT | Codex · Pi · Oh My Pi |
+| vLLM · llama.cpp · SGLang | SearXNG · Kokoro TTS · Parakeet STT | Codex · Claude Code · Pi · Oh My Pi |
 
 First-class setup and model discovery for local inference servers, plus hosted
 providers, custom endpoints, and MCP servers. The installer can also wire up

--- a/apps/cli/src/prompts.ts
+++ b/apps/cli/src/prompts.ts
@@ -310,6 +310,7 @@ async function detectedAgents(): Promise<string[]> {
     ["codex", "Codex"],
     ["pi", "Pi"],
     ["omp", "Oh My Pi"],
+    ["claude", "Claude Code"],
   ] as const;
   const detected: string[] = [];
   for (const [command, label] of agents) {
@@ -345,7 +346,7 @@ export async function promptInstallationConfig(
   const agents = await detectedAgents();
   note(
     [
-      "Use OvertChat as a client for coding agents such as Codex, Pi, and Oh My Pi.",
+      "Use OvertChat as a client for coding agents such as Codex, Claude Code, Pi, and Oh My Pi.",
       ...(agents.length > 0
         ? [`Detected on this machine: ${agents.join(", ")}`]
         : []),

--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -133,7 +133,7 @@ describe.sequential("connector client compatibility", () => {
 
     const headers = new Headers(requests[0]!.init?.headers);
     expect(headers.get("x-overtchat-connector-version")).toBeNull();
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.8.1");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.9.0");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -14,6 +14,7 @@
 /install/connector/0.7.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.7.0/install-connector.sh 302
 /install/connector/0.8.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.8.0/install-connector.sh 302
 /install/connector/0.8.1 https://github.com/yoloyash/overtchat/releases/download/connector-v0.8.1/install-connector.sh 302
+/install/connector/0.9.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.9.0/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.8.1 302
+/install-connector.sh /install/connector/0.9.0 302

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -2,7 +2,7 @@
   "format": 1,
   "cliVersion": "0.1.10",
   "appVersion": "0.17.1",
-  "connectorVersion": "0.8.1",
+  "connectorVersion": "0.9.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",
   "searxngImage": "docker.io/searxng/searxng@sha256:11a9b34cdc0b1ec2b991470a2762ecb5a1a531898289fb51dcd015260450729e",

--- a/apps/web/app/api/agent-connections/discover/route.test.ts
+++ b/apps/web/app/api/agent-connections/discover/route.test.ts
@@ -54,6 +54,7 @@ describe("Agent Connection discovery route", () => {
         },
         { provider: "codex", status: "unavailable" },
         { provider: "opencode", status: "unavailable" },
+        { provider: "claude", status: "unavailable" },
       ],
       refreshedAt: 123,
     });
@@ -87,6 +88,7 @@ describe("Agent Connection discovery route", () => {
           },
           { provider: "codex", status: "unavailable" },
           { provider: "opencode", status: "unavailable" },
+          { provider: "claude", status: "unavailable" },
         ],
         refreshedAt: 123,
       },

--- a/apps/web/app/api/host-connectors/channel/route.test.ts
+++ b/apps/web/app/api/host-connectors/channel/route.test.ts
@@ -118,10 +118,8 @@ describe("Host Connector command channel", () => {
     await response.body!.cancel();
   });
 
-  it("rejects an incompatible wire protocol", async () => {
-    const wrongProtocol = await GET(
-      request(HOST_CONNECTOR_PROTOCOL_VERSION + 1),
-    );
+  it("rejects a protocol-2 connector through the upgrade flow", async () => {
+    const wrongProtocol = await GET(request(2));
     expect(wrongProtocol.status).toBe(409);
     await expect(wrongProtocol.json()).resolves.toMatchObject({
       error: expect.stringContaining("overtchat update"),

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -83,7 +83,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.1 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.9.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -94,7 +94,7 @@ describe("Host Connectors route", () => {
         id: "managed",
         name: "Managed host",
         managed: true,
-        version: "0.8.1",
+        version: "0.9.0",
         lastSeenAt: new Date(12_000),
       },
     ]);
@@ -157,9 +157,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.8.1",
+            version: "0.9.0",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.8.1 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.9.0 | sh -s -- --upgrade",
           },
         },
       ],
@@ -172,14 +172,14 @@ describe("Host Connectors route", () => {
         id: "current",
         name: "Current",
         managed: false,
-        version: "0.8.1",
+        version: "0.9.0",
         lastSeenAt: null,
       },
       {
         id: "newer",
         name: "Newer",
         managed: false,
-        version: "0.8.1",
+        version: "0.9.0",
         lastSeenAt: null,
       },
     ]);

--- a/apps/web/lib/agents/connector/providerSnapshots.test.ts
+++ b/apps/web/lib/agents/connector/providerSnapshots.test.ts
@@ -48,6 +48,7 @@ const snapshot = {
       version: "1.2.3",
       shellMode: "interactive" as const,
     },
+    { provider: "claude" as const, status: "unavailable" as const },
   ],
   refreshedAt: 123,
 };

--- a/apps/web/lib/agents/createPreferences.test.ts
+++ b/apps/web/lib/agents/createPreferences.test.ts
@@ -69,4 +69,22 @@ describe("agent create preferences", () => {
       },
     });
   });
+
+  it("preserves Claude model, mode, and thinking preferences", () => {
+    expect(
+      parseAgentCreatePreferences({
+        providerPreferences: {
+          claude: {
+            model: "haiku",
+            mode: "auto",
+            thinkingByModel: { haiku: "medium" },
+          },
+        },
+      }),
+    ).toMatchObject({
+      providerPreferences: {
+        claude: { model: "haiku", mode: "auto" },
+      },
+    });
+  });
 });

--- a/apps/web/lib/agents/createPreferences.ts
+++ b/apps/web/lib/agents/createPreferences.ts
@@ -22,7 +22,7 @@ const providerPreferencesSchema = z.strictObject({
 const preferencesSchema = z.strictObject({
   providerPreferences: z
     .partialRecord(
-      z.enum(["pi", "omp", "codex", "opencode"]),
+      z.enum(["pi", "omp", "codex", "opencode", "claude"]),
       providerPreferencesSchema,
     )
     .optional(),

--- a/apps/web/lib/agents/providerVisuals.ts
+++ b/apps/web/lib/agents/providerVisuals.ts
@@ -1,5 +1,6 @@
 import type { StaticImageData } from "next/image";
 import codexIcon from "@/assets/agent-providers/codex.png";
+import claudeIcon from "@/assets/agent-providers/claude-code.png";
 import ompIcon from "@/assets/agent-providers/omp.svg";
 import openCodeIcon from "@/assets/agent-providers/opencode.svg";
 import piIcon from "@/assets/agent-providers/pi.svg";
@@ -18,4 +19,5 @@ export const AGENT_PROVIDER_VISUALS: Record<
   omp: { icon: ompIcon, darkSurface: true },
   codex: { icon: codexIcon, darkSurface: true },
   opencode: { icon: openCodeIcon, darkSurface: true },
+  claude: { icon: claudeIcon },
 };

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -67,6 +67,12 @@ Addresses configured in OvertChat must be reachable from the app container:
 - Configure MCP servers under **Settings → Tools**. STDIO commands run inside
   the app container; HTTP servers need a container-reachable URL.
 
+Claude Code connections use the `claude` executable and credentials already
+configured on the Host Connector machine. For SSH connections, install and
+authenticate Claude Code on the remote host as that SSH user. OvertChat does
+not copy or store Claude credentials; each execution target owns its Claude
+settings, skills, hooks, and MCP configuration.
+
 ## Status, logs, and backup
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,7 +552,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"
@@ -2931,6 +2931,156 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.246.tgz",
+      "integrity": "sha512-FtR0HoHHNqeqJWjZN8qLUAzZVFUI9ztXYNPPwv98Ecmv9qq2QTauI8IzkY26CC0mleWAqb9RQEW2C0OtiUliug==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.246",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.246",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.246",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.246",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.246",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.246",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.246",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.246"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.246.tgz",
+      "integrity": "sha512-pYDv2RT+UVOvEapMEWKf7Gm5a87Si1Zf+XR23IMGYbG5mESatNJ8Gz2PmkrwfTezZknb0ljWZe8zgcTFITM3dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.246.tgz",
+      "integrity": "sha512-yl+gMMFUQ8++SBaxUe2JxBqU0LOJO4HZTsWWTOrH5kRlTRhdQDF/lESsoNXCHgfF/+77YNKgef0h+rl/D12Jfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.246.tgz",
+      "integrity": "sha512-t7AEewD7bcjZYMmrfFLjsUSxPo4z+5J5O5cC9V2zOvAhNkefdMeGWI2/1cdqZxuaOiFVt46byjlZuiNNunF+bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.246.tgz",
+      "integrity": "sha512-AeiDXveuA9dVRDouSRiQzL40P3dOuJPfZOlwwsFNbVUN0D+06WtwgmeWYnyRG4dxsM67Pf4lYcRZ0x9pfEZUwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.246.tgz",
+      "integrity": "sha512-BIbBlJ6x7Cys6UFvahUfce26H+U+Q4tLWjKRD39AaV7JvRav8/vfdFytzWq6E+h9hT1OOWYuPYx2gMn5vDhZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.246.tgz",
+      "integrity": "sha512-+3PrWX3qXgakO3tZImr7keKFry5XIkbHBEaUxgi3/RtPmxGwS+JdVAr0xxzOoC2F6Y66Kn0lUnztRnZHORBc+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.246.tgz",
+      "integrity": "sha512-JV8b28OJ8d+EMVEVIWlN3aEkT8uSehO3ZN/PJzXFG7Jgn56oVYUew4aY9vK4jao/4E4mdfzvs358w4HcTBUzVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.246",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.246.tgz",
+      "integrity": "sha512-omI65bYGynLpE1Ybijk56K1wBnt0H6WujNwlg1LzIdeHrYmpUxoqncK92xKH5kb9XWUz3byHqArbv7wsT+M/2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.122.0.tgz",
+      "integrity": "sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9854,6 +10004,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -16649,6 +16806,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -18982,6 +19146,20 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -25406,6 +25584,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -26194,6 +26383,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -28771,6 +28967,7 @@
       "name": "@overtchat/agent-runtime",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.3.246",
         "@opencode-ai/sdk": "1.18.23",
         "@overtchat/agent-bridge": "*",
         "zod": "^4.4.3"

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -25,7 +25,7 @@ state model used by the web app, connector, and runtime.
 
 ## Agent runtime
 
-`agent-runtime` adapts Codex, Pi, and Oh My Pi into the bridge contracts and
+`agent-runtime` adapts supported coding agents into the bridge contracts and
 provides host-runtime primitives used by the connector.
 
 - `src/providers/types.ts` defines the provider adapter and runtime-client

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -3,7 +3,13 @@ import { z } from "zod";
 export const CONNECTOR_SHELL_MODES = ["interactive", "login"] as const;
 export type ConnectorShellMode = (typeof CONNECTOR_SHELL_MODES)[number];
 
-export const AGENT_PROVIDER_IDS = ["pi", "omp", "codex", "opencode"] as const;
+export const AGENT_PROVIDER_IDS = [
+  "pi",
+  "omp",
+  "codex",
+  "opencode",
+  "claude",
+] as const;
 export type AgentProviderId = (typeof AGENT_PROVIDER_IDS)[number];
 export type AgentRuntimeStatus = "idle" | "running" | "exited";
 

--- a/packages/agent-bridge/src/catalog.ts
+++ b/packages/agent-bridge/src/catalog.ts
@@ -52,6 +52,14 @@ export const AGENT_PROVIDERS: Record<
       steer: true,
     },
   },
+  claude: {
+    id: "claude",
+    label: "Claude Code",
+    executable: "claude",
+    capabilities: {
+      steer: true,
+    },
+  },
 };
 
 export function agentProviderMetadata(

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -20,9 +20,9 @@ import {
 } from "./agents";
 
 /** Increment only for a breaking web-to-connector wire contract change. */
-export const HOST_CONNECTOR_PROTOCOL_VERSION = 2;
+export const HOST_CONNECTOR_PROTOCOL_VERSION = 3;
 /** Published connector artifact version; independent of wire compatibility. */
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.8.1";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.9.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -10,7 +10,7 @@ import { agentProviderCatalogSchema } from "./agents";
 
 describe("Host Connector protocol compatibility", () => {
   it("identifies the current wire protocol", () => {
-    expect(HOST_CONNECTOR_PROTOCOL_VERSION).toBe(2);
+    expect(HOST_CONNECTOR_PROTOCOL_VERSION).toBe(3);
   });
 
   it("selects known capabilities and ignores unknown additive tokens", () => {

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.246",
     "@opencode-ai/sdk": "1.18.23",
     "@overtchat/agent-bridge": "*",
     "zod": "^4.4.3"

--- a/packages/agent-runtime/src/claude/client.test.ts
+++ b/packages/agent-runtime/src/claude/client.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.hoisted(() => vi.fn());
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({ query: queryMock }));
+
+import { ClaudeRuntimeClient } from "./client";
+
+class FakeQuery implements AsyncIterator<unknown> {
+  readonly inputs: AsyncIterable<unknown>;
+  readonly options: Record<string, unknown>;
+  readonly setModel = vi.fn(async () => {});
+  readonly setPermissionMode = vi.fn(async () => {});
+  readonly interrupt = vi.fn(async () => ({ still_queued: [] }));
+  private readonly values: unknown[] = [];
+  private readonly waiters: Array<(value: IteratorResult<unknown>) => void> = [];
+  private closed = false;
+
+  constructor(params: {
+    prompt: AsyncIterable<unknown>;
+    options: Record<string, unknown>;
+  }) {
+    this.inputs = params.prompt;
+    this.options = params.options;
+  }
+
+  initializationResult() {
+    return Promise.resolve({
+      commands: [
+        { name: "review", description: "Review changes", argumentHint: "" },
+      ],
+      agents: [],
+      output_style: "default",
+      available_output_styles: [],
+      account: { apiProvider: "firstParty" },
+      models: [
+        {
+          value: "haiku",
+          displayName: "Haiku",
+          description: "Fast",
+          supportsAutoMode: true,
+        },
+      ],
+    });
+  }
+
+  push(value: unknown): void {
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ value, done: false });
+    else this.values.push(value);
+  }
+
+  next(): Promise<IteratorResult<unknown>> {
+    const value = this.values.shift();
+    if (value) return Promise.resolve({ value, done: false });
+    if (this.closed) return Promise.resolve({ value: undefined, done: true });
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<unknown> {
+    return this;
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter({ value: undefined, done: true });
+    }
+  }
+}
+
+function nextTask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("Claude runtime client", () => {
+  it("initializes without a prompt and streams a normalized turn", async () => {
+    let query!: FakeQuery;
+    queryMock.mockImplementation((params) => {
+      query = new FakeQuery(params);
+      return query;
+    });
+    const client = new ClaudeRuntimeClient(
+      { transport: "local" },
+      {
+        executable: "/usr/bin/claude",
+        cwd: "/workspace",
+        model: "haiku",
+        thinkingOptionId: "off",
+        modeId: "auto",
+      },
+    );
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+
+    const state = await client.getState();
+    expect(state.sessionId).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(query.options).toMatchObject({
+      sessionId: state.sessionId,
+      pathToClaudeCodeExecutable: "/usr/bin/claude",
+      permissionMode: "auto",
+      includePartialMessages: true,
+      settingSources: ["user", "project", "local"],
+    });
+    expect(await client.getAvailableModels()).toContainEqual(
+      expect.objectContaining({ id: "haiku", provider: "claude" }),
+    );
+
+    await client.prompt("hello", [], { clientMessageId: "prompt:1" });
+    const input = await query.inputs[Symbol.asyncIterator]().next();
+    expect(input.value).toMatchObject({
+      type: "user",
+      message: { role: "user", content: "hello" },
+      origin: { kind: "human" },
+    });
+    query.push({
+      type: "assistant",
+      uuid: "00000000-0000-4000-8000-000000000002",
+      session_id: state.sessionId,
+      parent_tool_use_id: null,
+      message: {
+        id: "message-1",
+        role: "assistant",
+        content: [{ type: "text", text: "hello back" }],
+      },
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      uuid: "00000000-0000-4000-8000-000000000003",
+      session_id: state.sessionId,
+      is_error: false,
+      result: "hello back",
+      usage: {
+        input_tokens: 2,
+        output_tokens: 3,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      total_cost_usd: 0.001,
+    });
+    await nextTask();
+
+    expect(events).toContainEqual(expect.objectContaining({ type: "turn_start" }));
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "message_end",
+        message: expect.objectContaining({
+          id: "message-1",
+          content: [{ type: "text", text: "hello back" }],
+        }),
+      }),
+    );
+    expect(events).toContainEqual(expect.objectContaining({ type: "turn_end" }));
+    expect(await client.getSessionStats()).toMatchObject({
+      tokens: { input: 2, output: 3, total: 5 },
+      cost: 0.001,
+    });
+    await client.stop();
+  });
+
+  it("binds a prompt to the resumed query when a restart is already queued", async () => {
+    const queries: FakeQuery[] = [];
+    queryMock.mockImplementation((params) => {
+      const query = new FakeQuery(params);
+      queries.push(query);
+      return query;
+    });
+    const client = new ClaudeRuntimeClient(
+      { transport: "local" },
+      { executable: "claude", cwd: "/workspace", modeId: "default" },
+    );
+    await client.getState();
+
+    const restart = client.setThinkingLevel("off");
+    const prompt = client.prompt("after restart");
+    await Promise.all([restart, prompt]);
+
+    expect(queries).toHaveLength(2);
+    expect(queries[1]?.options).toMatchObject({
+      resume: expect.any(String),
+      thinking: { type: "disabled" },
+    });
+    await expect(
+      queries[0]!.inputs[Symbol.asyncIterator]().next(),
+    ).resolves.toMatchObject({ done: true });
+    await expect(
+      queries[1]!.inputs[Symbol.asyncIterator]().next(),
+    ).resolves.toMatchObject({
+      done: false,
+      value: expect.objectContaining({
+        type: "user",
+        message: { role: "user", content: "after restart" },
+      }),
+    });
+    await client.stop();
+  });
+
+  it("maps tool approval and persistent permission suggestions", async () => {
+    let query!: FakeQuery;
+    queryMock.mockImplementation((params) => {
+      query = new FakeQuery(params);
+      return query;
+    });
+    const client = new ClaudeRuntimeClient(
+      { transport: "local" },
+      { executable: "claude", cwd: "/workspace", modeId: "default" },
+    );
+    await client.getState();
+    const events: Array<Record<string, unknown>> = [];
+    client.onEvent((event) => events.push(event));
+    const canUseTool = query.options.canUseTool as (
+      name: string,
+      input: Record<string, unknown>,
+      options: Record<string, unknown>,
+    ) => Promise<unknown>;
+    const controller = new AbortController();
+    const decision = canUseTool(
+      "Bash",
+      { command: "npm test" },
+      {
+        signal: controller.signal,
+        requestId: "permission-1",
+        toolUseID: "tool-1",
+        suggestions: [
+          {
+            type: "addRules",
+            rules: [{ toolName: "Bash", ruleContent: "npm test" }],
+            behavior: "allow",
+            destination: "session",
+          },
+        ],
+      },
+    );
+    await nextTask();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "interaction_request",
+        id: "claude:permission:permission-1",
+        approvalKind: "tool",
+        toolDetail: { type: "shell", command: "npm test" },
+      }),
+    );
+    client.respondToInteraction("claude:permission:permission-1", {
+      value: "Allow always",
+    });
+    await expect(decision).resolves.toMatchObject({
+      behavior: "allow",
+      decisionClassification: "user_permanent",
+      updatedPermissions: [expect.objectContaining({ destination: "session" })],
+    });
+    await client.stop();
+  });
+});

--- a/packages/agent-runtime/src/claude/client.ts
+++ b/packages/agent-runtime/src/claude/client.ts
@@ -1,0 +1,1064 @@
+import { randomUUID } from "node:crypto";
+import {
+  query as createSdkQuery,
+  type CanUseTool,
+  type PermissionMode,
+  type PermissionResult,
+  type PermissionUpdate,
+  type Query,
+  type SDKMessage,
+  type SDKUserMessage,
+  type SlashCommand,
+} from "@anthropic-ai/claude-agent-sdk";
+import type {
+  AgentInteractionValue,
+  AgentMode,
+  AgentModel,
+  AgentSessionStats,
+  AgentSlashCommand,
+} from "@overtchat/agent-bridge";
+import type {
+  AgentRuntimeClient,
+  AgentRuntimeEvent,
+  AgentSessionLaunch,
+  AgentSubmissionOptions,
+  ResolvedAgentImage,
+} from "@overtchat/agent-runtime/providers/types";
+import type { HostTarget } from "@overtchat/agent-runtime/runtime/process";
+import {
+  claudeModesForModels,
+  isClaudePermissionMode,
+  parseClaudeModels,
+  readClaudeSettingsModels,
+} from "@overtchat/agent-runtime/claude/models";
+import { spawnClaudeOnHost } from "@overtchat/agent-runtime/claude/process";
+import {
+  readClaudeSessionMessages,
+  renameClaudeSession,
+} from "@overtchat/agent-runtime/claude/sessions";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+class ClaudeInputQueue implements AsyncIterable<SDKUserMessage> {
+  private readonly values: SDKUserMessage[] = [];
+  private readonly waiters: Array<(value: IteratorResult<SDKUserMessage>) => void> = [];
+  private closed = false;
+
+  push(value: SDKUserMessage): void {
+    if (this.closed) throw new Error("Claude input is closed.");
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ value, done: false });
+    else this.values.push(value);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter({ value: undefined, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SDKUserMessage> {
+    return {
+      next: () => {
+        const value = this.values.shift();
+        if (value) return Promise.resolve({ value, done: false });
+        if (this.closed) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        return new Promise((resolve) => this.waiters.push(resolve));
+      },
+    };
+  }
+}
+
+type PendingInteraction = {
+  kind: "permission" | "question";
+  resolve(value: PermissionResult): void;
+  suggestions?: PermissionUpdate[];
+  input: Record<string, unknown>;
+  questions?: ClaudeQuestion[];
+  toolName: string;
+};
+
+type ClaudeQuestion = {
+  question: string;
+  header?: string;
+  multiSelect?: boolean;
+  options?: Array<{ label: string; description?: string }>;
+};
+
+type AssistantProjection = {
+  role: "assistant";
+  id: string;
+  content: Array<Record<string, unknown>>;
+  timestamp: number;
+  errorMessage?: string;
+};
+
+const EMPTY_STATS: AgentSessionStats = {
+  sessionFile: null,
+  sessionId: null,
+  userMessages: 0,
+  assistantMessages: 0,
+  toolCalls: 0,
+  toolResults: 0,
+  totalMessages: 0,
+  tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  cost: 0,
+};
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function commandRows(commands: readonly SlashCommand[]): AgentSlashCommand[] {
+  return commands.map((command) => ({
+    name: command.name,
+    description: command.description || undefined,
+    argumentHint: command.argumentHint || undefined,
+    source: "custom",
+  }));
+}
+
+function interactionToolDetail(
+  toolName: string,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  if (toolName === "Bash" && typeof input.command === "string") {
+    return { type: "shell", command: input.command };
+  }
+  const filePath =
+    typeof input.file_path === "string"
+      ? input.file_path
+      : typeof input.path === "string"
+        ? input.path
+        : undefined;
+  if (toolName === "Write" && filePath && typeof input.content === "string") {
+    return { type: "write", filePath, content: input.content };
+  }
+  if ((toolName === "Edit" || toolName === "NotebookEdit") && filePath) {
+    return { type: "edit", filePath };
+  }
+  return { type: "json", value: input };
+}
+
+function questionsFromInput(input: Record<string, unknown>): ClaudeQuestion[] {
+  if (!Array.isArray(input.questions)) return [];
+  return input.questions.flatMap((candidate) => {
+    const question = record(candidate);
+    if (!question || typeof question.question !== "string") return [];
+    const options = Array.isArray(question.options)
+      ? question.options.flatMap((candidateOption) => {
+          const option = record(candidateOption);
+          return option && typeof option.label === "string"
+            ? [{
+                label: option.label,
+                ...(typeof option.description === "string"
+                  ? { description: option.description }
+                  : {}),
+              }]
+            : [];
+        })
+      : [];
+    return [{
+      question: question.question,
+      ...(typeof question.header === "string" ? { header: question.header } : {}),
+      ...(question.multiSelect === true ? { multiSelect: true } : {}),
+      ...(options.length ? { options } : {}),
+    }];
+  });
+}
+
+function questionFields(questions: readonly ClaudeQuestion[]) {
+  return questions.map((question, index) => ({
+    id: String(index),
+    label: question.header || `Question ${index + 1}`,
+    description: question.question,
+    type: question.multiSelect
+      ? ("multiselect" as const)
+      : question.options?.length
+        ? ("select" as const)
+        : ("text" as const),
+    required: true,
+    secret: false,
+    options: (question.options ?? []).map((option) => ({
+      value: option.label,
+      label: option.label,
+      description: option.description,
+    })),
+  }));
+}
+
+function safeEnvironment(): Record<string, string | undefined> {
+  // The connector's local child already inherits process.env, while an SSH
+  // child inherits the remote login environment. Sending the connector's full
+  // environment as command prefixes would both override remote credentials
+  // and expose local secrets in process arguments.
+  return {
+    CLAUDE_AGENT_SDK_CLIENT_APP: "overtchat/0.9.0",
+    TERM: "dumb",
+    NO_COLOR: "1",
+  };
+}
+
+function thinkingOptions(level: string | undefined) {
+  if (level === "off") return { thinking: { type: "disabled" as const } };
+  if (["low", "medium", "high", "xhigh", "max"].includes(level ?? "")) {
+    return {
+      thinking: { type: "adaptive" as const },
+      effort: level as "low" | "medium" | "high" | "xhigh" | "max",
+    };
+  }
+  return {};
+}
+
+export class ClaudeRuntimeClient implements AgentRuntimeClient {
+  private readonly subscribers = new Set<(event: AgentRuntimeEvent) => void>();
+  private readonly pendingInteractions = new Map<string, PendingInteraction>();
+  private readonly assistantMessages = new Map<string, AssistantProjection>();
+  private readonly toolNames = new Map<string, string>();
+  private input = new ClaudeInputQueue();
+  private sdkQuery!: Query;
+  private consumeGeneration = 0;
+  private consumePromise: Promise<void> = Promise.resolve();
+  private lifecycleTail: Promise<void> = Promise.resolve();
+  private readyPromise: Promise<void>;
+  private sessionId?: string;
+  private sessionName: string | null = null;
+  private models: AgentModel[] = [];
+  private modes: AgentMode[] = [];
+  private commands: AgentSlashCommand[] = [];
+  private messages: unknown[] = [];
+  private stats: AgentSessionStats = EMPTY_STATS;
+  private selectedModel?: string;
+  private thinkingOptionId?: string;
+  private modeId: PermissionMode;
+  private active = false;
+  private compacting = false;
+  private stopped = false;
+  private restarting = false;
+  private recentStderr = "";
+  private currentStreamMessageId?: string;
+
+  constructor(
+    private readonly target: HostTarget,
+    private readonly launch: AgentSessionLaunch,
+  ) {
+    this.sessionId = launch.resume?.providerSessionId ?? randomUUID();
+    this.selectedModel = launch.model;
+    this.thinkingOptionId = launch.thinkingOptionId;
+    this.modeId = isClaudePermissionMode(launch.modeId ?? "")
+      ? launch.modeId as PermissionMode
+      : "auto";
+    this.startQuery(launch.resume?.providerSessionId);
+    this.readyPromise = this.initialize();
+    void this.readyPromise.catch(() => {});
+  }
+
+  onEvent(subscriber: (event: AgentRuntimeEvent) => void): () => void {
+    this.subscribers.add(subscriber);
+    return () => this.subscribers.delete(subscriber);
+  }
+
+  async getState(): Promise<Record<string, unknown>> {
+    await this.readyPromise;
+    return {
+      sessionId: this.sessionId,
+      sessionFile: this.launch.resume?.providerSessionPath ?? this.sessionId,
+      sessionName: this.sessionName,
+      model: this.selectedModel
+        ? { provider: "claude", id: this.selectedModel }
+        : null,
+      thinkingLevel: this.thinkingOptionId ?? "high",
+      modeId: this.modeId,
+      modes: this.modes,
+      isStreaming: this.active,
+      isCompacting: this.compacting,
+    };
+  }
+
+  async getMessages(): Promise<{ messages: unknown[] }> {
+    await this.readyPromise;
+    return { messages: [...this.messages] };
+  }
+
+  async getAvailableModels(): Promise<AgentModel[]> {
+    await this.readyPromise;
+    return this.models;
+  }
+
+  async getSessionStats(): Promise<AgentSessionStats> {
+    await this.readyPromise;
+    const counts = this.messages.reduce<{
+      userMessages: number;
+      assistantMessages: number;
+      toolCalls: number;
+      toolResults: number;
+    }>(
+      (current, message) => {
+        const value = record(message);
+        const role = value?.role;
+        if (role === "user") current.userMessages += 1;
+        if (role === "assistant") {
+          current.assistantMessages += 1;
+          const content = Array.isArray(value?.content) ? value.content : [];
+          current.toolCalls += content.filter(
+            (part) => record(part)?.type === "toolCall",
+          ).length;
+        }
+        if (role === "toolResult") current.toolResults += 1;
+        return current;
+      },
+      { userMessages: 0, assistantMessages: 0, toolCalls: 0, toolResults: 0 },
+    );
+    return {
+      ...this.stats,
+      ...counts,
+      sessionFile: this.launch.resume?.providerSessionPath ?? this.sessionId ?? null,
+      sessionId: this.sessionId ?? null,
+      totalMessages: this.messages.length,
+    };
+  }
+
+  async getCommands(): Promise<AgentSlashCommand[]> {
+    await this.readyPromise;
+    return this.commands;
+  }
+
+  async prompt(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+    options: AgentSubmissionOptions = {},
+  ): Promise<unknown> {
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      return this.submit(message, images, options, false);
+    });
+  }
+
+  async steer(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+    options: AgentSubmissionOptions = {},
+  ): Promise<unknown> {
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      return this.submit(message, images, options, true);
+    });
+  }
+
+  async abort(): Promise<unknown> {
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      this.cancelInteractions(new Error("Claude interaction was cancelled."));
+      const result = await this.sdkQuery.interrupt();
+      await this.restartQuery();
+      return result;
+    });
+  }
+
+  async setModel(modelId: string): Promise<unknown> {
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      if (!this.models.some((model) => model.id === modelId)) {
+        throw new Error(`Claude Code did not report model ${modelId}.`);
+      }
+      await this.sdkQuery.setModel(modelId);
+      this.selectedModel = modelId;
+      this.emitConfig();
+      return undefined;
+    });
+  }
+
+  async setThinkingLevel(level: string): Promise<unknown> {
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      const model = this.models.find((candidate) => candidate.id === this.selectedModel);
+      if (!model?.thinkingOptions?.some((option) => option.id === level)) {
+        throw new Error(`Claude model ${this.selectedModel ?? "selection"} does not provide thinking level ${level}.`);
+      }
+      this.thinkingOptionId = level;
+      await this.restartQuery();
+      this.emitConfig();
+      return undefined;
+    });
+  }
+
+  async setMode(modeId: string): Promise<unknown> {
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      if (!isClaudePermissionMode(modeId) || !this.modes.some((mode) => mode.id === modeId)) {
+        throw new Error(`Claude Code does not provide permission mode ${modeId}.`);
+      }
+      await this.sdkQuery.setPermissionMode(modeId);
+      this.modeId = modeId;
+      this.emitConfig();
+      return undefined;
+    });
+  }
+
+  async compact(customInstructions?: string): Promise<unknown> {
+    if (customInstructions) {
+      throw new Error("Claude Code does not accept custom compaction instructions.");
+    }
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      this.compacting = true;
+      this.emit({ type: "compaction_start" });
+      return this.submit("/compact", [], {}, false);
+    });
+  }
+
+  setAutoCompaction(): Promise<unknown> {
+    return Promise.reject(
+      new Error("Claude Code manages context compaction automatically."),
+    );
+  }
+
+  async setSessionName(name: string): Promise<unknown> {
+    return this.withLifecycle(async () => {
+      await this.readyPromise;
+      await renameClaudeSession(
+        this.target,
+        this.launch.resume?.providerSessionPath ?? this.sessionId!,
+        this.sessionId!,
+        name,
+      );
+      this.sessionName = name;
+      this.emit({ type: "session_info_update", title: name });
+      return undefined;
+    });
+  }
+
+  respondToInteraction(
+    id: string,
+    response: {
+      value?: string;
+      values?: Record<string, AgentInteractionValue>;
+      confirmed?: boolean;
+      cancelled?: boolean;
+    },
+  ): void {
+    const pending = this.pendingInteractions.get(id);
+    if (!pending) return;
+    this.pendingInteractions.delete(id);
+    this.emit({ type: "interaction_resolved", id });
+    if (pending.kind === "question") {
+      if (response.cancelled) {
+        pending.resolve({
+          behavior: "deny",
+          message: "The user cancelled the question.",
+          decisionClassification: "user_reject",
+        });
+        return;
+      }
+      const answers = Object.fromEntries(
+        (pending.questions ?? []).map((question, index) => {
+          const value = response.values?.[String(index)];
+          return [
+            question.question,
+            Array.isArray(value) ? value.join(", ") : String(value ?? ""),
+          ];
+        }),
+      );
+      pending.resolve({
+        behavior: "allow",
+        updatedInput: { ...pending.input, answers },
+        decisionClassification: "user_temporary",
+      });
+      return;
+    }
+    const allow =
+      !response.cancelled &&
+      (response.confirmed === true ||
+        response.value === "Allow once" ||
+        response.value === "Allow always");
+    if (!allow) {
+      pending.resolve({
+        behavior: "deny",
+        message: "The user denied this action.",
+        decisionClassification: "user_reject",
+      });
+      return;
+    }
+    const always = response.value === "Allow always";
+    if (pending.toolName === "ExitPlanMode") {
+      this.modeId = "acceptEdits";
+      void this.sdkQuery.setPermissionMode("acceptEdits").catch(() => {});
+      this.emitConfig();
+    }
+    pending.resolve({
+      behavior: "allow",
+      updatedInput: pending.input,
+      ...(always && pending.suggestions?.length
+        ? { updatedPermissions: pending.suggestions }
+        : {}),
+      decisionClassification: always ? "user_permanent" : "user_temporary",
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.cancelInteractions(new Error("Claude session stopped."));
+    this.input.close();
+    this.sdkQuery.close();
+    await this.consumePromise.catch(() => {});
+  }
+
+  private async initialize(): Promise<void> {
+    const [initialized, settingsModels] = await Promise.all([
+      this.sdkQuery.initializationResult(),
+      readClaudeSettingsModels(this.target),
+    ]);
+    const models = initialized.models;
+    const commands = initialized.commands;
+    this.models = parseClaudeModels(models, settingsModels);
+    if (!this.models.length) {
+      throw new Error("Claude Code did not report any usable models.");
+    }
+    this.commands = commandRows(commands);
+    this.modes = claudeModesForModels(models);
+    if (!this.modes.some((mode) => mode.id === this.modeId)) {
+      this.modeId = "default";
+      await this.sdkQuery.setPermissionMode(this.modeId);
+    }
+    this.selectedModel ??= this.models.find((model) => model.isDefault)?.id ?? this.models[0]?.id;
+    this.thinkingOptionId ??= this.models.find((model) => model.id === this.selectedModel)?.defaultThinkingOptionId;
+    if (this.launch.resume?.providerSessionPath) {
+      this.messages = await readClaudeSessionMessages(
+        this.target,
+        this.launch.resume.providerSessionPath,
+      );
+    }
+  }
+
+  private startQuery(resume?: string): void {
+    const generation = ++this.consumeGeneration;
+    this.input = new ClaudeInputQueue();
+    this.sdkQuery = createSdkQuery({
+      prompt: this.input,
+      options: {
+        cwd: this.launch.cwd,
+        env: safeEnvironment(),
+        pathToClaudeCodeExecutable: this.launch.executable,
+        ...(resume ? { resume } : { sessionId: this.sessionId }),
+        ...(this.selectedModel ? { model: this.selectedModel } : {}),
+        ...thinkingOptions(this.thinkingOptionId),
+        includePartialMessages: true,
+        settingSources: ["user", "project", "local"],
+        systemPrompt: { type: "preset", preset: "claude_code" },
+        permissionMode: this.modeId,
+        allowDangerouslySkipPermissions: true,
+        canUseTool: this.canUseTool,
+        stderr: (data) => this.captureStderr(data),
+        spawnClaudeCodeProcess: (options) =>
+          spawnClaudeOnHost(this.target, options, (data) => this.captureStderr(data)),
+      },
+    });
+    this.consumePromise = this.consume(this.sdkQuery, generation);
+  }
+
+  private readonly canUseTool: CanUseTool = async (toolName, input, options) => {
+    const pending = deferred<PermissionResult>();
+    const questions = toolName === "AskUserQuestion" ? questionsFromInput(input) : [];
+    const id = `claude:${questions.length ? "question" : "permission"}:${options.requestId}`;
+    this.pendingInteractions.set(id, {
+      kind: questions.length ? "question" : "permission",
+      resolve: pending.resolve,
+      suggestions: options.suggestions,
+      input,
+      questions,
+      toolName,
+    });
+    if (questions.length) {
+      this.emit({
+        type: "interaction_request",
+        id,
+        method: "form",
+        title: questions.length === 1
+          ? questions[0]?.header ?? "Claude needs your input"
+          : "Claude needs your input",
+        message: questions.length === 1
+          ? questions[0]?.question
+          : "Answer the following questions to continue.",
+        fields: questionFields(questions),
+      });
+    } else {
+      const title = options.title || `Allow ${options.displayName || toolName}?`;
+      this.emit({
+        type: "interaction_request",
+        id,
+        method: "select",
+        title,
+        message: options.description || options.decisionReason || "Claude needs permission to continue.",
+        options: ["Allow once", "Allow always", "Deny"],
+        approvalKind: "tool",
+        toolName,
+        toolDetail: interactionToolDetail(toolName, input),
+        approveValue: "Allow once",
+        alwaysValue: "Allow always",
+        denyValue: "Deny",
+      });
+    }
+    const abort = () => {
+      if (!this.pendingInteractions.delete(id)) return;
+      this.emit({ type: "interaction_resolved", id });
+      pending.resolve({
+        behavior: "deny",
+        message: "The action was cancelled.",
+        interrupt: true,
+      });
+    };
+    options.signal.addEventListener("abort", abort, { once: true });
+    try {
+      return await pending.promise;
+    } finally {
+      options.signal.removeEventListener("abort", abort);
+    }
+  };
+
+  private async submit(
+    message: string,
+    images: readonly ResolvedAgentImage[],
+    options: AgentSubmissionOptions,
+    steering: boolean,
+  ): Promise<void> {
+    if (this.stopped) throw new Error("Claude session is stopped.");
+    const content = images.length
+      ? [
+          { type: "text", text: message },
+          ...images.map((image) => ({
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: image.mediaType,
+              data: image.data,
+            },
+          })),
+        ]
+      : message;
+    const user = {
+      role: "user",
+      id: randomUUID(),
+      content: [
+        ...(message ? [{ type: "text", text: message }] : []),
+        ...images.map((image) => ({
+          type: "image",
+          url: `/api/uploads/${image.uploadId}`,
+          mimeType: image.mediaType,
+          filename: image.filename,
+        })),
+      ],
+      timestamp: Date.now(),
+      ...(options.clientMessageId
+        ? { overtchatSubmissionId: options.clientMessageId }
+        : {}),
+    };
+    this.messages.push(user);
+    this.emit({ type: "message_end", message: user });
+    if (!this.active) {
+      this.active = true;
+      this.emit({ type: "turn_start" });
+    }
+    this.input.push({
+      type: "user",
+      message: { role: "user", content } as SDKUserMessage["message"],
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+      origin: { kind: "human" },
+      ...(steering ? { priority: "next" as const } : {}),
+    });
+  }
+
+  private async restartQuery(): Promise<void> {
+    if (this.stopped) return;
+    this.restarting = true;
+    const oldInput = this.input;
+    const oldQuery = this.sdkQuery;
+    oldInput.close();
+    oldQuery.close();
+    await this.consumePromise.catch(() => {});
+    this.restarting = false;
+    this.active = false;
+    this.compacting = false;
+    if (this.stopped) return;
+    this.startQuery(this.sessionId);
+    const [initialized, settingsModels] = await Promise.all([
+      this.sdkQuery.initializationResult(),
+      readClaudeSettingsModels(this.target),
+    ]);
+    const models = initialized.models;
+    const commands = initialized.commands;
+    this.models = parseClaudeModels(models, settingsModels);
+    this.modes = claudeModesForModels(models);
+    this.commands = commandRows(commands);
+  }
+
+  private async consume(query: Query, generation: number): Promise<void> {
+    try {
+      for await (const message of query) {
+        if (generation !== this.consumeGeneration) return;
+        this.handleMessage(message);
+      }
+      if (!this.stopped && !this.restarting && generation === this.consumeGeneration) {
+        throw new Error("Claude Code exited unexpectedly.");
+      }
+    } catch (error) {
+      if (this.stopped || this.restarting || generation !== this.consumeGeneration) return;
+      const detail = this.recentStderr.trim();
+      const message = `${errorText(error)}${detail ? `\n${detail}` : ""}`;
+      this.emit({ type: "rpc_error", error: message });
+      this.emit({ type: "process_exit", error: message });
+    }
+  }
+
+  private handleMessage(message: SDKMessage): void {
+    if (message.type === "system") {
+      this.handleSystem(message as SDKMessage & Record<string, unknown>);
+      return;
+    }
+    if (message.type === "stream_event") {
+      this.handleStream(message as SDKMessage & Record<string, unknown>);
+      return;
+    }
+    if (message.type === "assistant") {
+      this.handleAssistant(message as SDKMessage & Record<string, unknown>);
+      return;
+    }
+    if (message.type === "user") {
+      this.handleUser(message as SDKMessage & Record<string, unknown>);
+      return;
+    }
+    if (message.type === "result") {
+      this.handleResult(message as SDKMessage & Record<string, unknown>);
+    }
+  }
+
+  private handleSystem(message: SDKMessage & Record<string, unknown>): void {
+    const subtype = message.subtype;
+    if (subtype === "init") {
+      this.sessionId = String(message.session_id);
+      if (typeof message.model === "string") this.selectedModel = message.model;
+      if (isClaudePermissionMode(String(message.permissionMode ?? ""))) {
+        this.modeId = message.permissionMode as PermissionMode;
+      }
+      if (Array.isArray(message.slash_commands)) {
+        this.commands = message.slash_commands.flatMap((name) =>
+          typeof name === "string"
+            ? [{ name: name.replace(/^\//u, ""), source: "custom" as const }]
+            : [],
+        );
+        this.emit({ type: "available_commands_update", commands: this.commands });
+      }
+      this.emitConfig();
+      return;
+    }
+    if (subtype === "commands_changed" && Array.isArray(message.commands)) {
+      this.commands = commandRows(message.commands as SlashCommand[]);
+      this.emit({ type: "available_commands_update", commands: this.commands });
+      return;
+    }
+    if (subtype === "session_state_changed") {
+      if (message.state === "running" && !this.active) {
+        this.active = true;
+        this.emit({ type: "turn_start" });
+      } else if (message.state === "idle") {
+        this.finishTurn();
+      }
+      return;
+    }
+    if (subtype === "status") {
+      if (message.status === "compacting" && !this.compacting) {
+        this.compacting = true;
+        this.emit({ type: "compaction_start" });
+      } else if (message.status === null && this.compacting) {
+        this.compacting = false;
+        this.emit({
+          type: "compaction_end",
+          ...(typeof message.compact_error === "string"
+            ? { error: message.compact_error }
+            : {}),
+        });
+      }
+      return;
+    }
+    if (subtype === "compact_boundary") {
+      if (this.compacting) {
+        this.compacting = false;
+        this.emit({ type: "compaction_end" });
+      }
+    }
+  }
+
+  private handleStream(message: SDKMessage & Record<string, unknown>): void {
+    const event = record(message.event);
+    if (!event) return;
+    if (event.type === "message_start") {
+      const native = record(event.message);
+      if (typeof native?.id === "string") {
+        this.currentStreamMessageId = native.id;
+        this.ensureAssistant(native.id);
+      }
+      return;
+    }
+    const messageId = this.currentStreamMessageId;
+    if (!messageId) return;
+    const index = typeof event.index === "number" ? event.index : 0;
+    if (event.type === "content_block_start") {
+      const block = record(event.content_block);
+      if (block) this.mergeAssistantBlock(messageId, block, index);
+      return;
+    }
+    if (event.type === "content_block_delta") {
+      const delta = record(event.delta);
+      if (!delta) return;
+      const projection = this.ensureAssistant(messageId);
+      const part = projection.content[index];
+      if (delta.type === "text_delta" && typeof delta.text === "string") {
+        projection.content[index] = {
+          type: "text",
+          text: `${typeof part?.text === "string" ? part.text : ""}${delta.text}`,
+        };
+      } else if (delta.type === "thinking_delta" && typeof delta.thinking === "string") {
+        projection.content[index] = {
+          type: "thinking",
+          thinking: `${typeof part?.thinking === "string" ? part.thinking : ""}${delta.thinking}`,
+        };
+      } else if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") {
+        projection.content[index] = {
+          ...(part ?? { type: "toolCall", id: `tool-${index}`, name: "tool" }),
+          overtchatPartialArguments: `${typeof part?.overtchatPartialArguments === "string" ? part.overtchatPartialArguments : ""}${delta.partial_json}`,
+        };
+      }
+      this.publishAssistant(projection, "message_update");
+    }
+  }
+
+  private handleAssistant(message: SDKMessage & Record<string, unknown>): void {
+    const native = record(message.message);
+    if (!native || typeof native.id !== "string") return;
+    const projection = this.ensureAssistant(native.id);
+    if (typeof message.error === "string") projection.errorMessage = message.error;
+    const content = Array.isArray(native.content) ? native.content : [];
+    for (const [index, block] of content.entries()) {
+      const value = record(block);
+      if (value) this.mergeAssistantBlock(native.id, value, index);
+    }
+    this.publishAssistant(projection, "message_end");
+    if (this.currentStreamMessageId === native.id) {
+      this.currentStreamMessageId = undefined;
+    }
+  }
+
+  private mergeAssistantBlock(
+    messageId: string,
+    block: Record<string, unknown>,
+    index: number,
+  ): void {
+    const projection = this.ensureAssistant(messageId);
+    const matchingIndex = projection.content.findIndex((candidate) => {
+      if (block.type === "tool_use") return candidate.id === block.id;
+      if (block.type === "text") return candidate.type === "text";
+      if (block.type === "thinking") return candidate.type === "thinking";
+      return false;
+    });
+    const destination = matchingIndex >= 0
+      ? matchingIndex
+      : projection.content[index] === undefined
+        ? index
+        : projection.content.length;
+    if (block.type === "text" && typeof block.text === "string") {
+      projection.content[destination] = { type: "text", text: block.text };
+    } else if (block.type === "thinking" && typeof block.thinking === "string") {
+      projection.content[destination] = { type: "thinking", thinking: block.thinking };
+    } else if (block.type === "tool_use" && typeof block.id === "string") {
+      const name = typeof block.name === "string" ? block.name : "tool";
+      this.toolNames.set(block.id, name);
+      projection.content[destination] = {
+        type: "toolCall",
+        id: block.id,
+        name,
+        arguments: record(block.input) ?? block.input ?? {},
+      };
+    }
+  }
+
+  private handleUser(message: SDKMessage & Record<string, unknown>): void {
+    const native = record(message.message);
+    if (!native || !Array.isArray(native.content)) return;
+    for (const blockValue of native.content) {
+      const block = record(blockValue);
+      if (block?.type !== "tool_result" || typeof block.tool_use_id !== "string") continue;
+      const content = typeof block.content === "string"
+        ? [{ type: "text", text: block.content }]
+        : Array.isArray(block.content)
+          ? block.content
+          : [{ type: "text", text: JSON.stringify(block.content ?? "") }];
+      const toolName = this.toolNames.get(block.tool_use_id) ?? "Claude tool";
+      const normalized = {
+        role: "toolResult",
+        toolCallId: block.tool_use_id,
+        toolName,
+        content,
+        isError: block.is_error === true,
+        timestamp: Date.now(),
+      };
+      this.messages.push(normalized);
+      this.emit({
+        type: "tool_execution_end",
+        toolCallId: block.tool_use_id,
+        toolName,
+        result: { content },
+        isError: block.is_error === true,
+      });
+    }
+  }
+
+  private handleResult(message: SDKMessage & Record<string, unknown>): void {
+    const usage = record(message.usage);
+    const modelUsage = record(message.modelUsage);
+    const totals = modelUsage
+      ? Object.values(modelUsage).reduce<{
+          input: number;
+          output: number;
+          cacheRead: number;
+          cacheWrite: number;
+        }>(
+          (current, candidate) => {
+            const value = record(candidate);
+            current.input += Number(value?.inputTokens ?? 0);
+            current.output += Number(value?.outputTokens ?? 0);
+            current.cacheRead += Number(value?.cacheReadInputTokens ?? 0);
+            current.cacheWrite += Number(value?.cacheCreationInputTokens ?? 0);
+            return current;
+          },
+          { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        )
+      : {
+          input: Number(usage?.input_tokens ?? 0),
+          output: Number(usage?.output_tokens ?? 0),
+          cacheRead: Number(usage?.cache_read_input_tokens ?? 0),
+          cacheWrite: Number(usage?.cache_creation_input_tokens ?? 0),
+        };
+    this.stats = {
+      ...this.stats,
+      tokens: {
+        ...totals,
+        total: totals.input + totals.output + totals.cacheRead + totals.cacheWrite,
+      },
+      cost: typeof message.total_cost_usd === "number" ? message.total_cost_usd : 0,
+    };
+    if (message.is_error === true) {
+      const errors = Array.isArray(message.errors)
+        ? message.errors.filter((value): value is string => typeof value === "string")
+        : [];
+      this.emit({
+        type: "rpc_error",
+        error: errors.join("\n") || String(message.result ?? "Claude Code turn failed."),
+      });
+    }
+    this.finishTurn();
+  }
+
+  private ensureAssistant(id: string): AssistantProjection {
+    const current = this.assistantMessages.get(id);
+    if (current) return current;
+    const projection: AssistantProjection = {
+      role: "assistant",
+      id,
+      content: [],
+      timestamp: Date.now(),
+    };
+    this.assistantMessages.set(id, projection);
+    this.messages.push(projection);
+    this.emit({ type: "message_start", message: projection });
+    return projection;
+  }
+
+  private publishAssistant(
+    projection: AssistantProjection,
+    type: "message_update" | "message_end",
+  ): void {
+    this.emit({ type, message: { ...projection, content: [...projection.content] } });
+  }
+
+  private finishTurn(): void {
+    if (this.currentStreamMessageId) {
+      const projection = this.assistantMessages.get(this.currentStreamMessageId);
+      if (projection) this.publishAssistant(projection, "message_end");
+      this.currentStreamMessageId = undefined;
+    }
+    if (!this.active) return;
+    this.active = false;
+    this.emit({ type: "turn_end" });
+  }
+
+  private emitConfig(): void {
+    this.emit({
+      type: "config_update",
+      model: this.selectedModel ? { provider: "claude", id: this.selectedModel } : null,
+      thinkingLevel: this.thinkingOptionId ?? "high",
+      modeId: this.modeId,
+      modes: this.modes,
+    });
+  }
+
+  private cancelInteractions(error: Error): void {
+    for (const [id, pending] of this.pendingInteractions) {
+      pending.resolve({
+        behavior: "deny",
+        message: error.message,
+        interrupt: true,
+      });
+      this.emit({ type: "interaction_resolved", id });
+    }
+    this.pendingInteractions.clear();
+  }
+
+  private captureStderr(data: string): void {
+    this.recentStderr = `${this.recentStderr}${data}`.slice(-16_000);
+  }
+
+  private emit(event: AgentRuntimeEvent): void {
+    for (const subscriber of this.subscribers) subscriber(event);
+  }
+
+  private withLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.lifecycleTail.then(operation, operation);
+    this.lifecycleTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}
+
+export function startClaudeRuntime(
+  target: HostTarget,
+  launch: AgentSessionLaunch,
+): ClaudeRuntimeClient {
+  return new ClaudeRuntimeClient(target, launch);
+}

--- a/packages/agent-runtime/src/claude/models.test.ts
+++ b/packages/agent-runtime/src/claude/models.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { claudeModesForModels, parseClaudeModels } from "./models";
+
+describe("Claude model catalog", () => {
+  it("maps SDK models, effort controls, images, and Auto support", () => {
+    const native = [
+      {
+        value: "haiku",
+        displayName: "Claude Haiku",
+        description: "Fast",
+        supportsAdaptiveThinking: true,
+        supportsEffort: true,
+        supportedEffortLevels: [
+          "low",
+          "medium",
+          "high",
+        ] as Array<"low" | "medium" | "high">,
+        supportsAutoMode: true,
+      },
+    ];
+    expect(parseClaudeModels(native)).toEqual([
+      expect.objectContaining({
+        provider: "claude",
+        id: "haiku",
+        label: "Claude Haiku",
+        input: ["text", "image"],
+        metadata: { provider: "anthropic", modelId: "haiku" },
+        defaultThinkingOptionId: "high",
+      }),
+    ]);
+    expect(parseClaudeModels(native)[0]?.thinkingOptions).toContainEqual(
+      expect.objectContaining({ id: "off" }),
+    );
+    expect(claudeModesForModels(native).map((mode) => mode.id)).toContain("auto");
+  });
+
+  it("adds target-configured aliases without replacing SDK metadata", () => {
+    const models = parseClaudeModels(
+      [{
+        value: "opus[1m]",
+        resolvedModel: "claude-opus-5[1m]",
+        displayName: "Opus",
+        description: "Capable",
+      }],
+      [
+        { id: "opus[1m]", description: "duplicate" },
+        {
+          id: "openrouter/anthropic/custom",
+          description: "From Claude settings.json env.ANTHROPIC_MODEL",
+        },
+      ],
+    );
+    expect(models).toHaveLength(2);
+    expect(models[0]).toMatchObject({
+      id: "opus[1m]",
+      contextWindow: 1_000_000,
+      metadata: { modelId: "claude-opus-5[1m]" },
+    });
+    expect(models[1]).toMatchObject({
+      id: "openrouter/anthropic/custom",
+      description: "From Claude settings.json env.ANTHROPIC_MODEL",
+    });
+  });
+
+  it("falls back to approval modes when Auto is unavailable", () => {
+    expect(
+      claudeModesForModels([
+        { value: "bedrock", displayName: "Bedrock", description: "Managed" },
+      ]).map((mode) => mode.id),
+    ).not.toContain("auto");
+  });
+});

--- a/packages/agent-runtime/src/claude/models.ts
+++ b/packages/agent-runtime/src/claude/models.ts
@@ -1,0 +1,190 @@
+import type {
+  AgentMode,
+  AgentModel,
+  AgentSelectOption,
+} from "@overtchat/agent-bridge";
+import type { ModelInfo, PermissionMode } from "@anthropic-ai/claude-agent-sdk";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@overtchat/agent-runtime/runtime/process";
+
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+const EXTENDED_CONTEXT_WINDOW = 1_000_000;
+
+export type ClaudeSettingsModel = {
+  id: string;
+  description: string;
+};
+
+const CLAUDE_SETTINGS_MODELS_SCRIPT = String.raw`
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const config = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+const keys = [
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+];
+const found = [];
+const add = (value, source) => {
+  if (typeof value !== "string" || !value.trim()) return;
+  const id = value.trim();
+  if (!found.some((model) => model.id === id)) found.push({ id, description: "From Claude settings.json " + source });
+};
+try {
+  const settings = JSON.parse(fs.readFileSync(path.join(config, "settings.json"), "utf8"));
+  if (settings && typeof settings === "object" && !Array.isArray(settings)) {
+    add(settings.model, "model");
+    if (settings.env && typeof settings.env === "object" && !Array.isArray(settings.env)) {
+      for (const key of keys) add(settings.env[key], "env." + key);
+    }
+  }
+} catch {}
+process.stdout.write(JSON.stringify(found));
+`.trim();
+
+export const CLAUDE_MODES: readonly AgentMode[] = [
+  {
+    id: "plan",
+    label: "Plan",
+    description: "Inspect and plan without modifying the workspace.",
+  },
+  {
+    id: "default",
+    label: "Always Ask",
+    description: "Ask before actions that require permission.",
+  },
+  {
+    id: "acceptEdits",
+    label: "Accept Edits",
+    description: "Approve workspace file edits while asking for other actions.",
+  },
+  {
+    id: "auto",
+    label: "Auto",
+    description: "Let Claude classify routine actions and ask when needed.",
+  },
+  {
+    id: "bypassPermissions",
+    label: "Bypass Permissions",
+    description: "Run tools without approval prompts.",
+    dangerous: true,
+  },
+];
+
+export function isClaudePermissionMode(value: string): value is PermissionMode {
+  return CLAUDE_MODES.some((mode) => mode.id === value);
+}
+
+function thinkingOptions(model: ModelInfo): AgentSelectOption[] {
+  const effort = model.supportedEffortLevels ?? [];
+  const options: AgentSelectOption[] = [
+    {
+      id: "off",
+      label: "Off",
+      description: "Disable extended thinking.",
+    },
+  ];
+  if (model.supportsAdaptiveThinking || effort.length > 0) {
+    const levels = effort.length > 0 ? effort : (["low", "medium", "high"] as const);
+    options.push(
+      ...levels.map((level) => ({
+        id: level,
+        label: level === "xhigh" ? "Extra High" : `${level[0]?.toUpperCase()}${level.slice(1)}`,
+        isDefault: level === "high",
+      })),
+    );
+  }
+  return options;
+}
+
+function configuredModel(model: ClaudeSettingsModel): AgentModel {
+  return {
+    provider: "claude",
+    id: model.id,
+    label: model.id,
+    description: model.description,
+    api: "claude-agent-sdk",
+    baseUrl: "",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: model.id.toLowerCase().includes("[1m]")
+      ? EXTENDED_CONTEXT_WINDOW
+      : DEFAULT_CONTEXT_WINDOW,
+    maxTokens: null,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  };
+}
+
+export function parseClaudeModels(
+  models: readonly ModelInfo[],
+  settingsModels: readonly ClaudeSettingsModel[] = [],
+): AgentModel[] {
+  const discovered: AgentModel[] = models.map((model, index) => {
+    const options = thinkingOptions(model);
+    const resolvedModel = "resolvedModel" in model &&
+        typeof model.resolvedModel === "string"
+      ? model.resolvedModel
+      : model.value;
+    return {
+      provider: "claude",
+      id: model.value,
+      label: model.displayName || model.value,
+      description: model.description || undefined,
+      isDefault: index === 0,
+      api: "claude-agent-sdk",
+      baseUrl: "",
+      reasoning: options.length > 1,
+      input: ["text", "image"],
+      metadata: { provider: "anthropic", modelId: resolvedModel },
+      contextWindow: `${model.value} ${resolvedModel}`.toLowerCase().includes("[1m]")
+        ? EXTENDED_CONTEXT_WINDOW
+        : DEFAULT_CONTEXT_WINDOW,
+      maxTokens: null,
+      thinkingOptions: options,
+      defaultThinkingOptionId: options.some((option) => option.id === "high")
+        ? "high"
+        : options.at(-1)?.id ?? "off",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+  });
+  const discoveredIds = new Set(discovered.map((model) => model.id));
+  return [
+    ...discovered,
+    ...settingsModels
+      .filter((model) => !discoveredIds.has(model.id))
+      .map(configuredModel),
+  ];
+}
+
+export function claudeModesForModels(models: readonly ModelInfo[]): AgentMode[] {
+  const supportsAuto = models.some((model) => model.supportsAutoMode === true);
+  return CLAUDE_MODES.filter((mode) => mode.id !== "auto" || supportsAuto);
+}
+
+export async function readClaudeSettingsModels(
+  target: HostTarget,
+): Promise<ClaudeSettingsModel[]> {
+  try {
+    const result = await executeOnHost(target, {
+      command: "node",
+      args: ["-e", CLAUDE_SETTINGS_MODELS_SCRIPT],
+    });
+    const parsed: unknown = JSON.parse(result.stdout);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((candidate) => {
+      if (!candidate || typeof candidate !== "object") return [];
+      const id = Reflect.get(candidate, "id");
+      const description = Reflect.get(candidate, "description");
+      return typeof id === "string" && id.trim() && typeof description === "string"
+        ? [{ id: id.trim(), description }]
+        : [];
+    });
+  } catch {
+    return [];
+  }
+}

--- a/packages/agent-runtime/src/claude/probe.test.ts
+++ b/packages/agent-runtime/src/claude/probe.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  executeOnHost: vi.fn(),
+  startClaudeRuntime: vi.fn(),
+}));
+
+vi.mock("@overtchat/agent-runtime/runtime/process", () => ({
+  executeOnHost: mocks.executeOnHost,
+}));
+vi.mock("@overtchat/agent-runtime/claude/client", () => ({
+  startClaudeRuntime: mocks.startClaudeRuntime,
+}));
+vi.mock("@overtchat/agent-runtime/runtime/discovery", () => ({
+  parseAgentVersion: (output: string) => output.match(/\d+\.\d+\.\d+/u)?.[0] ?? null,
+  shellModesForTarget: () => ["interactive"],
+  targetWithShellMode: (target: object, shellMode: string) => ({ ...target, shellMode }),
+  targetForConnectionDraft: () => ({ transport: "local" }),
+}));
+
+import { probeClaudeTarget } from "./probe";
+
+describe("Claude connection probe", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("requires target authentication and returns SDK models", async () => {
+    mocks.executeOnHost
+      .mockResolvedValueOnce({ stdout: "2.1.250 (Claude Code)\n", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ loggedIn: true, authMethod: "api_key" }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({ stdout: "/workspace\n", stderr: "" });
+    const client = {
+      getState: vi.fn(async () => ({ sessionId: "session" })),
+      getAvailableModels: vi.fn(async () => [
+        {
+          provider: "claude",
+          id: "haiku",
+          label: "Haiku",
+          api: "claude-agent-sdk",
+          baseUrl: "",
+          reasoning: false,
+          input: ["text", "image"],
+          contextWindow: 200_000,
+          maxTokens: null,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        },
+      ]),
+      stop: vi.fn(async () => {}),
+    };
+    mocks.startClaudeRuntime.mockReturnValue(client);
+
+    await expect(
+      probeClaudeTarget({ transport: "local" }, "/usr/bin/claude"),
+    ).resolves.toMatchObject({
+      version: "2.1.250",
+      shellMode: "interactive",
+      models: [expect.objectContaining({ id: "haiku" })],
+    });
+    expect(mocks.executeOnHost).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ shellMode: "interactive" }),
+      { command: "/usr/bin/claude", args: ["auth", "status", "--json"] },
+    );
+    expect(client.stop).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an unauthenticated target before starting the SDK", async () => {
+    mocks.executeOnHost
+      .mockResolvedValueOnce({ stdout: "2.1.250\n", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ loggedIn: false }),
+        stderr: "",
+      });
+    await expect(
+      probeClaudeTarget({ transport: "local" }, "claude"),
+    ).rejects.toThrow("not authenticated");
+    expect(mocks.startClaudeRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-runtime/src/claude/probe.ts
+++ b/packages/agent-runtime/src/claude/probe.ts
@@ -1,0 +1,94 @@
+import type {
+  AgentConnectionDraft,
+  AgentConnectionProbe,
+  AgentReadyConnectionProbe,
+  ConnectorShellMode,
+} from "@overtchat/agent-bridge";
+import { startClaudeRuntime } from "@overtchat/agent-runtime/claude/client";
+import {
+  parseAgentVersion,
+  shellModesForTarget,
+  targetForConnectionDraft,
+  targetWithShellMode,
+} from "@overtchat/agent-runtime/runtime/discovery";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@overtchat/agent-runtime/runtime/process";
+
+export async function probeClaudeTarget(
+  target: HostTarget,
+  executable: string,
+): Promise<AgentReadyConnectionProbe> {
+  let resolved:
+    | { target: HostTarget; shellMode: ConnectorShellMode; version: string }
+    | undefined;
+  const failures: string[] = [];
+  for (const shellMode of shellModesForTarget(target)) {
+    try {
+      const resolvedTarget = targetWithShellMode(target, shellMode);
+      const result = await executeOnHost(resolvedTarget, {
+        command: executable,
+        args: ["--version"],
+      });
+      const version = parseAgentVersion(`${result.stdout}\n${result.stderr}`);
+      if (!version) throw new Error("Claude Code returned an invalid version.");
+      resolved = { target: resolvedTarget, shellMode, version };
+      break;
+    } catch (error) {
+      failures.push(
+        `${shellMode === "interactive" ? "Interactive login" : "Login"}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  if (!resolved) {
+    throw new Error(`Claude Code could not be started. ${failures.join(" ")}`);
+  }
+  const authResult = await executeOnHost(resolved.target, {
+    command: executable,
+    args: ["auth", "status", "--json"],
+  });
+  let authenticated = false;
+  try {
+    const status = JSON.parse(authResult.stdout) as Record<string, unknown>;
+    authenticated = status.loggedIn === true;
+  } catch {
+    // The explicit error below is clearer than surfacing JSON parser details.
+  }
+  if (!authenticated) {
+    throw new Error(
+      "Claude Code is installed but not authenticated on this execution target.",
+    );
+  }
+  const remoteCwd = (
+    await executeOnHost(resolved.target, { command: "/bin/pwd" })
+  ).stdout.trim();
+  const client = startClaudeRuntime(resolved.target, {
+    executable,
+    cwd: remoteCwd || "/",
+    modeId: "default",
+  });
+  try {
+    await client.getState();
+    const models = await client.getAvailableModels();
+    if (!models.length) {
+      throw new Error("Claude Code did not report any usable models.");
+    }
+    return {
+      status: "ready",
+      version: resolved.version,
+      models,
+      shellMode: resolved.shellMode,
+    };
+  } finally {
+    await client.stop();
+  }
+}
+
+export function probeClaudeConnection(
+  draft: AgentConnectionDraft,
+): Promise<AgentConnectionProbe> {
+  return probeClaudeTarget(targetForConnectionDraft(draft), draft.executable);
+}

--- a/packages/agent-runtime/src/claude/process.test.ts
+++ b/packages/agent-runtime/src/claude/process.test.ts
@@ -1,0 +1,50 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { configureProcessSpawner } from "../runtime/process";
+import { spawnClaudeOnHost } from "./process";
+
+describe("Claude host process", () => {
+  it("keeps target auth local and forwards lifecycle events", async () => {
+    const launches: Array<Record<string, unknown>> = [];
+    let finish!: (value: { code: number; signal: null }) => void;
+    configureProcessSpawner((_target, launch) => {
+      launches.push(launch);
+      return {
+        stdin: new PassThrough(),
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        exit: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        kill: vi.fn(() => true),
+      };
+    });
+    const controller = new AbortController();
+    const process = spawnClaudeOnHost(
+      { transport: "ssh", alias: "workstation" },
+      {
+        command: "/usr/bin/claude",
+        args: ["--output-format", "stream-json"],
+        cwd: "/workspace",
+        env: {
+          ANTHROPIC_API_KEY: "must-not-cross-ssh",
+          CLAUDE_AGENT_SDK_CLIENT_APP: "overtchat/test",
+        },
+        signal: controller.signal,
+      },
+      vi.fn(),
+    );
+    expect(launches[0]).toMatchObject({
+      command: "/usr/bin/claude",
+      cwd: "/workspace",
+      env: { CLAUDE_AGENT_SDK_CLIENT_APP: "overtchat/test" },
+    });
+    const env = Reflect.get(launches[0]!, "env") as Record<string, string>;
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+
+    const exited = new Promise((resolve) => process.once("exit", resolve));
+    finish({ code: 0, signal: null });
+    await exited;
+    expect(process.exitCode).toBe(0);
+  });
+});

--- a/packages/agent-runtime/src/claude/process.ts
+++ b/packages/agent-runtime/src/claude/process.ts
@@ -1,0 +1,86 @@
+import { EventEmitter } from "node:events";
+import type {
+  SpawnedProcess,
+  SpawnOptions,
+} from "@anthropic-ai/claude-agent-sdk";
+import {
+  spawnOnHost,
+  type AgentProcess,
+  type HostTarget,
+} from "@overtchat/agent-runtime/runtime/process";
+
+const REMOTE_ENV_ALLOWLIST = new Set([
+  "CLAUDE_AGENT_SDK_CLIENT_APP",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+  "NO_COLOR",
+  "TERM",
+]);
+
+function hostEnvironment(
+  target: HostTarget,
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).flatMap(([key, value]) => {
+      if (typeof value !== "string") return [];
+      if (target.transport === "ssh" && !REMOTE_ENV_ALLOWLIST.has(key)) {
+        return [];
+      }
+      return [[key, value]];
+    }),
+  );
+}
+
+export class ClaudeHostProcess
+  extends EventEmitter
+  implements SpawnedProcess
+{
+  killed = false;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+
+  readonly stdin: AgentProcess["stdin"];
+  readonly stdout: AgentProcess["stdout"];
+
+  constructor(private readonly process: AgentProcess) {
+    super();
+    this.stdin = process.stdin;
+    this.stdout = process.stdout;
+    void process.exit.then(({ code, signal, error }) => {
+      this.exitCode = code;
+      this.signalCode = signal;
+      if (error) this.emit("error", error);
+      this.emit("exit", code, signal);
+    });
+  }
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.killed = true;
+    return this.process.kill(signal);
+  }
+}
+
+export function spawnClaudeOnHost(
+  target: HostTarget,
+  options: SpawnOptions,
+  onStderr: (data: string) => void,
+): SpawnedProcess {
+  const process = spawnOnHost(target, {
+    command: options.command,
+    args: options.args,
+    cwd: options.cwd,
+    env: hostEnvironment(target, options.env),
+  });
+  process.stderr.on("data", (chunk) => onStderr(chunk.toString()));
+  const spawned = new ClaudeHostProcess(process);
+  if (options.signal.aborted) spawned.kill("SIGTERM");
+  else {
+    options.signal.addEventListener(
+      "abort",
+      () => spawned.kill("SIGTERM"),
+      { once: true },
+    );
+  }
+  return spawned;
+}

--- a/packages/agent-runtime/src/claude/sessions.test.ts
+++ b/packages/agent-runtime/src/claude/sessions.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { configureLocalTestProcessSpawner } from "../runtime/local-process.test-helper";
+import {
+  listClaudeWorkspaceSessions,
+  readClaudeSessionMessages,
+  renameClaudeSession,
+} from "./sessions";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  delete process.env.CLAUDE_CONFIG_DIR;
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("Claude target session storage", () => {
+  it("lists, replays, and renames tolerant JSONL history", async () => {
+    configureLocalTestProcessSpawner();
+    const root = await mkdtemp(join(tmpdir(), "overtchat-claude-"));
+    temporaryDirectories.push(root);
+    const config = join(root, "config");
+    const project = join(config, "projects", "-workspace");
+    const workspace = join(root, "workspace");
+    await mkdir(project, { recursive: true });
+    await mkdir(workspace, { recursive: true });
+    process.env.CLAUDE_CONFIG_DIR = config;
+    const sessionId = "00000000-0000-4000-8000-000000000001";
+    const sessionPath = join(project, `${sessionId}.jsonl`);
+    await writeFile(
+      sessionPath,
+      [
+        "not-json",
+        JSON.stringify({
+          type: "user",
+          uuid: "user-1",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          cwd: workspace,
+          sessionId,
+          message: { role: "user", content: "Repair the build" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          uuid: "assistant-1",
+          timestamp: "2026-01-01T00:00:01.000Z",
+          cwd: workspace,
+          sessionId,
+          message: {
+            role: "assistant",
+            model: "haiku",
+            content: [
+              { type: "thinking", thinking: "Inspecting" },
+              { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "npm test" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          uuid: "tool-result-1",
+          timestamp: "2026-01-01T00:00:02.000Z",
+          cwd: workspace,
+          sessionId,
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "tool-1", content: "passed" }],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+
+    const sessions = await listClaudeWorkspaceSessions(
+      { transport: "local" },
+      workspace,
+    );
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      providerSessionId: sessionId,
+      firstMessage: "Repair the build",
+      messageCount: 3,
+      launchConfig: { model: "haiku" },
+    });
+    expect(await readClaudeSessionMessages({ transport: "local" }, sessionPath)).toEqual([
+      expect.objectContaining({ role: "user" }),
+      expect.objectContaining({
+        role: "assistant",
+        content: expect.arrayContaining([
+          expect.objectContaining({ type: "thinking" }),
+          expect.objectContaining({ type: "toolCall", id: "tool-1" }),
+        ]),
+      }),
+      expect.objectContaining({ role: "toolResult", toolCallId: "tool-1" }),
+    ]);
+
+    await renameClaudeSession(
+      { transport: "local" },
+      sessionPath,
+      sessionId,
+      "Repair session",
+    );
+    expect(
+      await listClaudeWorkspaceSessions({ transport: "local" }, workspace),
+    ).toContainEqual(expect.objectContaining({ name: "Repair session" }));
+  });
+});

--- a/packages/agent-runtime/src/claude/sessions.ts
+++ b/packages/agent-runtime/src/claude/sessions.ts
@@ -1,0 +1,260 @@
+import { z } from "zod";
+import {
+  agentSessionLaunchConfigSchema,
+  type AgentProviderSessionMetadata,
+} from "@overtchat/agent-bridge";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@overtchat/agent-runtime/runtime/process";
+
+const SESSION_TIMEOUT_MS = 60_000;
+
+const metadataSchema = z.array(
+  z.object({
+    providerSessionId: z.string().min(1),
+    providerSessionPath: z.string().min(1),
+    name: z.string().nullable(),
+    firstMessage: z.string().nullable(),
+    messageCount: z.number().int().nonnegative(),
+    createdAt: z.number().finite().nullable(),
+    modifiedAt: z.number().finite().nullable(),
+    launchConfig: agentSessionLaunchConfigSchema.optional(),
+  }),
+);
+
+const historySchema = z.array(z.unknown());
+
+// Self-contained because it runs on both the connector host and SSH targets.
+const CLAUDE_SESSION_SCRIPT = String.raw`
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const readline = require("node:readline");
+
+const mode = process.argv[1];
+const input = process.argv[2];
+const root = process.env.CLAUDE_CONFIG_DIR
+  ? path.join(process.env.CLAUDE_CONFIG_DIR, "projects")
+  : path.join(os.homedir(), ".claude", "projects");
+const clip = (value, limit = 50000) =>
+  typeof value === "string" && value.length > limit
+    ? value.slice(0, limit) + "\n… [" + (value.length - limit) + " characters truncated]"
+    : value;
+const boundedInput = (value) => {
+  try {
+    const serialized = JSON.stringify(value ?? {});
+    return serialized.length > 50000
+      ? { overtchatTruncated: true, preview: serialized.slice(0, 50000) }
+      : value ?? {};
+  } catch {
+    return { overtchatTruncated: true };
+  }
+};
+
+const text = (content) => {
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  return content.filter((part) => part && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text).join("\n").trim();
+};
+
+async function files(directory) {
+  let projects;
+  try { projects = await fsp.readdir(directory, { withFileTypes: true }); }
+  catch { return []; }
+  const found = [];
+  for (const project of projects) {
+    if (!project.isDirectory()) continue;
+    let entries;
+    try { entries = await fsp.readdir(path.join(directory, project.name), { withFileTypes: true }); }
+    catch { continue; }
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+        found.push(path.join(directory, project.name, entry.name));
+      }
+    }
+  }
+  return found;
+}
+
+async function readEntries(file) {
+  const entries = [];
+  const lines = readline.createInterface({
+    input: fs.createReadStream(file, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+  for await (const line of lines) {
+    try { entries.push(JSON.parse(line)); } catch {}
+  }
+  return entries;
+}
+
+function entryCwd(entries) {
+  return entries.find((entry) => typeof entry.cwd === "string")?.cwd || null;
+}
+
+function normalized(entries) {
+  const messages = [];
+  for (const entry of entries) {
+    if (entry.isSidechain || !entry.message || !["user", "assistant"].includes(entry.type)) continue;
+    const message = entry.message;
+    const timestamp = Number.isFinite(Date.parse(entry.timestamp)) ? Date.parse(entry.timestamp) : Date.now();
+    if (entry.type === "assistant") {
+      const content = Array.isArray(message.content) ? message.content.flatMap((part) => {
+        if (part?.type === "text" && typeof part.text === "string") return [{ type: "text", text: clip(part.text) }];
+        if (part?.type === "thinking" && typeof part.thinking === "string") return [{ type: "thinking", thinking: clip(part.thinking) }];
+        if (part?.type === "tool_use" && typeof part.id === "string") return [{ type: "toolCall", id: part.id, name: String(part.name || "tool"), arguments: boundedInput(part.input) }];
+        return [];
+      }) : [];
+      if (content.length) messages.push({ role: "assistant", id: entry.uuid || message.id, content, timestamp });
+      continue;
+    }
+    const blocks = Array.isArray(message.content) ? message.content : null;
+    if (blocks) {
+      for (const part of blocks) {
+        if (part?.type !== "tool_result" || typeof part.tool_use_id !== "string") continue;
+        const resultText = typeof part.content === "string" ? part.content : text(part.content) || JSON.stringify(part.content ?? "");
+        messages.push({
+          role: "toolResult",
+          toolCallId: part.tool_use_id,
+          toolName: "Claude tool",
+          content: [{ type: "text", text: clip(resultText) }],
+          isError: part.is_error === true,
+          timestamp,
+        });
+      }
+    }
+    const body = text(message.content);
+    if (body && !entry.isSynthetic) messages.push({ role: "user", id: entry.uuid, content: [{ type: "text", text: body }], timestamp });
+  }
+  return messages.slice(-1500);
+}
+
+function boundedHistory(messages) {
+  const kept = [];
+  let bytes = 2;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const serialized = JSON.stringify(messages[index]);
+    if (bytes + Buffer.byteLength(serialized) + 1 > 1500000) continue;
+    kept.unshift(messages[index]);
+    bytes += Buffer.byteLength(serialized) + 1;
+  }
+  return kept;
+}
+
+async function metadata(file, requestedCwd) {
+  const entries = await readEntries(file);
+  const cwd = entryCwd(entries);
+  if (!cwd) return null;
+  let actual;
+  try { actual = fs.realpathSync(cwd); } catch { actual = path.resolve(cwd); }
+  if (actual !== requestedCwd) return null;
+  const id = path.basename(file, ".jsonl");
+  let name = null;
+  let firstMessage = null;
+  let model = null;
+  let modeId = null;
+  let createdAt = null;
+  for (const entry of entries) {
+    if (entry.type === "custom-title" && typeof entry.customTitle === "string" && entry.customTitle.trim()) name = entry.customTitle.trim();
+    if (entry.type === "permission-mode" && typeof entry.permissionMode === "string") modeId = entry.permissionMode;
+    if (!createdAt && typeof entry.timestamp === "string" && Number.isFinite(Date.parse(entry.timestamp))) createdAt = Date.parse(entry.timestamp);
+    if (!firstMessage && entry.type === "user" && !entry.isSynthetic && entry.message) firstMessage = text(entry.message.content) || null;
+    if (entry.type === "assistant" && typeof entry.message?.model === "string") model = entry.message.model;
+  }
+  const stat = await fsp.stat(file);
+  return {
+    providerSessionId: id,
+    providerSessionPath: file,
+    name,
+    firstMessage,
+    messageCount: normalized(entries).length,
+    createdAt,
+    modifiedAt: stat.mtimeMs,
+    ...((model || modeId) ? { launchConfig: { ...(model ? { model } : {}), ...(modeId ? { modeId } : {}) } } : {}),
+  };
+}
+
+(async () => {
+  if (mode === "history") {
+    process.stdout.write(JSON.stringify(boundedHistory(normalized(await readEntries(input)))));
+    return;
+  }
+  let requestedCwd;
+  try { requestedCwd = fs.realpathSync(input); } catch { requestedCwd = path.resolve(input); }
+  const ranked = await Promise.all((await files(root)).map(async (file) => ({ file, mtime: (await fsp.stat(file)).mtimeMs })));
+  ranked.sort((a, b) => b.mtime - a.mtime);
+  const result = [];
+  for (const item of ranked) {
+    if (result.length >= 200) break;
+    try { const value = await metadata(item.file, requestedCwd); if (value) result.push(value); } catch {}
+  }
+  process.stdout.write(JSON.stringify(result));
+})().catch((error) => {
+  process.stderr.write(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+`.trim();
+
+export async function listClaudeWorkspaceSessions(
+  target: HostTarget,
+  workspacePath: string,
+): Promise<AgentProviderSessionMetadata[]> {
+  const result = await executeOnHost(
+    target,
+    { command: "node", args: ["-e", CLAUDE_SESSION_SCRIPT, "list", workspacePath] },
+    { timeoutMs: SESSION_TIMEOUT_MS },
+  );
+  return metadataSchema.parse(JSON.parse(result.stdout)).map((session) => ({
+    ...session,
+    createdAt: session.createdAt === null ? null : new Date(session.createdAt),
+    modifiedAt: session.modifiedAt === null ? null : new Date(session.modifiedAt),
+  }));
+}
+
+export async function readClaudeSessionMessages(
+  target: HostTarget,
+  providerSessionPath: string,
+): Promise<unknown[]> {
+  if (!providerSessionPath.endsWith(".jsonl")) return [];
+  const result = await executeOnHost(
+    target,
+    { command: "node", args: ["-e", CLAUDE_SESSION_SCRIPT, "history", providerSessionPath] },
+    { timeoutMs: SESSION_TIMEOUT_MS },
+  );
+  return historySchema.parse(JSON.parse(result.stdout));
+}
+
+export async function renameClaudeSession(
+  target: HostTarget,
+  providerSessionPath: string,
+  sessionId: string,
+  title: string,
+): Promise<void> {
+  const script = String.raw`
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+const os = require("node:os");
+const path = require("node:path");
+const entry = { type: "custom-title", customTitle: process.argv[2], sessionId: process.argv[1], uuid: crypto.randomUUID(), timestamp: new Date().toISOString() };
+let file = process.argv[3];
+if (!file.endsWith(".jsonl")) {
+  const root = process.env.CLAUDE_CONFIG_DIR
+    ? path.join(process.env.CLAUDE_CONFIG_DIR, "projects")
+    : path.join(os.homedir(), ".claude", "projects");
+  for (const project of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!project.isDirectory()) continue;
+    const candidate = path.join(root, project.name, process.argv[1] + ".jsonl");
+    if (fs.existsSync(candidate)) { file = candidate; break; }
+  }
+}
+if (!file.endsWith(".jsonl")) throw new Error("Claude session history is not available for rename yet.");
+fs.appendFileSync(file, JSON.stringify(entry) + "\n");
+`;
+  await executeOnHost(target, {
+    command: "node",
+    args: ["-e", script, sessionId, title, providerSessionPath],
+  });
+}

--- a/packages/agent-runtime/src/providers/claude.test.ts
+++ b/packages/agent-runtime/src/providers/claude.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  startClaudeRuntime: vi.fn(),
+  probeClaudeConnection: vi.fn(),
+  probeClaudeTarget: vi.fn(),
+  listClaudeWorkspaceSessions: vi.fn(),
+}));
+
+vi.mock("@overtchat/agent-runtime/claude/client", () => ({
+  startClaudeRuntime: mocks.startClaudeRuntime,
+}));
+vi.mock("@overtchat/agent-runtime/claude/probe", () => ({
+  probeClaudeConnection: mocks.probeClaudeConnection,
+  probeClaudeTarget: mocks.probeClaudeTarget,
+}));
+vi.mock("@overtchat/agent-runtime/claude/sessions", () => ({
+  listClaudeWorkspaceSessions: mocks.listClaudeWorkspaceSessions,
+}));
+
+import { claudeProviderAdapter } from "./claude";
+
+describe("Claude provider adapter", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("launches and resumes through the target-owned runtime", () => {
+    const client = {};
+    mocks.startClaudeRuntime.mockReturnValue(client);
+    const target = { transport: "ssh" as const, alias: "workstation" };
+    const launch = {
+      executable: "/usr/bin/claude",
+      cwd: "/workspace",
+      model: "haiku",
+      thinkingOptionId: "medium",
+      modeId: "auto",
+      resume: {
+        providerSessionId: "00000000-0000-4000-8000-000000000001",
+        providerSessionPath: "/home/user/.claude/projects/project/session.jsonl",
+      },
+    };
+    expect(claudeProviderAdapter.startSession(target, launch)).toBe(client);
+    expect(mocks.startClaudeRuntime).toHaveBeenCalledWith(target, launch);
+  });
+
+  it("owns identity, terminal events, and generic command normalization", () => {
+    expect(
+      claudeProviderAdapter.sessionIdentity({
+        sessionId: "session",
+        sessionFile: "/session.jsonl",
+        sessionName: "Repair",
+      }),
+    ).toEqual({
+      providerSessionId: "session",
+      providerSessionPath: "/session.jsonl",
+      sessionName: "Repair",
+    });
+    expect(
+      claudeProviderAdapter.createEventClassifier().classify({ type: "turn_end" }),
+    ).toEqual({ started: false, terminal: true });
+    expect(
+      claudeProviderAdapter.normalizeCommand(
+        { type: "prompt", message: "/compact" },
+        {},
+      ),
+    ).toEqual({ type: "compact" });
+    expect(() =>
+      claudeProviderAdapter.normalizeCommand(
+        { type: "set_auto_compaction", enabled: true },
+        {},
+      ),
+    ).toThrow("manages context compaction automatically");
+  });
+});

--- a/packages/agent-runtime/src/providers/claude.ts
+++ b/packages/agent-runtime/src/providers/claude.ts
@@ -1,0 +1,117 @@
+import type {
+  AgentProviderCatalog,
+  AgentSlashCommand,
+} from "@overtchat/agent-bridge";
+import {
+  mergeAgentSlashCommands,
+  normalizeAgentSessionCommand,
+} from "@overtchat/agent-bridge";
+import { startClaudeRuntime } from "@overtchat/agent-runtime/claude/client";
+import {
+  probeClaudeConnection,
+  probeClaudeTarget,
+} from "@overtchat/agent-runtime/claude/probe";
+import { listClaudeWorkspaceSessions } from "@overtchat/agent-runtime/claude/sessions";
+import type {
+  AgentProviderAdapter,
+  AgentRuntimeEvent,
+  AgentRuntimeEventClassifier,
+  AgentSessionIdentity,
+  AgentSessionLaunch,
+} from "@overtchat/agent-runtime/providers/types";
+import type { HostTarget } from "@overtchat/agent-runtime/runtime/process";
+
+const COMMANDS: readonly AgentSlashCommand[] = [
+  { name: "new", description: "Start a new session", source: "builtin" },
+  {
+    name: "compact",
+    description: "Compact conversation context",
+    source: "builtin",
+  },
+  {
+    name: "name",
+    description: "Set the session name",
+    argumentHint: "<name>",
+    source: "builtin",
+  },
+];
+
+class ClaudeEventClassifier implements AgentRuntimeEventClassifier {
+  reset(): void {}
+
+  classify(event: AgentRuntimeEvent) {
+    return {
+      started: event.type === "turn_start" || event.type === "compaction_start",
+      terminal: event.type === "turn_end" || event.type === "compaction_end",
+    };
+  }
+}
+
+function sessionIdentity(state: Record<string, unknown>): AgentSessionIdentity {
+  if (typeof state.sessionId !== "string" || !state.sessionId) {
+    throw new Error("Claude Code did not return a session ID.");
+  }
+  return {
+    providerSessionId: state.sessionId,
+    providerSessionPath:
+      typeof state.sessionFile === "string" && state.sessionFile
+        ? state.sessionFile
+        : state.sessionId,
+    sessionName:
+      typeof state.sessionName === "string" && state.sessionName.trim()
+        ? state.sessionName.trim()
+        : null,
+  };
+}
+
+async function fetchCatalog(
+  target: HostTarget,
+  launch: Omit<AgentSessionLaunch, "resume">,
+): Promise<AgentProviderCatalog> {
+  const client = startClaudeRuntime(target, launch);
+  try {
+    const [models, state] = await Promise.all([
+      client.getAvailableModels(),
+      client.getState(),
+    ]);
+    const modes = Array.isArray(state.modes) ? state.modes : [];
+    return {
+      provider: "claude",
+      models,
+      modes: modes as AgentProviderCatalog["modes"],
+      defaultModeId:
+        modes.some(
+          (mode) =>
+            mode && typeof mode === "object" && Reflect.get(mode, "id") === "auto",
+        )
+          ? "auto"
+          : "default",
+    };
+  } finally {
+    await client.stop();
+  }
+}
+
+export const claudeProviderAdapter: AgentProviderAdapter = {
+  provider: "claude",
+  startSession: startClaudeRuntime,
+  probeConnection: probeClaudeConnection,
+  probeTarget: probeClaudeTarget,
+  listWorkspaceSessions: (target, _executable, workspacePath) =>
+    listClaudeWorkspaceSessions(target, workspacePath),
+  fetchCatalog,
+  sessionIdentity,
+  createEventClassifier: () => new ClaudeEventClassifier(),
+  commandsFromEvent: (event) =>
+    event.type === "available_commands_update" && Array.isArray(event.commands)
+      ? (event.commands as AgentSlashCommand[])
+      : null,
+  mergeCommands: (discovered) => mergeAgentSlashCommands(COMMANDS, discovered),
+  normalizeCommand: (command, state) => {
+    const normalized = normalizeAgentSessionCommand(command, state);
+    if (normalized.type === "set_auto_compaction") {
+      throw new Error("Claude Code manages context compaction automatically.");
+    }
+    return normalized;
+  },
+};

--- a/packages/agent-runtime/src/providers/registry.ts
+++ b/packages/agent-runtime/src/providers/registry.ts
@@ -3,6 +3,7 @@ import { piProviderAdapter } from "@overtchat/agent-runtime/providers/pi";
 import { ompProviderAdapter } from "@overtchat/agent-runtime/providers/omp";
 import { codexProviderAdapter } from "@overtchat/agent-runtime/providers/codex";
 import { openCodeProviderAdapter } from "@overtchat/agent-runtime/providers/opencode";
+import { claudeProviderAdapter } from "@overtchat/agent-runtime/providers/claude";
 import type { AgentProviderId } from "@overtchat/agent-bridge";
 
 const adapters = {
@@ -10,6 +11,7 @@ const adapters = {
   omp: ompProviderAdapter,
   codex: codexProviderAdapter,
   opencode: openCodeProviderAdapter,
+  claude: claudeProviderAdapter,
 } satisfies Record<AgentProviderId, AgentProviderAdapter>;
 
 export function agentProviderAdapter(

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.8.1"
+connector_version="0.9.0"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

- add Claude Code as a fifth coding-agent provider using one long-lived Agent SDK streaming query per session
- support local and SSH process execution, permissions/questions, images, steering, abort, compaction, model/mode/thinking changes, and session history/resume
- integrate Claude with provider discovery, create preferences, visuals, CLI detection, and operator documentation
- bump the exact Host Connector protocol to 3 and reserve connector 0.9.0 across release metadata

## Architecture

The connector owns process and SSH execution, agent-runtime owns Claude normalization and lifecycle, and agent-bridge remains the generic wire contract. Claude Code remains the authority for target-local authentication, settings, skills, hooks, and MCP configuration.

The SDK is pinned to `@anthropic-ai/claude-agent-sdk@0.3.246`. OvertChat launches the installed `claude` executable on each target; it does not copy or store Claude credentials.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run deps:check`
- [x] `npm run build -w apps/connector --`
- [x] `npm run build -w apps/web --`
- [x] local Claude smoke: probe/model discovery, create, streaming, image input, tool use, abort, history discovery, resume, and context recall
- [x] connector binary compilation and version smoke
- [x] live SSH create/resume/abort smoke, including confirming no surviving remote Claude or MCP process tree

## Release notes

Protocol 3 changes provider snapshots from four exact entries to five. Protocol-2 connectors are rejected through the existing upgrade flow. The connector version, lockfile, installer, redirects, and stable manifest are coordinated at 0.9.0.

## Deferred

Managed MCP injection, file checkpoints/rewind, forks, rich nested-agent panes, fast mode, usage/quota UI, and Claude-specific ephemeral-session cleanup remain follow-up work.