### PR TITLE
fix: keep dev data out of build cache

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -11,6 +11,9 @@ const nextConfig: NextConfig = {
       "./lib/providers/server/model-catalog.manifest.json",
     ],
   },
+  outputFileTracingExcludes: {
+    "/*": ["./data/**/*"],
+  },
   transpilePackages: ["@overtchat/agent-bridge", "@overtchat/shared"],
   // Hosts allowed to load `next dev` assets cross-origin. Only used in dev
   // (Next.js ignores this at build time). Phone-on-LAN testing needs the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "mkdir -p data && next dev -p ${PORT:-4717}",
     "build": "next build",
+    "postbuild": "node scripts/sanitize-build-output.mjs",
     "start": "mkdir -p data && next start -p 4717",
     "lint": "eslint",
     "typecheck": "next typegen && tsc --noEmit",

--- a/apps/web/scripts/sanitize-build-output.mjs
+++ b/apps/web/scripts/sanitize-build-output.mjs
@@ -1,0 +1,57 @@
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const webRoot = path.resolve(import.meta.dirname, "..");
+const dataRoot = path.join(webRoot, "data");
+const nextRoot = path.join(webRoot, ".next");
+const instrumentationTrace = path.join(
+  nextRoot,
+  "server",
+  "instrumentation.js.nft.json",
+);
+const standaloneData = path.join(
+  nextRoot,
+  "standalone",
+  "apps",
+  "web",
+  "data",
+);
+
+function isWithin(parent, candidate) {
+  const relative = path.relative(parent, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function removeDataFromInstrumentationTrace() {
+  let trace;
+  try {
+    trace = JSON.parse(await readFile(instrumentationTrace, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return 0;
+    throw error;
+  }
+
+  const traceDir = path.dirname(instrumentationTrace);
+  const files = Array.isArray(trace.files) ? trace.files : [];
+  const filtered = files.filter(
+    (file) => !isWithin(dataRoot, path.resolve(traceDir, file)),
+  );
+  const removed = files.length - filtered.length;
+
+  if (removed > 0) {
+    await writeFile(
+      instrumentationTrace,
+      JSON.stringify({ ...trace, files: filtered }),
+    );
+  }
+  return removed;
+}
+
+const removedTraceEntries = await removeDataFromInstrumentationTrace();
+await rm(standaloneData, { recursive: true, force: true });
+
+if (removedTraceEntries > 0) {
+  console.log(
+    `Removed ${removedTraceEntries} runtime-data entries from the standalone build trace.`,
+  );
+}

--- a/turbo.json
+++ b/turbo.json
@@ -3,15 +3,17 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "inputs": ["$TURBO_DEFAULT$", ".env*"]
     },
     "@overtchat/mobile#build": {
       "cache": false
     },
+    "@overtchat/web#build": {
+      "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**"]
+    },
     "@overtchat/site#build": {
       "env": ["GITHUB_TOKEN", "NEXT_PUBLIC_BASE_PATH", "NEXT_PUBLIC_SITE_ORIGIN"],
-      "outputs": [".next/**", "!.next/cache/**", "out/**"]
+      "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**", "out/**"]
     },
     "@overtchat/connector#build": {
       "outputs": ["dist/**"]


### PR DESCRIPTION
## Summary

- scope Next.js build outputs to the web and site workspaces
- exclude persistent Next development output from Turbo archives
- keep local runtime data out of standalone traces and cached artifacts
- sanitize the special instrumentation trace that Next does not cover with the route exclusion

## Validation

- web production build succeeds
- repeated Turbo build is a full cache hit
- resulting cache archive contains zero .next/dev, runtime-data, or database entries
- focused upload tests pass
- web typecheck passes
- changed configuration and sanitizer pass ESLint

No release is required for this developer/build-artifact fix; it can ship with the next normal feature release.