### PR TITLE
release: v0.19.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = "0.1.10";
+export const CLI_VERSION = "0.1.11";
 
 export const APP_IMAGE = "ghcr.io/yoloyash/overtchat-app";
 export const VOICE_IMAGE = "ghcr.io/yoloyash/overtchat-voice";

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.10"
+cli_version="0.1.11"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
-  "cliVersion": "0.1.10",
-  "appVersion": "0.18.1",
+  "cliVersion": "0.1.11",
+  "appVersion": "0.19.0",
   "voiceVersion": "0.1.0",
   "connectorVersion": "0.9.0",
   "sttVersion": "0.1.1",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.18.1}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.19.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },


### PR DESCRIPTION
## Release versions

- App: `0.19.0`
- CLI: `0.1.11`
- Realtime voice: `0.1.0`
- Connector: unchanged at `0.9.0`
- STT: unchanged at `0.1.1`

## Validation

- `npm run deps:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- CLI build and embedded-version check
- Production app image build and filesystem inspection
- Realtime voice image build and focused Python tests