### PR TITLE
fix(cli): make optional provider setup explicit

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/cli/src/compose.test.ts
+++ b/apps/cli/src/compose.test.ts
@@ -168,6 +168,38 @@ describe("managed Compose configuration", () => {
     );
   });
 
+  it("does not enable bundled profiles for external speech providers", () => {
+    const externalConfig = config();
+    externalConfig.search = { provider: "brave", bundledInstalled: false };
+    externalConfig.tts = {
+      provider: "openai-compatible",
+      bundledInstalled: false,
+      baseUrl: "http://tts.example.com",
+    };
+    externalConfig.stt = {
+      provider: "openai-compatible",
+      bundledInstalled: false,
+      baseUrl: "http://stt.example.com",
+    };
+
+    const environment = renderStackEnvironment(
+      externalConfig,
+      {
+        betterAuthSecret: "auth",
+        managementSecret: "management",
+        searxngSecret: "search",
+        voiceSharedSecret: "voice",
+      },
+      paths,
+    );
+
+    expect(environment).toContain('COMPOSE_PROFILES="voice"');
+    expect(environment).not.toContain("stt-gpu");
+    expect(environment).not.toContain("stt-cpu");
+    expect(environment).not.toContain("tts-gpu");
+    expect(environment).not.toContain("tts-cpu");
+  });
+
   it("preserves an adopted bind-mounted data directory", () => {
     const bindConfig = {
       ...config(),

--- a/apps/cli/src/compose.ts
+++ b/apps/cli/src/compose.ts
@@ -23,7 +23,11 @@ function profileList(config: InstallationConfig): string[] {
     );
   }
   if (config.stt.bundledInstalled) {
-    profiles.push(config.stt.accelerator === "cpu" ? "stt-cpu" : "stt-gpu");
+    profiles.push(
+      config.stt.accelerator === "auto" || config.stt.accelerator === "gpu"
+        ? "stt-gpu"
+        : "stt-cpu",
+    );
   }
   if (config.voice.installed) profiles.push("voice");
   return profiles;

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -188,6 +188,28 @@ describe("managed installation state", () => {
     }
   });
 
+  it("keeps missing STT accelerator state on CPU", async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "overtchat-legacy-stt-state-"),
+    );
+    const paths = pathsFor(directory);
+    try {
+      const legacy = defaultInstallationConfig(null, manifest);
+      legacy.stt = { provider: "bundled", bundledInstalled: true };
+      await writeFile(paths.stateFile, JSON.stringify(legacy));
+
+      await expect(readInstallationConfig(paths)).resolves.toMatchObject({
+        stt: {
+          provider: "bundled",
+          bundledInstalled: true,
+          accelerator: "cpu",
+        },
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("never persists provider API keys", async () => {
     const directory = await mkdtemp(
       path.join(os.tmpdir(), "overtchat-installation-state-"),

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -210,6 +210,49 @@ describe("managed installation state", () => {
     }
   });
 
+  it("repairs stale bundled state for external and deferred providers", async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "overtchat-stale-provider-state-"),
+    );
+    const paths = pathsFor(directory);
+    try {
+      const stale = defaultInstallationConfig(null, manifest);
+      stale.search = { provider: "brave", bundledInstalled: true };
+      stale.tts = {
+        provider: "openai-compatible",
+        bundledInstalled: true,
+        baseUrl: "http://tts.example.com",
+        accelerator: "gpu",
+        gpuUuid: "GPU-tts",
+        gpuVariant: "blackwell",
+      };
+      stale.stt = {
+        provider: "disabled",
+        bundledInstalled: true,
+        accelerator: "gpu",
+        gpuUuid: "GPU-stt",
+      };
+      stale.voice = { installed: true };
+      await writeFile(paths.stateFile, JSON.stringify(stale));
+
+      const loaded = await readInstallationConfig(paths);
+
+      expect(loaded?.search.bundledInstalled).toBe(false);
+      expect(loaded?.tts).toEqual({
+        provider: "openai-compatible",
+        bundledInstalled: false,
+        baseUrl: "http://tts.example.com",
+      });
+      expect(loaded?.stt).toEqual({
+        provider: "disabled",
+        bundledInstalled: false,
+      });
+      expect(loaded?.voice).toEqual({ installed: false });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("never persists provider API keys", async () => {
     const directory = await mkdtemp(
       path.join(os.tmpdir(), "overtchat-installation-state-"),

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -161,6 +161,12 @@ export async function readInstallationConfig(
         ...config.tts,
         accelerator: config.tts.accelerator ?? "cpu",
       },
+      // Missing STT accelerator state is also a legacy CPU selection. Never
+      // turn an unknown value into an implicit NVIDIA service.
+      stt: {
+        ...config.stt,
+        accelerator: config.stt.accelerator ?? "cpu",
+      },
     });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -5,6 +5,8 @@ import type {
   ExistingInstallation,
   InstallationConfig,
   RuntimePaths,
+  SttConfig,
+  TtsConfig,
 } from "./types.js";
 import {
   APP_IMAGE,
@@ -136,7 +138,7 @@ export async function readInstallationConfig(
       throw new Error(`Unsupported installation state at ${paths.stateFile}.`);
     }
     const config = parsed as InstallationConfig;
-    return withoutProviderKeys({
+    const migrated = {
       ...config,
       // State written by the first installer draft only supported volumes.
       dataMountType: config.dataMountType ?? "volume",
@@ -155,23 +157,68 @@ export async function readInstallationConfig(
         config.voiceImage ??
         `${VOICE_IMAGE}:${config.voiceVersion ?? "0.0.0"}`,
       voice: config.voice ?? { installed: false },
-      // Bundled TTS predates accelerator selection. Missing state is the
-      // existing CPU service, never an implicit migration onto a GPU.
-      tts: {
-        ...config.tts,
-        accelerator: config.tts.accelerator ?? "cpu",
-      },
-      // Missing STT accelerator state is also a legacy CPU selection. Never
-      // turn an unknown value into an implicit NVIDIA service.
-      stt: {
-        ...config.stt,
-        accelerator: config.stt.accelerator ?? "cpu",
-      },
-    });
+    };
+    return withoutProviderKeys(normalizeInstallationConfig(migrated));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
   }
+}
+
+function normalizeTtsConfig(tts: TtsConfig): TtsConfig {
+  if (tts.provider === "bundled") {
+    return {
+      ...tts,
+      bundledInstalled: true,
+      // Bundled TTS predates accelerator selection. Missing state is the
+      // existing CPU service, never an implicit migration onto a GPU.
+      accelerator: tts.accelerator ?? "cpu",
+    };
+  }
+  const normalized = { ...tts, bundledInstalled: false };
+  delete normalized.accelerator;
+  delete normalized.gpuUuid;
+  delete normalized.gpuVariant;
+  return normalized;
+}
+
+function normalizeSttConfig(stt: SttConfig): SttConfig {
+  if (stt.provider === "bundled") {
+    return {
+      ...stt,
+      bundledInstalled: true,
+      // Missing STT accelerator state is also a legacy CPU selection. Never
+      // turn an unknown value into an implicit NVIDIA service.
+      accelerator: stt.accelerator ?? "cpu",
+    };
+  }
+  const normalized = { ...stt, bundledInstalled: false };
+  delete normalized.accelerator;
+  delete normalized.gpuUuid;
+  return normalized;
+}
+
+export function normalizeInstallationConfig(
+  config: InstallationConfig,
+): InstallationConfig {
+  const tts = normalizeTtsConfig(config.tts);
+  const stt = normalizeSttConfig(config.stt);
+
+  return {
+    ...config,
+    search: {
+      ...config.search,
+      bundledInstalled: config.search.provider === "bundled",
+    },
+    tts,
+    stt,
+    voice: {
+      installed:
+        config.voice.installed &&
+        tts.provider !== "disabled" &&
+        stt.provider !== "disabled",
+    },
+  };
 }
 
 function withoutApiKey<T extends { apiKey?: string }>(
@@ -264,7 +311,11 @@ export async function writeInstallationConfig(
 ): Promise<void> {
   await writeAtomic(
     paths.stateFile,
-    `${JSON.stringify(withoutProviderKeys(config), null, 2)}\n`,
+    `${JSON.stringify(
+      withoutProviderKeys(normalizeInstallationConfig(config)),
+      null,
+      2,
+    )}\n`,
     0o600,
   );
 }

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = "0.1.12";
+export const CLI_VERSION = "0.1.13";
 
 export const APP_IMAGE = "ghcr.io/yoloyash/overtchat-app";
 export const VOICE_IMAGE = "ghcr.io/yoloyash/overtchat-voice";

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -330,14 +330,18 @@ export async function reconcileManagedSidecars(
       containerName: "overtchat-stt-cpu",
       label: "Parakeet (CPU)",
       selected:
-        config.stt.bundledInstalled && config.stt.accelerator === "cpu",
+        config.stt.bundledInstalled &&
+        config.stt.accelerator !== "auto" &&
+        config.stt.accelerator !== "gpu",
       service: "stt-cpu",
     },
     {
       containerName: "overtchat-stt-gpu",
       label: "Parakeet (NVIDIA)",
       selected:
-        config.stt.bundledInstalled && config.stt.accelerator !== "cpu",
+        config.stt.bundledInstalled &&
+        (config.stt.accelerator === "auto" ||
+          config.stt.accelerator === "gpu"),
       service: "stt-gpu",
     },
   ];

--- a/apps/cli/src/prompts.test.ts
+++ b/apps/cli/src/prompts.test.ts
@@ -1,9 +1,65 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   existingInstallationSummary,
   kokoroGpuVariant,
+  promptInstallationConfig,
 } from "./prompts.js";
-import type { ExistingInstallation } from "./types.js";
+import type { ExistingInstallation, InstallationConfig } from "./types.js";
+
+const promptAnswers = vi.hoisted(() => new Map<string, unknown>());
+const selectPrompts = vi.hoisted(
+  () =>
+    [] as Array<{
+      message: string;
+      options: Array<{ value: string; label: string }>;
+    }>,
+);
+const confirmPrompts = vi.hoisted(
+  () =>
+    [] as Array<{
+      message: string;
+      active: string;
+      inactive: string;
+    }>,
+);
+
+vi.mock("@clack/prompts", () => ({
+  cancel: vi.fn(),
+  confirm: vi.fn(
+    async (prompt: { message: string; active: string; inactive: string }) => {
+      confirmPrompts.push(prompt);
+      return promptAnswers.get(prompt.message);
+    },
+  ),
+  intro: vi.fn(),
+  isCancel: vi.fn(() => false),
+  note: vi.fn(),
+  password: vi.fn(async ({ message }: { message: string }) =>
+    promptAnswers.get(message),
+  ),
+  select: vi.fn(
+    async (prompt: {
+      message: string;
+      options: Array<{ value: string; label: string }>;
+    }) => {
+      selectPrompts.push(prompt);
+      return promptAnswers.get(prompt.message);
+    },
+  ),
+  text: vi.fn(async ({ message }: { message: string }) =>
+    promptAnswers.get(message),
+  ),
+}));
+
+vi.mock("./process.js", () => ({
+  commandExists: vi.fn(async () => false),
+}));
+
+beforeEach(() => {
+  promptAnswers.clear();
+  selectPrompts.length = 0;
+  confirmPrompts.length = 0;
+});
 
 function installation(
   overrides: Partial<ExistingInstallation> = {},
@@ -23,6 +79,47 @@ function installation(
     bundledServices: { search: true, tts: true, stt: true },
     sttAccelerator: "cpu",
     ...overrides,
+  };
+}
+
+function setupConfig(): InstallationConfig {
+  return {
+    format: 1,
+    appVersion: "1.2.3",
+    appImage: "ghcr.io/example/overtchat:1.2.3",
+    voiceVersion: "1.0.0",
+    voiceImage: "ghcr.io/example/overtchat-voice:1.0.0",
+    connectorVersion: "2.0.0",
+    sttVersion: "3.0.0",
+    redisImage: "redis",
+    searxngImage: "searxng",
+    kokoroImage: "kokoro-cpu",
+    kokoroGpuImage: "kokoro-gpu",
+    kokoroGpuBlackwellImage: "kokoro-gpu-blackwell",
+    appPort: 4717,
+    bindAddress: "0.0.0.0",
+    publicUrl: "http://localhost:4717",
+    extraTrustedOrigins: [],
+    connectorServerUrl: "http://127.0.0.1:4717",
+    composeProject: "overtchat",
+    dataMountType: "volume",
+    dataVolume: "overtchat-data",
+    search: { provider: "bundled", bundledInstalled: true },
+    tts: {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "gpu",
+      gpuUuid: "GPU-old",
+      gpuVariant: "standard",
+    },
+    stt: {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "gpu",
+      gpuUuid: "GPU-old",
+    },
+    voice: { installed: true },
+    agents: { installed: true },
   };
 }
 
@@ -72,5 +169,86 @@ describe("existing installation summary", () => {
     expect(
       kokoroGpuVariant({ ...gpu, name: "RTX 4090", computeCapability: 8.9 }, "x64"),
     ).toBe("standard");
+  });
+});
+
+describe("setup provider selection", () => {
+  it("removes hidden bundled speech services after external providers are selected", async () => {
+    const config = setupConfig();
+    promptAnswers.set("Web search", "brave");
+    promptAnswers.set("Brave Search API key", "brave-key");
+    promptAnswers.set("Text-to-speech", "openai-compatible");
+    promptAnswers.set("TTS API base URL", "http://tts.example.com");
+    promptAnswers.set("TTS API key (leave blank when not required)", "");
+    promptAnswers.set("TTS model", "kokoro");
+    promptAnswers.set("Default voice", "af_heart");
+    promptAnswers.set("Speech-to-text", "openai-compatible");
+    promptAnswers.set("STT API base URL", "http://stt.example.com");
+    promptAnswers.set("STT API key (leave blank when not required)", "");
+    promptAnswers.set("STT model", "parakeet");
+    promptAnswers.set("Install realtime voice conversations?", true);
+    promptAnswers.set("Install Agent Connections?", false);
+
+    const selected = await promptInstallationConfig(config, []);
+
+    expect(selected.search).toMatchObject({
+      provider: "brave",
+      bundledInstalled: false,
+    });
+    expect(selected.tts).toMatchObject({
+      provider: "openai-compatible",
+      bundledInstalled: false,
+    });
+    expect(selected.tts).not.toHaveProperty("accelerator");
+    expect(selected.tts).not.toHaveProperty("gpuUuid");
+    expect(selected.stt).toMatchObject({
+      provider: "openai-compatible",
+      bundledInstalled: false,
+    });
+    expect(selected.stt).not.toHaveProperty("accelerator");
+    expect(selected.stt).not.toHaveProperty("gpuUuid");
+    for (const message of ["Web search", "Text-to-speech", "Speech-to-text"]) {
+      expect(
+        selectPrompts.find((prompt) => prompt.message === message)?.options,
+      ).toContainEqual({
+        value: "disabled",
+        label: "Set up later",
+        hint: expect.any(String),
+      });
+    }
+    for (const message of [
+      "Install realtime voice conversations?",
+      "Install Agent Connections?",
+    ]) {
+      expect(
+        confirmPrompts.find((prompt) => prompt.message === message),
+      ).toMatchObject({
+        active: "Yes",
+        inactive: "Set up later",
+      });
+    }
+  });
+
+  it("removes previously installed optional services when setup is deferred", async () => {
+    promptAnswers.set("Web search", "disabled");
+    promptAnswers.set("Text-to-speech", "disabled");
+    promptAnswers.set("Speech-to-text", "disabled");
+    promptAnswers.set("Install Agent Connections?", false);
+
+    const selected = await promptInstallationConfig(setupConfig(), []);
+
+    expect(selected.search).toEqual({
+      provider: "disabled",
+      bundledInstalled: false,
+    });
+    expect(selected.tts).toEqual({
+      provider: "disabled",
+      bundledInstalled: false,
+    });
+    expect(selected.stt).toEqual({
+      provider: "disabled",
+      bundledInstalled: false,
+    });
+    expect(selected.voice).toEqual({ installed: false });
   });
 });

--- a/apps/cli/src/prompts.ts
+++ b/apps/cli/src/prompts.ts
@@ -55,7 +55,11 @@ async function promptSearch(
         },
         { value: "brave", label: "Brave Search API" },
         { value: "searxng", label: "Existing SearXNG" },
-        { value: "disabled", label: "Disabled" },
+        {
+          value: "disabled",
+          label: "Set up later",
+          hint: "web search stays unavailable",
+        },
       ],
     }),
   );
@@ -75,7 +79,7 @@ async function promptSearch(
     );
     return {
       provider,
-      bundledInstalled: current.bundledInstalled,
+      bundledInstalled: false,
       apiKey: apiKey.trim() || current.apiKey,
     };
   }
@@ -90,13 +94,13 @@ async function promptSearch(
     );
     return {
       provider,
-      bundledInstalled: current.bundledInstalled,
+      bundledInstalled: false,
       baseUrl: baseUrl.trim().replace(/\/$/u, ""),
     };
   }
   return {
     provider,
-    bundledInstalled: current.bundledInstalled || provider === "bundled",
+    bundledInstalled: provider === "bundled",
   };
 }
 
@@ -115,18 +119,16 @@ async function promptTts(
           hint: "local CPU or NVIDIA GPU service",
         },
         { value: "openai-compatible", label: "OpenAI-compatible API" },
-        { value: "disabled", label: "Disabled" },
+        {
+          value: "disabled",
+          label: "Set up later",
+          hint: "text-to-speech stays unavailable",
+        },
       ],
     }),
   );
   if (provider === "disabled") {
-    return {
-      provider,
-      bundledInstalled: current.bundledInstalled,
-      accelerator: current.accelerator,
-      gpuUuid: current.gpuUuid,
-      gpuVariant: current.gpuVariant,
-    };
+    return { provider, bundledInstalled: false };
   }
   if (provider === "bundled") {
     if (gpus.length === 0) {
@@ -210,14 +212,11 @@ async function promptTts(
   );
   return {
     provider,
-    bundledInstalled: current.bundledInstalled,
+    bundledInstalled: false,
     baseUrl: baseUrl.trim().replace(/\/$/u, ""),
     apiKey: apiKey.trim() || current.apiKey || "",
     model: model.trim(),
     voice: voice.trim(),
-    accelerator: current.accelerator,
-    gpuUuid: current.gpuUuid,
-    gpuVariant: current.gpuVariant,
   };
 }
 
@@ -295,7 +294,11 @@ async function promptStt(
           hint: gpus.length > 0 ? `${gpus.length} NVIDIA GPU${gpus.length === 1 ? "" : "s"} detected` : "CPU",
         },
         { value: "openai-compatible", label: "OpenAI-compatible API" },
-        { value: "disabled", label: "Disabled" },
+        {
+          value: "disabled",
+          label: "Set up later",
+          hint: "speech-to-text stays unavailable",
+        },
       ],
     }),
   );
@@ -325,14 +328,14 @@ async function promptStt(
     );
     return {
       provider,
-      bundledInstalled: current.bundledInstalled,
+      bundledInstalled: false,
       baseUrl: baseUrl.trim().replace(/\/$/u, ""),
       apiKey: apiKey.trim() || current.apiKey || "",
       model: model.trim(),
     };
   }
   if (provider === "disabled") {
-    return { provider, bundledInstalled: current.bundledInstalled };
+    return { provider, bundledInstalled: false };
   }
   if (gpus.length === 0) {
     note("No NVIDIA GPU was detected. Parakeet will use the CPU image.", "Local STT accelerator");
@@ -427,10 +430,16 @@ export async function promptInstallationConfig(
           message: "Install realtime voice conversations?",
           initialValue: initial.voice.installed,
           active: "Yes",
-          inactive: "No",
+          inactive: "Set up later",
         }),
       )
     : false;
+  if (!voiceAvailable) {
+    note(
+      "Run overtchat setup again after configuring both text-to-speech and speech-to-text.",
+      "Realtime voice set up later",
+    );
+  }
   const agents = await detectedAgents();
   note(
     [
@@ -446,7 +455,7 @@ export async function promptInstallationConfig(
       message: "Install Agent Connections?",
       initialValue: initial.agents.installed || agents.length > 0,
       active: "Yes",
-      inactive: "No",
+      inactive: "Set up later",
     }),
   );
   return {

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -397,7 +397,8 @@ export async function setup(
     config.tts.provider === "bundled" &&
     (config.tts.accelerator === "auto" || config.tts.accelerator === "gpu");
   const sttUsesGpu =
-    config.stt.provider === "bundled" && config.stt.accelerator !== "cpu";
+    config.stt.provider === "bundled" &&
+    (config.stt.accelerator === "auto" || config.stt.accelerator === "gpu");
   if (
     (ttsUsesGpu || sttUsesGpu) &&
     !(await nvidiaContainerRuntimeAvailable(docker))

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -4,6 +4,7 @@ import { confirm, isCancel, note, outro, spinner } from "@clack/prompts";
 import {
   defaultInstallationConfig,
   initialSecrets,
+  normalizeInstallationConfig,
   readInstallationConfig,
   readInstallationSecrets,
   writeInstallationConfig,
@@ -342,6 +343,7 @@ export async function setup(
       await runningCapabilities(config, previousSecrets.managementSecret),
     );
   }
+  config = normalizeInstallationConfig(config);
   if (options.development) {
     if (!(await exists(path.join(sourceDirectory, "Dockerfile")))) {
       throw new Error(

--- a/apps/cli/src/status.test.ts
+++ b/apps/cli/src/status.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { providerStatus } from "./status.js";
+
+describe("provider status", () => {
+  it("describes deferred setup without exposing the internal provider value", () => {
+    expect(providerStatus("disabled")).toBe("not configured");
+  });
+
+  it("preserves configured provider names", () => {
+    expect(providerStatus("bundled")).toBe("bundled");
+    expect(providerStatus("openai-compatible")).toBe("openai-compatible");
+  });
+});

--- a/apps/cli/src/status.ts
+++ b/apps/cli/src/status.ts
@@ -2,6 +2,10 @@ import { readInstallationConfig } from "./config.js";
 import { detectDockerCommand, runDocker } from "./docker.js";
 import { runtimePaths } from "./paths.js";
 
+export function providerStatus(provider: string): string {
+  return provider === "disabled" ? "not configured" : provider;
+}
+
 export async function status(): Promise<void> {
   const paths = runtimePaths();
   const config = await readInstallationConfig(paths);
@@ -21,15 +25,15 @@ export async function status(): Promise<void> {
   console.log(`OvertChat ${config.appVersion}`);
   console.log(`Status: ${app?.exitCode === 0 ? app.stdout.trim() : "unavailable"}`);
   console.log(`URL: ${config.publicUrl}`);
-  console.log(`Web search: ${config.search.provider}`);
+  console.log(`Web search: ${providerStatus(config.search.provider)}`);
   console.log(
-    `Text-to-speech: ${config.tts.provider}${
+    `Text-to-speech: ${providerStatus(config.tts.provider)}${
       config.tts.provider === "bundled"
         ? ` (${config.tts.accelerator === "auto" || config.tts.accelerator === "gpu" ? "NVIDIA" : "CPU"})`
         : ""
     }`,
   );
-  console.log(`Speech-to-text: ${config.stt.provider}`);
+  console.log(`Speech-to-text: ${providerStatus(config.stt.provider)}`);
   console.log(`Realtime voice: ${config.voice.installed ? "installed" : "not installed"}`);
   console.log(`Agent Connections: ${config.agents.installed ? "installed" : "not installed"}`);
 }

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -35,13 +35,17 @@ vi.mock("@clack/prompts", () => ({
   }),
 }));
 
-vi.mock("./config.js", () => ({
-  initialSecrets: mocks.initialSecrets,
-  readInstallationConfig: mocks.readInstallationConfig,
-  readInstallationSecrets: mocks.readInstallationSecrets,
-  writeInstallationConfig: mocks.writeInstallationConfig,
-  writeSecretsFile: mocks.writeSecretsFile,
-}));
+vi.mock("./config.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./config.js")>();
+  return {
+    ...original,
+    initialSecrets: mocks.initialSecrets,
+    readInstallationConfig: mocks.readInstallationConfig,
+    readInstallationSecrets: mocks.readInstallationSecrets,
+    writeInstallationConfig: mocks.writeInstallationConfig,
+    writeSecretsFile: mocks.writeSecretsFile,
+  };
+});
 
 vi.mock("./connector.js", () => ({
   installManagedConnector: mocks.installManagedConnector,
@@ -121,7 +125,11 @@ function config(
     dataMountType: "volume",
     dataVolume: "overtchat-data",
     search: { provider: "bundled", bundledInstalled: true },
-    tts: { provider: "bundled", bundledInstalled: true },
+    tts: {
+      provider: "bundled",
+      bundledInstalled: true,
+      accelerator: "cpu",
+    },
     stt: { provider: "disabled", bundledInstalled: false },
     voice: { installed: false },
     agents: { installed: false },
@@ -268,6 +276,53 @@ describe("managed updates", () => {
       mocks.waitForApp.mock.invocationCallOrder[0],
     ).toBeLessThan(mocks.reconcileManagedSidecars.mock.invocationCallOrder[0]!);
     expect(mocks.outro).toHaveBeenCalledWith("Open: https://chat.example.com");
+  });
+
+  it("repairs stale provider state before pulling update images", async () => {
+    const stale = config({
+      search: { provider: "brave", bundledInstalled: true },
+      tts: {
+        provider: "openai-compatible",
+        bundledInstalled: true,
+        baseUrl: "http://tts.example.com",
+        accelerator: "gpu",
+        gpuUuid: "GPU-tts",
+        gpuVariant: "blackwell",
+      },
+      stt: {
+        provider: "disabled",
+        bundledInstalled: true,
+        accelerator: "gpu",
+        gpuUuid: "GPU-stt",
+      },
+      voice: { installed: true },
+    });
+    mocks.readInstallationConfig.mockResolvedValue(stale);
+
+    await update();
+
+    const repaired = {
+      ...stale,
+      search: { provider: "brave", bundledInstalled: false },
+      tts: {
+        provider: "openai-compatible",
+        bundledInstalled: false,
+        baseUrl: "http://tts.example.com",
+      },
+      stt: { provider: "disabled", bundledInstalled: false },
+      voice: { installed: false },
+    };
+    expect(mocks.prepareFiles).toHaveBeenCalledWith(repaired, undefined);
+    expect(mocks.renderStackEnvironment).toHaveBeenCalledWith(
+      repaired,
+      secrets,
+      paths,
+    );
+    expect(mocks.writeInstallationConfig).toHaveBeenCalledWith(paths, repaired);
+    expect(mocks.reconcileManagedSidecars).toHaveBeenCalledWith(
+      "docker",
+      repaired,
+    );
   });
 
   it("updates every component without downgrading newer local versions", async () => {

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -1,6 +1,7 @@
 import { outro, spinner } from "@clack/prompts";
 import {
   initialSecrets,
+  normalizeInstallationConfig,
   readInstallationConfig,
   readInstallationSecrets,
   writeInstallationConfig,
@@ -61,7 +62,9 @@ export async function update(): Promise<void> {
       return;
     }
 
-    const nextConfig = applyReleaseManifest(config, manifest);
+    const nextConfig = normalizeInstallationConfig(
+      applyReleaseManifest(config, manifest),
+    );
     await prepareFiles(nextConfig, undefined);
     await writeSecretsFile(
       paths,

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-cli_version="0.1.12"
+cli_version="0.1.13"
 
 say() {
   printf '%s\n' "$*"

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "cliVersion": "0.1.12",
+  "cliVersion": "0.1.13",
   "appVersion": "0.19.0",
   "voiceVersion": "0.1.0",
   "connectorVersion": "0.9.0",

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -12,6 +12,8 @@ curl -fsSL https://overtchat.com/install | sh
 The wizard installs Docker when needed and configures the app, optional local
 services, realtime voice, and Agent Connections. Realtime voice requires both
 speech-to-text and text-to-speech; the wizard offers it after those providers.
+Choose **Set up later** for any optional provider you do not want to configure
+or install yet, then rerun `overtchat setup` when you are ready.
 Bundled Kokoro and Parakeet services can independently use the CPU or a
 detected NVIDIA GPU. GPU services require NVIDIA Container Toolkit; setup can
 install it on supported Linux distributions. Kokoro uses roughly 3–4 GB of

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -12,8 +12,6 @@ curl -fsSL https://overtchat.com/install | sh
 The wizard installs Docker when needed and configures the app, optional local
 services, realtime voice, and Agent Connections. Realtime voice requires both
 speech-to-text and text-to-speech; the wizard offers it after those providers.
-Choose **Set up later** for any optional provider you do not want to configure
-or install yet, then rerun `overtchat setup` when you are ready.
 Bundled Kokoro and Parakeet services can independently use the CPU or a
 detected NVIDIA GPU. GPU services require NVIDIA Container Toolkit; setup can
 install it on supported Linux distributions. Kokoro uses roughly 3–4 GB of

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "apps/cli": {
       "name": "@overtchat/cli",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@clack/prompts": "^0.11.0"
       },


### PR DESCRIPTION
## Summary

- stop retaining bundled search, TTS, and STT sidecars when setup selects an external provider or Set up later
- treat legacy STT state without an accelerator as CPU and enable NVIDIA profiles only for explicit GPU selections
- make deferred setup clear in the wizard and status output, and prepare CLI 0.1.13

## Why

Setup preserved hidden bundledInstalled state after external speech providers were selected. Compose used that state to start a bundled sidecar, while the NVIDIA runtime check used the active provider. An external STT configuration could therefore pull and start the GPU image on a host without NVIDIA support. TTS could likewise remain installed despite an external selection.

External search selections now remove bundled SearXNG as well. Brave continues to use the existing keyless Firecrawl, Exa, and DuckDuckGo fallback chain.

## Validation

- npm run lint
- npm run typecheck
- npm run test
- npm run deps:check
- npm run build -w apps/cli --
- built CLI reports version 0.1.13