### PR TITLE
fix(release): validate the production app image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ apps/site/*
 !apps/site/public
 apps/site/public/*
 !apps/site/public/install-manifest.json
+# Root maintenance tooling is not used by the app build. apps/web/scripts is.
 scripts
 **/test-results
 **/playwright-report
@@ -38,7 +39,6 @@ compose.override.yaml
 .gemini
 .claude
 .DS_Store
-apps/web/scripts
 **/tsconfig.tsbuildinfo
 docs
 searxng

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,3 +58,25 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  container:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Build production app image
+        run: docker build --platform linux/amd64 --tag "overtchat-app-ci:$GITHUB_SHA" .
+
+      - name: Verify runtime image contents
+        run: |
+          docker run --rm --entrypoint sh "overtchat-app-ci:$GITHUB_SHA" -c '
+            test -f /app/apps/web/server.js
+            test -d /app/apps/web/drizzle
+            test ! -e /app/apps/web/data
+            test ! -e /app/apps/web/scripts
+          '

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.10",
-  "appVersion": "0.18.0",
+  "appVersion": "0.18.1",
   "connectorVersion": "0.9.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.18.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.18.1}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/docs/release.md
+++ b/docs/release.md
@@ -89,6 +89,19 @@ and run the workflow preflight before spending time on a release build.
 Run the standard repository lint, typecheck, and test scripts, followed by the
 release-specific checks below.
 
+For an app release, build and inspect the production image that the tag workflow
+will publish:
+
+```bash
+docker build --platform linux/amd64 --tag overtchat-app-release-check .
+docker run --rm --entrypoint sh overtchat-app-release-check -c '
+  test -f /app/apps/web/server.js
+  test -d /app/apps/web/drizzle
+  test ! -e /app/apps/web/data
+  test ! -e /app/apps/web/scripts
+'
+```
+
 For a CLI release, build the CLI workspace and then verify the bundled version:
 
 ```bash


### PR DESCRIPTION
## Summary

- fix the production app image build by keeping required web build scripts in the Docker context
- add a CI check that builds and inspects the final app image
- prepare app `0.18.1` with connector `0.9.0`

`v0.18.0` did not produce an app image or GitHub release, and stable was not changed.

## Validation

- repository lint, typecheck, tests, and builds
- Actionlint and release-version checks
- production image build and runtime-content checks
- live container `/api/ping` smoke test