### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.17.1",
+  "appVersion": "0.18.0",
   "connectorVersion": "0.9.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.17.1}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.18.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- release Claude Code agent support from #211
- release personalization and saved memories from #213
- set the stable app version to 0.18.0
- retain the coordinated Host Connector version at 0.9.0

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run deps:check`
- `npm run build`
- app/connector release version consistency assertions

## Release order

After this PR lands, tag the same merge commit as `connector-v0.9.0` first and wait for its public artifacts, then tag it as `v0.18.0`. This keeps the protocol-compatible app and connector pair atomic in the stable manifest.