### PR TITLE
chore(mobile): prepare 1.4.0 release

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "overtchat",
     "slug": "overtchat",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "orientation": "portrait",
     "scheme": "overtchat",
     "userInterfaceStyle": "automatic",
@@ -10,11 +10,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.overtchat.mobile",
-      "buildNumber": "11"
+      "buildNumber": "12"
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 11,
+      "versionCode": 12,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@overtchat/mobile",
   "main": "expo-router/entry",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "expo start --host=lan",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1081,7 +1081,7 @@
     },
     "apps/mobile": {
       "name": "@overtchat/mobile",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@ai-sdk/react": "^4.0.87",
         "@better-auth/expo": "1.6.23",


### PR DESCRIPTION
## Summary

- Bump the mobile app version from `1.3.1` to `1.4.0`.
- Increment Android `versionCode` from `11` to `12`.
- Mirror build number `12` in dormant iOS metadata to preserve the repository invariant; this release builds and publishes Android only.
- Leave the stable web application version and release manifest unchanged at `0.19.0`.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- Verified package, Expo, Android, and mirrored build versions locally.
