### PR TITLE
fix(release): ignore component-prefixed app tags

### DIFF
--- a/.github/workflows/app-image.yml
+++ b/.github/workflows/app-image.yml
@@ -4,7 +4,7 @@ name: Build and publish app image
 # Built for linux/amd64 + linux/arm64.
 on:
   push:
-    tags: ["v*"]
+    tags: ["v[0-9]*"]
 
 permissions: {}
 


### PR DESCRIPTION
The app workflow's `v*` tag filter also matches `voice-v*`, creating a guaranteed-failing app release run for every realtime voice release. Restrict the trigger to tags beginning with `v` followed by a digit; the existing semantic-version validator remains authoritative.