### PR TITLE
feat(voice): add NVIDIA Kokoro TTS

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -68,6 +68,8 @@ jobs:
             redisImage: "docker.io/library/redis",
             searxngImage: "docker.io/searxng/searxng",
             kokoroImage: "ghcr.io/remsky/kokoro-fastapi-cpu",
+            kokoroGpuImage: "ghcr.io/remsky/kokoro-fastapi-gpu",
+            kokoroGpuBlackwellImage: "ghcr.io/remsky/kokoro-fastapi-gpu",
           };
           for (const [field, repository] of Object.entries(images)) {
             const prefix = `${repository}@sha256:`;
@@ -103,6 +105,8 @@ jobs:
             `redis_image=${manifest.redisImage}`,
             `searxng_image=${manifest.searxngImage}`,
             `kokoro_image=${manifest.kokoroImage}`,
+            `kokoro_gpu_image=${manifest.kokoroGpuImage}`,
+            `kokoro_gpu_blackwell_image=${manifest.kokoroGpuBlackwellImage}`,
             "",
           ].join("\n"));
           NODE
@@ -191,6 +195,8 @@ jobs:
           REDIS_IMAGE: ${{ steps.manifest.outputs.redis_image }}
           SEARXNG_IMAGE: ${{ steps.manifest.outputs.searxng_image }}
           KOKORO_IMAGE: ${{ steps.manifest.outputs.kokoro_image }}
+          KOKORO_GPU_IMAGE: ${{ steps.manifest.outputs.kokoro_gpu_image }}
+          KOKORO_GPU_BLACKWELL_IMAGE: ${{ steps.manifest.outputs.kokoro_gpu_blackwell_image }}
         run: |
           verification_directory=$(mktemp -d)
           trap 'rm -rf "$verification_directory"' EXIT HUP INT TERM
@@ -238,6 +244,16 @@ jobs:
           inspect_image "$KOKORO_IMAGE" "$verification_directory/kokoro.json"
           node .github/scripts/assert-image-platforms.mjs \
             "$verification_directory/kokoro.json" linux/amd64 linux/arm64
+
+          inspect_image "$KOKORO_GPU_IMAGE" \
+            "$verification_directory/kokoro-gpu.json"
+          node .github/scripts/assert-image-platforms.mjs \
+            "$verification_directory/kokoro-gpu.json" linux/amd64 linux/arm64
+
+          inspect_image "$KOKORO_GPU_BLACKWELL_IMAGE" \
+            "$verification_directory/kokoro-gpu-blackwell.json"
+          node .github/scripts/assert-image-platforms.mjs \
+            "$verification_directory/kokoro-gpu-blackwell.json" linux/amd64
 
       - name: Require a complete candidate release
         id: readiness

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -80,7 +80,7 @@ jobs:
             }
           }
           const compose = fs.readFileSync("compose.yml", "utf8");
-          for (const field of Object.keys(images)) {
+          for (const field of ["redisImage", "searxngImage", "kokoroImage"]) {
             if (!compose.includes(`image: ${manifest[field]}`)) {
               throw new Error(`compose.yml does not select manifest ${field}.`);
             }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/compose.test.ts
+++ b/apps/cli/src/compose.test.ts
@@ -25,6 +25,8 @@ function config(): InstallationConfig {
     redisImage: `docker.io/library/redis@sha256:${"a".repeat(64)}`,
     searxngImage: `docker.io/searxng/searxng@sha256:${"b".repeat(64)}`,
     kokoroImage: `ghcr.io/remsky/kokoro-fastapi-cpu@sha256:${"c".repeat(64)}`,
+    kokoroGpuImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"d".repeat(64)}`,
+    kokoroGpuBlackwellImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"e".repeat(64)}`,
     appPort: 4718,
     bindAddress: "0.0.0.0",
     publicUrl: "http://192.168.1.10:4718",
@@ -69,7 +71,7 @@ describe("managed Compose configuration", () => {
     );
 
     expect(environment).toContain(
-      'COMPOSE_PROFILES="tts-bundled,stt-gpu,voice"',
+      'COMPOSE_PROFILES="tts-cpu,stt-gpu,voice"',
     );
     expect(environment).toContain(
       'OVERTCHAT_INSTALLED_CAPABILITIES="tts,stt,voice,agents"',
@@ -83,10 +85,14 @@ describe("managed Compose configuration", () => {
     );
     expect(environment).toContain('DISABLE_UPDATE_CHECK="false"');
     expect(environment).toContain('STT_GPU_DEVICE_ID="GPU-abc"');
+    expect(environment).toContain('TTS_GPU_DEVICE_ID="0"');
     expect(environment).toContain('VOICE_VERSION="0.1.0"');
     expect(environment).toContain(`OVERTCHAT_REDIS_IMAGE="${config().redisImage}"`);
     expect(environment).toContain(`OVERTCHAT_SEARXNG_IMAGE="${config().searxngImage}"`);
     expect(environment).toContain(`OVERTCHAT_KOKORO_IMAGE="${config().kokoroImage}"`);
+    expect(environment).toContain(
+      `OVERTCHAT_KOKORO_GPU_IMAGE="${config().kokoroGpuImage}"`,
+    );
     expect(environment).toContain(`OVERTCHAT_VOICE_IMAGE="${config().voiceImage}"`);
     expect(environment).toContain('VOICE_SHARED_SECRET="voice-secret"');
     expect(environment).toContain(
@@ -103,17 +109,20 @@ describe("managed Compose configuration", () => {
   it("keeps optional services behind Compose profiles", () => {
     const compose = renderComposeFile(config());
     expect(compose).toContain("profiles: [search-bundled]");
-    expect(compose).toContain("profiles: [tts-bundled]");
+    expect(compose).toContain("profiles: [tts-cpu]");
+    expect(compose).toContain("profiles: [tts-gpu]");
     expect(compose).toContain("profiles: [stt-cpu]");
     expect(compose).toContain("profiles: [stt-gpu]");
     expect(compose).toContain("profiles: [voice]");
     expect(compose).toContain("image: ${OVERTCHAT_REDIS_IMAGE}");
     expect(compose).toContain("image: ${OVERTCHAT_SEARXNG_IMAGE}");
     expect(compose).toContain("image: ${OVERTCHAT_KOKORO_IMAGE}");
+    expect(compose).toContain("image: ${OVERTCHAT_KOKORO_GPU_IMAGE}");
     expect(compose).toContain("image: ${OVERTCHAT_VOICE_IMAGE}");
     expect(compose).toContain("VOICE_SHARED_SECRET: ${VOICE_SHARED_SECRET}");
     expect(compose).not.toContain("8765:8765");
     expect(compose).toContain('device_ids: ["${STT_GPU_DEVICE_ID}"]');
+    expect(compose).toContain('device_ids: ["${TTS_GPU_DEVICE_ID}"]');
     expect(compose).toContain(
       "DISABLE_UPDATE_CHECK: ${DISABLE_UPDATE_CHECK:-false}",
     );
@@ -123,6 +132,40 @@ describe("managed Compose configuration", () => {
     expect(compose).not.toContain("BRAVE_SEARCH_API_KEY");
     expect(compose).not.toContain("TTS_API_KEY");
     expect(compose).not.toContain("STT_API_KEY");
+  });
+
+  it("selects the Blackwell image and GPU profile independently from STT", () => {
+    const gpuConfig = config();
+    gpuConfig.tts = {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "gpu",
+      gpuUuid: "GPU-5090",
+      gpuVariant: "blackwell",
+    };
+    gpuConfig.stt = {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "cpu",
+    };
+
+    const environment = renderStackEnvironment(
+      gpuConfig,
+      {
+        betterAuthSecret: "auth",
+        managementSecret: "management",
+        searxngSecret: "search",
+        voiceSharedSecret: "voice",
+      },
+      paths,
+    );
+
+    expect(environment).toContain('COMPOSE_PROFILES="tts-gpu,stt-cpu,voice"');
+    expect(environment).toContain('TTS_GPU_DEVICE_ID="GPU-5090"');
+    expect(environment).toContain('TTS_GPU_VARIANT="blackwell"');
+    expect(environment).toContain(
+      `OVERTCHAT_KOKORO_GPU_IMAGE="${gpuConfig.kokoroGpuBlackwellImage}"`,
+    );
   });
 
   it("preserves an adopted bind-mounted data directory", () => {

--- a/apps/cli/src/compose.ts
+++ b/apps/cli/src/compose.ts
@@ -15,7 +15,13 @@ function composeBindAddress(value: string): string {
 function profileList(config: InstallationConfig): string[] {
   const profiles: string[] = [];
   if (config.search.bundledInstalled) profiles.push("search-bundled");
-  if (config.tts.bundledInstalled) profiles.push("tts-bundled");
+  if (config.tts.bundledInstalled) {
+    profiles.push(
+      config.tts.accelerator === "auto" || config.tts.accelerator === "gpu"
+        ? "tts-gpu"
+        : "tts-cpu",
+    );
+  }
   if (config.stt.bundledInstalled) {
     profiles.push(config.stt.accelerator === "cpu" ? "stt-cpu" : "stt-gpu");
   }
@@ -53,6 +59,12 @@ export function renderStackEnvironment(
     ["OVERTCHAT_REDIS_IMAGE", config.redisImage],
     ["OVERTCHAT_SEARXNG_IMAGE", config.searxngImage],
     ["OVERTCHAT_KOKORO_IMAGE", config.kokoroImage],
+    [
+      "OVERTCHAT_KOKORO_GPU_IMAGE",
+      config.tts.gpuVariant === "blackwell"
+        ? config.kokoroGpuBlackwellImage
+        : config.kokoroGpuImage,
+    ],
     ["APP_PORT", config.appPort],
     ["APP_BIND_ADDRESS", composeBindAddress(config.bindAddress)],
     ["BETTER_AUTH_URL", config.publicUrl],
@@ -98,6 +110,8 @@ export function renderStackEnvironment(
     ],
     ["TTS_MODEL", config.tts.model ?? "kokoro"],
     ["TTS_VOICE", config.tts.voice ?? "af_heart"],
+    ["TTS_GPU_DEVICE_ID", config.tts.gpuUuid ?? "0"],
+    ["TTS_GPU_VARIANT", config.tts.gpuVariant ?? "standard"],
     ["STT_PROVIDER", config.stt.provider],
     [
       "OVERTCHAT_STT_URL",
@@ -153,6 +167,7 @@ services:
       KOKORO_URL: \${OVERTCHAT_TTS_URL:-}
       TTS_MODEL: \${TTS_MODEL:-kokoro}
       TTS_VOICE: \${TTS_VOICE:-af_heart}
+      TTS_GPU_VARIANT: \${TTS_GPU_VARIANT:-standard}
       STT_PROVIDER: \${STT_PROVIDER}
       STT_URL: \${OVERTCHAT_STT_URL:-}
       STT_MODEL: \${STT_MODEL:-parakeet-tdt-0.6b-v3}
@@ -170,6 +185,9 @@ ${appDataMount}
         condition: service_healthy
         required: false
       kokoro:
+        condition: service_healthy
+        required: false
+      kokoro-gpu:
         condition: service_healthy
         required: false
 
@@ -216,7 +234,7 @@ ${appDataMount}
     image: \${OVERTCHAT_KOKORO_IMAGE}
     container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-kokoro
     restart: unless-stopped
-    profiles: [tts-bundled]
+    profiles: [tts-cpu]
     healthcheck:
       test:
         - CMD-SHELL
@@ -225,6 +243,30 @@ ${appDataMount}
       timeout: 5s
       retries: 20
       start_period: 60s
+
+  kokoro-gpu:
+    image: \${OVERTCHAT_KOKORO_GPU_IMAGE}
+    container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-kokoro-gpu
+    restart: unless-stopped
+    profiles: [tts-gpu]
+    networks:
+      default:
+        aliases: [kokoro]
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)"
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["\${TTS_GPU_DEVICE_ID}"]
+              capabilities: [gpu]
 
   stt-cpu:
     image: ghcr.io/yoloyash/overtchat-stt-cpu:\${STT_VERSION}

--- a/apps/cli/src/compose.ts
+++ b/apps/cli/src/compose.ts
@@ -235,6 +235,8 @@ ${appDataMount}
     container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-kokoro
     restart: unless-stopped
     profiles: [tts-cpu]
+    labels:
+      com.overtchat.tts.accelerator: cpu
     healthcheck:
       test:
         - CMD-SHELL
@@ -249,6 +251,9 @@ ${appDataMount}
     container_name: \${OVERTCHAT_CONTAINER_PREFIX:-overtchat}-kokoro-gpu
     restart: unless-stopped
     profiles: [tts-gpu]
+    labels:
+      com.overtchat.tts.accelerator: gpu
+      com.overtchat.tts.gpu-variant: \${TTS_GPU_VARIANT:-standard}
     networks:
       default:
         aliases: [kokoro]

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -25,6 +25,8 @@ const manifest: ReleaseManifest = {
   redisImage: `docker.io/library/redis@sha256:${"a".repeat(64)}`,
   searxngImage: `docker.io/searxng/searxng@sha256:${"b".repeat(64)}`,
   kokoroImage: `ghcr.io/remsky/kokoro-fastapi-cpu@sha256:${"c".repeat(64)}`,
+  kokoroGpuImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"d".repeat(64)}`,
+  kokoroGpuBlackwellImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"e".repeat(64)}`,
 };
 
 afterEach(() => {
@@ -84,6 +86,8 @@ describe("existing installation adoption", () => {
       redisImage: manifest.redisImage,
       searxngImage: manifest.searxngImage,
       kokoroImage: manifest.kokoroImage,
+      kokoroGpuImage: manifest.kokoroGpuImage,
+      kokoroGpuBlackwellImage: manifest.kokoroGpuBlackwellImage,
     });
   });
 
@@ -156,6 +160,28 @@ describe("managed installation state", () => {
         voiceVersion: "0.0.0",
         voiceImage: "ghcr.io/yoloyash/overtchat-voice:0.0.0",
         voice: { installed: false },
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps pre-accelerator bundled TTS installations on CPU", async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "overtchat-legacy-tts-state-"),
+    );
+    const paths = pathsFor(directory);
+    try {
+      const legacy = defaultInstallationConfig(null, manifest);
+      delete legacy.tts.accelerator;
+      await writeFile(paths.stateFile, JSON.stringify(legacy));
+
+      await expect(readInstallationConfig(paths)).resolves.toMatchObject({
+        tts: {
+          provider: "bundled",
+          bundledInstalled: true,
+          accelerator: "cpu",
+        },
       });
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -60,6 +60,8 @@ export function defaultInstallationConfig(
     redisImage: manifest.redisImage,
     searxngImage: manifest.searxngImage,
     kokoroImage: manifest.kokoroImage,
+    kokoroGpuImage: manifest.kokoroGpuImage,
+    kokoroGpuBlackwellImage: manifest.kokoroGpuBlackwellImage,
     appPort: existing?.appPort ?? DEFAULT_APP_PORT,
     bindAddress: existing?.bindAddress ?? "0.0.0.0",
     publicUrl:
@@ -89,7 +91,15 @@ export function defaultInstallationConfig(
           bundledInstalled: false,
           baseUrl: ttsUrl,
         }
-      : { provider: "bundled", bundledInstalled: true },
+      : existing?.ttsAccelerator
+        ? {
+            provider: "bundled",
+            bundledInstalled: true,
+            accelerator: existing.ttsAccelerator,
+            gpuUuid: existing.ttsGpuUuid,
+            gpuVariant: existing.ttsGpuVariant,
+          }
+        : { provider: "bundled", bundledInstalled: true },
     stt:
       sttUrl && sttUrl !== "http://stt:5092"
         ? {
@@ -145,6 +155,12 @@ export async function readInstallationConfig(
         config.voiceImage ??
         `${VOICE_IMAGE}:${config.voiceVersion ?? "0.0.0"}`,
       voice: config.voice ?? { installed: false },
+      // Bundled TTS predates accelerator selection. Missing state is the
+      // existing CPU service, never an implicit migration onto a GPU.
+      tts: {
+        ...config.tts,
+        accelerator: config.tts.accelerator ?? "cpu",
+      },
     });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = "0.1.11";
+export const CLI_VERSION = "0.1.12";
 
 export const APP_IMAGE = "ghcr.io/yoloyash/overtchat-app";
 export const VOICE_IMAGE = "ghcr.io/yoloyash/overtchat-voice";

--- a/apps/cli/src/docker.test.ts
+++ b/apps/cli/src/docker.test.ts
@@ -13,7 +13,12 @@ vi.mock("./process.js", () => ({
   runCommand: mocks.runCommand,
 }));
 
-import { parseNvidiaSmi, reconcileManagedSidecars } from "./docker.js";
+import {
+  detectExistingInstallation,
+  detectNvidiaGpus,
+  parseNvidiaSmi,
+  reconcileManagedSidecars,
+} from "./docker.js";
 
 function config(
   overrides: Partial<InstallationConfig> = {},
@@ -29,6 +34,8 @@ function config(
     redisImage: `docker.io/library/redis@sha256:${"a".repeat(64)}`,
     searxngImage: `docker.io/searxng/searxng@sha256:${"b".repeat(64)}`,
     kokoroImage: `ghcr.io/remsky/kokoro-fastapi-cpu@sha256:${"c".repeat(64)}`,
+    kokoroGpuImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"d".repeat(64)}`,
+    kokoroGpuBlackwellImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"e".repeat(64)}`,
     appPort: 4718,
     bindAddress: "127.0.0.1",
     publicUrl: "https://chat.example.com",
@@ -76,7 +83,7 @@ describe("NVIDIA GPU discovery", () => {
   it("keeps stable UUIDs alongside the friendly index and memory", () => {
     expect(
       parseNvidiaSmi(
-        "0, GPU-4090, NVIDIA GeForce RTX 4090, 24564\n1, GPU-A4000, NVIDIA RTX A4000, 16376\n",
+        "0, GPU-4090, NVIDIA GeForce RTX 4090, 24564, 8.9\n1, GPU-A4000, NVIDIA RTX A4000, 16376, 8.6\n",
       ),
     ).toEqual([
       {
@@ -84,12 +91,14 @@ describe("NVIDIA GPU discovery", () => {
         uuid: "GPU-4090",
         name: "NVIDIA GeForce RTX 4090",
         memoryMiB: 24_564,
+        computeCapability: 8.9,
       },
       {
         index: 1,
         uuid: "GPU-A4000",
         name: "NVIDIA RTX A4000",
         memoryMiB: 16_376,
+        computeCapability: 8.6,
       },
     ]);
   });
@@ -104,6 +113,30 @@ describe("NVIDIA GPU discovery", () => {
           memoryMiB: 49_140,
         },
       ]);
+  });
+
+  it("falls back when an older driver cannot report compute capability", async () => {
+    mocks.commandExists.mockResolvedValue(true);
+    mocks.runCommand
+      .mockResolvedValueOnce({ stdout: "", stderr: "unknown field", exitCode: 1 })
+      .mockResolvedValueOnce({
+        stdout: "0, GPU-A4000, NVIDIA RTX A4000, 16376\n",
+        stderr: "",
+        exitCode: 0,
+      });
+
+    await expect(detectNvidiaGpus()).resolves.toEqual([
+      {
+        index: 0,
+        uuid: "GPU-A4000",
+        name: "NVIDIA RTX A4000",
+        memoryMiB: 16_376,
+      },
+    ]);
+    expect(mocks.runCommand).toHaveBeenNthCalledWith(2, "nvidia-smi", [
+      "--query-gpu=index,uuid,name,memory.total",
+      "--format=csv,noheader,nounits",
+    ]);
   });
 });
 
@@ -252,7 +285,100 @@ describe("managed sidecar reconciliation", () => {
 
     expect(result).toEqual({
       removed: [],
-      warnings: ["Could not remove Kokoro: container is busy"],
+      warnings: ["Could not remove Kokoro (CPU): container is busy"],
+    });
+  });
+
+  it("removes the CPU Kokoro container when TTS moves to NVIDIA", async () => {
+    mocks.runCommand.mockImplementation(
+      async (_command: string, args: string[]) => ({
+        stdout:
+          args[0] === "inspect" && args[1] === "overtchat-kokoro"
+            ? inspectedContainer("overtchat-kokoro", "kokoro")
+            : "",
+        stderr: args[0] === "inspect" ? "No such container" : "",
+        exitCode:
+          args[0] === "inspect" && args[1] !== "overtchat-kokoro" ? 1 : 0,
+      }),
+    );
+
+    const result = await reconcileManagedSidecars(
+      { command: "docker", prefix: [] },
+      config({
+        tts: {
+          provider: "bundled",
+          bundledInstalled: true,
+          accelerator: "gpu",
+          gpuUuid: "GPU-4090",
+          gpuVariant: "standard",
+        },
+      }),
+    );
+
+    expect(result).toEqual({ removed: ["Kokoro (CPU)"], warnings: [] });
+  });
+});
+
+describe("existing TTS accelerator detection", () => {
+  it("adopts the source Blackwell profile as bundled GPU TTS", async () => {
+    mocks.runCommand.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] !== "inspect") {
+          return { stdout: "", stderr: "", exitCode: 1 };
+        }
+        const name = args[1];
+        if (name === "overtchat-app") {
+          return {
+            stdout: JSON.stringify([
+              {
+                Name: "/overtchat-app",
+                Config: {
+                  Image: "ghcr.io/yoloyash/overtchat-app:0.14.0",
+                  Env: [
+                    "BETTER_AUTH_URL=https://chat.example.com",
+                    "TTS_GPU_VARIANT=blackwell",
+                  ],
+                  Labels: { "com.docker.compose.project": "overtchat" },
+                },
+                Mounts: [
+                  {
+                    Destination: "/app/data",
+                    Name: "overtchat-data",
+                    Type: "volume",
+                  },
+                ],
+                NetworkSettings: {
+                  Ports: { "4717/tcp": [{ HostIp: "0.0.0.0", HostPort: "4718" }] },
+                },
+              },
+            ]),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        if (name === "overtchat-kokoro-gpu-blackwell") {
+          return {
+            stdout: JSON.stringify([
+              {
+                Name: "/overtchat-kokoro-gpu-blackwell",
+                HostConfig: { DeviceRequests: [{ DeviceIDs: ["GPU-5090"] }] },
+              },
+            ]),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "No such container", exitCode: 1 };
+      },
+    );
+
+    await expect(
+      detectExistingInstallation({ command: "docker", prefix: [] }),
+    ).resolves.toMatchObject({
+      bundledServices: { tts: true },
+      ttsAccelerator: "gpu",
+      ttsGpuUuid: "GPU-5090",
+      ttsGpuVariant: "blackwell",
     });
   });
 });

--- a/apps/cli/src/docker.test.ts
+++ b/apps/cli/src/docker.test.ts
@@ -320,7 +320,7 @@ describe("managed sidecar reconciliation", () => {
 });
 
 describe("existing TTS accelerator detection", () => {
-  it("adopts the source Blackwell profile as bundled GPU TTS", async () => {
+  it("adopts managed Blackwell TTS as bundled GPU TTS", async () => {
     mocks.runCommand.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] !== "inspect") {
@@ -356,11 +356,19 @@ describe("existing TTS accelerator detection", () => {
             exitCode: 0,
           };
         }
-        if (name === "overtchat-kokoro-gpu-blackwell") {
+        if (name === "overtchat-kokoro-gpu") {
           return {
             stdout: JSON.stringify([
               {
-                Name: "/overtchat-kokoro-gpu-blackwell",
+                Name: "/overtchat-kokoro-gpu",
+                Config: {
+                  Image:
+                    "ghcr.io/remsky/kokoro-fastapi-gpu@sha256:gpu-image",
+                  Labels: {
+                    "com.overtchat.tts.accelerator": "gpu",
+                    "com.overtchat.tts.gpu-variant": "blackwell",
+                  },
+                },
                 HostConfig: { DeviceRequests: [{ DeviceIDs: ["GPU-5090"] }] },
               },
             ]),

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -304,9 +304,27 @@ export async function reconcileManagedSidecars(
     },
     {
       containerName: "overtchat-kokoro",
-      label: "Kokoro",
-      selected: config.tts.bundledInstalled,
+      label: "Kokoro (CPU)",
+      selected:
+        config.tts.bundledInstalled &&
+        config.tts.accelerator !== "auto" &&
+        config.tts.accelerator !== "gpu",
       service: "kokoro",
+    },
+    {
+      containerName: "overtchat-kokoro-gpu",
+      label: "Kokoro (NVIDIA)",
+      selected:
+        config.tts.bundledInstalled &&
+        (config.tts.accelerator === "auto" ||
+          config.tts.accelerator === "gpu"),
+      service: "kokoro-gpu",
+    },
+    {
+      containerName: "overtchat-kokoro-gpu-blackwell",
+      label: "Kokoro (legacy Blackwell profile)",
+      selected: false,
+      service: "kokoro-gpu-blackwell",
     },
     {
       containerName: "overtchat-voice",
@@ -435,6 +453,12 @@ async function stoppedComposeInstallation(
   const redis = await inspectContainer(docker, "overtchat-redis");
   const searxng = await inspectContainer(docker, "overtchat-searxng");
   const kokoro = await inspectContainer(docker, "overtchat-kokoro");
+  const kokoroGpu = await inspectContainer(docker, "overtchat-kokoro-gpu");
+  const kokoroGpuBlackwell = await inspectContainer(
+    docker,
+    "overtchat-kokoro-gpu-blackwell",
+  );
+  const selectedKokoroGpu = kokoroGpuBlackwell ?? kokoroGpu;
   const voice = await inspectContainer(docker, "overtchat-voice");
   const sttGpu = await inspectContainer(docker, "overtchat-stt-gpu");
   const sttCpu = sttGpu
@@ -456,10 +480,14 @@ async function stoppedComposeInstallation(
     )?.Source,
     bundledServices: {
       search: Boolean(searxng),
-      tts: Boolean(kokoro),
+      tts: Boolean(selectedKokoroGpu ?? kokoro),
       stt: Boolean(sttGpu ?? sttCpu),
       voice: Boolean(voice),
     },
+    ttsAccelerator: selectedKokoroGpu ? "gpu" : kokoro ? "cpu" : undefined,
+    ttsGpuUuid:
+      selectedKokoroGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
+    ttsGpuVariant: kokoroGpuBlackwell ? "blackwell" : undefined,
     sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
     sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
   };
@@ -496,6 +524,12 @@ export async function detectExistingInstallation(
 
   const searxng = await inspectContainer(docker, "overtchat-searxng");
   const kokoro = await inspectContainer(docker, "overtchat-kokoro");
+  const kokoroGpu = await inspectContainer(docker, "overtchat-kokoro-gpu");
+  const kokoroGpuBlackwell = await inspectContainer(
+    docker,
+    "overtchat-kokoro-gpu-blackwell",
+  );
+  const selectedKokoroGpu = kokoroGpuBlackwell ?? kokoroGpu;
   const voice = await inspectContainer(docker, "overtchat-voice");
   const searxngConfigPath = searxng?.Mounts?.find(
     (mount) => mount.Destination === "/etc/searxng",
@@ -521,10 +555,19 @@ export async function detectExistingInstallation(
     searxngConfigPath,
     bundledServices: {
       search: Boolean(searxng),
-      tts: Boolean(kokoro),
+      tts: Boolean(selectedKokoroGpu ?? kokoro),
       stt: Boolean(sttGpu ?? sttCpu),
       voice: Boolean(voice),
     },
+    ttsAccelerator: selectedKokoroGpu ? "gpu" : kokoro ? "cpu" : undefined,
+    ttsGpuUuid:
+      selectedKokoroGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
+    ttsGpuVariant:
+      kokoroGpuBlackwell || environment.get("TTS_GPU_VARIANT") === "blackwell"
+        ? "blackwell"
+        : selectedKokoroGpu
+          ? "standard"
+          : undefined,
     sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
     sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
   };
@@ -532,10 +575,18 @@ export async function detectExistingInstallation(
 
 export async function detectNvidiaGpus(): Promise<Gpu[]> {
   if (!(await commandExists("nvidia-smi"))) return [];
-  const result = await runCommand("nvidia-smi", [
-    "--query-gpu=index,uuid,name,memory.total",
+  let result = await runCommand("nvidia-smi", [
+    "--query-gpu=index,uuid,name,memory.total,compute_cap",
     "--format=csv,noheader,nounits",
   ]);
+  // Older drivers do not expose compute_cap as a query field. Keep GPU
+  // acceleration available; only Blackwell auto-detection is lost.
+  if (result.exitCode !== 0) {
+    result = await runCommand("nvidia-smi", [
+      "--query-gpu=index,uuid,name,memory.total",
+      "--format=csv,noheader,nounits",
+    ]);
+  }
   if (result.exitCode !== 0) return [];
   return parseNvidiaSmi(result.stdout);
 }
@@ -544,7 +595,7 @@ export function parseNvidiaSmi(output: string): Gpu[] {
   const gpus: Gpu[] = [];
   for (const line of output.split(/\r?\n/u)) {
     if (!line.trim()) continue;
-    const [rawIndex, rawUuid, rawName, rawMemory] = line
+    const [rawIndex, rawUuid, rawName, rawMemory, rawComputeCapability] = line
       .split(",")
       .map((value) => value.trim());
     const index = Number(rawIndex);
@@ -557,7 +608,14 @@ export function parseNvidiaSmi(output: string): Gpu[] {
     ) {
       continue;
     }
-    gpus.push({ index, uuid: rawUuid, name: rawName, memoryMiB });
+    const computeCapability = Number(rawComputeCapability);
+    gpus.push({
+      index,
+      uuid: rawUuid,
+      name: rawName,
+      memoryMiB,
+      ...(Number.isFinite(computeCapability) ? { computeCapability } : {}),
+    });
   }
   return gpus;
 }

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -321,12 +321,6 @@ export async function reconcileManagedSidecars(
       service: "kokoro-gpu",
     },
     {
-      containerName: "overtchat-kokoro-gpu-blackwell",
-      label: "Kokoro (legacy Blackwell profile)",
-      selected: false,
-      service: "kokoro-gpu-blackwell",
-    },
-    {
       containerName: "overtchat-voice",
       label: "Realtime voice",
       selected: config.voice.installed,
@@ -419,6 +413,16 @@ async function inspectContainer(
   }
 }
 
+function kokoroGpuVariant(
+  container: DockerInspect | null,
+): "standard" | "blackwell" | undefined {
+  if (!container) return undefined;
+  return container.Config?.Labels?.["com.overtchat.tts.gpu-variant"] ===
+    "blackwell"
+    ? "blackwell"
+    : "standard";
+}
+
 async function stoppedComposeInstallation(
   docker: DockerCommand,
 ): Promise<ExistingInstallation | null> {
@@ -454,11 +458,6 @@ async function stoppedComposeInstallation(
   const searxng = await inspectContainer(docker, "overtchat-searxng");
   const kokoro = await inspectContainer(docker, "overtchat-kokoro");
   const kokoroGpu = await inspectContainer(docker, "overtchat-kokoro-gpu");
-  const kokoroGpuBlackwell = await inspectContainer(
-    docker,
-    "overtchat-kokoro-gpu-blackwell",
-  );
-  const selectedKokoroGpu = kokoroGpuBlackwell ?? kokoroGpu;
   const voice = await inspectContainer(docker, "overtchat-voice");
   const sttGpu = await inspectContainer(docker, "overtchat-stt-gpu");
   const sttCpu = sttGpu
@@ -480,14 +479,13 @@ async function stoppedComposeInstallation(
     )?.Source,
     bundledServices: {
       search: Boolean(searxng),
-      tts: Boolean(selectedKokoroGpu ?? kokoro),
+      tts: Boolean(kokoroGpu ?? kokoro),
       stt: Boolean(sttGpu ?? sttCpu),
       voice: Boolean(voice),
     },
-    ttsAccelerator: selectedKokoroGpu ? "gpu" : kokoro ? "cpu" : undefined,
-    ttsGpuUuid:
-      selectedKokoroGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
-    ttsGpuVariant: kokoroGpuBlackwell ? "blackwell" : undefined,
+    ttsAccelerator: kokoroGpu ? "gpu" : kokoro ? "cpu" : undefined,
+    ttsGpuUuid: kokoroGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
+    ttsGpuVariant: kokoroGpuVariant(kokoroGpu),
     sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
     sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
   };
@@ -525,11 +523,6 @@ export async function detectExistingInstallation(
   const searxng = await inspectContainer(docker, "overtchat-searxng");
   const kokoro = await inspectContainer(docker, "overtchat-kokoro");
   const kokoroGpu = await inspectContainer(docker, "overtchat-kokoro-gpu");
-  const kokoroGpuBlackwell = await inspectContainer(
-    docker,
-    "overtchat-kokoro-gpu-blackwell",
-  );
-  const selectedKokoroGpu = kokoroGpuBlackwell ?? kokoroGpu;
   const voice = await inspectContainer(docker, "overtchat-voice");
   const searxngConfigPath = searxng?.Mounts?.find(
     (mount) => mount.Destination === "/etc/searxng",
@@ -555,19 +548,16 @@ export async function detectExistingInstallation(
     searxngConfigPath,
     bundledServices: {
       search: Boolean(searxng),
-      tts: Boolean(selectedKokoroGpu ?? kokoro),
+      tts: Boolean(kokoroGpu ?? kokoro),
       stt: Boolean(sttGpu ?? sttCpu),
       voice: Boolean(voice),
     },
-    ttsAccelerator: selectedKokoroGpu ? "gpu" : kokoro ? "cpu" : undefined,
-    ttsGpuUuid:
-      selectedKokoroGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
+    ttsAccelerator: kokoroGpu ? "gpu" : kokoro ? "cpu" : undefined,
+    ttsGpuUuid: kokoroGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
     ttsGpuVariant:
-      kokoroGpuBlackwell || environment.get("TTS_GPU_VARIANT") === "blackwell"
+      environment.get("TTS_GPU_VARIANT") === "blackwell"
         ? "blackwell"
-        : selectedKokoroGpu
-          ? "standard"
-          : undefined,
+        : kokoroGpuVariant(kokoroGpu),
     sttAccelerator: sttGpu ? "gpu" : sttCpu ? "cpu" : undefined,
     sttGpuUuid: sttGpu?.HostConfig?.DeviceRequests?.[0]?.DeviceIDs?.[0],
   };

--- a/apps/cli/src/prompts.test.ts
+++ b/apps/cli/src/prompts.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { existingInstallationSummary } from "./prompts.js";
+import {
+  existingInstallationSummary,
+  kokoroGpuVariant,
+} from "./prompts.js";
 import type { ExistingInstallation } from "./types.js";
 
 function installation(
@@ -32,7 +35,7 @@ describe("existing installation summary", () => {
         "Published port: 127.0.0.1:49317",
         "Data: Docker volume overtchat_overtchat-data",
         "Compose directory: /home/yash/dev/overtchat",
-        "Bundled services: SearXNG, Kokoro, Parakeet (CPU)",
+        "Bundled services: SearXNG, Kokoro (CPU), Parakeet (CPU)",
         "",
         "This storage will be reused. A verified SQLite snapshot will be created before the app is replaced or migrations run.",
       ].join("\n"),
@@ -53,5 +56,21 @@ describe("existing installation summary", () => {
     expect(summary).toContain("Version: unknown");
     expect(summary).toContain("Data: Bind mount /srv/overtchat/data");
     expect(summary).toContain("Bundled services: none detected");
+  });
+
+  it("selects the Blackwell image only for x64 compute capability 12 GPUs", () => {
+    const gpu = {
+      index: 0,
+      uuid: "GPU-5090",
+      name: "NVIDIA GeForce RTX 5090",
+      memoryMiB: 32_000,
+      computeCapability: 12,
+    };
+
+    expect(kokoroGpuVariant(gpu, "x64")).toBe("blackwell");
+    expect(kokoroGpuVariant(gpu, "arm64")).toBe("standard");
+    expect(
+      kokoroGpuVariant({ ...gpu, name: "RTX 4090", computeCapability: 8.9 }, "x64"),
+    ).toBe("standard");
   });
 });

--- a/apps/cli/src/prompts.ts
+++ b/apps/cli/src/prompts.ts
@@ -13,6 +13,7 @@ import type {
   ExistingInstallation,
   Gpu,
   InstallationConfig,
+  KokoroGpuVariant,
   SearchProvider,
   SttProvider,
   TtsProvider,
@@ -101,6 +102,7 @@ async function promptSearch(
 
 async function promptTts(
   current: InstallationConfig["tts"],
+  gpus: Gpu[],
 ): Promise<InstallationConfig["tts"]> {
   const provider = chosen(
     await select<TtsProvider>({
@@ -110,17 +112,70 @@ async function promptTts(
         {
           value: "bundled",
           label: "Bundled Kokoro",
-          hint: "local CPU service",
+          hint: "local CPU or NVIDIA GPU service",
         },
         { value: "openai-compatible", label: "OpenAI-compatible API" },
         { value: "disabled", label: "Disabled" },
       ],
     }),
   );
-  if (provider !== "openai-compatible") {
+  if (provider === "disabled") {
     return {
       provider,
-      bundledInstalled: current.bundledInstalled || provider === "bundled",
+      bundledInstalled: current.bundledInstalled,
+      accelerator: current.accelerator,
+      gpuUuid: current.gpuUuid,
+      gpuVariant: current.gpuVariant,
+    };
+  }
+  if (provider === "bundled") {
+    if (gpus.length === 0) {
+      note(
+        "No NVIDIA GPU was detected. Kokoro will use the CPU image.",
+        "Local TTS accelerator",
+      );
+      return { provider, bundledInstalled: true, accelerator: "cpu" };
+    }
+    const autoGpu = [...gpus].sort(
+      (left, right) => right.memoryMiB - left.memoryMiB,
+    )[0];
+    const currentSelection =
+      current.accelerator === "cpu"
+        ? "cpu"
+        : current.accelerator === "gpu" && current.gpuUuid
+          ? `gpu:${current.gpuUuid}`
+          : "auto";
+    const accelerator = chosen(
+      await select<string>({
+        message: "Local TTS accelerator",
+        initialValue: currentSelection,
+        options: [
+          {
+            value: "auto",
+            label: `Auto — ${autoGpu?.name ?? gpus[0]?.name}`,
+            hint: "uses about 3–4 GB VRAM when loaded",
+          },
+          ...gpus.map((gpu) => ({
+            value: `gpu:${gpu.uuid}`,
+            label: gpuLabel(gpu),
+          })),
+          { value: "cpu", label: "CPU", hint: "smaller download and no VRAM use" },
+        ],
+      }),
+    );
+    if (accelerator === "cpu") {
+      return { provider, bundledInstalled: true, accelerator: "cpu" };
+    }
+    const selectedGpu =
+      accelerator === "auto"
+        ? autoGpu ?? gpus[0]
+        : gpus.find((gpu) => gpu.uuid === accelerator.slice("gpu:".length));
+    return {
+      provider,
+      bundledInstalled: true,
+      accelerator: accelerator === "auto" ? "auto" : "gpu",
+      gpuUuid: selectedGpu?.uuid,
+      gpuVariant: kokoroGpuVariant(selectedGpu),
     };
   }
   const baseUrl = chosen(
@@ -160,7 +215,23 @@ async function promptTts(
     apiKey: apiKey.trim() || current.apiKey || "",
     model: model.trim(),
     voice: voice.trim(),
+    accelerator: current.accelerator,
+    gpuUuid: current.gpuUuid,
+    gpuVariant: current.gpuVariant,
   };
+}
+
+export function kokoroGpuVariant(
+  gpu: Gpu | undefined,
+  architecture = process.arch,
+): KokoroGpuVariant {
+  if (
+    architecture === "x64" &&
+    ((gpu?.computeCapability ?? 0) >= 12 || /\bRTX\s*(?:PRO\s*)?50\d{2}\b/iu.test(gpu?.name ?? ""))
+  ) {
+    return "blackwell";
+  }
+  return "standard";
 }
 
 function gpuLabel(gpu: Gpu): string {
@@ -177,7 +248,13 @@ export function existingInstallationSummary(
       : `Bind mount ${existing.dataVolume}`;
   const services = [
     ...(existing.bundledServices.search ? ["SearXNG"] : []),
-    ...(existing.bundledServices.tts ? ["Kokoro"] : []),
+    ...(existing.bundledServices.tts
+      ? [
+          existing.ttsAccelerator === "gpu"
+            ? "Kokoro (NVIDIA)"
+            : "Kokoro (CPU)",
+        ]
+      : []),
     ...(existing.bundledServices.stt
       ? [
           existing.sttAccelerator === "gpu"
@@ -341,7 +418,7 @@ export async function promptInstallationConfig(
     }
   }
   const search = await promptSearch(initial.search);
-  const tts = await promptTts(initial.tts);
+  const tts = await promptTts(initial.tts, gpus);
   const stt = await promptStt(initial.stt, gpus);
   const voiceAvailable = tts.provider !== "disabled" && stt.provider !== "disabled";
   const installVoice = voiceAvailable

--- a/apps/cli/src/release.test.ts
+++ b/apps/cli/src/release.test.ts
@@ -10,6 +10,8 @@ const releaseImages = {
   redisImage: `docker.io/library/redis@sha256:${"a".repeat(64)}`,
   searxngImage: `docker.io/searxng/searxng@sha256:${"b".repeat(64)}`,
   kokoroImage: `ghcr.io/remsky/kokoro-fastapi-cpu@sha256:${"c".repeat(64)}`,
+  kokoroGpuImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"d".repeat(64)}`,
+  kokoroGpuBlackwellImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"e".repeat(64)}`,
 };
 
 function config(
@@ -150,5 +152,21 @@ describe("release manifest", () => {
         searxngImage: "docker.io/searxng/searxng:latest",
       }),
     ).toThrow("invalid SearXNG image");
+  });
+
+  it("requires both CUDA variants to use pinned Kokoro GPU images", () => {
+    expect(() =>
+      parseReleaseManifest({
+        format: 1,
+        cliVersion: "1.2.3",
+        appVersion: "4.5.6",
+        voiceVersion: "0.1.0",
+        connectorVersion: "7.8.9",
+        sttVersion: "0.1.0",
+        ...releaseImages,
+        kokoroGpuBlackwellImage:
+          "ghcr.io/remsky/kokoro-fastapi-cpu@sha256:" + "e".repeat(64),
+      }),
+    ).toThrow("invalid Kokoro Blackwell image");
   });
 });

--- a/apps/cli/src/release.ts
+++ b/apps/cli/src/release.ts
@@ -29,6 +29,8 @@ export type ReleaseManifest = {
   redisImage: string;
   searxngImage: string;
   kokoroImage: string;
+  kokoroGpuImage: string;
+  kokoroGpuBlackwellImage: string;
 };
 
 const VERSION_PATTERN = /^\d+\.\d+\.\d+$/u;
@@ -84,6 +86,8 @@ export function applyReleaseManifest(
     redisImage: manifest.redisImage,
     searxngImage: manifest.searxngImage,
     kokoroImage: manifest.kokoroImage,
+    kokoroGpuImage: manifest.kokoroGpuImage,
+    kokoroGpuBlackwellImage: manifest.kokoroGpuBlackwellImage,
   };
 }
 
@@ -120,6 +124,11 @@ export function parseReleaseManifest(value: unknown): ReleaseManifest {
   const redisImage = Reflect.get(value, "redisImage");
   const searxngImage = Reflect.get(value, "searxngImage");
   const kokoroImage = Reflect.get(value, "kokoroImage");
+  const kokoroGpuImage = Reflect.get(value, "kokoroGpuImage");
+  const kokoroGpuBlackwellImage = Reflect.get(
+    value,
+    "kokoroGpuBlackwellImage",
+  );
   assertVersion(cliVersion, "CLI version");
   assertVersion(appVersion, "app version");
   assertVersion(voiceVersion, "voice version");
@@ -132,6 +141,16 @@ export function parseReleaseManifest(value: unknown): ReleaseManifest {
     "Kokoro image",
     "ghcr.io/remsky/kokoro-fastapi-cpu",
   );
+  assertDigestImage(
+    kokoroGpuImage,
+    "Kokoro GPU image",
+    "ghcr.io/remsky/kokoro-fastapi-gpu",
+  );
+  assertDigestImage(
+    kokoroGpuBlackwellImage,
+    "Kokoro Blackwell image",
+    "ghcr.io/remsky/kokoro-fastapi-gpu",
+  );
   return {
     format: 1,
     cliVersion,
@@ -142,6 +161,8 @@ export function parseReleaseManifest(value: unknown): ReleaseManifest {
     redisImage,
     searxngImage,
     kokoroImage,
+    kokoroGpuImage,
+    kokoroGpuBlackwellImage,
   };
 }
 

--- a/apps/cli/src/setup.test.ts
+++ b/apps/cli/src/setup.test.ts
@@ -15,6 +15,8 @@ function config(): InstallationConfig {
     redisImage: `docker.io/library/redis@sha256:${"a".repeat(64)}`,
     searxngImage: `docker.io/searxng/searxng@sha256:${"b".repeat(64)}`,
     kokoroImage: `ghcr.io/remsky/kokoro-fastapi-cpu@sha256:${"c".repeat(64)}`,
+    kokoroGpuImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"d".repeat(64)}`,
+    kokoroGpuBlackwellImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"e".repeat(64)}`,
     appPort: 4718,
     bindAddress: "0.0.0.0",
     publicUrl: "http://localhost:4718",

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -31,7 +31,10 @@ import {
 import { primaryLanAddress } from "./network.js";
 import { runtimePaths } from "./paths.js";
 import { requireSuccessful } from "./process.js";
-import { promptInstallationConfig } from "./prompts.js";
+import {
+  kokoroGpuVariant,
+  promptInstallationConfig,
+} from "./prompts.js";
 import {
   applyReleaseManifest,
   parseReleaseManifest,
@@ -99,6 +102,7 @@ function mergeRunningCapabilities(
       : config.search,
     tts: tts
       ? {
+          ...config.tts,
           provider: tts.provider as InstallationConfig["tts"]["provider"],
           bundledInstalled: tts.bundledInstalled,
           baseUrl: tts.baseUrl ?? undefined,
@@ -355,6 +359,19 @@ export async function setup(
     if (lanAddress) config.publicUrl = `http://${lanAddress}:${config.appPort}`;
   }
   const gpus = await detectNvidiaGpus();
+  if (
+    (config.tts.accelerator === "auto" || config.tts.accelerator === "gpu") &&
+    !config.tts.gpuVariant
+  ) {
+    const selectedGpu =
+      gpus.find((gpu) => gpu.uuid === config.tts.gpuUuid) ??
+      [...gpus].sort((left, right) => right.memoryMiB - left.memoryMiB)[0];
+    config.tts = {
+      ...config.tts,
+      gpuUuid: selectedGpu?.uuid ?? config.tts.gpuUuid,
+      gpuVariant: kokoroGpuVariant(selectedGpu),
+    };
+  }
   if (!options.defaults) {
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
       throw new Error(
@@ -376,13 +393,27 @@ export async function setup(
     };
   }
 
+  const ttsUsesGpu =
+    config.tts.provider === "bundled" &&
+    (config.tts.accelerator === "auto" || config.tts.accelerator === "gpu");
+  const sttUsesGpu =
+    config.stt.provider === "bundled" && config.stt.accelerator !== "cpu";
   if (
-    config.stt.provider === "bundled" &&
-    config.stt.accelerator !== "cpu" &&
+    (ttsUsesGpu || sttUsesGpu) &&
     !(await nvidiaContainerRuntimeAvailable(docker))
   ) {
     if (options.defaults) {
-      config.stt = { ...config.stt, accelerator: "cpu", gpuUuid: undefined };
+      if (ttsUsesGpu) {
+        config.tts = {
+          ...config.tts,
+          accelerator: "cpu",
+          gpuUuid: undefined,
+          gpuVariant: undefined,
+        };
+      }
+      if (sttUsesGpu) {
+        config.stt = { ...config.stt, accelerator: "cpu", gpuUuid: undefined };
+      }
     } else {
       const installToolkit = await confirm({
         message:
@@ -405,7 +436,17 @@ export async function setup(
           );
         }
       } else {
-        config.stt = { ...config.stt, accelerator: "cpu", gpuUuid: undefined };
+        if (ttsUsesGpu) {
+          config.tts = {
+            ...config.tts,
+            accelerator: "cpu",
+            gpuUuid: undefined,
+            gpuVariant: undefined,
+          };
+        }
+        if (sttUsesGpu) {
+          config.stt = { ...config.stt, accelerator: "cpu", gpuUuid: undefined };
+        }
       }
     }
   }

--- a/apps/cli/src/snapshot.test.ts
+++ b/apps/cli/src/snapshot.test.ts
@@ -35,6 +35,8 @@ function config(): InstallationConfig {
     redisImage: `docker.io/library/redis@sha256:${"a".repeat(64)}`,
     searxngImage: `docker.io/searxng/searxng@sha256:${"b".repeat(64)}`,
     kokoroImage: `ghcr.io/remsky/kokoro-fastapi-cpu@sha256:${"c".repeat(64)}`,
+    kokoroGpuImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"d".repeat(64)}`,
+    kokoroGpuBlackwellImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"e".repeat(64)}`,
     appPort: 4718,
     bindAddress: "127.0.0.1",
     publicUrl: "https://chat.example.com",

--- a/apps/cli/src/status.ts
+++ b/apps/cli/src/status.ts
@@ -22,7 +22,13 @@ export async function status(): Promise<void> {
   console.log(`Status: ${app?.exitCode === 0 ? app.stdout.trim() : "unavailable"}`);
   console.log(`URL: ${config.publicUrl}`);
   console.log(`Web search: ${config.search.provider}`);
-  console.log(`Text-to-speech: ${config.tts.provider}`);
+  console.log(
+    `Text-to-speech: ${config.tts.provider}${
+      config.tts.provider === "bundled"
+        ? ` (${config.tts.accelerator === "auto" || config.tts.accelerator === "gpu" ? "NVIDIA" : "CPU"})`
+        : ""
+    }`,
+  );
   console.log(`Speech-to-text: ${config.stt.provider}`);
   console.log(`Realtime voice: ${config.voice.installed ? "installed" : "not installed"}`);
   console.log(`Agent Connections: ${config.agents.installed ? "installed" : "not installed"}`);

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -1,13 +1,15 @@
 export type SearchProvider = "bundled" | "brave" | "searxng" | "disabled";
 export type TtsProvider = "bundled" | "openai-compatible" | "disabled";
 export type SttProvider = "bundled" | "openai-compatible" | "disabled";
-export type SttAccelerator = "auto" | "cpu" | "gpu";
+export type SpeechAccelerator = "auto" | "cpu" | "gpu";
+export type KokoroGpuVariant = "standard" | "blackwell";
 
 export type Gpu = {
   index: number;
   uuid: string;
   name: string;
   memoryMiB: number;
+  computeCapability?: number;
 };
 
 export type SearchConfig = {
@@ -24,6 +26,9 @@ export type TtsConfig = {
   apiKey?: string;
   model?: string;
   voice?: string;
+  accelerator?: SpeechAccelerator;
+  gpuUuid?: string;
+  gpuVariant?: KokoroGpuVariant;
 };
 
 export type SttConfig = {
@@ -32,7 +37,7 @@ export type SttConfig = {
   baseUrl?: string;
   apiKey?: string;
   model?: string;
-  accelerator?: SttAccelerator;
+  accelerator?: SpeechAccelerator;
   gpuUuid?: string;
 };
 
@@ -55,6 +60,8 @@ export type InstallationConfig = {
   redisImage: string;
   searxngImage: string;
   kokoroImage: string;
+  kokoroGpuImage: string;
+  kokoroGpuBlackwellImage: string;
   appPort: number;
   bindAddress: string;
   publicUrl: string;
@@ -91,6 +98,9 @@ export type ExistingInstallation = {
     stt: boolean;
     voice?: boolean;
   };
+  ttsAccelerator?: "cpu" | "gpu";
+  ttsGpuUuid?: string;
+  ttsGpuVariant?: KokoroGpuVariant;
   sttAccelerator?: "cpu" | "gpu";
   sttGpuUuid?: string;
 };

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -96,6 +96,8 @@ const releaseImages = {
   redisImage: `docker.io/library/redis@sha256:${"a".repeat(64)}`,
   searxngImage: `docker.io/searxng/searxng@sha256:${"b".repeat(64)}`,
   kokoroImage: `ghcr.io/remsky/kokoro-fastapi-cpu@sha256:${"c".repeat(64)}`,
+  kokoroGpuImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"d".repeat(64)}`,
+  kokoroGpuBlackwellImage: `ghcr.io/remsky/kokoro-fastapi-gpu@sha256:${"e".repeat(64)}`,
 };
 
 function config(

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.11"
+cli_version="0.1.12"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -7,5 +7,7 @@
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",
   "searxngImage": "docker.io/searxng/searxng@sha256:11a9b34cdc0b1ec2b991470a2762ecb5a1a531898289fb51dcd015260450729e",
-  "kokoroImage": "ghcr.io/remsky/kokoro-fastapi-cpu@sha256:c8812546d358cbfd6a5c4087a28795b2b001d8e32d7a322eedd246e6bc13cb55"
+  "kokoroImage": "ghcr.io/remsky/kokoro-fastapi-cpu@sha256:28d6f0b6e4df369559012578299d201b855a08fac466f616653edd1f08c5370a",
+  "kokoroGpuImage": "ghcr.io/remsky/kokoro-fastapi-gpu@sha256:9e5336d8ebc4984a78ae9181ce3280b285c96d9cbea9b20957e3526868ceb01d",
+  "kokoroGpuBlackwellImage": "ghcr.io/remsky/kokoro-fastapi-gpu@sha256:b75ec27022d6187cf6e6aa4f9053cc64f4c3904fa80dc997c87d3b7a4abffed1"
 }

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "cliVersion": "0.1.11",
+  "cliVersion": "0.1.12",
   "appVersion": "0.19.0",
   "voiceVersion": "0.1.0",
   "connectorVersion": "0.9.0",

--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,12 @@ services:
       kokoro:
         condition: service_healthy
         required: false
+      kokoro-gpu:
+        condition: service_healthy
+        required: false
+      kokoro-gpu-blackwell:
+        condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
 
@@ -82,16 +88,66 @@ services:
       retries: 10
       start_period: 10s
 
+  # Text-to-speech via Kokoro. Off by default; opt in with:
+  #   docker compose --profile tts-cpu up -d    (CPU)
+  #   docker compose --profile tts-gpu up -d    (NVIDIA GPU, requires NVIDIA Container Toolkit)
+  #   docker compose --profile tts-gpu-blackwell up -d  (RTX 50-series)
+  # Both services are reachable from `app` as `http://kokoro:8880`.
   kokoro:
-    image: ghcr.io/remsky/kokoro-fastapi-cpu@sha256:c8812546d358cbfd6a5c4087a28795b2b001d8e32d7a322eedd246e6bc13cb55
+    image: ghcr.io/remsky/kokoro-fastapi-cpu@sha256:28d6f0b6e4df369559012578299d201b855a08fac466f616653edd1f08c5370a
     container_name: overtchat-kokoro
     restart: unless-stopped
+    profiles: [tts-cpu]
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)\""]
       interval: 15s
       timeout: 5s
       retries: 20
       start_period: 60s
+
+  kokoro-gpu:
+    image: ghcr.io/remsky/kokoro-fastapi-gpu@sha256:9e5336d8ebc4984a78ae9181ce3280b285c96d9cbea9b20957e3526868ceb01d
+    container_name: overtchat-kokoro-gpu
+    restart: unless-stopped
+    profiles: [tts-gpu]
+    networks:
+      default:
+        aliases: [kokoro]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)\""]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+  kokoro-gpu-blackwell:
+    image: ghcr.io/remsky/kokoro-fastapi-gpu@sha256:b75ec27022d6187cf6e6aa4f9053cc64f4c3904fa80dc997c87d3b7a4abffed1
+    container_name: overtchat-kokoro-gpu-blackwell
+    restart: unless-stopped
+    profiles: [tts-gpu-blackwell]
+    networks:
+      default:
+        aliases: [kokoro]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)\""]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 
   # Speech-to-text via Parakeet TDT v3. Off by default; opt in with:
   #   docker compose --profile stt up -d        (CPU, ~670MB model, ~2GB RAM)

--- a/compose.yml
+++ b/compose.yml
@@ -30,12 +30,6 @@ services:
       kokoro:
         condition: service_healthy
         required: false
-      kokoro-gpu:
-        condition: service_healthy
-        required: false
-      kokoro-gpu-blackwell:
-        condition: service_healthy
-        required: false
       redis:
         condition: service_healthy
 
@@ -88,66 +82,20 @@ services:
       retries: 10
       start_period: 10s
 
-  # Text-to-speech via Kokoro. Off by default; opt in with:
-  #   docker compose --profile tts-cpu up -d    (CPU)
-  #   docker compose --profile tts-gpu up -d    (NVIDIA GPU, requires NVIDIA Container Toolkit)
-  #   docker compose --profile tts-gpu-blackwell up -d  (RTX 50-series)
-  # Both services are reachable from `app` as `http://kokoro:8880`.
+  # Text-to-speech via Kokoro. The source stack keeps its existing CPU default;
+  # the managed installer owns accelerator selection.
   kokoro:
     image: ghcr.io/remsky/kokoro-fastapi-cpu@sha256:28d6f0b6e4df369559012578299d201b855a08fac466f616653edd1f08c5370a
     container_name: overtchat-kokoro
     restart: unless-stopped
-    profiles: [tts-cpu]
+    labels:
+      com.overtchat.tts.accelerator: cpu
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)\""]
       interval: 15s
       timeout: 5s
       retries: 20
       start_period: 60s
-
-  kokoro-gpu:
-    image: ghcr.io/remsky/kokoro-fastapi-gpu@sha256:9e5336d8ebc4984a78ae9181ce3280b285c96d9cbea9b20957e3526868ceb01d
-    container_name: overtchat-kokoro-gpu
-    restart: unless-stopped
-    profiles: [tts-gpu]
-    networks:
-      default:
-        aliases: [kokoro]
-    healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)\""]
-      interval: 15s
-      timeout: 5s
-      retries: 20
-      start_period: 60s
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
-
-  kokoro-gpu-blackwell:
-    image: ghcr.io/remsky/kokoro-fastapi-gpu@sha256:b75ec27022d6187cf6e6aa4f9053cc64f4c3904fa80dc997c87d3b7a4abffed1
-    container_name: overtchat-kokoro-gpu-blackwell
-    restart: unless-stopped
-    profiles: [tts-gpu-blackwell]
-    networks:
-      default:
-        aliases: [kokoro]
-    healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8880/health').status==200 else 1)\""]
-      interval: 15s
-      timeout: 5s
-      retries: 20
-      start_period: 60s
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
   # Speech-to-text via Parakeet TDT v3. Off by default; opt in with:
   #   docker compose --profile stt up -d        (CPU, ~670MB model, ~2GB RAM)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -12,6 +12,11 @@ curl -fsSL https://overtchat.com/install | sh
 The wizard installs Docker when needed and configures the app, optional local
 services, realtime voice, and Agent Connections. Realtime voice requires both
 speech-to-text and text-to-speech; the wizard offers it after those providers.
+Bundled Kokoro and Parakeet services can independently use the CPU or a
+detected NVIDIA GPU. GPU services require NVIDIA Container Toolkit; setup can
+install it on supported Linux distributions. Kokoro uses roughly 3–4 GB of
+VRAM when loaded, so keep one or both speech services on CPU when GPU memory is
+limited.
 Open the printed URL; the first signup becomes the administrator.
 
 Use the manager for later changes:

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,7 +22,7 @@ stable channel used by both `overtchat setup` and `overtchat update`.
 | CLI | `apps/cli/package.json`; lockfile; `CLI_VERSION`; site installer; manifest `cliVersion` | `cli-vX.Y.Z` |
 | Connector | Package and lockfile; bridge release version; connector installer; site redirects; manifest `connectorVersion` | `connector-vX.Y.Z` |
 | STT | Manifest `sttVersion`; `compose.yml` default | `stt-vX.Y.Z` |
-| Bundled images | Manifest `redisImage`, `searxngImage`, or `kokoroImage` digest | None |
+| Bundled images | Manifest Redis, SearXNG, or Kokoro image digest | None |
 | Mobile | See [Mobile release](#mobile-release) | `mobile-vX.Y.Z` |
 
 Do not change unrelated manifest fields.
@@ -49,7 +49,9 @@ Do not change unrelated manifest fields.
   retain the current protocol.
 - **STT:** The STT workflow publishes both images and dispatches promotion.
 - **Bundled images:** Promotion verifies amd64 and arm64 for every selected
-  digest. A digest-only change does not require a CLI release.
+  digest except the amd64-only Kokoro Blackwell image. Keep the CPU, standard
+  CUDA, and Blackwell Kokoro digests on the same upstream release. A
+  digest-only change does not require a CLI release.
 - **Combined:** Artifacts may publish in any order; promotion succeeds only
   after every selected component is public.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },


### PR DESCRIPTION
## Summary

- add independently selectable CPU and NVIDIA GPU acceleration for bundled Kokoro TTS
- reuse managed GPU discovery, UUID selection, and NVIDIA Container Toolkit setup while preserving CPU for existing installations
- pin matching Kokoro v0.8.1 CPU, standard CUDA, and RTX 50-series Blackwell images with release-platform validation
- preserve the stable OpenAI-compatible `kokoro:8880` endpoint across sidecars and document VRAM considerations

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build -w apps/cli --`
- `NEXT_TELEMETRY_DISABLED=1 npm run build -w apps/site --`
- Docker Compose config validation for `tts-cpu`, `tts-gpu`, and `tts-gpu-blackwell`
- image platform validation for all three pinned Kokoro digests