### PR TITLE
fix(web): keep long chats responsive

### DIFF
--- a/apps/web/app/(app)/chat/[id]/page.tsx
+++ b/apps/web/app/(app)/chat/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth/server";
-import { getChat, getMessages } from "@/lib/db/chats";
+import { getChat, getMessagesPage } from "@/lib/db/chats";
 import { ChatArea } from "@/components/chat/ChatArea";
 
 export default async function Page({
@@ -14,13 +14,14 @@ export default async function Page({
   if (!session) redirect("/login");
   const chat = await getChat(id, session.user.id);
   if (!chat) redirect("/");
-  const initialMessages = await getMessages(id);
+  const initialPage = await getMessagesPage(id);
   return (
     <ChatArea
       key={id}
       chatId={id}
       projectId={chat.projectId ?? null}
-      initialMessages={initialMessages}
+      initialMessages={initialPage.messages}
+      initialMessageCursor={initialPage.nextCursor}
     />
   );
 }

--- a/apps/web/app/api/chat/[id]/messages/route.test.ts
+++ b/apps/web/app/api/chat/[id]/messages/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getChat: vi.fn(),
+  getMessages: vi.fn(),
+  getMessagesPage: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/chats", () => ({
+  getChat: mocks.getChat,
+  getMessages: mocks.getMessages,
+  getMessagesPage: mocks.getMessagesPage,
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({ id: "chat" }) };
+
+describe("chat message history route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getSession.mockResolvedValue({ user: { id: "user" } });
+    mocks.getChat.mockResolvedValue({ id: "chat", projectId: "project" });
+    mocks.getMessages.mockResolvedValue([]);
+    mocks.getMessagesPage.mockResolvedValue({
+      messages: [{ id: "message", role: "user", parts: [] }],
+      nextCursor: "41",
+    });
+  });
+
+  it("serves an authenticated cursor page", async () => {
+    const request = new Request(
+      "http://server.test/api/chat/chat/messages?cursor=42&limit=32",
+    );
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    expect(mocks.getMessagesPage).toHaveBeenCalledWith("chat", {
+      cursor: "42",
+      limit: 32,
+    });
+    await expect(response.json()).resolves.toEqual({
+      messages: [{ id: "message", role: "user", parts: [] }],
+      nextCursor: "41",
+      projectId: "project",
+    });
+  });
+
+  it("rejects malformed pagination without querying messages", async () => {
+    const request = new Request(
+      "http://server.test/api/chat/chat/messages?cursor=nope&limit=500",
+    );
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(400);
+    expect(mocks.getMessagesPage).not.toHaveBeenCalled();
+    expect(mocks.getMessages).not.toHaveBeenCalled();
+  });
+
+  it("retains the unpaginated response for existing mobile clients", async () => {
+    const request = new Request(
+      "http://server.test/api/chat/chat/messages",
+    );
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    expect(mocks.getMessages).toHaveBeenCalledWith("chat");
+    expect(mocks.getMessagesPage).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      messages: [],
+      projectId: "project",
+    });
+  });
+});

--- a/apps/web/app/api/chat/[id]/messages/route.ts
+++ b/apps/web/app/api/chat/[id]/messages/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/lib/auth/server";
 import { preflight, withCors } from "@/lib/cors";
-import { getChat, getMessages } from "@/lib/db/chats";
+import { getChat, getMessages, getMessagesPage } from "@/lib/db/chats";
 
 export function OPTIONS(req: Request) {
   return preflight(req);
@@ -17,6 +17,33 @@ export async function GET(
   const chat = await getChat(id, session.user.id);
   if (!chat) return withCors(req, new Response("Not found", { status: 404 }));
 
+  const url = new URL(req.url);
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+  const requestedLimit = url.searchParams.get("limit");
+  if (cursor !== undefined || requestedLimit !== null) {
+    const limit = requestedLimit === null ? undefined : Number(requestedLimit);
+    if (
+      limit !== undefined &&
+      (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
+    ) {
+      return withCors(req, new Response("Invalid limit", { status: 400 }));
+    }
+    const cursorRowId = cursor === undefined ? undefined : Number(cursor);
+    if (
+      cursorRowId !== undefined &&
+      (!Number.isSafeInteger(cursorRowId) || cursorRowId <= 0)
+    ) {
+      return withCors(req, new Response("Invalid cursor", { status: 400 }));
+    }
+    const page = await getMessagesPage(id, { cursor, limit });
+    return withCors(
+      req,
+      Response.json({ ...page, projectId: chat.projectId }),
+    );
+  }
+
+  // Compatibility path for existing mobile clients. New clients should use
+  // cursor pagination so opening a chat never transfers unbounded history.
   const messages = await getMessages(id);
   return withCors(
     req,

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -12,10 +12,10 @@ const mocks = vi.hoisted(() => {
     getSession: vi.fn(),
     parseChatRequest: vi.fn(),
     getChat: vi.fn(),
+    getMessages: vi.fn(),
     clearActiveStreamId: vi.fn(),
     commitChatTurn: vi.fn(),
     completeChatStream: vi.fn(),
-    getChatMessage: vi.fn(),
     inlineUploads: vi.fn(),
     getModelConfig: vi.fn(),
     getTaskModelConfig: vi.fn(),
@@ -115,12 +115,14 @@ vi.mock("@/lib/chat/request", () => {
     parseChatRequest: mocks.parseChatRequest,
   };
 });
-vi.mock("@/lib/db/chats", () => ({ getChat: mocks.getChat }));
+vi.mock("@/lib/db/chats", () => ({
+  getChat: mocks.getChat,
+  getMessages: mocks.getMessages,
+}));
 vi.mock("@/lib/db/chatTurns", () => ({
   clearActiveStreamId: mocks.clearActiveStreamId,
   commitChatTurn: mocks.commitChatTurn,
   completeChatStream: mocks.completeChatStream,
-  getChatMessage: mocks.getChatMessage,
 }));
 vi.mock("@/lib/db/uploads", () => ({ inlineUploads: mocks.inlineUploads }));
 vi.mock("@/lib/db/modelConfigs", () => ({
@@ -253,9 +255,9 @@ describe("chat route setup boundary", () => {
       release: mocks.releaseMcpBinding,
     });
     mocks.getChat.mockResolvedValue(null);
+    mocks.getMessages.mockResolvedValue([]);
     mocks.getProject.mockResolvedValue(null);
     mocks.getActivePersonalization.mockResolvedValue(null);
-    mocks.getChatMessage.mockResolvedValue(null);
     mocks.createConfiguredLanguageModel.mockReturnValue({
       model: "language-model",
       providerOptions: undefined,
@@ -402,6 +404,50 @@ describe("chat route setup boundary", () => {
     expect(mocks.commitChatTurn).not.toHaveBeenCalled();
   });
 
+  it("reconstructs saved model context from persisted history", async () => {
+    const storedMessages = [
+      {
+        id: "stored-user",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "Earlier question" }],
+      },
+      {
+        id: "stored-assistant",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "Earlier answer" }],
+      },
+    ];
+    mocks.getChat.mockResolvedValue(existingChat());
+    mocks.getMessages.mockResolvedValue(storedMessages);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.inlineUploads).toHaveBeenCalledWith(
+      [...storedMessages, ...messages],
+      "user",
+    );
+    expect(mocks.uiStreamOptions?.originalMessages).toEqual([
+      ...storedMessages,
+      ...messages,
+    ]);
+  });
+
+  it("rejects a stale saved-history edit before model preparation", async () => {
+    mocks.parseChatRequest.mockResolvedValue({
+      ...parsedRequest,
+      messageId: "missing-user-message",
+    });
+    mocks.getChat.mockResolvedValue(existingChat());
+    mocks.getMessages.mockResolvedValue([]);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    expect(mocks.createConfiguredLanguageModel).not.toHaveBeenCalled();
+    expect(mocks.commitChatTurn).not.toHaveBeenCalled();
+  });
+
   it("prepares an edit before atomically truncating and replacing it", async () => {
     const events: string[] = [];
     mocks.parseChatRequest.mockResolvedValue({
@@ -409,11 +455,18 @@ describe("chat route setup boundary", () => {
       messageId: "edited-user-message",
     });
     mocks.getChat.mockResolvedValue(existingChat());
-    mocks.getChatMessage.mockResolvedValue({
-      id: "edited-user-message",
-      role: "user",
-      parts: [{ type: "text", text: "Old" }],
-    });
+    mocks.getMessages.mockResolvedValue([
+      {
+        id: "edited-user-message",
+        role: "user",
+        parts: [{ type: "text", text: "Old" }],
+      },
+      {
+        id: "old-assistant-message",
+        role: "assistant",
+        parts: [{ type: "text", text: "Old answer" }],
+      },
+    ]);
     mocks.createConfiguredLanguageModel.mockImplementation(() => {
       events.push("model");
       return {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -30,13 +30,16 @@ import {
 import { corsHeaders, preflight, withCors } from "@/lib/cors";
 import { auth } from "@/lib/auth/server";
 import { ChatRequestError, parseChatRequest } from "@/lib/chat/request";
-import { getChat } from "@/lib/db/chats";
+import {
+  ChatHistoryConflictError,
+  reconstructPersistedMessages,
+} from "@/lib/chat/history";
+import { getChat, getMessages } from "@/lib/db/chats";
 import { getServerCapability } from "@/lib/db/serverCapabilities";
 import {
   clearActiveStreamId,
   commitChatTurn,
   completeChatStream,
-  getChatMessage,
   type CompletedGenerationUsage,
 } from "@/lib/db/chatTurns";
 import { inlineUploads } from "@/lib/db/uploads";
@@ -116,7 +119,7 @@ async function handlePost(req: Request): Promise<Response> {
   }
   const userId = session.user.id;
   const {
-    messages,
+    messages: requestMessages,
     modelConfigId,
     webSearchEnabled,
     forceSearch,
@@ -163,16 +166,26 @@ async function handlePost(req: Request): Promise<Response> {
     : await getActivePersonalization(userId);
   const personalizationEnabled = activePersonalization !== null;
 
-  if (!temporary && messageId) {
-    const target = await getChatMessage(chatId, messageId);
-    const expectedRole =
-      trigger === "regenerate-message" ? "assistant" : "user";
-    if (!target || target.role !== expectedRole) {
-      throw new ChatRequestError(
-        "Chat history changed; refresh and try again",
-        409,
-      );
+  let messages = requestMessages;
+  if (existingChat) {
+    try {
+      messages = reconstructPersistedMessages({
+        storedMessages: await getMessages(chatId),
+        requestMessages,
+        trigger,
+        messageId,
+      });
+    } catch (error) {
+      if (error instanceof ChatHistoryConflictError) {
+        throw new ChatRequestError(error.message, 409);
+      }
+      throw error;
     }
+  } else if (!temporary && messageId) {
+    throw new ChatRequestError(
+      "Chat history changed; refresh and try again",
+      409,
+    );
   }
 
   // Everything above and through message conversion is read-only. A saved

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useChat } from "@ai-sdk/react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -17,6 +17,7 @@ import {
 import {
   useChats,
   useChatUsage,
+  useLoadOlderChatMessages,
   type ChatListItem,
 } from "@/lib/queries/chats";
 import { useLocalStorage } from "@/lib/useLocalStorage";
@@ -33,6 +34,7 @@ import {
   writeStoredMessageStats,
   type StoredMessageStats,
 } from "@/lib/chat/stats";
+import { messagesForChatRequest } from "@/lib/chat/history";
 import {
   CONTEXT_METER_STORAGE_KEY,
   DEFAULT_CONTEXT_METER_ENABLED,
@@ -53,6 +55,7 @@ import {
 import { hasSuccessfulMemoryMutation } from "@/lib/personalization/tool-parts";
 import { AdminOnboardingCard } from "@/components/AdminOnboardingCard";
 import { useSidebar } from "@/components/sidebar-context";
+import { toast } from "@/components/ui/toast";
 import { ChatHeader } from "./ChatHeader";
 import { Composer, type ComposerHandle } from "./Composer";
 import { MessageList } from "./MessageList";
@@ -67,6 +70,7 @@ function shouldAutofocusComposer() {
 interface Props {
   chatId: string;
   initialMessages?: UIMessage[];
+  initialMessageCursor?: string | null;
   isNew?: boolean;
   projectId?: string | null;
   initialQuery?: string;
@@ -75,6 +79,7 @@ interface Props {
 export function ChatArea({
   chatId,
   initialMessages,
+  initialMessageCursor,
   isNew,
   projectId,
   initialQuery,
@@ -165,7 +170,18 @@ export function ChatArea({
           trigger,
           messageId,
         }) => ({
-          body: { ...body, messages, trigger, messageId },
+          // Saved chats send only the user intent. The server reconstructs
+          // canonical context from persistence, avoiding an O(history) upload
+          // and preventing the browser from becoming the history authority.
+          body: {
+            ...body,
+            messages: messagesForChatRequest(
+              messages,
+              body?.temporary === true,
+            ),
+            trigger,
+            messageId,
+          },
         }),
       }),
   );
@@ -175,11 +191,20 @@ export function ChatArea({
     temporaryRef.current = temporary;
   }, [temporary]);
 
-  const { messages, sendMessage, regenerate, status, stop, error } = useChat({
+  const {
+    messages,
+    setMessages,
+    sendMessage,
+    regenerate,
+    status,
+    stop,
+    error,
+  } = useChat({
     id: temporary ? undefined : chatId,
     resume: !temporary && !isNew,
     transport,
     messages: initialMessages,
+    throttle: 32,
     onData: (part) => {
       if (
         part.type === INFERENCE_ACTIVITY_DATA_TYPE &&
@@ -212,6 +237,36 @@ export function ChatArea({
       ]);
     },
   });
+  const [olderMessageCursor, setOlderMessageCursor] = useState(
+    initialMessageCursor ?? null,
+  );
+  const {
+    mutateAsync: loadOlderMessages,
+    isPending: loadingOlderMessages,
+  } = useLoadOlderChatMessages(chatId);
+  const loadingOlderMessagesRef = useRef(false);
+  const handleLoadOlderMessages = useCallback(async () => {
+    if (!olderMessageCursor || loadingOlderMessagesRef.current) return;
+    loadingOlderMessagesRef.current = true;
+    try {
+      const page = await loadOlderMessages(olderMessageCursor);
+      setMessages((current) => {
+        const currentIds = new Set(current.map(({ id }) => id));
+        return [
+          ...page.messages.filter(({ id }) => !currentIds.has(id)),
+          ...current,
+        ];
+      });
+      setOlderMessageCursor(page.nextCursor);
+    } catch {
+      toast.error({
+        title: "Could not load older messages",
+        description: "Check your connection and try again.",
+      });
+    } finally {
+      loadingOlderMessagesRef.current = false;
+    }
+  }, [loadOlderMessages, olderMessageCursor, setMessages]);
 
   const speech = useSpeech();
   const { data: session } = authClient.useSession();
@@ -471,6 +526,9 @@ export function ChatArea({
             speech={speech}
             showStats={messageStatsEnabled}
             storedStats={storedStats}
+            hasOlderMessages={olderMessageCursor !== null}
+            loadingOlderMessages={loadingOlderMessages}
+            onLoadOlderMessages={handleLoadOlderMessages}
             onRegenerate={handleRegenerate}
             onEdit={handleEdit}
             onRetry={handleRetry}

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { ChatStatus, FileUIPart, UIMessage } from "ai";
-import { AlertTriangle, ChevronDown, RotateCcw } from "lucide-react";
-import { useStickToBottom } from "use-stick-to-bottom";
+import {
+  AlertTriangle,
+  ChevronDown,
+  LoaderCircle,
+  RotateCcw,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { chatErrorMessage } from "@/lib/chat/message";
 import type { InferenceActivity } from "@/lib/chat/inference-activity";
@@ -26,6 +32,9 @@ export function MessageList({
   speech,
   showStats,
   storedStats,
+  hasOlderMessages,
+  loadingOlderMessages,
+  onLoadOlderMessages,
   onRegenerate,
   onEdit,
   onRetry,
@@ -39,49 +48,161 @@ export function MessageList({
   speech: ReturnType<typeof useSpeech>;
   showStats: boolean;
   storedStats: StoredMessageStats;
+  hasOlderMessages: boolean;
+  loadingOlderMessages: boolean;
+  onLoadOlderMessages: () => void;
   onRegenerate: (id: string) => void;
   onEdit: (id: string, text: string, files: FileUIPart[]) => void;
   onRetry: () => void;
 }) {
-  const { scrollRef, contentRef, isAtBottom, scrollToBottom } =
-    useStickToBottom({
-      initial: "instant",
-      resize: "instant",
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const initialScrollCompleteRef = useRef(false);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [isAtTop, setIsAtTop] = useState(false);
+  const errorOffset = messages.length;
+  const count = error ? errorOffset + 1 : errorOffset;
+
+  const getItemKey = useCallback(
+    (index: number) => {
+      if (index < messages.length) {
+        return `message:${messages[index].id}`;
+      }
+      return "chat-error";
+    },
+    [messages],
+  );
+
+  // TanStack Virtual intentionally exposes imperative scroll/measure methods.
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) => {
+      if (error && index === errorOffset) return 64;
+      return 220;
+    },
+    getItemKey,
+    overscan: 5,
+    gap: 24,
+    paddingStart: 40,
+    paddingEnd: 32,
+    anchorTo: "end",
+    followOnAppend: true,
+    scrollEndThreshold: 80,
+    onChange(instance) {
+      const atBottom = instance.isAtEnd(80);
+      setIsAtBottom((current) =>
+        current === atBottom ? current : atBottom,
+      );
+      const atTop = (instance.scrollOffset ?? 0) <= 80;
+      setIsAtTop((current) => (current === atTop ? current : atTop));
+      if (
+        initialScrollCompleteRef.current &&
+        hasOlderMessages &&
+        atTop
+      ) {
+        onLoadOlderMessages();
+      }
+    },
+  });
+
+  useLayoutEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      virtualizer.scrollToEnd();
+      initialScrollCompleteRef.current = true;
     });
+    return () => cancelAnimationFrame(frame);
+    // Initial positioning only. Subsequent appends are handled by
+    // followOnAppend and dynamic measurement anchoring.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
       <div
         ref={scrollRef}
+        data-chat-transcript-scroll=""
         className="h-full overflow-y-auto overscroll-contain"
       >
         <div
-          ref={contentRef}
-          className="mx-auto w-full max-w-3xl space-y-6 px-4 pt-10 pb-8"
+          className="relative mx-auto w-full max-w-3xl"
+          style={{ height: virtualizer.getTotalSize() }}
         >
-          {messages.map((m, i) => (
-            <MessageBubble
-              key={m.id}
-              message={m}
-              streaming={streaming && i === messages.length - 1}
-              canAct={!streaming && configured}
-              onRegenerate={onRegenerate}
-              onEdit={onEdit}
-              speech={speech}
-              showStats={showStats}
-              stats={readMessageStats(m) ?? storedStats[m.id] ?? null}
-            />
-          ))}
-          {error && <ChatErrorBubble error={error} onRetry={onRetry} />}
-          {!error && streaming && inferenceActivity && (
-            <InferenceActivityIndicator activity={inferenceActivity} />
-          )}
-          {!error &&
-            !inferenceActivity &&
-            status === "submitted" &&
-            messages.at(-1)?.role === "user" && <PendingIndicator />}
+          {virtualizer.getVirtualItems().map((item) => {
+            let content;
+            const message = messages[item.index];
+            if (message) {
+              const isLast = item.index === messages.length - 1;
+              content = (
+                <>
+                  <MessageBubble
+                    message={message}
+                    streaming={streaming && isLast}
+                    canAct={!streaming && configured}
+                    onRegenerate={onRegenerate}
+                    onEdit={onEdit}
+                    speech={speech}
+                    showStats={showStats}
+                    stats={
+                      readMessageStats(message) ??
+                      storedStats[message.id] ??
+                      null
+                    }
+                  />
+                  {isLast && !error && streaming && inferenceActivity && (
+                    <InferenceActivityIndicator activity={inferenceActivity} />
+                  )}
+                  {isLast &&
+                    !error &&
+                    !inferenceActivity &&
+                    status === "submitted" &&
+                    message.role === "user" && <PendingIndicator />}
+                </>
+              );
+            } else if (error && item.index === errorOffset) {
+              content = <ChatErrorBubble error={error} onRetry={onRetry} />;
+            }
+
+            return (
+              <div
+                key={item.key}
+                ref={virtualizer.measureElement}
+                data-index={item.index}
+                data-transcript-item=""
+                data-message-id={message?.id}
+                className="absolute top-0 left-0 w-full px-4"
+                style={{ transform: `translateY(${item.start}px)` }}
+              >
+                {content}
+              </div>
+            );
+          })}
         </div>
       </div>
+
+      {(loadingOlderMessages || (hasOlderMessages && isAtTop)) && (
+        <div className="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
+          {loadingOlderMessages ? (
+            <span
+              className="flex items-center gap-2 rounded-full border bg-background/95 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur"
+              role="status"
+            >
+              <LoaderCircle className="size-3.5 animate-spin" />
+              Loading earlier messages
+            </span>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="pointer-events-auto rounded-full bg-background/95 shadow-sm backdrop-blur"
+              onClick={onLoadOlderMessages}
+            >
+              Load earlier messages
+            </Button>
+          )}
+        </div>
+      )}
 
       {!isAtBottom && (
         <div className="pointer-events-none absolute inset-x-0 bottom-3 z-10 flex justify-center">
@@ -90,7 +211,7 @@ export function MessageList({
             variant="outline"
             size="icon-sm"
             className="pointer-events-auto rounded-full bg-background/95 shadow-md backdrop-blur"
-            onClick={() => void scrollToBottom()}
+            onClick={() => virtualizer.scrollToEnd({ behavior: "smooth" })}
             aria-label="Scroll to bottom"
           >
             <ChevronDown />

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -86,6 +86,9 @@ export function MessageList({
     gap: 24,
     paddingStart: 40,
     paddingEnd: 32,
+    // TanStack recommends disabling its synchronous adapter updates on
+    // React 19, which otherwise calls flushSync during a layout lifecycle.
+    useFlushSync: false,
     anchorTo: "end",
     followOnAppend: true,
     scrollEndThreshold: 80,

--- a/apps/web/e2e/long-chat.spec.ts
+++ b/apps/web/e2e/long-chat.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+import { openE2eDatabase, resetE2eDatabase } from "./helpers/database";
+
+test.beforeEach(resetE2eDatabase);
+
+function seedLongChat(messageCount: number) {
+  const db = openE2eDatabase();
+  try {
+    const user = db.prepare("SELECT id FROM user LIMIT 1").get() as
+      | { id: string }
+      | undefined;
+    if (!user) throw new Error("Signup user was not created");
+
+    db.prepare(
+      `INSERT INTO chats (id, user_id, title, created_at, updated_at)
+       VALUES ('long-chat', ?, 'Long chat', 1, 1)`,
+    ).run(user.id);
+    const insert = db.prepare(
+      `INSERT INTO messages (id, chat_id, role, parts, created_at)
+       VALUES (?, 'long-chat', ?, ?, ?)`,
+    );
+    db.transaction(() => {
+      for (let index = 0; index < messageCount; index += 1) {
+        const role = index % 2 === 0 ? "user" : "assistant";
+        const text =
+          role === "user"
+            ? `Question ${index}: explain item ${index}.`
+            : [
+                `## Answer ${index}`,
+                "",
+                "- First point with **emphasis**",
+                "- Second point with `inline code`",
+                "",
+                "```ts",
+                `const answer = ${index};`,
+                "```",
+              ].join("\n");
+        insert.run(
+          `message-${String(index).padStart(3, "0")}`,
+          role,
+          JSON.stringify([{ type: "text", text }]),
+          index + 1,
+        );
+      }
+    })();
+  } finally {
+    db.close();
+  }
+}
+
+test("long chats page history while keeping the mounted DOM bounded", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+  await page.goto("/signup");
+  await page.locator("#name").fill("Long Chat Admin");
+  await page
+    .locator("#email")
+    .fill("long-chat-admin@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+  seedLongChat(320);
+
+  await page.goto("/chat/long-chat");
+  await expect(page.getByText("Answer 319", { exact: true })).toBeVisible();
+
+  const transcript = page.locator("[data-chat-transcript-scroll]");
+  const mountedItems = page.locator("[data-transcript-item]");
+  expect(await mountedItems.count()).toBeLessThan(24);
+  await expect(page.getByText("Question 0: explain item 0.")).toHaveCount(0);
+
+  for (let pageNumber = 0; pageNumber < 3; pageNumber += 1) {
+    const historyResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes("/messages?cursor=") &&
+        response.request().method() === "GET" &&
+        response.ok(),
+    );
+    await transcript.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    await historyResponse;
+    await expect(page.getByText("Loading earlier messages")).toHaveCount(0);
+  }
+
+  expect(await mountedItems.count()).toBeLessThan(24);
+  expect(
+    await transcript.evaluate((element) => element.scrollTop),
+  ).toBeGreaterThan(0);
+});

--- a/apps/web/lib/chat/history.test.ts
+++ b/apps/web/lib/chat/history.test.ts
@@ -1,0 +1,79 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  ChatHistoryConflictError,
+  messagesForChatRequest,
+  reconstructPersistedMessages,
+} from "./history";
+
+function message(id: string, role: UIMessage["role"]): UIMessage {
+  return { id, role, parts: [{ type: "text", text: id }] };
+}
+
+const stored = [
+  message("user-1", "user"),
+  message("assistant-1", "assistant"),
+  message("user-2", "user"),
+  message("assistant-2", "assistant"),
+];
+
+describe("messagesForChatRequest", () => {
+  it("sends only the current intent for a persisted chat", () => {
+    expect(messagesForChatRequest(stored, false)).toEqual([stored.at(-1)]);
+  });
+
+  it("keeps client-owned temporary chat context intact", () => {
+    expect(messagesForChatRequest(stored, true)).toBe(stored);
+  });
+});
+
+describe("reconstructPersistedMessages", () => {
+  it("appends only the requested user turn to canonical stored history", () => {
+    const next = message("user-3", "user");
+
+    expect(
+      reconstructPersistedMessages({
+        storedMessages: stored,
+        // A legacy client may upload stale or fabricated history. Only its
+        // final user intent is accepted for a saved chat.
+        requestMessages: [message("fabricated", "assistant"), next],
+        trigger: "submit-message",
+      }).map(({ id }) => id),
+    ).toEqual(["user-1", "assistant-1", "user-2", "assistant-2", "user-3"]);
+  });
+
+  it("replaces an edited user turn and drops its old branch", () => {
+    const replacement = message("user-2", "user");
+
+    expect(
+      reconstructPersistedMessages({
+        storedMessages: stored,
+        requestMessages: [replacement],
+        trigger: "submit-message",
+        messageId: "user-2",
+      }).map(({ id }) => id),
+    ).toEqual(["user-1", "assistant-1", "user-2"]);
+  });
+
+  it("reconstructs regeneration context through the preceding user turn", () => {
+    expect(
+      reconstructPersistedMessages({
+        storedMessages: stored,
+        requestMessages: [message("user-2", "user")],
+        trigger: "regenerate-message",
+        messageId: "assistant-2",
+      }).map(({ id }) => id),
+    ).toEqual(["user-1", "assistant-1", "user-2"]);
+  });
+
+  it("rejects stale targets instead of regenerating the wrong branch", () => {
+    expect(() =>
+      reconstructPersistedMessages({
+        storedMessages: stored,
+        requestMessages: [message("user-2", "user")],
+        trigger: "regenerate-message",
+        messageId: "missing",
+      }),
+    ).toThrow(ChatHistoryConflictError);
+  });
+});

--- a/apps/web/lib/chat/history.ts
+++ b/apps/web/lib/chat/history.ts
@@ -1,0 +1,67 @@
+import type { UIMessage } from "ai";
+
+export const CHAT_MESSAGE_PAGE_SIZE = 32;
+
+export type ChatMessagePage = {
+  messages: UIMessage[];
+  nextCursor: string | null;
+};
+
+export class ChatHistoryConflictError extends Error {
+  constructor() {
+    super("Chat history changed; refresh and try again");
+    this.name = "ChatHistoryConflictError";
+  }
+}
+
+export function messagesForChatRequest(
+  messages: UIMessage[],
+  temporary: boolean,
+): UIMessage[] {
+  return temporary ? messages : messages.slice(-1);
+}
+
+/**
+ * Rebuilds a saved chat from server-owned history and the request intent.
+ * Clients may still send legacy full transcripts, but persisted history is
+ * never trusted or uploaded as the source of truth for model context.
+ */
+export function reconstructPersistedMessages({
+  storedMessages,
+  requestMessages,
+  trigger,
+  messageId,
+}: {
+  storedMessages: UIMessage[];
+  requestMessages: UIMessage[];
+  trigger: "submit-message" | "regenerate-message";
+  messageId?: string;
+}): UIMessage[] {
+  const requestUserMessage = requestMessages.at(-1);
+  if (!requestUserMessage || requestUserMessage.role !== "user") {
+    throw new ChatHistoryConflictError();
+  }
+
+  if (!messageId) {
+    return [...storedMessages, requestUserMessage];
+  }
+
+  const targetIndex = storedMessages.findIndex(
+    (message) => message.id === messageId,
+  );
+  const target = storedMessages[targetIndex];
+  const expectedRole = trigger === "regenerate-message" ? "assistant" : "user";
+  if (!target || target.role !== expectedRole) {
+    throw new ChatHistoryConflictError();
+  }
+
+  const prefix = storedMessages.slice(0, targetIndex);
+  if (trigger === "regenerate-message") {
+    if (prefix.at(-1)?.role !== "user") {
+      throw new ChatHistoryConflictError();
+    }
+    return prefix;
+  }
+
+  return [...prefix, requestUserMessage];
+}

--- a/apps/web/lib/db/chatTurns.test.ts
+++ b/apps/web/lib/db/chatTurns.test.ts
@@ -509,4 +509,33 @@ describe("transactional chat turns", () => {
       },
     ]);
   });
+
+  it("keyset-paginates messages from the newest page in transcript order", async () => {
+    seedChat();
+
+    const newest = await chatDb.getMessagesPage("chat", { limit: 2 });
+    expect(newest.messages.map(({ id }) => id)).toEqual([
+      "edit",
+      "assistant",
+    ]);
+    expect(newest.messages[1].parts).toEqual([
+      { type: "text", text: "Old answer" },
+    ]);
+    expect(newest.nextCursor).toMatch(/^\d+$/);
+
+    const oldest = await chatDb.getMessagesPage("chat", {
+      limit: 2,
+      cursor: newest.nextCursor!,
+    });
+    expect(oldest.messages.map(({ id }) => id)).toEqual(["before"]);
+    expect(oldest.nextCursor).toBeNull();
+  });
+
+  it("rejects malformed message cursors", async () => {
+    seedChat();
+
+    await expect(
+      chatDb.getMessagesPage("chat", { cursor: "not-a-rowid" }),
+    ).rejects.toThrow("Invalid message cursor");
+  });
 });

--- a/apps/web/lib/db/chats.ts
+++ b/apps/web/lib/db/chats.ts
@@ -3,8 +3,43 @@ import { and, desc, eq, sql } from "drizzle-orm";
 import type { UIMessage } from "ai";
 import { db } from "@/lib/db/client";
 import { chats, messages } from "@/lib/db/schema";
+import {
+  CHAT_MESSAGE_PAGE_SIZE,
+  type ChatMessagePage,
+} from "@/lib/chat/history";
 
 export type ChatRow = typeof chats.$inferSelect;
+
+type MessageRow = typeof messages.$inferSelect;
+type MessageUIRow = Pick<MessageRow, "id" | "role" | "parts" | "metadata">;
+type RawMessagePageRow = {
+  id: string;
+  role: MessageRow["role"];
+  parts: string | MessageRow["parts"];
+  metadata: string | MessageRow["metadata"];
+  rowId: number;
+};
+
+function toUIMessage(row: MessageUIRow): UIMessage {
+  return {
+    id: row.id,
+    role: row.role as UIMessage["role"],
+    parts: row.parts as UIMessage["parts"],
+    ...(row.metadata ? { metadata: row.metadata } : {}),
+  };
+}
+
+function parseJsonColumn<T>(value: string | T): T {
+  return typeof value === "string" ? (JSON.parse(value) as T) : value;
+}
+
+function decodeMessageCursor(cursor: string): number {
+  const rowId = Number(cursor);
+  if (!Number.isSafeInteger(rowId) || rowId <= 0) {
+    throw new Error("Invalid message cursor");
+  }
+  return rowId;
+}
 
 export async function getChat(
   id: string,
@@ -75,12 +110,56 @@ export async function getMessages(chatId: string): Promise<UIMessage[]> {
     .from(messages)
     .where(eq(messages.chatId, chatId))
     .orderBy(sql`${messages}.rowid`);
-  return rows.map((row) => ({
-    id: row.id,
-    role: row.role as UIMessage["role"],
-    parts: row.parts as UIMessage["parts"],
-    ...(row.metadata ? { metadata: row.metadata } : {}),
-  }));
+  return rows.map(toUIMessage);
+}
+
+/**
+ * Loads a newest-first keyset page and returns it in transcript order.
+ * SQLite rowids are the existing canonical ordering for messages, so the
+ * cursor preserves edit/regenerate and import ordering without a migration.
+ */
+export async function getMessagesPage(
+  chatId: string,
+  options: { cursor?: string; limit?: number } = {},
+): Promise<ChatMessagePage> {
+  const limit = Math.min(
+    100,
+    Math.max(1, Math.trunc(options.limit ?? CHAT_MESSAGE_PAGE_SIZE)),
+  );
+  const beforeRowId = options.cursor
+    ? decodeMessageCursor(options.cursor)
+    : Number.MAX_SAFE_INTEGER;
+  const rows = await db.all<RawMessagePageRow>(sql`
+    SELECT
+      ${messages.id} AS id,
+      ${messages.role} AS role,
+      ${messages.parts} AS parts,
+      ${messages.metadata} AS metadata,
+      ${messages}.rowid AS rowId
+    FROM ${messages}
+    WHERE ${messages.chatId} = ${chatId}
+      AND ${messages}.rowid < ${beforeRowId}
+    ORDER BY ${messages}.rowid DESC
+    LIMIT ${limit + 1}
+  `);
+  const hasMore = rows.length > limit;
+  const pageRows = rows.slice(0, limit);
+  const oldest = pageRows.at(-1);
+  return {
+    messages: pageRows.reverse().map((row) =>
+      toUIMessage({
+        ...row,
+        parts: parseJsonColumn<MessageRow["parts"]>(row.parts),
+        metadata:
+          row.metadata === null
+            ? null
+            : parseJsonColumn<NonNullable<MessageRow["metadata"]>>(
+                row.metadata,
+              ),
+      }),
+    ),
+    nextCursor: hasMore && oldest ? String(oldest.rowId) : null,
+  };
 }
 
 export async function setTitleIfNull(

--- a/apps/web/lib/queries/chats.ts
+++ b/apps/web/lib/queries/chats.ts
@@ -5,6 +5,8 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import type { UIMessage } from "ai";
+import { CHAT_MESSAGE_PAGE_SIZE } from "@/lib/chat/history";
 import { chatKeys } from "@/lib/queries/keys";
 import type { ChatUsageResponse, UsageTotals } from "@/lib/usage/types";
 
@@ -41,6 +43,26 @@ export function useChatUsage(id: string, enabled = true) {
       return body.usage;
     },
     enabled,
+  });
+}
+
+export function useLoadOlderChatMessages(id: string) {
+  return useMutation({
+    mutationFn: async (cursor: string) => {
+      const params = new URLSearchParams({
+        cursor,
+        limit: String(CHAT_MESSAGE_PAGE_SIZE),
+      });
+      const response = await fetch(
+        `/api/chat/${encodeURIComponent(id)}/messages?${params}`,
+      );
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return (await response.json()) as {
+        messages: UIMessage[];
+        nextCursor: string | null;
+        projectId: string | null;
+      };
+    },
   });
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "@streamdown/math": "^1.0.2",
     "@tanstack/react-query": "^5.100.10",
     "@tanstack/react-query-devtools": "^5.100.10",
+    "@tanstack/react-virtual": "^3.14.10",
     "@yoloyash/web-basics": "0.5.0",
     "ai": "^7.0.31",
     "better-auth": "1.6.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2346,6 +2346,7 @@
         "@streamdown/math": "^1.0.2",
         "@tanstack/react-query": "^5.100.10",
         "@tanstack/react-query-devtools": "^5.100.10",
+        "@tanstack/react-virtual": "^3.14.10",
         "@yoloyash/web-basics": "0.5.0",
         "ai": "^7.0.31",
         "better-auth": "1.6.23",
@@ -10421,6 +10422,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.100.13",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {


### PR DESCRIPTION
## Summary

Long chats previously loaded and rendered the entire transcript, reaching nearly 98,000 browser nodes and a 15.7-second load in the 600-message benchmark.

This PR:

- loads saved history in 32-message cursor pages
- permanently virtualizes variable-height message rows
- preserves scroll position when older pages are prepended
- reconstructs saved-chat model context from server-owned history, so the client sends only the current intent
- throttles streamed UI updates to 32 ms

Edit and regenerate still use the existing transactional truncation and stream-claim boundaries. Stale targets fail with 409 before mutation.

## Compatibility

- no database migration
- temporary chats still send their full in-memory history
- the existing unpaginated endpoint remains available for current mobile clients
- coding-agent paths are unchanged

## Validation

- 643 tests, typecheck, and lint pass
- production standalone build passes
- a 320-message Playwright regression loads multiple history pages while keeping fewer than 24 transcript items mounted
