### PR TITLE
ci(android): harden release smoke test

### DIFF
--- a/.github/scripts/android-release-smoke.sh
+++ b/.github/scripts/android-release-smoke.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 APK_PATH="${1:?usage: android-release-smoke.sh <apk-path> [diagnostics-directory]}"
 DIAGNOSTICS_DIR="${2:-dist/mobile/smoke-diagnostics}"
 PACKAGE_NAME="com.overtchat.mobile"
+MAIN_ACTIVITY="$PACKAGE_NAME/.MainActivity"
+READY_TEST_ID="welcome-get-started"
 UI_DUMP_DEVICE_PATH="/sdcard/overtchat-window.xml"
 
 mkdir -p "$DIAGNOSTICS_DIR"
@@ -17,21 +19,54 @@ capture_diagnostics() {
 }
 trap capture_diagnostics EXIT
 
+dismiss_launcher_anr() {
+  local windows
+  windows="$(adb shell dumpsys window windows 2>/dev/null || true)"
+  if grep -Fq "Application Not Responding: com.android.launcher3" <<< "$windows"; then
+    echo "Dismissing an Android emulator launcher ANR."
+    adb shell input keyevent KEYCODE_BACK >/dev/null 2>&1 || true
+    sleep 1
+  fi
+}
+
+wait_for_android_idle() {
+  adb wait-for-device
+
+  # sys.boot_completed can become true before Launcher3 and package broadcasts
+  # have settled. Suppress dialogs only while Android-owned boot work finishes,
+  # then restore them so an OvertChat crash or ANR remains visible and fatal.
+  adb shell settings put global hide_error_dialogs 1
+  timeout 60 adb shell am wait-for-broadcast-idle >/dev/null
+  sleep 5
+  dismiss_launcher_anr
+  adb shell settings put global hide_error_dialogs 0
+}
+
+welcome_screen_is_visible() {
+  grep -Eq \
+    "resource-id=\"([^\"]*:id/)?${READY_TEST_ID}\"" \
+    "$DIAGNOSTICS_DIR/window.xml" 2>/dev/null
+}
+
 test -f "$APK_PATH"
+wait_for_android_idle
 adb logcat -c
 adb install --no-streaming -r "$APK_PATH"
-adb shell am force-stop "$PACKAGE_NAME"
 
-LAUNCH_OUTPUT="$(adb shell monkey \
-  -p "$PACKAGE_NAME" \
-  -c android.intent.category.LAUNCHER \
-  1 2>&1)"
+LAUNCH_OUTPUT="$(adb shell am start -W -S -n "$MAIN_ACTIVITY" 2>&1)"
 printf '%s\n' "$LAUNCH_OUTPUT"
-grep -Fq "Events injected: 1" <<< "$LAUNCH_OUTPUT"
+grep -Fq "Status: ok" <<< "$LAUNCH_OUTPUT"
+grep -Fq "Activity: $MAIN_ACTIVITY" <<< "$LAUNCH_OUTPUT"
 
 for attempt in {1..30}; do
+  RESUMED_ACTIVITY="$(
+    adb shell dumpsys activity activities 2>/dev/null \
+      | grep -F "topResumedActivity=" \
+      | head -n 1 \
+      || true
+  )"
   if adb shell pidof "$PACKAGE_NAME" >/dev/null 2>&1 && \
-    adb shell dumpsys activity activities | grep -Fq "$PACKAGE_NAME"; then
+    grep -Fq "$MAIN_ACTIVITY" <<< "$RESUMED_ACTIVITY"; then
     break
   fi
 
@@ -43,10 +78,11 @@ for attempt in {1..30}; do
 done
 
 for attempt in {1..30}; do
+  dismiss_launcher_anr
   adb shell uiautomator dump "$UI_DUMP_DEVICE_PATH" >/dev/null 2>&1 || true
   adb pull "$UI_DUMP_DEVICE_PATH" "$DIAGNOSTICS_DIR/window.xml" >/dev/null 2>&1 || true
 
-  if grep -Fq "Get started" "$DIAGNOSTICS_DIR/window.xml" 2>/dev/null; then
+  if welcome_screen_is_visible; then
     echo "Production APK launched and rendered the OvertChat welcome screen."
     exit 0
   fi

--- a/.github/workflows/mobile-eas.yml
+++ b/.github/workflows/mobile-eas.yml
@@ -148,7 +148,13 @@ jobs:
         with:
           api-level: 35
           arch: x86_64
-          profile: pixel_7_pro
+          profile: pixel_5
+          cores: 2
+          ram-size: 2048M
+          emulator-build: 15917651 # 37.1.11; validated with API 35 on ubuntu-24.04
+          emulator-options: >-
+            -no-window -gpu swiftshader_indirect -no-snapshot -noaudio
+            -no-boot-anim -no-metrics -camera-back none -camera-front none
           disable-animations: true
           script: >-
             bash .github/scripts/android-release-smoke.sh

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -25,6 +25,7 @@ export default function WelcomeScreen() {
         <Pressable
           accessibilityRole="button"
           onPress={() => router.push("/server")}
+          testID="welcome-get-started"
           style={({ pressed }) => [
             styles.cta,
             {


### PR DESCRIPTION
## Summary

- pin and right-size the Android release emulator for reproducible hosted runs
- wait for Android boot broadcasts to settle and recover only from Launcher3-owned ANR overlays
- launch the production activity explicitly and assert a stable welcome-screen test identifier

## Validation

- `npm run typecheck -w apps/mobile --`
- `npm run lint`
- `npm test`
- `npm run build`
- `bash -n .github/scripts/android-release-smoke.sh`
- `actionlint` using the same pinned image as CI