### PR TITLE
feat(web): autosave chat composer drafts

### DIFF
--- a/apps/web/components/AccountMenu.tsx
+++ b/apps/web/components/AccountMenu.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils";
 import { APP_VERSION } from "@/lib/version";
 import { useAppUpdate } from "@/lib/queries/appUpdate";
 import { useSidebar } from "@/components/sidebar-context";
+import { clearComposerDraftsForUser } from "@/lib/chat/composer-drafts";
 
 const UPDATE_COMMAND = "overtchat update";
 
@@ -62,6 +63,7 @@ export function AccountMenu() {
         });
         return;
       }
+      if (session?.user.id) clearComposerDraftsForUser(session.user.id);
       router.replace("/login");
       router.refresh();
     } catch (err) {

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -56,6 +56,10 @@ import {
   type InferenceActivity,
 } from "@/lib/chat/inference-activity";
 import { hasSuccessfulMemoryMutation } from "@/lib/personalization/tool-parts";
+import {
+  chatComposerDraftScope,
+  newChatComposerDraftScope,
+} from "@/lib/chat/composer-drafts";
 import { AdminOnboardingCard } from "@/components/AdminOnboardingCard";
 import { useSidebar } from "@/components/sidebar-context";
 import { toast } from "@/components/ui/toast";
@@ -138,6 +142,14 @@ export function ChatArea({
   );
 
   const [temporary, setTemporary] = useState(false);
+  const [composerDraftScope, setComposerDraftScope] = useState<string | null>(
+    () =>
+      initialQuery?.trim()
+        ? null
+        : isNew
+          ? newChatComposerDraftScope(projectId)
+          : chatComposerDraftScope(chatId),
+  );
   const [chatPersisted, setChatPersisted] = useState(!isNew);
   const { data: sessionUsage } = useChatUsage(
     chatId,
@@ -349,6 +361,7 @@ export function ChatArea({
     const wasNew = isNewRef.current && !temporary;
     if (wasNew) {
       isNewRef.current = false;
+      setComposerDraftScope(chatComposerDraftScope(chatId));
       window.history.replaceState(null, "", `/chat/${chatId}`);
       qc.setQueryData<ChatListItem[]>(chatKeys.list(), (prev) => {
         const next: ChatListItem = {
@@ -474,6 +487,9 @@ export function ChatArea({
       onSubmit={handleSubmit}
       onStop={handleStop}
       isAdmin={isAdmin}
+      draftUserId={session?.user.id}
+      draftScope={composerDraftScope}
+      draftEnabled={!temporary}
     />
   );
 

--- a/apps/web/components/chat/Composer.tsx
+++ b/apps/web/components/chat/Composer.tsx
@@ -2,6 +2,7 @@
 
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useId,
   useImperativeHandle,
@@ -37,6 +38,7 @@ import {
   getDataTransferFiles,
 } from "@/lib/chat/attachments";
 import { dictationErrorMessage } from "@/lib/chat/message";
+import { useComposerDraft } from "@/lib/chat/use-composer-draft";
 import { motionClasses } from "@/lib/motion";
 import { useDictation } from "@/lib/useDictation";
 import {
@@ -92,6 +94,9 @@ interface ComposerProps {
   onSubmit: (input: string, attachments: FileUIPart[]) => void;
   onStop: () => void;
   isAdmin: boolean;
+  draftUserId?: string;
+  draftScope: string | null;
+  draftEnabled: boolean;
 }
 
 export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer({
@@ -108,8 +113,28 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   onSubmit,
   onStop,
   isAdmin,
+  draftUserId,
+  draftScope,
+  draftEnabled,
 }, ref) {
-  const [input, setInput] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const handleDraftRestore = useCallback(() => {
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (el) el.setSelectionRange(el.value.length, el.value.length);
+    });
+  }, []);
+  const {
+    value: input,
+    setValue: setInput,
+    clear: clearDraft,
+  } = useComposerDraft({
+    userId: draftUserId,
+    scope: draftScope,
+    enabled: draftEnabled,
+    onRestore: handleDraftRestore,
+  });
   const {
     attachments,
     uploading,
@@ -118,9 +143,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     removeAttachment,
     clearAttachments,
   } = useChatAttachments();
-
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useImperativeHandle(
     ref,
@@ -389,7 +411,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     if (!text && readyParts.length === 0) return;
     if (!configured) return;
     onSubmit(text, readyParts);
-    setInput("");
+    clearDraft();
     setDismissedQuery(null);
     setActiveIndex(0);
     clearAttachments();

--- a/apps/web/e2e/composer-drafts.spec.ts
+++ b/apps/web/e2e/composer-drafts.spec.ts
@@ -135,26 +135,3 @@ test("moves the composer to the saved-chat scope after the first send", async ({
   await page.goto("/");
   await expect(composer(page)).toHaveValue("");
 });
-
-test("uses last-write-wins storage without replacing another tab's live input", async ({
-  page,
-  context,
-}) => {
-  await createAccountAndFixtures(page);
-  await page.goto("/chat/draft-chat-a");
-  await composer(page).fill("Draft from the first tab");
-  await page.waitForTimeout(500);
-
-  const secondPage = await context.newPage();
-  await secondPage.goto("/chat/draft-chat-a");
-  await expect(composer(secondPage)).toHaveValue("Draft from the first tab");
-  await composer(secondPage).fill("Newer draft from the second tab");
-  await secondPage.waitForTimeout(500);
-
-  await expect(composer(page)).toHaveValue("Draft from the first tab");
-  await page.close();
-  await secondPage.reload();
-  await expect(composer(secondPage)).toHaveValue(
-    "Newer draft from the second tab",
-  );
-});

--- a/apps/web/e2e/composer-drafts.spec.ts
+++ b/apps/web/e2e/composer-drafts.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type Page } from "@playwright/test";
+import { openE2eDatabase, resetE2eDatabase } from "./helpers/database";
+
+test.beforeEach(resetE2eDatabase);
+
+async function createAccountAndFixtures(page: Page) {
+  await page.goto("/signup");
+  await page.locator("#name").fill("Draft Test Admin");
+  await page.locator("#email").fill("draft-admin@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+
+  const db = openE2eDatabase();
+  const now = Date.now();
+  try {
+    const user = db.prepare("SELECT id FROM user LIMIT 1").get() as
+      { id: string } | undefined;
+    if (!user) throw new Error("Signup user was not created");
+
+    db.prepare(
+      `INSERT INTO projects (id, user_id, name, created_at, updated_at)
+       VALUES ('draft-project', ?, 'Draft project', ?, ?)`,
+    ).run(user.id, now, now);
+    const insertChat = db.prepare(
+      `INSERT INTO chats (id, user_id, title, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    insertChat.run("draft-chat-a", user.id, "Draft chat A", now, now);
+    insertChat.run("draft-chat-b", user.id, "Draft chat B", now, now - 1);
+    db.prepare(
+      `INSERT INTO model_configs (
+        id, label, provider_id, api_format, base_url, api_key, model,
+        tool_calling_enabled, enabled, sort_order, created_at, updated_at
+      ) VALUES (
+        'draft-model', 'Draft Model', 'custom', 'openai-chat',
+        'http://127.0.0.1:1/v1', 'test-key', 'draft-test-model',
+        0, 1, 0, ?, ?
+      )`,
+    ).run(now, now);
+    return user.id;
+  } finally {
+    db.close();
+  }
+}
+
+function composer(page: Page) {
+  return page.getByPlaceholder("Message…");
+}
+
+test("restores independent saved, root, and project drafts", async ({
+  page,
+}) => {
+  await createAccountAndFixtures(page);
+
+  await page.goto("/chat/draft-chat-a");
+  await composer(page).fill("  Draft A 🌲\n\n  with indentation  ");
+
+  await page.goto("/chat/draft-chat-b");
+  await composer(page).fill("Draft B");
+  await page.reload();
+  await expect(composer(page)).toHaveValue("Draft B");
+
+  await page.goto("/chat/draft-chat-a");
+  await expect(composer(page)).toHaveValue(
+    "  Draft A 🌲\n\n  with indentation  ",
+  );
+
+  await page.goto("/");
+  await composer(page).fill("Root new-chat draft");
+  await page.goto("/chat/draft-chat-a");
+  await page.goto("/");
+  await expect(composer(page)).toHaveValue("Root new-chat draft");
+
+  await page.goto("/?projectId=draft-project");
+  await expect(composer(page)).toHaveValue("");
+  await composer(page).fill("Project new-chat draft");
+  await page.goto("/");
+  await expect(composer(page)).toHaveValue("Root new-chat draft");
+  await page.goto("/?projectId=draft-project");
+  await expect(composer(page)).toHaveValue("Project new-chat draft");
+});
+
+test("clears sent and temporary drafts without a delayed write restoring them", async ({
+  page,
+}) => {
+  await createAccountAndFixtures(page);
+  await page.route("**/api/chat", (route) => route.abort());
+
+  await page.goto("/chat/draft-chat-a");
+  await composer(page).fill("Send this only once");
+  await page.getByLabel("Send message").click();
+  await expect(composer(page)).toHaveValue("");
+  await page.waitForTimeout(500);
+  await page.reload();
+  await expect(composer(page)).toHaveValue("");
+
+  await page.goto("/");
+  await composer(page).fill("Temporary secret");
+  await page.getByLabel("Enable temporary chat").click();
+  await page.reload();
+  await expect(composer(page)).toHaveValue("");
+});
+
+test("moves the composer to the saved-chat scope after the first send", async ({
+  page,
+}) => {
+  const userId = await createAccountAndFixtures(page);
+  await page.route("**/api/chat", (route) => route.abort());
+
+  await page.goto("/");
+  await composer(page).fill("Create this chat");
+  await page.getByLabel("Send message").click();
+  await expect(page).toHaveURL(/\/chat\/[^/]+$/);
+  await expect(composer(page)).toHaveValue("");
+
+  const chatId = new URL(page.url()).pathname.split("/").at(-1);
+  if (!chatId) throw new Error("New chat URL did not contain an id");
+  const db = openE2eDatabase();
+  try {
+    db.prepare(
+      `INSERT INTO chats (id, user_id, title, created_at, updated_at)
+       VALUES (?, ?, 'New draft chat', ?, ?)`,
+    ).run(chatId, userId, Date.now(), Date.now());
+  } finally {
+    db.close();
+  }
+
+  await composer(page).fill("Follow-up prepared after the first send");
+  await page.waitForTimeout(500);
+  await page.reload();
+  await expect(composer(page)).toHaveValue(
+    "Follow-up prepared after the first send",
+  );
+  await page.goto("/");
+  await expect(composer(page)).toHaveValue("");
+});
+
+test("uses last-write-wins storage without replacing another tab's live input", async ({
+  page,
+  context,
+}) => {
+  await createAccountAndFixtures(page);
+  await page.goto("/chat/draft-chat-a");
+  await composer(page).fill("Draft from the first tab");
+  await page.waitForTimeout(500);
+
+  const secondPage = await context.newPage();
+  await secondPage.goto("/chat/draft-chat-a");
+  await expect(composer(secondPage)).toHaveValue("Draft from the first tab");
+  await composer(secondPage).fill("Newer draft from the second tab");
+  await secondPage.waitForTimeout(500);
+
+  await expect(composer(page)).toHaveValue("Draft from the first tab");
+  await page.close();
+  await secondPage.reload();
+  await expect(composer(secondPage)).toHaveValue(
+    "Newer draft from the second tab",
+  );
+});

--- a/apps/web/lib/chat/composer-drafts.test.ts
+++ b/apps/web/lib/chat/composer-drafts.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
-  MAX_COMPOSER_DRAFTS_PER_USER,
   chatComposerDraftScope,
   clearComposerDraft,
-  clearComposerDraftScope,
   clearComposerDraftsForUser,
   newChatComposerDraftScope,
   readComposerDraft,
@@ -12,7 +10,7 @@ import {
 } from "./composer-drafts";
 
 class MemoryStorage implements ComposerDraftStorage {
-  protected readonly values = new Map<string, string>();
+  private readonly values = new Map<string, string>();
 
   get length() {
     return this.values.size;
@@ -35,19 +33,6 @@ class MemoryStorage implements ComposerDraftStorage {
   }
 }
 
-class QuotaStorage extends MemoryStorage {
-  constructor(private readonly maximumEntries: number) {
-    super();
-  }
-
-  override setItem(key: string, value: string) {
-    if (!this.values.has(key) && this.values.size >= this.maximumEntries) {
-      throw new DOMException("Storage quota exceeded", "QuotaExceededError");
-    }
-    super.setItem(key, value);
-  }
-}
-
 describe("composer drafts", () => {
   it("builds stable scopes for saved, root, and project chats", () => {
     expect(chatComposerDraftScope("chat-1")).toBe("chat:chat-1");
@@ -60,103 +45,38 @@ describe("composer drafts", () => {
   it("round-trips exact text while isolating users and conversations", () => {
     const storage = new MemoryStorage();
     const text = "  hello 🌲\n\n  indented  ";
-    writeComposerDraft("user-a", "chat:a", text, { storage, now: 1 });
+    writeComposerDraft("user-a", "chat:a", text, storage);
 
     expect(readComposerDraft("user-a", "chat:a", storage)).toBe(text);
     expect(readComposerDraft("user-a", "chat:b", storage)).toBe("");
     expect(readComposerDraft("user-b", "chat:a", storage)).toBe("");
   });
 
-  it("clears only the requested draft when the input becomes empty", () => {
+  it("clears one draft or all drafts for a user", () => {
     const storage = new MemoryStorage();
-    writeComposerDraft("user", "chat:a", "draft a", { storage, now: 1 });
-    writeComposerDraft("user", "chat:b", "draft b", { storage, now: 2 });
+    writeComposerDraft("user-a", "chat:a", "draft a", storage);
+    writeComposerDraft("user-a", "chat:b", "draft b", storage);
+    writeComposerDraft("user-b", "chat:a", "kept", storage);
 
-    expect(writeComposerDraft("user", "chat:a", "", { storage })).toBe(true);
-    expect(readComposerDraft("user", "chat:a", storage)).toBe("");
-    expect(readComposerDraft("user", "chat:b", storage)).toBe("draft b");
+    clearComposerDraft("user-a", "chat:a", storage);
+    expect(readComposerDraft("user-a", "chat:a", storage)).toBe("");
+    expect(readComposerDraft("user-a", "chat:b", storage)).toBe("draft b");
 
-    clearComposerDraft("user", "chat:b", storage);
-    expect(readComposerDraft("user", "chat:b", storage)).toBe("");
+    clearComposerDraftsForUser("user-a", storage);
+    expect(readComposerDraft("user-a", "chat:b", storage)).toBe("");
+    expect(readComposerDraft("user-b", "chat:a", storage)).toBe("kept");
   });
 
-  it("drops malformed records without affecting valid drafts", () => {
+  it("treats unavailable storage as a best-effort failure", () => {
     const storage = new MemoryStorage();
-    storage.setItem("overtchat_composer_draft:v1:user:chat%3Abad", "not json");
-    writeComposerDraft("user", "chat:good", "kept", { storage, now: 1 });
-
-    expect(readComposerDraft("user", "chat:bad", storage)).toBe("");
-    expect(readComposerDraft("user", "chat:good", storage)).toBe("kept");
-    expect(storage.length).toBe(1);
-  });
-
-  it("keeps only the most recently updated bounded set", () => {
-    const storage = new MemoryStorage();
-    for (let index = 0; index <= MAX_COMPOSER_DRAFTS_PER_USER; index += 1) {
-      writeComposerDraft("user", `chat:${index}`, `draft ${index}`, {
-        storage,
-        now: index,
-      });
-    }
-
-    expect(storage.length).toBe(MAX_COMPOSER_DRAFTS_PER_USER);
-    expect(readComposerDraft("user", "chat:0", storage)).toBe("");
-    expect(
-      readComposerDraft(
-        "user",
-        `chat:${MAX_COMPOSER_DRAFTS_PER_USER}`,
-        storage,
-      ),
-    ).toBe(`draft ${MAX_COMPOSER_DRAFTS_PER_USER}`);
-  });
-
-  it("evicts the oldest user draft and retries a quota-limited write", () => {
-    const storage = new QuotaStorage(2);
-    writeComposerDraft("user", "chat:old", "old", { storage, now: 1 });
-    writeComposerDraft("other", "chat:other", "other", { storage, now: 1 });
-
-    expect(
-      writeComposerDraft("user", "chat:new", "new", { storage, now: 2 }),
-    ).toBe(true);
-    expect(readComposerDraft("user", "chat:old", storage)).toBe("");
-    expect(readComposerDraft("user", "chat:new", storage)).toBe("new");
-    expect(readComposerDraft("other", "chat:other", storage)).toBe("other");
-  });
-
-  it("can clear a chat across users and all drafts for one user", () => {
-    const storage = new MemoryStorage();
-    writeComposerDraft("user-a", "chat:shared", "a", { storage, now: 1 });
-    writeComposerDraft("user-b", "chat:shared", "b", { storage, now: 2 });
-    writeComposerDraft("user-b", "chat:kept", "kept", { storage, now: 3 });
-
-    clearComposerDraftScope("chat:shared", storage);
-    expect(readComposerDraft("user-a", "chat:shared", storage)).toBe("");
-    expect(readComposerDraft("user-b", "chat:shared", storage)).toBe("");
-    expect(readComposerDraft("user-b", "chat:kept", storage)).toBe("kept");
-
-    clearComposerDraftsForUser("user-b", storage);
-    expect(readComposerDraft("user-b", "chat:kept", storage)).toBe("");
-  });
-
-  it("treats unavailable storage as a non-fatal best-effort failure", () => {
-    const storage: ComposerDraftStorage = {
-      get length(): number {
-        throw new DOMException("Denied", "SecurityError");
-      },
-      key: () => null,
-      getItem: () => {
-        throw new DOMException("Denied", "SecurityError");
-      },
-      setItem: () => {
-        throw new DOMException("Denied", "SecurityError");
-      },
-      removeItem: () => {
-        throw new DOMException("Denied", "SecurityError");
-      },
+    storage.getItem = () => {
+      throw new DOMException("Denied", "SecurityError");
+    };
+    storage.setItem = () => {
+      throw new DOMException("Full", "QuotaExceededError");
     };
 
     expect(readComposerDraft("user", "chat", storage)).toBe("");
-    expect(writeComposerDraft("user", "chat", "text", { storage })).toBe(false);
-    expect(() => clearComposerDraft("user", "chat", storage)).not.toThrow();
+    expect(writeComposerDraft("user", "chat", "text", storage)).toBe(false);
   });
 });

--- a/apps/web/lib/chat/composer-drafts.test.ts
+++ b/apps/web/lib/chat/composer-drafts.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_COMPOSER_DRAFTS_PER_USER,
+  chatComposerDraftScope,
+  clearComposerDraft,
+  clearComposerDraftScope,
+  clearComposerDraftsForUser,
+  newChatComposerDraftScope,
+  readComposerDraft,
+  writeComposerDraft,
+  type ComposerDraftStorage,
+} from "./composer-drafts";
+
+class MemoryStorage implements ComposerDraftStorage {
+  protected readonly values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+}
+
+class QuotaStorage extends MemoryStorage {
+  constructor(private readonly maximumEntries: number) {
+    super();
+  }
+
+  override setItem(key: string, value: string) {
+    if (!this.values.has(key) && this.values.size >= this.maximumEntries) {
+      throw new DOMException("Storage quota exceeded", "QuotaExceededError");
+    }
+    super.setItem(key, value);
+  }
+}
+
+describe("composer drafts", () => {
+  it("builds stable scopes for saved, root, and project chats", () => {
+    expect(chatComposerDraftScope("chat-1")).toBe("chat:chat-1");
+    expect(newChatComposerDraftScope()).toBe("new:root");
+    expect(newChatComposerDraftScope("project-1")).toBe(
+      "new:project:project-1",
+    );
+  });
+
+  it("round-trips exact text while isolating users and conversations", () => {
+    const storage = new MemoryStorage();
+    const text = "  hello 🌲\n\n  indented  ";
+    writeComposerDraft("user-a", "chat:a", text, { storage, now: 1 });
+
+    expect(readComposerDraft("user-a", "chat:a", storage)).toBe(text);
+    expect(readComposerDraft("user-a", "chat:b", storage)).toBe("");
+    expect(readComposerDraft("user-b", "chat:a", storage)).toBe("");
+  });
+
+  it("clears only the requested draft when the input becomes empty", () => {
+    const storage = new MemoryStorage();
+    writeComposerDraft("user", "chat:a", "draft a", { storage, now: 1 });
+    writeComposerDraft("user", "chat:b", "draft b", { storage, now: 2 });
+
+    expect(writeComposerDraft("user", "chat:a", "", { storage })).toBe(true);
+    expect(readComposerDraft("user", "chat:a", storage)).toBe("");
+    expect(readComposerDraft("user", "chat:b", storage)).toBe("draft b");
+
+    clearComposerDraft("user", "chat:b", storage);
+    expect(readComposerDraft("user", "chat:b", storage)).toBe("");
+  });
+
+  it("drops malformed records without affecting valid drafts", () => {
+    const storage = new MemoryStorage();
+    storage.setItem("overtchat_composer_draft:v1:user:chat%3Abad", "not json");
+    writeComposerDraft("user", "chat:good", "kept", { storage, now: 1 });
+
+    expect(readComposerDraft("user", "chat:bad", storage)).toBe("");
+    expect(readComposerDraft("user", "chat:good", storage)).toBe("kept");
+    expect(storage.length).toBe(1);
+  });
+
+  it("keeps only the most recently updated bounded set", () => {
+    const storage = new MemoryStorage();
+    for (let index = 0; index <= MAX_COMPOSER_DRAFTS_PER_USER; index += 1) {
+      writeComposerDraft("user", `chat:${index}`, `draft ${index}`, {
+        storage,
+        now: index,
+      });
+    }
+
+    expect(storage.length).toBe(MAX_COMPOSER_DRAFTS_PER_USER);
+    expect(readComposerDraft("user", "chat:0", storage)).toBe("");
+    expect(
+      readComposerDraft(
+        "user",
+        `chat:${MAX_COMPOSER_DRAFTS_PER_USER}`,
+        storage,
+      ),
+    ).toBe(`draft ${MAX_COMPOSER_DRAFTS_PER_USER}`);
+  });
+
+  it("evicts the oldest user draft and retries a quota-limited write", () => {
+    const storage = new QuotaStorage(2);
+    writeComposerDraft("user", "chat:old", "old", { storage, now: 1 });
+    writeComposerDraft("other", "chat:other", "other", { storage, now: 1 });
+
+    expect(
+      writeComposerDraft("user", "chat:new", "new", { storage, now: 2 }),
+    ).toBe(true);
+    expect(readComposerDraft("user", "chat:old", storage)).toBe("");
+    expect(readComposerDraft("user", "chat:new", storage)).toBe("new");
+    expect(readComposerDraft("other", "chat:other", storage)).toBe("other");
+  });
+
+  it("can clear a chat across users and all drafts for one user", () => {
+    const storage = new MemoryStorage();
+    writeComposerDraft("user-a", "chat:shared", "a", { storage, now: 1 });
+    writeComposerDraft("user-b", "chat:shared", "b", { storage, now: 2 });
+    writeComposerDraft("user-b", "chat:kept", "kept", { storage, now: 3 });
+
+    clearComposerDraftScope("chat:shared", storage);
+    expect(readComposerDraft("user-a", "chat:shared", storage)).toBe("");
+    expect(readComposerDraft("user-b", "chat:shared", storage)).toBe("");
+    expect(readComposerDraft("user-b", "chat:kept", storage)).toBe("kept");
+
+    clearComposerDraftsForUser("user-b", storage);
+    expect(readComposerDraft("user-b", "chat:kept", storage)).toBe("");
+  });
+
+  it("treats unavailable storage as a non-fatal best-effort failure", () => {
+    const storage: ComposerDraftStorage = {
+      get length(): number {
+        throw new DOMException("Denied", "SecurityError");
+      },
+      key: () => null,
+      getItem: () => {
+        throw new DOMException("Denied", "SecurityError");
+      },
+      setItem: () => {
+        throw new DOMException("Denied", "SecurityError");
+      },
+      removeItem: () => {
+        throw new DOMException("Denied", "SecurityError");
+      },
+    };
+
+    expect(readComposerDraft("user", "chat", storage)).toBe("");
+    expect(writeComposerDraft("user", "chat", "text", { storage })).toBe(false);
+    expect(() => clearComposerDraft("user", "chat", storage)).not.toThrow();
+  });
+});

--- a/apps/web/lib/chat/composer-drafts.ts
+++ b/apps/web/lib/chat/composer-drafts.ts
@@ -1,0 +1,244 @@
+const STORAGE_PREFIX = "overtchat_composer_draft:v1:";
+
+export const MAX_COMPOSER_DRAFTS_PER_USER = 100;
+
+export interface ComposerDraftStorage {
+  readonly length: number;
+  key(index: number): string | null;
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+interface StoredComposerDraft {
+  version: 1;
+  text: string;
+  updatedAt: number;
+}
+
+interface DraftEntry {
+  key: string;
+  updatedAt: number;
+}
+
+export function chatComposerDraftScope(chatId: string): string {
+  return `chat:${chatId}`;
+}
+
+export function newChatComposerDraftScope(projectId?: string | null): string {
+  return projectId ? `new:project:${projectId}` : "new:root";
+}
+
+export function readComposerDraft(
+  userId: string,
+  scope: string,
+  storage: ComposerDraftStorage | null = browserStorage(),
+): string {
+  if (!storage) return "";
+  const key = draftKey(userId, scope);
+  try {
+    const raw = storage.getItem(key);
+    if (raw === null) return "";
+    const parsed = parseDraft(raw);
+    if (!parsed) {
+      storage.removeItem(key);
+      return "";
+    }
+    return parsed.text;
+  } catch {
+    return "";
+  }
+}
+
+export function writeComposerDraft(
+  userId: string,
+  scope: string,
+  text: string,
+  options: {
+    storage?: ComposerDraftStorage | null;
+    now?: number;
+  } = {},
+): boolean {
+  const storage =
+    options.storage === undefined ? browserStorage() : options.storage;
+  if (!storage) return false;
+  if (text === "") {
+    clearComposerDraft(userId, scope, storage);
+    return true;
+  }
+
+  const key = draftKey(userId, scope);
+  const value = JSON.stringify({
+    version: 1,
+    text,
+    updatedAt: options.now ?? Date.now(),
+  } satisfies StoredComposerDraft);
+
+  try {
+    storage.setItem(key, value);
+  } catch (error) {
+    if (!isQuotaExceeded(error)) return false;
+    if (!makeRoomForDraft(storage, userId, key, value)) return false;
+  }
+
+  pruneUserDrafts(storage, userId, MAX_COMPOSER_DRAFTS_PER_USER);
+  return true;
+}
+
+export function clearComposerDraft(
+  userId: string,
+  scope: string,
+  storage: ComposerDraftStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(draftKey(userId, scope));
+  } catch {
+    // Browser privacy settings can make storage unavailable. Draft cleanup
+    // must never interfere with sending a message.
+  }
+}
+
+export function clearComposerDraftScope(
+  scope: string,
+  storage: ComposerDraftStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  const suffix = `:${encodeURIComponent(scope)}`;
+  for (const key of storageKeys(storage)) {
+    if (!key.startsWith(STORAGE_PREFIX) || !key.endsWith(suffix)) continue;
+    try {
+      storage.removeItem(key);
+    } catch {
+      return;
+    }
+  }
+}
+
+export function clearComposerDraftsForUser(
+  userId: string,
+  storage: ComposerDraftStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  const prefix = userPrefix(userId);
+  for (const key of storageKeys(storage)) {
+    if (!key.startsWith(prefix)) continue;
+    try {
+      storage.removeItem(key);
+    } catch {
+      return;
+    }
+  }
+}
+
+function browserStorage(): ComposerDraftStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function draftKey(userId: string, scope: string): string {
+  return `${userPrefix(userId)}${encodeURIComponent(scope)}`;
+}
+
+function userPrefix(userId: string): string {
+  return `${STORAGE_PREFIX}${encodeURIComponent(userId)}:`;
+}
+
+function parseDraft(raw: string): StoredComposerDraft | null {
+  try {
+    const value = JSON.parse(raw) as Partial<StoredComposerDraft> | null;
+    if (
+      value?.version !== 1 ||
+      typeof value.text !== "string" ||
+      typeof value.updatedAt !== "number" ||
+      !Number.isFinite(value.updatedAt)
+    ) {
+      return null;
+    }
+    return value as StoredComposerDraft;
+  } catch {
+    return null;
+  }
+}
+
+function storageKeys(storage: ComposerDraftStorage): string[] {
+  try {
+    return Array.from({ length: storage.length }, (_, index) =>
+      storage.key(index),
+    ).filter((key): key is string => key !== null);
+  } catch {
+    return [];
+  }
+}
+
+function userDraftEntries(
+  storage: ComposerDraftStorage,
+  userId: string,
+): DraftEntry[] {
+  const prefix = userPrefix(userId);
+  const entries: DraftEntry[] = [];
+  for (const key of storageKeys(storage)) {
+    if (!key.startsWith(prefix)) continue;
+    try {
+      const raw = storage.getItem(key);
+      const draft = raw === null ? null : parseDraft(raw);
+      if (!draft) {
+        storage.removeItem(key);
+        continue;
+      }
+      entries.push({ key, updatedAt: draft.updatedAt });
+    } catch {
+      // A single unreadable entry should not prevent other drafts from saving.
+    }
+  }
+  return entries.sort((left, right) => left.updatedAt - right.updatedAt);
+}
+
+function pruneUserDrafts(
+  storage: ComposerDraftStorage,
+  userId: string,
+  limit: number,
+): void {
+  const prefix = userPrefix(userId);
+  const keys = storageKeys(storage).filter((key) => key.startsWith(prefix));
+  if (keys.length <= limit) return;
+  const entries = userDraftEntries(storage, userId);
+  for (const { key } of entries.slice(0, Math.max(0, entries.length - limit))) {
+    try {
+      storage.removeItem(key);
+    } catch {
+      return;
+    }
+  }
+}
+
+function makeRoomForDraft(
+  storage: ComposerDraftStorage,
+  userId: string,
+  targetKey: string,
+  value: string,
+): boolean {
+  const candidates = userDraftEntries(storage, userId).filter(
+    ({ key }) => key !== targetKey,
+  );
+  for (const { key } of candidates) {
+    try {
+      storage.removeItem(key);
+      storage.setItem(targetKey, value);
+      return true;
+    } catch (error) {
+      if (!isQuotaExceeded(error)) return false;
+    }
+  }
+  return false;
+}
+
+function isQuotaExceeded(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  return candidate.name === "QuotaExceededError" || candidate.code === 22;
+}

--- a/apps/web/lib/chat/composer-drafts.ts
+++ b/apps/web/lib/chat/composer-drafts.ts
@@ -1,25 +1,9 @@
 const STORAGE_PREFIX = "overtchat_composer_draft:v1:";
 
-export const MAX_COMPOSER_DRAFTS_PER_USER = 100;
-
-export interface ComposerDraftStorage {
-  readonly length: number;
-  key(index: number): string | null;
-  getItem(key: string): string | null;
-  setItem(key: string, value: string): void;
-  removeItem(key: string): void;
-}
-
-interface StoredComposerDraft {
-  version: 1;
-  text: string;
-  updatedAt: number;
-}
-
-interface DraftEntry {
-  key: string;
-  updatedAt: number;
-}
+export type ComposerDraftStorage = Pick<
+  Storage,
+  "length" | "key" | "getItem" | "setItem" | "removeItem"
+>;
 
 export function chatComposerDraftScope(chatId: string): string {
   return `chat:${chatId}`;
@@ -35,16 +19,8 @@ export function readComposerDraft(
   storage: ComposerDraftStorage | null = browserStorage(),
 ): string {
   if (!storage) return "";
-  const key = draftKey(userId, scope);
   try {
-    const raw = storage.getItem(key);
-    if (raw === null) return "";
-    const parsed = parseDraft(raw);
-    if (!parsed) {
-      storage.removeItem(key);
-      return "";
-    }
-    return parsed.text;
+    return storage.getItem(draftKey(userId, scope)) ?? "";
   } catch {
     return "";
   }
@@ -54,35 +30,18 @@ export function writeComposerDraft(
   userId: string,
   scope: string,
   text: string,
-  options: {
-    storage?: ComposerDraftStorage | null;
-    now?: number;
-  } = {},
+  storage: ComposerDraftStorage | null = browserStorage(),
 ): boolean {
-  const storage =
-    options.storage === undefined ? browserStorage() : options.storage;
   if (!storage) return false;
-  if (text === "") {
-    clearComposerDraft(userId, scope, storage);
-    return true;
-  }
-
-  const key = draftKey(userId, scope);
-  const value = JSON.stringify({
-    version: 1,
-    text,
-    updatedAt: options.now ?? Date.now(),
-  } satisfies StoredComposerDraft);
-
   try {
-    storage.setItem(key, value);
-  } catch (error) {
-    if (!isQuotaExceeded(error)) return false;
-    if (!makeRoomForDraft(storage, userId, key, value)) return false;
+    const key = draftKey(userId, scope);
+    if (text === "") storage.removeItem(key);
+    else storage.setItem(key, text);
+    return true;
+  } catch {
+    // Draft persistence is best-effort and must not interrupt composing.
+    return false;
   }
-
-  pruneUserDrafts(storage, userId, MAX_COMPOSER_DRAFTS_PER_USER);
-  return true;
 }
 
 export function clearComposerDraft(
@@ -90,29 +49,7 @@ export function clearComposerDraft(
   scope: string,
   storage: ComposerDraftStorage | null = browserStorage(),
 ): void {
-  if (!storage) return;
-  try {
-    storage.removeItem(draftKey(userId, scope));
-  } catch {
-    // Browser privacy settings can make storage unavailable. Draft cleanup
-    // must never interfere with sending a message.
-  }
-}
-
-export function clearComposerDraftScope(
-  scope: string,
-  storage: ComposerDraftStorage | null = browserStorage(),
-): void {
-  if (!storage) return;
-  const suffix = `:${encodeURIComponent(scope)}`;
-  for (const key of storageKeys(storage)) {
-    if (!key.startsWith(STORAGE_PREFIX) || !key.endsWith(suffix)) continue;
-    try {
-      storage.removeItem(key);
-    } catch {
-      return;
-    }
-  }
+  writeComposerDraft(userId, scope, "", storage);
 }
 
 export function clearComposerDraftsForUser(
@@ -121,17 +58,19 @@ export function clearComposerDraftsForUser(
 ): void {
   if (!storage) return;
   const prefix = userPrefix(userId);
-  for (const key of storageKeys(storage)) {
-    if (!key.startsWith(prefix)) continue;
-    try {
-      storage.removeItem(key);
-    } catch {
-      return;
+  try {
+    const keys = Array.from({ length: storage.length }, (_, index) =>
+      storage.key(index),
+    );
+    for (const key of keys) {
+      if (key?.startsWith(prefix)) storage.removeItem(key);
     }
+  } catch {
+    // Storage can be unavailable under browser privacy restrictions.
   }
 }
 
-function browserStorage(): ComposerDraftStorage | null {
+function browserStorage(): Storage | null {
   if (typeof window === "undefined") return null;
   try {
     return window.localStorage;
@@ -146,99 +85,4 @@ function draftKey(userId: string, scope: string): string {
 
 function userPrefix(userId: string): string {
   return `${STORAGE_PREFIX}${encodeURIComponent(userId)}:`;
-}
-
-function parseDraft(raw: string): StoredComposerDraft | null {
-  try {
-    const value = JSON.parse(raw) as Partial<StoredComposerDraft> | null;
-    if (
-      value?.version !== 1 ||
-      typeof value.text !== "string" ||
-      typeof value.updatedAt !== "number" ||
-      !Number.isFinite(value.updatedAt)
-    ) {
-      return null;
-    }
-    return value as StoredComposerDraft;
-  } catch {
-    return null;
-  }
-}
-
-function storageKeys(storage: ComposerDraftStorage): string[] {
-  try {
-    return Array.from({ length: storage.length }, (_, index) =>
-      storage.key(index),
-    ).filter((key): key is string => key !== null);
-  } catch {
-    return [];
-  }
-}
-
-function userDraftEntries(
-  storage: ComposerDraftStorage,
-  userId: string,
-): DraftEntry[] {
-  const prefix = userPrefix(userId);
-  const entries: DraftEntry[] = [];
-  for (const key of storageKeys(storage)) {
-    if (!key.startsWith(prefix)) continue;
-    try {
-      const raw = storage.getItem(key);
-      const draft = raw === null ? null : parseDraft(raw);
-      if (!draft) {
-        storage.removeItem(key);
-        continue;
-      }
-      entries.push({ key, updatedAt: draft.updatedAt });
-    } catch {
-      // A single unreadable entry should not prevent other drafts from saving.
-    }
-  }
-  return entries.sort((left, right) => left.updatedAt - right.updatedAt);
-}
-
-function pruneUserDrafts(
-  storage: ComposerDraftStorage,
-  userId: string,
-  limit: number,
-): void {
-  const prefix = userPrefix(userId);
-  const keys = storageKeys(storage).filter((key) => key.startsWith(prefix));
-  if (keys.length <= limit) return;
-  const entries = userDraftEntries(storage, userId);
-  for (const { key } of entries.slice(0, Math.max(0, entries.length - limit))) {
-    try {
-      storage.removeItem(key);
-    } catch {
-      return;
-    }
-  }
-}
-
-function makeRoomForDraft(
-  storage: ComposerDraftStorage,
-  userId: string,
-  targetKey: string,
-  value: string,
-): boolean {
-  const candidates = userDraftEntries(storage, userId).filter(
-    ({ key }) => key !== targetKey,
-  );
-  for (const { key } of candidates) {
-    try {
-      storage.removeItem(key);
-      storage.setItem(targetKey, value);
-      return true;
-    } catch (error) {
-      if (!isQuotaExceeded(error)) return false;
-    }
-  }
-  return false;
-}
-
-function isQuotaExceeded(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-  const candidate = error as { name?: unknown; code?: unknown };
-  return candidate.name === "QuotaExceededError" || candidate.code === 22;
 }

--- a/apps/web/lib/chat/use-composer-draft.ts
+++ b/apps/web/lib/chat/use-composer-draft.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type SetStateAction,
+} from "react";
+import {
+  clearComposerDraft,
+  readComposerDraft,
+  writeComposerDraft,
+} from "./composer-drafts";
+
+const SAVE_DELAY_MS = 400;
+
+interface DraftIdentity {
+  userId: string;
+  scope: string;
+}
+
+export function useComposerDraft({
+  userId,
+  scope,
+  enabled,
+  onRestore,
+}: {
+  userId?: string;
+  scope: string | null;
+  enabled: boolean;
+  onRestore?: (text: string) => void;
+}) {
+  const [value, setStoredValue] = useState("");
+  const valueRef = useRef(value);
+  const identityRef = useRef<DraftIdentity | null>(null);
+  const dirtyRef = useRef(false);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelScheduledSave = useCallback(() => {
+    if (saveTimerRef.current === null) return;
+    clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = null;
+  }, []);
+
+  const persist = useCallback(
+    (identity: DraftIdentity, text: string) =>
+      writeComposerDraft(identity.userId, identity.scope, text),
+    [],
+  );
+
+  const setValue = useCallback(
+    (nextValue: SetStateAction<string>) => {
+      const next =
+        typeof nextValue === "function"
+          ? nextValue(valueRef.current)
+          : nextValue;
+      valueRef.current = next;
+      dirtyRef.current = true;
+      setStoredValue(next);
+
+      const identity = identityRef.current;
+      if (!identity) return;
+      cancelScheduledSave();
+      if (next === "") {
+        clearComposerDraft(identity.userId, identity.scope);
+        dirtyRef.current = false;
+        return;
+      }
+      saveTimerRef.current = setTimeout(() => {
+        saveTimerRef.current = null;
+        if (persist(identity, valueRef.current)) dirtyRef.current = false;
+      }, SAVE_DELAY_MS);
+    },
+    [cancelScheduledSave, persist],
+  );
+
+  const clear = useCallback(() => {
+    cancelScheduledSave();
+    valueRef.current = "";
+    dirtyRef.current = false;
+    setStoredValue("");
+    const identity = identityRef.current;
+    if (identity) clearComposerDraft(identity.userId, identity.scope);
+  }, [cancelScheduledSave]);
+
+  useEffect(() => {
+    const nextIdentity = enabled && userId && scope ? { userId, scope } : null;
+    const previousIdentity = identityRef.current;
+    if (
+      previousIdentity?.userId === nextIdentity?.userId &&
+      previousIdentity?.scope === nextIdentity?.scope
+    ) {
+      return;
+    }
+
+    cancelScheduledSave();
+
+    if (previousIdentity) {
+      if (nextIdentity) {
+        if (dirtyRef.current) persist(previousIdentity, valueRef.current);
+      } else {
+        // Disabling persistence means temporary/private mode or loss of the
+        // authenticated owner. Keep the visible text, but remove its disk copy.
+        clearComposerDraft(previousIdentity.userId, previousIdentity.scope);
+      }
+      dirtyRef.current = false;
+    }
+
+    identityRef.current = nextIdentity;
+    if (!nextIdentity) return;
+
+    // The session can resolve after the user has started typing. Their live
+    // input wins over an older stored value and becomes the new draft.
+    if (!previousIdentity && valueRef.current !== "") {
+      persist(nextIdentity, valueRef.current);
+      dirtyRef.current = false;
+      return;
+    }
+
+    const restored = readComposerDraft(nextIdentity.userId, nextIdentity.scope);
+    valueRef.current = restored;
+    dirtyRef.current = false;
+    const restoreFrame = requestAnimationFrame(() => {
+      if (
+        identityRef.current?.userId !== nextIdentity.userId ||
+        identityRef.current.scope !== nextIdentity.scope ||
+        valueRef.current !== restored
+      ) {
+        return;
+      }
+      setStoredValue(restored);
+      if (restored !== "") onRestore?.(restored);
+    });
+    return () => cancelAnimationFrame(restoreFrame);
+  }, [cancelScheduledSave, enabled, onRestore, persist, scope, userId]);
+
+  useEffect(() => {
+    const flush = () => {
+      cancelScheduledSave();
+      const identity = identityRef.current;
+      if (identity && dirtyRef.current) {
+        if (persist(identity, valueRef.current)) dirtyRef.current = false;
+      }
+    };
+    window.addEventListener("pagehide", flush);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      flush();
+    };
+  }, [cancelScheduledSave, persist]);
+
+  return { value, setValue, clear };
+}

--- a/apps/web/lib/queries/chats.ts
+++ b/apps/web/lib/queries/chats.ts
@@ -9,10 +9,6 @@ import type { UIMessage } from "ai";
 import { CHAT_MESSAGE_PAGE_SIZE } from "@/lib/chat/history";
 import { chatKeys } from "@/lib/queries/keys";
 import type { ChatUsageResponse, UsageTotals } from "@/lib/usage/types";
-import {
-  chatComposerDraftScope,
-  clearComposerDraftScope,
-} from "@/lib/chat/composer-drafts";
 
 export type ChatListItem = {
   id: string;
@@ -92,10 +88,7 @@ export function useDeleteChat() {
       const r = await fetch(`/api/chats/${id}`, { method: "DELETE" });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
     },
-    onSuccess: (_, id) => {
-      clearComposerDraftScope(chatComposerDraftScope(id));
-      return qc.invalidateQueries({ queryKey: chatKeys.list() });
-    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
   });
 }
 

--- a/apps/web/lib/queries/chats.ts
+++ b/apps/web/lib/queries/chats.ts
@@ -9,6 +9,10 @@ import type { UIMessage } from "ai";
 import { CHAT_MESSAGE_PAGE_SIZE } from "@/lib/chat/history";
 import { chatKeys } from "@/lib/queries/keys";
 import type { ChatUsageResponse, UsageTotals } from "@/lib/usage/types";
+import {
+  chatComposerDraftScope,
+  clearComposerDraftScope,
+} from "@/lib/chat/composer-drafts";
 
 export type ChatListItem = {
   id: string;
@@ -88,7 +92,10 @@ export function useDeleteChat() {
       const r = await fetch(`/api/chats/${id}`, { method: "DELETE" });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
+    onSuccess: (_, id) => {
+      clearComposerDraftScope(chatComposerDraftScope(id));
+      return qc.invalidateQueries({ queryKey: chatKeys.list() });
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

- autosave web chat composer text in user-scoped local browser storage
- restore independent drafts for saved chats, root new chats, and project new chats
- transition new-chat drafts to the persisted chat identity after the first send
- clear drafts on send, temporary mode, and explicit logout
- debounce writes and flush pending input on navigation or hard reload
- treat unavailable or quota-limited browser storage as a non-fatal best-effort failure

## Implementation

Drafts use small, versioned localStorage keys containing the text directly. The lifecycle logic stays in a focused composer hook; there is no database/API work, retention subsystem, quota eviction, or cross-tab synchronization layer.

## Scope

This PR is web-only and text-only. It does not change Android/iOS, Agent Connections composers, message editing, server APIs, database schema, or attachment persistence.

Attachments remain excluded because unsent uploads are currently eligible for orphan cleanup after 24 hours; durable attachment drafts need a separate server-lifecycle design.

## Validation

- npm run test -w apps/web -- (102 files, 663 tests)
- npm run typecheck -w apps/web --
- npm run lint -w apps/web --
- E2E_PORT=4733 npm run test:e2e -w apps/web -- e2e/composer-drafts.spec.ts (3 passed, including the production build)