### PR TITLE
docs: capture realtime voice boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ runbook instead of copying its instructions.
 | `packages/agent-runtime` | Coding-agent provider adapters plus host runtime primitives |
 | `packages/shared` | Cross-client chat/tool/model contracts and generated web/native theme outputs |
 | `scripts/dev.mjs` | Root development-stack orchestration |
-| `compose.yml`, `searxng/`, `stt/` | Self-hosted application and bundled sidecars |
+| `compose.yml`, `searxng/`, `stt/`, `voice/` | Self-hosted application and bundled sidecars |
 | `.github/` | Validation, artifact publication, and release promotion automation |
 
 Keep these boundaries strict:

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -12,12 +12,17 @@ and operator choices into a managed Compose stack and optional Host Connector.
 - `src/update.ts` applies newer manifest versions through the same rendering,
   Compose, readiness, and connector paths.
 - `src/config.ts`, `src/paths.ts`, and `src/compose.ts` own persisted
-  installation state, managed locations, secrets/environment output, and
-  Compose rendering.
+  installation state, managed locations, secrets/environment output, optional
+  service profiles, and Compose rendering.
 - `src/docker.ts` owns Docker discovery, existing-install detection, GPU
   support, and bundled-sidecar reconciliation.
 - `src/release.ts` validates the published manifest and handles CLI
   self-updates; `src/connector.ts` installs and verifies the managed connector.
+
+Preserve optional-service selections across updates. Realtime voice is a
+separately versioned optional image selected by the release manifest; setup and
+update must not couple its version to the app or expose its container port.
+Release procedures remain in `docs/release.md`.
 
 Setup and update can modify the host installation. Keep ordinary iteration in
 unit tests and reserve end-to-end runs for a disposable installation. Run the

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -18,6 +18,9 @@ chat delivery.
   owns cancellation and optional reconnectable-stream integration.
 - `lib/capabilities` validates search and speech configuration;
   `lib/db/serverCapabilities.ts` persists it.
+- `lib/voice` owns realtime-session tickets, browser transport, history
+  conversion, tool definitions, and service availability. Durable voice chats
+  remain ordinary chat records distinguished by their chat kind.
 - `lib/agents` owns Agent Connections projections and access rules.
   `lib/agents/connector` owns the authorized web-side connector relay.
 - `lib/mcp` owns MCP configuration, connections, tool bindings, and lifecycle.
@@ -33,6 +36,11 @@ Host Connector routes authenticate connector tokens. Internal management routes
 authenticate `OVERTCHAT_MANAGEMENT_SECRET`. Keep both separate from user
 sessions, and never expose connector tokens, management secrets, provider keys,
 or executable MCP configuration through user APIs.
+
+Realtime voice browser routes require the user session and issue short-lived,
+chat-bound tickets. Internal voice routes independently authenticate
+`VOICE_SHARED_SECRET` and verify the ticket; the sidecar must not become a
+trusted substitute for user authorization.
 
 The first created user becomes the administrator. Public signup closes after
 that; administrators create subsequent users through Better Auth's admin path.


### PR DESCRIPTION
Document the final realtime voice ownership and security boundaries for future agents:

- include the voice sidecar in the repository map
- preserve optional voice installation and independent image versioning in the CLI
- record the web-side ticket, internal authentication, and durable chat boundaries

No runtime behavior changes.