### PR TITLE
fix(agents): preserve pasted images in session history

### DIFF
--- a/packages/agent-bridge/src/state.test.ts
+++ b/packages/agent-bridge/src/state.test.ts
@@ -167,6 +167,7 @@ describe("agent runtime event reducer", () => {
           role: "user",
           content: submittedContent,
           timestamp: 100,
+          overtchatProviderTimestamp: 200,
           overtchatSubmissionId: "submission-1",
         },
       ],
@@ -198,6 +199,7 @@ describe("agent runtime event reducer", () => {
         role: "user",
         content: submittedContent,
         timestamp: 100,
+        overtchatProviderTimestamp: 200,
         overtchatSubmissionId: "submission-1",
       },
     ]);
@@ -210,7 +212,7 @@ describe("agent runtime event reducer", () => {
     ]);
   });
 
-  it("reconciles repeated prompt text with the nearest provider row", () => {
+  it("does not infer submission identity from repeated prompt text", () => {
     const submittedContent = [
       { type: "text", text: "Inspect this" },
       {
@@ -258,9 +260,11 @@ describe("agent runtime event reducer", () => {
       {
         id: "provider-user-2",
         role: "user",
-        content: submittedContent,
-        timestamp: 100,
-        overtchatSubmissionId: "submission-1",
+        content: [
+          { type: "text", text: "Inspect this" },
+          { data: "aW1hZ2U=", mimeType: "image/png" },
+        ],
+        timestamp: 200,
       },
     ]);
   });
@@ -773,6 +777,7 @@ describe("agent runtime event reducer", () => {
           role: "user",
           content: "Next prompt",
           timestamp: 200,
+          overtchatSubmissionId: "submission:1",
         },
       }),
     )!;
@@ -783,6 +788,7 @@ describe("agent runtime event reducer", () => {
         role: "user",
         content: "Next prompt",
         timestamp: 100,
+        overtchatProviderTimestamp: 200,
         overtchatSubmissionId: "submission:1",
       },
     ]);

--- a/packages/agent-bridge/src/state.test.ts
+++ b/packages/agent-bridge/src/state.test.ts
@@ -150,18 +150,36 @@ describe("agent runtime event reducer", () => {
     expect(twice.messages).toEqual(providerMessages);
   });
 
-  it("drops an optimistic row once an uncertain provider snapshot is available", () => {
+  it("preserves submitted image presentation when provider history takes over", () => {
+    const submittedContent = [
+      { type: "text", text: "Run tests" },
+      {
+        type: "image",
+        url: "/api/uploads/image-1",
+        mimeType: "image/png",
+        filename: "screen.png",
+      },
+    ];
     const durable = {
       ...snapshot(),
       messages: [
         {
           role: "user",
-          content: "Run tests",
+          content: submittedContent,
+          timestamp: 100,
           overtchatSubmissionId: "submission-1",
         },
       ],
     };
-    const providerMessage = { role: "user", content: "Run tests" };
+    const providerMessage = {
+      id: "provider-message",
+      role: "user",
+      content: [
+        { type: "text", text: "Run tests" },
+        { data: "aW1hZ2U=", mimeType: "image/png" },
+      ],
+      timestamp: 200,
+    };
     const reconciled = reconcileAgentRuntimeSnapshot(durable, {
       ...snapshot(),
       messages: [providerMessage],
@@ -174,12 +192,75 @@ describe("agent runtime event reducer", () => {
       ],
     });
 
-    expect(reconciled.messages).toEqual([providerMessage]);
+    expect(reconciled.messages).toEqual([
+      {
+        id: "provider-message",
+        role: "user",
+        content: submittedContent,
+        timestamp: 100,
+        overtchatSubmissionId: "submission-1",
+      },
+    ]);
     expect(reconciled.queuedMessages).toEqual([
       {
         id: "submission-1",
         message: "Run tests",
         status: "uncertain",
+      },
+    ]);
+  });
+
+  it("reconciles repeated prompt text with the nearest provider row", () => {
+    const submittedContent = [
+      { type: "text", text: "Inspect this" },
+      {
+        type: "image",
+        url: "/api/uploads/image-1",
+        mimeType: "image/png",
+        filename: "screen.png",
+      },
+    ];
+    const reconciled = reconcileAgentRuntimeSnapshot(
+      {
+        ...snapshot(),
+        messages: [
+          { role: "user", content: "Inspect this" },
+          { role: "assistant", content: "First response" },
+          {
+            role: "user",
+            content: submittedContent,
+            timestamp: 100,
+            overtchatSubmissionId: "submission-1",
+          },
+        ],
+      },
+      {
+        ...snapshot(),
+        messages: [
+          { id: "provider-user-1", role: "user", content: "Inspect this" },
+          { id: "provider-assistant", role: "assistant", content: "First response" },
+          {
+            id: "provider-user-2",
+            role: "user",
+            content: [
+              { type: "text", text: "Inspect this" },
+              { data: "aW1hZ2U=", mimeType: "image/png" },
+            ],
+            timestamp: 200,
+          },
+        ],
+      },
+    );
+
+    expect(reconciled.messages).toEqual([
+      { id: "provider-user-1", role: "user", content: "Inspect this" },
+      { id: "provider-assistant", role: "assistant", content: "First response" },
+      {
+        id: "provider-user-2",
+        role: "user",
+        content: submittedContent,
+        timestamp: 100,
+        overtchatSubmissionId: "submission-1",
       },
     ]);
   });
@@ -698,7 +779,12 @@ describe("agent runtime event reducer", () => {
 
     expect(acknowledged.messages).toEqual([
       { role: "user", content: "Hello" },
-      { role: "user", content: "Next prompt", timestamp: 200 },
+      {
+        role: "user",
+        content: "Next prompt",
+        timestamp: 100,
+        overtchatSubmissionId: "submission:1",
+      },
     ]);
   });
 
@@ -752,6 +838,7 @@ describe("agent runtime event reducer", () => {
         id: "provider:2",
         role: "user",
         content: "Same follow-up",
+        timestamp: 100,
         overtchatSubmissionId: "submission:2",
       },
     ]);

--- a/packages/agent-bridge/src/state.ts
+++ b/packages/agent-bridge/src/state.ts
@@ -65,6 +65,12 @@ function turnIdOf(message: unknown): string | null {
   return typeof id === "string" && id ? id : null;
 }
 
+function providerTimestampOf(message: unknown): number | null {
+  if (!message || typeof message !== "object") return null;
+  const timestamp = Reflect.get(message, "overtchatProviderTimestamp");
+  return typeof timestamp === "number" ? timestamp : null;
+}
+
 function withSubmittedUserPresentation(
   submitted: unknown,
   provider: unknown,
@@ -78,36 +84,21 @@ function withSubmittedUserPresentation(
     return provider;
   }
   const timestamp = timestampOf(submitted);
+  const providerTimestamp = providerTimestampOf(provider) ?? timestampOf(provider);
   return {
     ...submitted,
     ...provider,
     content: Reflect.get(submitted, "content"),
     ...(timestamp !== null ? { timestamp } : {}),
+    ...(providerTimestamp !== null
+      ? { overtchatProviderTimestamp: providerTimestamp }
+      : {}),
     overtchatSubmissionId: submissionIdOf(submitted),
   };
 }
 
 function submittedUserMessage(message: unknown): boolean {
   return roleOf(message) === "user" && submissionIdOf(message) !== null;
-}
-
-function closestMessageIndex(
-  messages: readonly unknown[],
-  targetIndex: number,
-  claimedIndexes: ReadonlySet<number>,
-  matches: (message: unknown) => boolean,
-): number {
-  let closest = -1;
-  let distance = Number.POSITIVE_INFINITY;
-  for (const [index, message] of messages.entries()) {
-    if (claimedIndexes.has(index) || !matches(message)) continue;
-    const candidateDistance = Math.abs(index - targetIndex);
-    if (candidateDistance < distance) {
-      closest = index;
-      distance = candidateDistance;
-    }
-  }
-  return closest;
 }
 
 /** Keep OvertChat's accepted user-message presentation while adopting the
@@ -119,11 +110,11 @@ export function reconcileSubmittedUserMessages(
   const messages = [...provider];
   const claimedProviderIndexes = new Set<number>();
 
-  for (const [submittedIndex, message] of submitted.entries()) {
+  for (const message of submitted) {
     if (!submittedUserMessage(message)) continue;
     const submissionId = submissionIdOf(message);
     const nativeId = idOf(message);
-    const text = textOf(message);
+    const providerTimestamp = providerTimestampOf(message);
     let providerIndex = messages.findIndex(
       (candidate, index) =>
         !claimedProviderIndexes.has(index) &&
@@ -138,15 +129,12 @@ export function reconcileSubmittedUserMessages(
           idOf(candidate) === nativeId,
       );
     }
-    if (providerIndex < 0) {
-      providerIndex = closestMessageIndex(
-        messages,
-        submittedIndex,
-        claimedProviderIndexes,
-        (candidate) =>
+    if (providerIndex < 0 && providerTimestamp !== null) {
+      providerIndex = messages.findIndex(
+        (candidate, index) =>
+          !claimedProviderIndexes.has(index) &&
           roleOf(candidate) === "user" &&
-          submissionIdOf(candidate) === null &&
-          textOf(candidate) === text,
+          timestampOf(candidate) === providerTimestamp,
       );
     }
     if (providerIndex < 0) continue;
@@ -221,22 +209,6 @@ function upsertMessage(messages: unknown[], message: unknown): unknown[] {
       }
       next.push(message);
       return next;
-    }
-    if (!submissionId) {
-      const text = textOf(message);
-      const pendingIndex = next.findIndex(
-        (candidate) =>
-          roleOf(candidate) === "user" &&
-          submissionIdOf(candidate) !== null &&
-          textOf(candidate) === text,
-      );
-      if (pendingIndex >= 0) {
-        next[pendingIndex] = withSubmittedUserPresentation(
-          next[pendingIndex],
-          message,
-        );
-        return next;
-      }
     }
   }
   const id = idOf(message);

--- a/packages/agent-bridge/src/state.ts
+++ b/packages/agent-bridge/src/state.ts
@@ -65,6 +65,100 @@ function turnIdOf(message: unknown): string | null {
   return typeof id === "string" && id ? id : null;
 }
 
+function withSubmittedUserPresentation(
+  submitted: unknown,
+  provider: unknown,
+): unknown {
+  if (
+    !submitted ||
+    typeof submitted !== "object" ||
+    !provider ||
+    typeof provider !== "object"
+  ) {
+    return provider;
+  }
+  const timestamp = timestampOf(submitted);
+  return {
+    ...submitted,
+    ...provider,
+    content: Reflect.get(submitted, "content"),
+    ...(timestamp !== null ? { timestamp } : {}),
+    overtchatSubmissionId: submissionIdOf(submitted),
+  };
+}
+
+function submittedUserMessage(message: unknown): boolean {
+  return roleOf(message) === "user" && submissionIdOf(message) !== null;
+}
+
+function closestMessageIndex(
+  messages: readonly unknown[],
+  targetIndex: number,
+  claimedIndexes: ReadonlySet<number>,
+  matches: (message: unknown) => boolean,
+): number {
+  let closest = -1;
+  let distance = Number.POSITIVE_INFINITY;
+  for (const [index, message] of messages.entries()) {
+    if (claimedIndexes.has(index) || !matches(message)) continue;
+    const candidateDistance = Math.abs(index - targetIndex);
+    if (candidateDistance < distance) {
+      closest = index;
+      distance = candidateDistance;
+    }
+  }
+  return closest;
+}
+
+/** Keep OvertChat's accepted user-message presentation while adopting the
+ * provider's native identity and history metadata. */
+export function reconcileSubmittedUserMessages(
+  submitted: readonly unknown[],
+  provider: readonly unknown[],
+): unknown[] {
+  const messages = [...provider];
+  const claimedProviderIndexes = new Set<number>();
+
+  for (const [submittedIndex, message] of submitted.entries()) {
+    if (!submittedUserMessage(message)) continue;
+    const submissionId = submissionIdOf(message);
+    const nativeId = idOf(message);
+    const text = textOf(message);
+    let providerIndex = messages.findIndex(
+      (candidate, index) =>
+        !claimedProviderIndexes.has(index) &&
+        roleOf(candidate) === "user" &&
+        submissionIdOf(candidate) === submissionId,
+    );
+    if (providerIndex < 0 && nativeId) {
+      providerIndex = messages.findIndex(
+        (candidate, index) =>
+          !claimedProviderIndexes.has(index) &&
+          roleOf(candidate) === "user" &&
+          idOf(candidate) === nativeId,
+      );
+    }
+    if (providerIndex < 0) {
+      providerIndex = closestMessageIndex(
+        messages,
+        submittedIndex,
+        claimedProviderIndexes,
+        (candidate) =>
+          roleOf(candidate) === "user" &&
+          submissionIdOf(candidate) === null &&
+          textOf(candidate) === text,
+      );
+    }
+    if (providerIndex < 0) continue;
+    claimedProviderIndexes.add(providerIndex);
+    messages[providerIndex] = withSubmittedUserPresentation(
+      message,
+      messages[providerIndex],
+    );
+  }
+  return messages;
+}
+
 function replaceTurnMessages(
   messages: unknown[],
   turnId: string,
@@ -72,8 +166,18 @@ function replaceTurnMessages(
 ): unknown[] {
   // The provider projection owns order within a turn. Replace that block as one
   // unit so neither connector nor browser delivery timing can reorder its rows.
+  const projected = incoming.map((message) => {
+    const submissionId = submissionIdOf(message);
+    if (!submissionId) return message;
+    const submitted = messages.find(
+      (candidate) => submissionIdOf(candidate) === submissionId,
+    );
+    return submitted
+      ? withSubmittedUserPresentation(submitted, message)
+      : message;
+  });
   const incomingSubmissionIds = new Set(
-    incoming.flatMap((message) => {
+    projected.flatMap((message) => {
       const id = submissionIdOf(message);
       return id ? [id] : [];
     }),
@@ -93,7 +197,7 @@ function replaceTurnMessages(
   );
   return [
     ...remaining.slice(0, insertionIndex),
-    ...incoming,
+    ...projected,
     ...remaining.slice(insertionIndex),
   ];
 }
@@ -109,7 +213,10 @@ function upsertMessage(messages: unknown[], message: unknown): unknown[] {
         (candidate) => submissionIdOf(candidate) === submissionId,
       );
       if (submissionIndex >= 0) {
-        next[submissionIndex] = message;
+        next[submissionIndex] = withSubmittedUserPresentation(
+          next[submissionIndex],
+          message,
+        );
         return next;
       }
       next.push(message);
@@ -124,7 +231,10 @@ function upsertMessage(messages: unknown[], message: unknown): unknown[] {
           textOf(candidate) === text,
       );
       if (pendingIndex >= 0) {
-        next[pendingIndex] = message;
+        next[pendingIndex] = withSubmittedUserPresentation(
+          next[pendingIndex],
+          message,
+        );
         return next;
       }
     }
@@ -333,12 +443,16 @@ export function reconcileAgentRuntimeSnapshot(
   durable: AgentRuntimeSnapshot,
   fresh: AgentRuntimeSnapshot,
 ): AgentRuntimeSnapshot {
+  const providerMessages = reconcileSubmittedUserMessages(
+    durable.messages,
+    fresh.messages,
+  );
   const connectorRowsByProviderUnit = new Map<number, unknown[]>();
   let providerUnit = 0;
   for (let index = 0; index < durable.messages.length; index += 1) {
     const message = durable.messages[index];
     if (isConnectorCheckpointMessage(message)) {
-      if (!freshContainsConnectorMessage(fresh.messages, message)) {
+      if (!freshContainsConnectorMessage(providerMessages, message)) {
         const rows = connectorRowsByProviderUnit.get(providerUnit) ?? [];
         rows.push(message);
         connectorRowsByProviderUnit.set(providerUnit, rows);
@@ -356,13 +470,13 @@ export function reconcileAgentRuntimeSnapshot(
     messages.push(...(connectorRowsByProviderUnit.get(providerUnit) ?? []));
     insertedUnits.add(providerUnit);
   };
-  for (let index = 0; index < fresh.messages.length; index += 1) {
-    const message = fresh.messages[index];
+  for (let index = 0; index < providerMessages.length; index += 1) {
+    const message = providerMessages[index];
     if (!isConnectorCheckpointMessage(message)) insertConnectorRows();
     messages.push(message);
     if (
       !isConnectorCheckpointMessage(message) &&
-      endsProviderHistoryUnit(fresh.messages, index)
+      endsProviderHistoryUnit(providerMessages, index)
     ) {
       providerUnit += 1;
     }

--- a/packages/agent-runtime/src/omp/client.test.ts
+++ b/packages/agent-runtime/src/omp/client.test.ts
@@ -191,6 +191,55 @@ describe("OmpClient", () => {
     await client.stop();
   });
 
+  it("sends typed image attachments with prompts and steering", async () => {
+    const process = new FakeAgentProcess((command, fake) => {
+      if (command.type === "negotiate_protocol") {
+        fake.reply(command, { protocolVersion: 2 });
+        return;
+      }
+      fake.reply(command);
+    });
+    const client = new OmpClient(process, "full");
+    announceReady(process);
+    const image = {
+      uploadId: "11111111-1111-4111-8111-111111111111",
+      filename: "screen.png",
+      mediaType: "image/png" as const,
+      data: "aW1hZ2U=",
+    };
+
+    await client.prompt("Inspect this", [image]);
+    await client.steer("", [image]);
+
+    expect(process.commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "prompt",
+          message: "Inspect this",
+          images: [
+            {
+              type: "image",
+              data: "aW1hZ2U=",
+              mimeType: "image/png",
+            },
+          ],
+        }),
+        expect.objectContaining({
+          type: "steer",
+          message: "",
+          images: [
+            {
+              type: "image",
+              data: "aW1hZ2U=",
+              mimeType: "image/png",
+            },
+          ],
+        }),
+      ]),
+    );
+    await client.stop();
+  });
+
   it("surfaces OMP prompt failures emitted after acceptance", async () => {
     const process = new FakeAgentProcess((command, fake) => {
       if (command.type === "negotiate_protocol") {

--- a/packages/agent-runtime/src/omp/client.test.ts
+++ b/packages/agent-runtime/src/omp/client.test.ts
@@ -240,6 +240,64 @@ describe("OmpClient", () => {
     await client.stop();
   });
 
+  it("attaches submission identity to provider user-message echoes", async () => {
+    const process = new FakeAgentProcess((command, fake) => {
+      if (command.type === "negotiate_protocol") {
+        fake.reply(command, { protocolVersion: 2 });
+        return;
+      }
+      const message = {
+        role: "user",
+        content: command.message,
+        timestamp: command.type === "prompt" ? 100 : 200,
+      };
+      fake.stdout.write(
+        `${JSON.stringify({ type: "message_start", message })}\n`,
+      );
+      fake.stdout.write(`${JSON.stringify({ type: "message_end", message })}\n`);
+      fake.reply(command);
+    });
+    const client = new OmpClient(process, "full");
+    const events: unknown[] = [];
+    client.onEvent((event) => events.push(event));
+    announceReady(process);
+
+    await client.prompt("Start", [], { clientMessageId: "client-prompt" });
+    await client.steer("Adjust", [], { clientMessageId: "client-steer" });
+
+    expect(events).toEqual([
+      {
+        type: "message_start",
+        message: expect.objectContaining({
+          content: "Start",
+          overtchatSubmissionId: "client-prompt",
+        }),
+      },
+      {
+        type: "message_end",
+        message: expect.objectContaining({
+          content: "Start",
+          overtchatSubmissionId: "client-prompt",
+        }),
+      },
+      {
+        type: "message_start",
+        message: expect.objectContaining({
+          content: "Adjust",
+          overtchatSubmissionId: "client-steer",
+        }),
+      },
+      {
+        type: "message_end",
+        message: expect.objectContaining({
+          content: "Adjust",
+          overtchatSubmissionId: "client-steer",
+        }),
+      },
+    ]);
+    await client.stop();
+  });
+
   it("surfaces OMP prompt failures emitted after acceptance", async () => {
     const process = new FakeAgentProcess((command, fake) => {
       if (command.type === "negotiate_protocol") {

--- a/packages/agent-runtime/src/omp/client.ts
+++ b/packages/agent-runtime/src/omp/client.ts
@@ -128,7 +128,15 @@ export class OmpClient {
     return this.request({
       type: "prompt",
       message,
-      ...(images.length ? { images: images.map((image) => ({ data: image.data, mimeType: image.mediaType })) } : {}),
+      ...(images.length
+        ? {
+            images: images.map((image) => ({
+              type: "image" as const,
+              data: image.data,
+              mimeType: image.mediaType,
+            })),
+          }
+        : {}),
     });
   }
 
@@ -136,7 +144,15 @@ export class OmpClient {
     return this.request({
       type: "steer",
       message,
-      ...(images.length ? { images: images.map((image) => ({ data: image.data, mimeType: image.mediaType })) } : {}),
+      ...(images.length
+        ? {
+            images: images.map((image) => ({
+              type: "image" as const,
+              data: image.data,
+              mimeType: image.mediaType,
+            })),
+          }
+        : {}),
     });
   }
 

--- a/packages/agent-runtime/src/omp/client.ts
+++ b/packages/agent-runtime/src/omp/client.ts
@@ -12,6 +12,7 @@ import {
   JsonlRpcTransport,
 } from "@overtchat/agent-runtime/runtime/jsonl-rpc";
 import { type AgentProcess, type HostTarget, spawnOnHost } from "@overtchat/agent-runtime/runtime/process";
+import { SubmissionEchoTracker } from "@overtchat/agent-runtime/runtime/submission-echo";
 
 const READY_TIMEOUT_MS = 30_000;
 const MAX_FRAME_BYTES = 64 * 1024 * 1024;
@@ -33,6 +34,7 @@ type OmpEvent = { type: string; [key: string]: unknown };
 export class OmpClient {
   private readonly transport: JsonlRpcTransport;
   private readonly subscribers = new Set<(event: OmpEvent) => void>();
+  private readonly submissionEchoes = new SubmissionEchoTracker();
   private readonly ready: Promise<void>;
   private resolveReady: () => void = () => {};
   private rejectReady: (error: Error) => void = () => {};
@@ -124,7 +126,12 @@ export class OmpClient {
     return this.request({ type: "get_messages" });
   }
 
-  prompt(message: string, images: readonly ResolvedAgentImage[] = [], _options: AgentSubmissionOptions = {}): Promise<unknown> {
+  prompt(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+    options: AgentSubmissionOptions = {},
+  ): Promise<unknown> {
+    const cancelEcho = this.submissionEchoes.track(options.clientMessageId);
     return this.request({
       type: "prompt",
       message,
@@ -137,10 +144,18 @@ export class OmpClient {
             })),
           }
         : {}),
+    }).catch((error) => {
+      cancelEcho();
+      throw error;
     });
   }
 
-  steer(message: string, images: readonly ResolvedAgentImage[] = [], _options: AgentSubmissionOptions = {}): Promise<unknown> {
+  steer(
+    message: string,
+    images: readonly ResolvedAgentImage[] = [],
+    options: AgentSubmissionOptions = {},
+  ): Promise<unknown> {
+    const cancelEcho = this.submissionEchoes.track(options.clientMessageId);
     return this.request({
       type: "steer",
       message,
@@ -153,10 +168,18 @@ export class OmpClient {
             })),
           }
         : {}),
+    }).catch((error) => {
+      cancelEcho();
+      throw error;
     });
   }
 
-  abort(): Promise<unknown> { return this.request({ type: "abort" }); }
+  abort(): Promise<unknown> {
+    return this.request({ type: "abort" }).then((result) => {
+      this.submissionEchoes.clear();
+      return result;
+    });
+  }
 
   setModel(modelId: string): Promise<unknown> {
     const separator = modelId.indexOf("/");
@@ -183,6 +206,7 @@ export class OmpClient {
   }
 
   async stop(): Promise<void> {
+    this.submissionEchoes.clear();
     this.failReady(new Error("The Oh My Pi RPC process was stopped."));
     await this.transport.stop();
   }
@@ -199,7 +223,7 @@ export class OmpClient {
       return;
     }
     if (typeof record.type !== "string") { this.transport.fail("Oh My Pi RPC event is missing a type."); return; }
-    this.emit(mapOmpUiRequest(record) as OmpEvent);
+    this.emit(mapOmpUiRequest(this.submissionEchoes.annotate(record)) as OmpEvent);
   }
 
   private handleReady(record: Record<string, unknown>): void {

--- a/packages/agent-runtime/src/pi/client.test.ts
+++ b/packages/agent-runtime/src/pi/client.test.ts
@@ -122,6 +122,61 @@ describe("PiClient", () => {
     await client.stop();
   });
 
+  it("attaches submission identity to provider user-message echoes", async () => {
+    const process = new FakeAgentProcess((command, fake) => {
+      const clientMessageId =
+        command.type === "prompt" ? "client-prompt" : "client-steer";
+      const message = {
+        role: "user",
+        content: command.message,
+        timestamp: command.type === "prompt" ? 100 : 200,
+      };
+      fake.stdout.write(
+        `${JSON.stringify({ type: "message_start", message })}\n`,
+      );
+      fake.stdout.write(`${JSON.stringify({ type: "message_end", message })}\n`);
+      fake.reply(command, { clientMessageId });
+    });
+    const client = new PiClient(process);
+    const events: unknown[] = [];
+    client.onEvent((event) => events.push(event));
+
+    await client.prompt("Start", [], { clientMessageId: "client-prompt" });
+    await client.steer("Adjust", [], { clientMessageId: "client-steer" });
+
+    expect(events).toEqual([
+      {
+        type: "message_start",
+        message: expect.objectContaining({
+          content: "Start",
+          overtchatSubmissionId: "client-prompt",
+        }),
+      },
+      {
+        type: "message_end",
+        message: expect.objectContaining({
+          content: "Start",
+          overtchatSubmissionId: "client-prompt",
+        }),
+      },
+      {
+        type: "message_start",
+        message: expect.objectContaining({
+          content: "Adjust",
+          overtchatSubmissionId: "client-steer",
+        }),
+      },
+      {
+        type: "message_end",
+        message: expect.objectContaining({
+          content: "Adjust",
+          overtchatSubmissionId: "client-steer",
+        }),
+      },
+    ]);
+    await client.stop();
+  });
+
   it("sends native image attachments with prompts and steering", async () => {
     const process = new FakeAgentProcess((command, fake) => {
       fake.reply(command);

--- a/packages/agent-runtime/src/pi/client.test.ts
+++ b/packages/agent-runtime/src/pi/client.test.ts
@@ -143,6 +143,7 @@ describe("PiClient", () => {
         message: "Inspect this",
         images: [
           {
+            type: "image",
             data: "aW1hZ2U=",
             mimeType: "image/png",
           },
@@ -153,6 +154,7 @@ describe("PiClient", () => {
         message: "",
         images: [
           {
+            type: "image",
             data: "aW1hZ2U=",
             mimeType: "image/png",
           },

--- a/packages/agent-runtime/src/pi/client.ts
+++ b/packages/agent-runtime/src/pi/client.ts
@@ -43,6 +43,7 @@ function promptFrame(
     ...(images.length
       ? {
           images: images.map((image) => ({
+            type: "image" as const,
             data: image.data,
             mimeType: image.mediaType,
           })),

--- a/packages/agent-runtime/src/pi/client.ts
+++ b/packages/agent-runtime/src/pi/client.ts
@@ -20,6 +20,7 @@ import {
   type HostTarget,
   spawnOnHost,
 } from "@overtchat/agent-runtime/runtime/process";
+import { SubmissionEchoTracker } from "@overtchat/agent-runtime/runtime/submission-echo";
 
 export type PiLaunch = {
   executable: string;
@@ -55,6 +56,7 @@ function promptFrame(
 export class PiClient {
   private readonly transport: JsonlRpcTransport;
   private readonly subscribers = new Set<(event: PiRpcEvent) => void>();
+  private readonly submissionEchoes = new SubmissionEchoTracker();
 
   constructor(process: AgentProcess) {
     this.transport = new JsonlRpcTransport(process, "Pi");
@@ -63,10 +65,11 @@ export class PiClient {
         this.transport.fail("Pi RPC event is missing a type.");
         return;
       }
+      const event = this.submissionEchoes.annotate(record);
       this.emit(
-        record.type === "extension_ui_request"
-          ? ({ ...record, type: "interaction_request" } as PiRpcEvent)
-          : (record as PiRpcEvent),
+        event.type === "extension_ui_request"
+          ? ({ ...event, type: "interaction_request" } as PiRpcEvent)
+          : (event as PiRpcEvent),
       );
     });
   }
@@ -120,21 +123,34 @@ export class PiClient {
   prompt(
     message: string,
     images: readonly ResolvedAgentImage[] = [],
-    _options: AgentSubmissionOptions = {},
+    options: AgentSubmissionOptions = {},
   ): Promise<unknown> {
-    return this.request(promptFrame("prompt", message, images));
+    const cancelEcho = this.submissionEchoes.track(options.clientMessageId);
+    return this.request(promptFrame("prompt", message, images)).catch(
+      (error) => {
+        cancelEcho();
+        throw error;
+      },
+    );
   }
 
   steer(
     message: string,
     images: readonly ResolvedAgentImage[] = [],
-    _options: AgentSubmissionOptions = {},
+    options: AgentSubmissionOptions = {},
   ): Promise<unknown> {
-    return this.request(promptFrame("steer", message, images));
+    const cancelEcho = this.submissionEchoes.track(options.clientMessageId);
+    return this.request(promptFrame("steer", message, images)).catch((error) => {
+      cancelEcho();
+      throw error;
+    });
   }
 
   abort(): Promise<unknown> {
-    return this.request({ type: "abort" });
+    return this.request({ type: "abort" }).then((result) => {
+      this.submissionEchoes.clear();
+      return result;
+    });
   }
 
   setModel(modelId: string): Promise<unknown> {
@@ -179,6 +195,7 @@ export class PiClient {
   }
 
   stop(): Promise<void> {
+    this.submissionEchoes.clear();
     return this.transport.stop();
   }
 

--- a/packages/agent-runtime/src/runtime/registry.test.ts
+++ b/packages/agent-runtime/src/runtime/registry.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   saveQueue: vi.fn(),
   getState: vi.fn(),
   getMessages: vi.fn(),
+  getAvailableModels: vi.fn(),
   setModel: vi.fn(),
   setThinkingLevel: vi.fn(),
   setMode: vi.fn(),
@@ -54,9 +55,7 @@ vi.mock("@overtchat/agent-runtime/providers/registry", () => ({
       }),
       getState: mocks.getState,
       getMessages: mocks.getMessages,
-      getAvailableModels: vi.fn().mockResolvedValue([
-        { provider: "openai", id: "gpt-5", name: "GPT-5", input: ["text"] },
-      ]),
+      getAvailableModels: mocks.getAvailableModels,
       getSessionStats: vi.fn().mockResolvedValue(stats),
       getCommands: vi.fn().mockResolvedValue([]),
       prompt: mocks.prompt,
@@ -145,6 +144,9 @@ describe("agent runtime", () => {
       sessionFile: "/sessions/provider-session.jsonl",
     });
     mocks.getMessages.mockResolvedValue({ messages: [] });
+    mocks.getAvailableModels.mockResolvedValue([
+      { provider: "openai", id: "gpt-5", name: "GPT-5", input: ["text"] },
+    ]);
     mocks.eventSubscriber = null;
   });
 
@@ -1137,7 +1139,92 @@ describe("agent runtime", () => {
         id: "provider-message",
         role: "user",
         content: "Continue the task",
-        timestamp: 123,
+        timestamp: expect.any(Number),
+        overtchatSubmissionId: "client-message",
+      },
+    ]);
+    await registry.stopAll();
+  });
+
+  it("keeps submitted image presentation through provider history refresh", async () => {
+    mocks.getState.mockResolvedValue({
+      isStreaming: false,
+      sessionId: "provider-session",
+      sessionFile: "/sessions/provider-session.jsonl",
+      model: { provider: "codex", id: "gpt-5" },
+    });
+    mocks.getAvailableModels.mockResolvedValue([
+      {
+        provider: "codex",
+        id: "gpt-5",
+        name: "GPT-5",
+        input: ["text", "image"],
+      },
+    ]);
+    mocks.getMessages
+      .mockResolvedValueOnce({ messages: [] })
+      .mockResolvedValueOnce({
+        messages: [
+          {
+            id: "provider-message",
+            role: "user",
+            content: [
+              { type: "text", text: "Inspect this" },
+              { data: "aW1hZ2U=", mimeType: "image/png" },
+            ],
+            timestamp: 200,
+          },
+        ],
+      });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [
+        {
+          uploadId: "11111111-1111-4111-8111-111111111111",
+          filename: "screen.png",
+          mediaType: "image/png",
+          data: "aW1hZ2U=",
+        },
+      ],
+    });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+      launchConfig: {},
+    });
+
+    await runtime.command(
+      {
+        type: "prompt",
+        message: "Inspect this",
+        images: [
+          {
+            uploadId: "11111111-1111-4111-8111-111111111111",
+            filename: "screen.png",
+            mediaType: "image/png",
+          },
+        ],
+      },
+      "client-message",
+    );
+    const submitted = runtime.snapshot().messages[0] as Record<string, unknown>;
+
+    mocks.eventSubscriber?.({ type: "agent_end", messages: [] });
+    await vi.waitFor(() => expect(mocks.getMessages).toHaveBeenCalledTimes(2));
+
+    expect(runtime.snapshot().messages).toEqual([
+      {
+        id: "provider-message",
+        role: "user",
+        content: submitted.content,
+        timestamp: submitted.timestamp,
+        overtchatSubmissionId: "client-message",
       },
     ]);
     await registry.stopAll();

--- a/packages/agent-runtime/src/runtime/registry.test.ts
+++ b/packages/agent-runtime/src/runtime/registry.test.ts
@@ -1101,7 +1101,7 @@ describe("agent runtime", () => {
   );
 
   it("publishes one canonical user message when a provider echoes before accepting", async () => {
-    mocks.prompt.mockImplementation(async () => {
+    mocks.prompt.mockImplementation(async (_message, _images, options) => {
       mocks.eventSubscriber?.({
         type: "message_start",
         message: {
@@ -1109,6 +1109,7 @@ describe("agent runtime", () => {
           role: "user",
           content: "Continue the task",
           timestamp: 123,
+          overtchatSubmissionId: options?.clientMessageId,
         },
       });
       return { accepted: true };
@@ -1140,6 +1141,7 @@ describe("agent runtime", () => {
         role: "user",
         content: "Continue the task",
         timestamp: expect.any(Number),
+        overtchatProviderTimestamp: 123,
         overtchatSubmissionId: "client-message",
       },
     ]);
@@ -1176,6 +1178,22 @@ describe("agent runtime", () => {
           },
         ],
       });
+    mocks.prompt.mockImplementation(async (_message, _images, options) => {
+      mocks.eventSubscriber?.({
+        type: "message_start",
+        message: {
+          id: "provider-message",
+          role: "user",
+          content: [
+            { type: "text", text: "Inspect this" },
+            { data: "aW1hZ2U=", mimeType: "image/png" },
+          ],
+          timestamp: 200,
+          overtchatSubmissionId: options?.clientMessageId,
+        },
+      });
+      return { accepted: true };
+    });
     const registry = new AgentRuntimeRegistry({
       resolveImages: async () => [
         {
@@ -1224,6 +1242,7 @@ describe("agent runtime", () => {
         role: "user",
         content: submitted.content,
         timestamp: submitted.timestamp,
+        overtchatProviderTimestamp: 200,
         overtchatSubmissionId: "client-message",
       },
     ]);
@@ -1306,7 +1325,7 @@ describe("agent runtime", () => {
   });
 
   it("reconciles a native steering echo with the canonical steer message", async () => {
-    mocks.prompt.mockImplementation(async () => {
+    mocks.prompt.mockImplementation(async (_message, _images, options) => {
       mocks.eventSubscriber?.({
         type: "message_start",
         message: {
@@ -1314,11 +1333,12 @@ describe("agent runtime", () => {
           role: "user",
           content: "Start the task",
           timestamp: 123,
+          overtchatSubmissionId: options?.clientMessageId,
         },
       });
       return { accepted: true };
     });
-    mocks.steer.mockImplementation(async () => {
+    mocks.steer.mockImplementation(async (_message, _images, options) => {
       mocks.eventSubscriber?.({
         type: "message_start",
         message: {
@@ -1326,6 +1346,7 @@ describe("agent runtime", () => {
           role: "user",
           content: "Use the other approach",
           timestamp: 124,
+          overtchatSubmissionId: options?.clientMessageId,
         },
       });
       return { accepted: true };

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -21,6 +21,7 @@ import {
   agentProviderMetadata,
   isAgentProviderId,
   isAgentProviderNotice,
+  reconcileSubmittedUserMessages,
 } from "@overtchat/agent-bridge";
 import { agentProviderAdapter } from "@overtchat/agent-runtime/providers/registry";
 import type {
@@ -906,13 +907,16 @@ export class AgentSessionRuntime {
           this.client.getCommands().catch(() => this.commands),
         ]);
       this.state = state;
-      this.messages = messageData.messages;
+      this.messages = reconcileSubmittedUserMessages(
+        this.messages,
+        messageData.messages,
+      );
       this.stats = stats;
       this.commands = this.adapter.mergeCommands(commands);
       this.status = state.isStreaming === true ? "running" : "idle";
       const reconciledQueue = reconcileRestoredQueuedMessages(
         this.queuedMessages,
-        this.messages,
+        messageData.messages,
       );
       if (reconciledQueue.changed) {
         this.queuedMessages = reconciledQueue.messages;

--- a/packages/agent-runtime/src/runtime/submission-echo.ts
+++ b/packages/agent-runtime/src/runtime/submission-echo.ts
@@ -1,0 +1,54 @@
+type SubmissionEcho = {
+  id: string;
+};
+
+function userMessage(
+  record: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const message = record.message;
+  return message && typeof message === "object" && Reflect.get(message, "role") === "user"
+    ? (message as Record<string, unknown>)
+    : null;
+}
+
+/** Correlates provider user-message lifecycle events with submissions that the
+ * provider protocol cannot carry an application-defined message id for. */
+export class SubmissionEchoTracker {
+  private readonly pending: SubmissionEcho[] = [];
+  private active: SubmissionEcho | null = null;
+
+  track(id: string | undefined): () => void {
+    if (!id) return () => {};
+    const echo = { id };
+    this.pending.push(echo);
+    return () => {
+      const index = this.pending.indexOf(echo);
+      if (index >= 0) this.pending.splice(index, 1);
+    };
+  }
+
+  annotate(record: Record<string, unknown>): Record<string, unknown> {
+    if (record.type === "prompt_result" && record.agentInvoked === false) {
+      this.pending.shift();
+      return record;
+    }
+    if (record.type !== "message_start" && record.type !== "message_end") {
+      return record;
+    }
+    const message = userMessage(record);
+    if (!message) return record;
+    const echo = this.active ?? this.pending.shift() ?? null;
+    if (!echo) return record;
+    if (record.type === "message_start") this.active = echo;
+    if (record.type === "message_end") this.active = null;
+    return {
+      ...record,
+      message: { ...message, overtchatSubmissionId: echo.id },
+    };
+  }
+
+  clear(): void {
+    this.pending.splice(0, this.pending.length);
+    this.active = null;
+  }
+}


### PR DESCRIPTION
## Summary

- fix Pi and Oh My Pi image payloads
- preserve pasted images when provider history replaces the live message
- correlate provider echoes by submission identity, without text matching

## Scope

Does not address upload retention or the separate Claude/Codex resume-history gaps.

## Validation

Relevant bridge, runtime, connector, and web checks pass.