### PR TITLE
fix(web): unify chat title generation

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -18,14 +18,13 @@ const mocks = vi.hoisted(() => {
     completeChatStream: vi.fn(),
     inlineUploads: vi.fn(),
     getModelConfig: vi.fn(),
-    getTaskModelConfig: vi.fn(),
     getServerCapability: vi.fn(),
     listEffectiveMcpServers: vi.fn(),
     acquireMcpBinding: vi.fn(),
     releaseMcpBinding: vi.fn(),
     getProject: vi.fn(),
     getActivePersonalization: vi.fn(),
-    generateChatTitle: vi.fn(),
+    ensureChatTitle: vi.fn(),
     getProvider: vi.fn(),
     modelIconForModel: vi.fn(),
     catalogEntryFor: vi.fn(),
@@ -129,7 +128,6 @@ vi.mock("@/lib/db/chatTurns", () => ({
 vi.mock("@/lib/db/uploads", () => ({ inlineUploads: mocks.inlineUploads }));
 vi.mock("@/lib/db/modelConfigs", () => ({
   getModelConfig: mocks.getModelConfig,
-  getTaskModelConfig: mocks.getTaskModelConfig,
 }));
 vi.mock("@/lib/db/serverCapabilities", () => ({
   getServerCapability: mocks.getServerCapability,
@@ -145,7 +143,7 @@ vi.mock("@/lib/db/personalization", () => ({
   getActivePersonalization: mocks.getActivePersonalization,
 }));
 vi.mock("@/lib/title", () => ({
-  generateChatTitle: mocks.generateChatTitle,
+  ensureChatTitle: mocks.ensureChatTitle,
 }));
 vi.mock("@/lib/providers/catalog", () => ({
   getProvider: mocks.getProvider,
@@ -248,7 +246,6 @@ describe("chat route setup boundary", () => {
     mocks.getSession.mockResolvedValue({ user: { id: "user" } });
     mocks.parseChatRequest.mockResolvedValue({ ...parsedRequest });
     mocks.getModelConfig.mockResolvedValue({ ...modelConfig });
-    mocks.getTaskModelConfig.mockReturnValue(null);
     mocks.getServerCapability.mockReturnValue({ provider: "bundled" });
     mocks.listEffectiveMcpServers.mockResolvedValue([]);
     mocks.releaseMcpBinding.mockResolvedValue(undefined);
@@ -281,7 +278,7 @@ describe("chat route setup boundary", () => {
     mocks.commitChatTurn.mockReturnValue("committed");
     mocks.completeChatStream.mockReturnValue(true);
     mocks.clearActiveStreamId.mockResolvedValue(undefined);
-    mocks.generateChatTitle.mockResolvedValue(null);
+    mocks.ensureChatTitle.mockResolvedValue(null);
     mocks.getStreamContext.mockReturnValue(null);
     mocks.currentDateSystemPrompt.mockReturnValue(mocks.currentDatePrompt);
     mocks.consumeStream.mockResolvedValue(undefined);
@@ -1244,34 +1241,14 @@ describe("chat route setup boundary", () => {
         userMessage: { id: "user-message", parts: messages[0].parts },
       }),
     );
-    expect(mocks.generateChatTitle).toHaveBeenCalledWith(
+    expect(mocks.ensureChatTitle).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user",
-        modelConfig,
-        userParts: messages[0].parts,
+        fallbackModelConfig: modelConfig,
       }),
     );
     expect(messages).toEqual(originalMessages);
     expect(mocks.agentSettings[0]).not.toHaveProperty("runtimeContext");
-  });
-
-  it("uses a dedicated task model for title generation even when hidden from chat", async () => {
-    const taskModelConfig = {
-      ...modelConfig,
-      id: "task-model",
-      label: "Fast task model",
-      model: "fast-model",
-      enabled: false,
-      taskModel: true,
-    };
-    mocks.getTaskModelConfig.mockReturnValue(taskModelConfig);
-
-    await POST(request());
-
-    expect(mocks.getTaskModelConfig).toHaveBeenCalledOnce();
-    expect(mocks.generateChatTitle).toHaveBeenCalledWith(
-      expect.objectContaining({ modelConfig: taskModelConfig }),
-    );
   });
 
   it("emits provider cache token details in finish metadata", async () => {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -45,15 +45,12 @@ import {
   type CompletedGenerationUsage,
 } from "@/lib/db/chatTurns";
 import { inlineUploads } from "@/lib/db/uploads";
-import {
-  getModelConfig,
-  getTaskModelConfig,
-} from "@/lib/db/modelConfigs";
+import { getModelConfig } from "@/lib/db/modelConfigs";
 import { getProject } from "@/lib/db/projects";
 import { getActivePersonalization } from "@/lib/db/personalization";
 import { listEffectiveMcpServers } from "@/lib/db/mcpServers";
 import { acquireMcpBinding } from "@/lib/mcp/manager";
-import { generateChatTitle } from "@/lib/title";
+import { ensureChatTitle } from "@/lib/title";
 import { getProvider, modelIconForModel } from "@/lib/providers/catalog";
 import {
   memorySystemPrompt,
@@ -269,9 +266,6 @@ async function handlePost(req: Request): Promise<Response> {
   const mcpTools = mcpBinding?.tools ?? {};
 
   const last = messages[messages.length - 1];
-  const userMessageCount = messages.filter(
-    (message) => message.role === "user",
-  ).length;
   const streamId = crypto.randomUUID();
   const controller = temporary ? null : new AbortController();
   let streamClaimed = false;
@@ -388,19 +382,11 @@ async function handlePost(req: Request): Promise<Response> {
           ...(streamInclude ? { include: streamInclude } : {}),
         }).stream({ messages: modelMessages, abortSignal });
 
-    if (
-      !temporary &&
-      (existingChat?.title ?? null) === null &&
-      persistUserMessage &&
-      truncateFromMessageId === undefined &&
-      userMessageCount === 1
-    ) {
-      const titleModelConfig = getTaskModelConfig() ?? modelConfig;
-      titlePromise = generateChatTitle({
+    if (!temporary && (existingChat?.title ?? null) === null) {
+      titlePromise = ensureChatTitle({
         chatId,
         userId,
-        modelConfig: titleModelConfig,
-        userParts: last.parts,
+        fallbackModelConfig: modelConfig,
       });
     }
 

--- a/apps/web/app/api/voice/history/route.test.ts
+++ b/apps/web/app/api/voice/history/route.test.ts
@@ -6,8 +6,7 @@ const mocks = vi.hoisted(() => ({
   syncVoiceHistory: vi.fn(),
   getChat: vi.fn(),
   getModelConfig: vi.fn(),
-  getTaskModelConfig: vi.fn(),
-  generateChatTitle: vi.fn(),
+  ensureChatTitle: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/server", () => ({
@@ -22,9 +21,8 @@ vi.mock("@/lib/db/voiceChats", () => ({
 vi.mock("@/lib/db/chats", () => ({ getChat: mocks.getChat }));
 vi.mock("@/lib/db/modelConfigs", () => ({
   getModelConfig: mocks.getModelConfig,
-  getTaskModelConfig: mocks.getTaskModelConfig,
 }));
-vi.mock("@/lib/title", () => ({ generateChatTitle: mocks.generateChatTitle }));
+vi.mock("@/lib/title", () => ({ ensureChatTitle: mocks.ensureChatTitle }));
 
 import { POST } from "./route";
 
@@ -51,10 +49,8 @@ describe("voice history sync", () => {
       status: "ok",
       createdChat: true,
       changed: true,
-      firstUserParts: [{ type: "text", text: "Hello" }],
     });
     mocks.getModelConfig.mockResolvedValue({ id: "model-1", enabled: true });
-    mocks.getTaskModelConfig.mockReturnValue(null);
     mocks.getChat.mockResolvedValue({
       id: "chat-1",
       title: null,
@@ -65,7 +61,7 @@ describe("voice history sync", () => {
   });
 
   it("persists completed transcript and tool items under the ticket chat", async () => {
-    mocks.generateChatTitle.mockImplementation(async () => {
+    mocks.ensureChatTitle.mockImplementation(async () => {
       await Promise.resolve();
       mocks.getChat.mockResolvedValue({
         id: "chat-1",
@@ -110,9 +106,11 @@ describe("voice history sync", () => {
         ],
       }),
     );
-    expect(mocks.generateChatTitle).toHaveBeenCalledWith(
-      expect.objectContaining({ chatId: "chat-1", userId: "user-1" }),
-    );
+    expect(mocks.ensureChatTitle).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      userId: "user-1",
+      fallbackModelConfig: { id: "model-1", enabled: true },
+    });
     await expect(response.json()).resolves.toMatchObject({
       chat: { id: "chat-1", title: "Greeting" },
     });

--- a/apps/web/app/api/voice/history/route.ts
+++ b/apps/web/app/api/voice/history/route.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import { auth } from "@/lib/auth/server";
 import { getChat } from "@/lib/db/chats";
-import { getModelConfig, getTaskModelConfig } from "@/lib/db/modelConfigs";
+import { getModelConfig } from "@/lib/db/modelConfigs";
 import { syncVoiceHistory } from "@/lib/db/voiceChats";
-import { generateChatTitle } from "@/lib/title";
+import { ensureChatTitle } from "@/lib/title";
 import { voiceHistoryToUiMessages } from "@/lib/voice/history";
 import { verifyVoiceTicket } from "@/lib/voice/ticket";
 
@@ -70,18 +70,12 @@ export async function POST(request: Request) {
     );
   }
 
-  if (result.firstUserParts) {
-    const selectedModel = await getModelConfig(ticket.modelConfigId);
-    const titleModel = getTaskModelConfig() ?? selectedModel;
-    if (titleModel?.enabled) {
-      await generateChatTitle({
-        chatId: ticket.chatId,
-        userId: ticket.userId,
-        modelConfig: titleModel,
-        userParts: result.firstUserParts,
-      });
-    }
-  }
+  const selectedModel = await getModelConfig(ticket.modelConfigId);
+  await ensureChatTitle({
+    chatId: ticket.chatId,
+    userId: ticket.userId,
+    fallbackModelConfig: selectedModel,
+  });
   const chat = await getChat(ticket.chatId, ticket.userId);
   return Response.json({
     chat: chat

--- a/apps/web/lib/db/chats.ts
+++ b/apps/web/lib/db/chats.ts
@@ -53,6 +53,30 @@ export async function getChat(
   return row ?? null;
 }
 
+export async function getChatTitleContext(
+  id: string,
+  userId: string,
+): Promise<{
+  title: string | null;
+  firstUserParts: UIMessage["parts"] | null;
+} | null> {
+  const [row] = await db
+    .select({
+      title: chats.title,
+      firstUserParts: messages.parts,
+    })
+    .from(chats)
+    .leftJoin(
+      messages,
+      and(eq(messages.chatId, chats.id), eq(messages.role, "user")),
+    )
+    .where(and(eq(chats.id, id), eq(chats.userId, userId)))
+    .orderBy(sql`${messages}.rowid`)
+    .limit(1);
+
+  return row ?? null;
+}
+
 export async function listChats(
   userId: string,
   limit = 100,

--- a/apps/web/lib/db/voiceChats.test.ts
+++ b/apps/web/lib/db/voiceChats.test.ts
@@ -47,9 +47,13 @@ raw.exec(`
 `);
 
 let voiceChats: typeof import("./voiceChats");
+let chatQueries: typeof import("./chats");
 
 beforeAll(async () => {
-  voiceChats = await import("./voiceChats");
+  [voiceChats, chatQueries] = await Promise.all([
+    import("./voiceChats"),
+    import("./chats"),
+  ]);
 });
 
 beforeEach(() => {
@@ -87,7 +91,6 @@ describe("voice chat persistence", () => {
       status: "ok",
       createdChat: true,
       changed: true,
-      firstUserParts: user.parts,
     });
     expect(raw.prepare("SELECT kind FROM chats WHERE id = 'chat'").get()).toEqual({
       kind: "voice",
@@ -116,6 +119,26 @@ describe("voice chat persistence", () => {
     expect(raw.prepare("SELECT content FROM messages_fts").get()).toEqual({
       content: "Hello there",
     });
+  });
+
+  it("reads title context from the first persisted user message", async () => {
+    raw.exec(`
+      INSERT INTO chats (id, user_id, kind) VALUES ('chat', 'user', 'voice');
+      INSERT INTO messages (id, chat_id, role, parts) VALUES
+        ('assistant', 'chat', 'assistant', '[{"type":"text","text":"Earlier assistant"}]'),
+        ('first-user', 'chat', 'user', '[{"type":"text","text":"First topic"}]'),
+        ('second-user', 'chat', 'user', '[{"type":"text","text":"Follow-up"}]');
+    `);
+
+    await expect(
+      chatQueries.getChatTitleContext("chat", "user"),
+    ).resolves.toEqual({
+      title: null,
+      firstUserParts: [{ type: "text", text: "First topic" }],
+    });
+    await expect(
+      chatQueries.getChatTitleContext("chat", "other"),
+    ).resolves.toBeNull();
   });
 
   it("never converts a text chat or another user's chat", () => {

--- a/apps/web/lib/db/voiceChats.ts
+++ b/apps/web/lib/db/voiceChats.ts
@@ -10,7 +10,6 @@ export type SyncVoiceHistoryResult =
       status: "ok";
       createdChat: boolean;
       changed: boolean;
-      firstUserParts: UIMessage["parts"] | null;
     }
   | { status: "not-found" | "wrong-kind" | "invalid-project" };
 
@@ -93,7 +92,6 @@ export function syncVoiceHistory({
     }
 
     let changed = false;
-    let firstUserParts: UIMessage["parts"] | null = null;
     for (const message of history) {
       const existingMessage = existingMessages.get(message.id);
       if (existingMessage) {
@@ -113,9 +111,6 @@ export function syncVoiceHistory({
             parts: message.parts,
           })
           .run();
-        if (message.role === "user" && firstUserParts === null) {
-          firstUserParts = message.parts;
-        }
       }
 
       tx.run(sql`
@@ -142,7 +137,6 @@ export function syncVoiceHistory({
       status: "ok" as const,
       createdChat,
       changed,
-      firstUserParts,
     };
   });
 }

--- a/apps/web/lib/title.test.ts
+++ b/apps/web/lib/title.test.ts
@@ -4,6 +4,8 @@ import type { UIMessage } from "ai";
 const mocks = vi.hoisted(() => ({
   createConfiguredLanguageModel: vi.fn(),
   generateText: vi.fn(),
+  getChatTitleContext: vi.fn(),
+  getTaskModelConfig: vi.fn(),
   setTitleIfNull: vi.fn(),
   tryRecordGenerationUsage: vi.fn(),
 }));
@@ -11,7 +13,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("server-only", () => ({}));
 vi.mock("ai", () => ({ generateText: mocks.generateText }));
 vi.mock("@/lib/db/chats", () => ({
+  getChatTitleContext: mocks.getChatTitleContext,
   setTitleIfNull: mocks.setTitleIfNull,
+}));
+vi.mock("@/lib/db/modelConfigs", () => ({
+  getTaskModelConfig: mocks.getTaskModelConfig,
 }));
 vi.mock("@/lib/db/generationUsage", () => ({
   tryRecordGenerationUsage: mocks.tryRecordGenerationUsage,
@@ -23,8 +29,8 @@ vi.mock("@/lib/providers/server/registry", () => ({
 import {
   buildTitlePromptText,
   cleanGeneratedTitle,
+  ensureChatTitle,
   extractTextForTitle,
-  generateChatTitle,
 } from "./title";
 
 type Part = UIMessage["parts"][number];
@@ -93,6 +99,11 @@ describe("title helpers", () => {
     );
     mocks.tryRecordGenerationUsage.mockReturnValue(true);
     mocks.setTitleIfNull.mockImplementation(async (_chatId, title) => title);
+    mocks.getChatTitleContext.mockResolvedValue({
+      title: null,
+      firstUserParts,
+    });
+    mocks.getTaskModelConfig.mockReturnValue(null);
   });
 
   it("cleans generated title output", () => {
@@ -138,12 +149,66 @@ describe("title helpers", () => {
     expect(prompt).not.toContain("hidden query");
   });
 
-  it("returns null without calling the model when first-user text is empty", async () => {
-    const title = await generateChatTitle({
+  it("does nothing when the persisted chat already has a title", async () => {
+    mocks.getChatTitleContext.mockResolvedValue({
+      title: "Existing title",
+      firstUserParts,
+    });
+
+    await expect(
+      ensureChatTitle({
+        chatId: "chat",
+        userId: "user",
+        fallbackModelConfig: modelConfig,
+      }),
+    ).resolves.toBeNull();
+
+    expect(mocks.getTaskModelConfig).not.toHaveBeenCalled();
+    expect(mocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("uses a dedicated task model even when it is hidden from chat", async () => {
+    const hiddenTaskModel = {
+      ...modelConfig,
+      model: "hidden-task-model",
+      enabled: false,
+      taskModel: true,
+    };
+    mocks.getTaskModelConfig.mockReturnValue(hiddenTaskModel);
+
+    await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig,
-      userParts: [reasoning("private thought"), search(), file(), text(" ")],
+      fallbackModelConfig: modelConfig,
+    });
+
+    expect(mocks.createConfiguredLanguageModel).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "hidden-task-model" }),
+    );
+  });
+
+  it("does nothing without a task model or chat-model fallback", async () => {
+    await expect(
+      ensureChatTitle({
+        chatId: "chat",
+        userId: "user",
+        fallbackModelConfig: null,
+      }),
+    ).resolves.toBeNull();
+
+    expect(mocks.generateText).not.toHaveBeenCalled();
+  });
+
+  it("returns null without calling the model when first-user text is empty", async () => {
+    mocks.getChatTitleContext.mockResolvedValue({
+      title: null,
+      firstUserParts: [reasoning("private thought"), search(), file(), text(" ")],
+    });
+
+    const title = await ensureChatTitle({
+      chatId: "chat",
+      userId: "user",
+      fallbackModelConfig: modelConfig,
     });
 
     expect(title).toBeNull();
@@ -156,11 +221,10 @@ describe("title helpers", () => {
       generationResult('"Dependency Cleanup!"'),
     );
 
-    const title = await generateChatTitle({
+    const title = await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig,
-      userParts: firstUserParts,
+      fallbackModelConfig: modelConfig,
     });
 
     expect(mocks.generateText).toHaveBeenCalledWith(
@@ -201,16 +265,15 @@ describe("title helpers", () => {
       generationResult("Priced Title"),
     );
 
-    await generateChatTitle({
+    await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig: {
+      fallbackModelConfig: {
         ...modelConfig,
         providerId: "anthropic",
         apiFormat: "auto",
         model: "claude-sonnet-4-6",
       },
-      userParts: firstUserParts,
     });
 
     expect(mocks.tryRecordGenerationUsage).toHaveBeenCalledWith(
@@ -232,10 +295,10 @@ describe("title helpers", () => {
       generationResult("Configured Price"),
     );
 
-    await generateChatTitle({
+    await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig: {
+      fallbackModelConfig: {
         ...modelConfig,
         pricing: {
           input: 2,
@@ -244,7 +307,6 @@ describe("title helpers", () => {
           cacheWrite: 2.5,
         },
       },
-      userParts: firstUserParts,
     });
 
     expect(mocks.tryRecordGenerationUsage).toHaveBeenCalledWith(
@@ -266,11 +328,10 @@ describe("title helpers", () => {
       providerOptionsKey: "custom",
     });
 
-    await generateChatTitle({
+    await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig,
-      userParts: firstUserParts,
+      fallbackModelConfig: modelConfig,
     });
 
     expect(mocks.generateText).toHaveBeenCalledWith(
@@ -287,11 +348,10 @@ describe("title helpers", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mocks.generateText.mockRejectedValue(err);
 
-    const title = await generateChatTitle({
+    const title = await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig,
-      userParts: firstUserParts,
+      fallbackModelConfig: modelConfig,
     });
 
     expect(title).toBeNull();
@@ -308,11 +368,10 @@ describe("title helpers", () => {
       throw err;
     });
 
-    const title = await generateChatTitle({
+    const title = await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig,
-      userParts: firstUserParts,
+      fallbackModelConfig: modelConfig,
     });
 
     expect(title).toBeNull();
@@ -326,11 +385,10 @@ describe("title helpers", () => {
   it("records usage without persisting an empty generated title", async () => {
     mocks.generateText.mockResolvedValue(generationResult("..."));
 
-    const title = await generateChatTitle({
+    const title = await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig,
-      userParts: firstUserParts,
+      fallbackModelConfig: modelConfig,
     });
 
     expect(title).toBeNull();
@@ -344,11 +402,10 @@ describe("title helpers", () => {
     );
     mocks.setTitleIfNull.mockResolvedValue(null);
 
-    const title = await generateChatTitle({
+    const title = await ensureChatTitle({
       chatId: "chat",
       userId: "user",
-      modelConfig,
-      userParts: firstUserParts,
+      fallbackModelConfig: modelConfig,
     });
 
     expect(title).toBeNull();

--- a/apps/web/lib/title.ts
+++ b/apps/web/lib/title.ts
@@ -1,9 +1,12 @@
 import "server-only";
 import { generateText, type UIMessage } from "ai";
 import { stripCitationMarkers } from "@/lib/citations";
-import { setTitleIfNull } from "@/lib/db/chats";
+import { getChatTitleContext, setTitleIfNull } from "@/lib/db/chats";
 import { tryRecordGenerationUsage } from "@/lib/db/generationUsage";
-import type { ModelConfigRow } from "@/lib/db/modelConfigs";
+import {
+  getTaskModelConfig,
+  type ModelConfigRow,
+} from "@/lib/db/modelConfigs";
 import { estimateGenerationCost } from "@/lib/providers/server/model-cost";
 import { createConfiguredLanguageModel } from "@/lib/providers/server/registry";
 
@@ -21,18 +24,27 @@ type TitleModelConfig = Pick<
   | "providerOptions"
 >;
 
-export async function generateChatTitle({
+export async function ensureChatTitle({
   chatId,
   userId,
-  modelConfig,
-  userParts,
+  fallbackModelConfig,
 }: {
   chatId: string;
   userId: string;
-  modelConfig: TitleModelConfig;
-  userParts: UIMessage["parts"];
+  fallbackModelConfig: TitleModelConfig | null;
 }): Promise<string | null> {
   try {
+    const context = await getChatTitleContext(chatId, userId);
+    if (!context || context.title !== null || !context.firstUserParts) {
+      return null;
+    }
+
+    // `enabled` controls chat-picker visibility. A dedicated task model is
+    // intentionally allowed to remain hidden from chat.
+    const modelConfig = getTaskModelConfig() ?? fallbackModelConfig;
+    if (!modelConfig) return null;
+
+    const userParts = context.firstUserParts;
     const prompt = buildTitlePromptText(userParts);
     if (!prompt) return null;
 


### PR DESCRIPTION
## Summary

- centralize title eligibility, first-user-message lookup, and task-model selection in one idempotent title operation
- have both text and realtime voice transports invoke that operation after durable persistence
- remove the voice persistence layer's title-specific `firstUserParts` signal
- retry title generation on later persisted activity while a chat remains untitled

## Root cause

Realtime voice independently implemented title-model eligibility and required `titleModel.enabled`. In OvertChat, `enabled` controls whether a model appears in chat; a dedicated task model is intentionally allowed to be hidden. As a result, voice history was persisted normally but title generation was silently skipped whenever the configured task model was not exposed in chat. The text route already supported that configuration.

The shared operation now reads the untitled chat and its first persisted user message, resolves the dedicated task model (or the active chat model fallback), and relies on `setTitleIfNull` for idempotent persistence.

## Validation

- `npm run test -w @overtchat/web --` (112 files, 701 tests)
- `npm run typecheck -w @overtchat/web --`
- `npm run lint -w @overtchat/web --`
- `npm run build -w @overtchat/web --`
