### PR TITLE
fix(web): restore chat scroll following

### DIFF
--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -57,6 +57,7 @@ export function MessageList({
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const initialScrollCompleteRef = useRef(false);
+  const latestMessageIdRef = useRef(messages.at(-1)?.id);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [isAtTop, setIsAtTop] = useState(false);
   const errorOffset = messages.length;
@@ -119,6 +120,27 @@ export function MessageList({
     // followOnAppend and dynamic measurement anchoring.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const latestMessage = messages.at(-1);
+  const latestMessageId = latestMessage?.id;
+  const latestMessageRole = latestMessage?.role;
+  useLayoutEffect(() => {
+    const previousLatestMessageId = latestMessageIdRef.current;
+    latestMessageIdRef.current = latestMessageId;
+    if (
+      !initialScrollCompleteRef.current ||
+      !latestMessageId ||
+      latestMessageRole !== "user" ||
+      latestMessageId === previousLatestMessageId
+    ) {
+      return;
+    }
+
+    // A send is an explicit request to return to the active turn, even if the
+    // reader had scrolled up. Assistant appends and streaming growth still use
+    // followOnAppend, which only follows while the reader remains at the end.
+    virtualizer.scrollToEnd();
+  }, [latestMessageId, latestMessageRole, virtualizer]);
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">

--- a/apps/web/e2e/long-chat.spec.ts
+++ b/apps/web/e2e/long-chat.spec.ts
@@ -1,7 +1,69 @@
 import { expect, test } from "@playwright/test";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { openE2eDatabase, resetE2eDatabase } from "./helpers/database";
 
 test.beforeEach(resetE2eDatabase);
+
+let modelServer: Server;
+let modelBaseUrl: string;
+
+test.beforeAll(async () => {
+  modelServer = createServer(async (req, res) => {
+    for await (const chunk of req) {
+      // Consume the request before responding.
+      void chunk;
+    }
+    const created = Math.floor(Date.now() / 1_000);
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    for (let index = 0; index < 24; index += 1) {
+      res.write(
+        `data: ${JSON.stringify({
+          id: "long-chat-response",
+          object: "chat.completion.chunk",
+          created,
+          model: "long-chat-test-model",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: index === 0 ? "assistant" : undefined,
+                content: `Streaming response ${index}. `,
+              },
+              finish_reason: null,
+            },
+          ],
+        })}\n\n`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 40));
+    }
+    res.write(
+      `data: ${JSON.stringify({
+        id: "long-chat-response",
+        object: "chat.completion.chunk",
+        created,
+        model: "long-chat-test-model",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    );
+    res.end("data: [DONE]\n\n");
+  });
+  await new Promise<void>((resolve) => {
+    modelServer.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = modelServer.address() as AddressInfo;
+  modelBaseUrl = `http://127.0.0.1:${port}/v1`;
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    modelServer.close((error) => (error ? reject(error) : resolve()));
+  });
+});
 
 function seedLongChat(messageCount: number) {
   const db = openE2eDatabase();
@@ -48,6 +110,24 @@ function seedLongChat(messageCount: number) {
   }
 }
 
+function seedModel() {
+  const db = openE2eDatabase();
+  const now = Date.now();
+  try {
+    db.prepare(
+      `INSERT INTO model_configs (
+        id, label, provider_id, api_format, base_url, api_key, model,
+        tool_calling_enabled, enabled, sort_order, created_at, updated_at
+      ) VALUES (
+        'long-chat-model', 'Long Chat Model', 'custom', 'openai-chat',
+        ?, 'test-key', 'long-chat-test-model', 1, 1, 0, ?, ?
+      )`,
+    ).run(modelBaseUrl, now, now);
+  } finally {
+    db.close();
+  }
+}
+
 test("long chats page history while keeping the mounted DOM bounded", async ({
   page,
 }) => {
@@ -89,4 +169,74 @@ test("long chats page history while keeping the mounted DOM bounded", async ({
   expect(
     await transcript.evaluate((element) => element.scrollTop),
   ).toBeGreaterThan(0);
+});
+
+test("sending returns to latest while manual scrolling stops stream following", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+  await page.goto("/signup");
+  await page.locator("#name").fill("Long Chat Admin");
+  await page
+    .locator("#email")
+    .fill("long-chat-admin@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+  seedLongChat(320);
+  seedModel();
+
+  await page.goto("/chat/long-chat");
+  const transcript = page.locator("[data-chat-transcript-scroll]");
+  await expect(page.getByText("Answer 319", { exact: true })).toBeVisible();
+  await transcript.evaluate((element) => {
+    element.scrollTop -= 600;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect(
+    page.getByRole("button", { name: "Scroll to bottom" }),
+  ).toBeVisible();
+
+  const composer = page.getByPlaceholder("Message…");
+  await composer.fill("Take me back to the latest turn.");
+  await page.getByLabel("Send message").click();
+  await expect
+    .poll(() =>
+      transcript.evaluate(
+        (element) =>
+          element.scrollHeight - element.clientHeight - element.scrollTop,
+      ),
+    )
+    .toBeLessThanOrEqual(80);
+
+  await expect(page.getByText("Streaming response 0.")).toBeVisible();
+  await transcript.evaluate((element) => {
+    element.scrollTop -= 500;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect(
+    page.getByRole("button", { name: "Scroll to bottom" }),
+  ).toBeVisible();
+  await expect(page.getByLabel("Send message")).toBeVisible();
+  await expect
+    .poll(() =>
+      transcript.evaluate(
+        (element) =>
+          element.scrollHeight - element.clientHeight - element.scrollTop,
+      ),
+    )
+    .toBeGreaterThan(200);
+
+  await page.getByRole("button", { name: "Scroll to bottom" }).click();
+  await expect
+    .poll(() =>
+      transcript.evaluate(
+        (element) =>
+          element.scrollHeight - element.clientHeight - element.scrollTop,
+      ),
+    )
+    .toBeLessThanOrEqual(80);
+  await expect(
+    page.getByRole("button", { name: "Scroll to bottom" }),
+  ).toHaveCount(0);
 });


### PR DESCRIPTION
## What changed

- return to the latest turn when the user sends a message
- keep streaming pinned only while the reader remains at the bottom
- preserve manual scroll position and jump-to-latest behavior
- cover the scrolling contract in the long-chat browser test

## Validation

- `npm run typecheck -w @overtchat/web --`
- `npm run lint -w @overtchat/web -- components/chat/MessageList.tsx e2e/long-chat.spec.ts`
- `npm run test -w @overtchat/web`
- long-chat Playwright tests (2 passed)