### PR TITLE
feat(agents): improve session identity and transcript links

### DIFF
--- a/apps/web/components/agents/AgentLinkIcon.tsx
+++ b/apps/web/components/agents/AgentLinkIcon.tsx
@@ -1,10 +1,14 @@
-import { File, FileCode2, Globe2, Link2 } from "lucide-react";
+import CsharpPlain from "devicons-react/icons/CsharpPlain";
+import { Braces, File, FileCode2, Globe2, Link2 } from "lucide-react";
 import {
+  siC,
+  siCplusplus,
   siGithub,
+  siGo,
   siJavascript,
-  siJson,
   siMarkdown,
   siPython,
+  siRust,
   siTypescript,
   type SimpleIcon,
 } from "simple-icons";
@@ -48,13 +52,28 @@ export function AgentLinkIcon({ kind }: { kind?: unknown }) {
       icon = <BrandMark icon={siJavascript} />;
       break;
     case "json":
-      icon = <BrandMark icon={siJson} />;
+      icon = <Braces className="size-3.5" />;
       break;
     case "markdown":
       icon = <BrandMark icon={siMarkdown} />;
       break;
     case "python":
       icon = <BrandMark icon={siPython} />;
+      break;
+    case "c":
+      icon = <BrandMark icon={siC} />;
+      break;
+    case "cplusplus":
+      icon = <BrandMark icon={siCplusplus} />;
+      break;
+    case "csharp":
+      icon = <CsharpPlain size="0.875rem" color="currentColor" />;
+      break;
+    case "go":
+      icon = <BrandMark icon={siGo} />;
+      break;
+    case "rust":
+      icon = <BrandMark icon={siRust} />;
       break;
     case "code":
       icon = <FileCode2 className="size-3.5" />;

--- a/apps/web/components/agents/AgentLinkIcon.tsx
+++ b/apps/web/components/agents/AgentLinkIcon.tsx
@@ -1,0 +1,79 @@
+import { File, FileCode2, Globe2, Link2 } from "lucide-react";
+import {
+  siGithub,
+  siJavascript,
+  siJson,
+  siMarkdown,
+  siPython,
+  siTypescript,
+  type SimpleIcon,
+} from "simple-icons";
+import {
+  AGENT_LINK_ICON_KINDS,
+  type AgentLinkIconKind,
+} from "@/lib/agents/links";
+
+function isAgentLinkIconKind(value: unknown): value is AgentLinkIconKind {
+  return (
+    typeof value === "string" &&
+    (AGENT_LINK_ICON_KINDS as readonly string[]).includes(value)
+  );
+}
+
+function BrandMark({ icon }: { icon: SimpleIcon }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="size-3.5">
+      <path d={icon.path} />
+    </svg>
+  );
+}
+
+export function AgentLinkIcon({ kind }: { kind?: unknown }) {
+  const resolvedKind: AgentLinkIconKind = isAgentLinkIconKind(kind)
+    ? kind
+    : "link";
+  let icon: React.ReactNode;
+
+  switch (resolvedKind) {
+    case "github":
+      icon = <BrandMark icon={siGithub} />;
+      break;
+    case "web":
+      icon = <Globe2 className="size-3.5" />;
+      break;
+    case "typescript":
+      icon = <BrandMark icon={siTypescript} />;
+      break;
+    case "javascript":
+      icon = <BrandMark icon={siJavascript} />;
+      break;
+    case "json":
+      icon = <BrandMark icon={siJson} />;
+      break;
+    case "markdown":
+      icon = <BrandMark icon={siMarkdown} />;
+      break;
+    case "python":
+      icon = <BrandMark icon={siPython} />;
+      break;
+    case "code":
+      icon = <FileCode2 className="size-3.5" />;
+      break;
+    case "file":
+      icon = <File className="size-3.5" />;
+      break;
+    case "link":
+      icon = <Link2 className="size-3.5" />;
+      break;
+  }
+
+  return (
+    <span
+      data-testid={`agent-link-icon-${resolvedKind}`}
+      aria-hidden="true"
+      className="mr-1 inline-flex shrink-0 self-center text-primary"
+    >
+      {icon}
+    </span>
+  );
+}

--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -23,6 +23,7 @@ import {
   STREAMDOWN_DEFAULT_REMARK_PLUGINS,
   STREAMDOWN_PLUGINS,
 } from "@/lib/chat/markdown";
+import { remarkAgentLinks } from "@/lib/agents/links";
 import {
   agentActivitySequencePosition,
   describeAgentActivity,
@@ -40,10 +41,34 @@ import {
   type AgentRunActivity,
 } from "./AgentActivity";
 import { AgentTaskProgressCard } from "./AgentTaskList";
+import { AgentLinkIcon } from "./AgentLinkIcon";
+import { AgentWorkspaceLink } from "./AgentWorkspaceLink";
 
 export type { AgentRunActivity } from "./AgentActivity";
 
 type UnknownRecord = Record<string, unknown>;
+
+const AGENT_REMARK_PLUGINS = [
+  ...STREAMDOWN_DEFAULT_REMARK_PLUGINS,
+  remarkAgentLinks,
+];
+
+const AGENT_MARKDOWN_ALLOWED_TAGS = {
+  "agent-link-icon": ["kind"],
+  "agent-workspace-link": ["path", "linestart", "lineend"],
+};
+
+const AGENT_MARKDOWN_COMPONENTS = {
+  "agent-link-icon": AgentLinkIcon,
+  "agent-workspace-link": AgentWorkspaceLink,
+};
+
+const AGENT_MARKDOWN_CLASSES = cn(
+  "font-sans space-y-3 text-[15px] leading-relaxed",
+  "[&_[data-streamdown=link]]:inline-flex [&_[data-streamdown=link]]:max-w-full [&_[data-streamdown=link]]:items-baseline",
+  "[&_[data-streamdown=link]]:font-medium [&_[data-streamdown=link]]:text-primary [&_[data-streamdown=link]]:no-underline",
+  "[&_[data-streamdown=link]]:motion-colors [&_[data-streamdown=link]]:hover:underline",
+);
 
 function recordOf(value: unknown): UnknownRecord | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -606,9 +631,11 @@ function Markdown({
 }) {
   return (
     <Streamdown
-      className="font-sans space-y-3 text-[15px] leading-relaxed"
+      className={AGENT_MARKDOWN_CLASSES}
       plugins={STREAMDOWN_PLUGINS}
-      remarkPlugins={STREAMDOWN_DEFAULT_REMARK_PLUGINS}
+      remarkPlugins={AGENT_REMARK_PLUGINS}
+      allowedTags={AGENT_MARKDOWN_ALLOWED_TAGS}
+      components={AGENT_MARKDOWN_COMPONENTS}
       isAnimating={streaming}
       caret={streaming ? "block" : undefined}
     >

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -3,6 +3,7 @@
 import { writeText as clipboardWriteText } from "clipboard-polyfill";
 import { Menu } from "@base-ui/react/menu";
 import { Popover } from "@base-ui/react/popover";
+import Image from "next/image";
 import {
   Coins,
   Copy,
@@ -15,15 +16,19 @@ import {
 import { Button } from "@/components/ui/button";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import type {
+  AgentProviderId,
   AgentSessionStats,
   AgentWorkspaceGitStatus,
 } from "@overtchat/agent-bridge";
+import { agentProviderMetadata } from "@overtchat/agent-bridge";
+import { AGENT_PROVIDER_VISUALS } from "@/lib/agents/providerVisuals";
 import { motionClasses } from "@/lib/motion";
 import { useAgentWorkspaceGitStatus } from "@/lib/queries/agentWorkspaces";
 import { cn } from "@/lib/utils";
 import { toast } from "@/components/ui/toast";
 
 export function AgentSessionHeader({
+  provider,
   workspaceId,
   workspaceName,
   workspacePath,
@@ -34,6 +39,7 @@ export function AgentSessionHeader({
   onRename,
   onCompact,
 }: {
+  provider: AgentProviderId;
   workspaceId: string;
   workspaceName: string;
   workspacePath: string;
@@ -44,6 +50,8 @@ export function AgentSessionHeader({
   onRename: () => void;
   onCompact: () => void;
 }) {
+  const providerMetadata = agentProviderMetadata(provider);
+  const providerVisual = AGENT_PROVIDER_VISUALS[provider];
   const gitStatus = useAgentWorkspaceGitStatus(workspaceId, {
     active: true,
     running,
@@ -65,11 +73,33 @@ export function AgentSessionHeader({
       className="flex h-12 shrink-0 items-center gap-1 border-b px-3"
     >
       <SidebarToggle />
-      <span
-        className="hidden max-w-40 truncate px-1 text-sm font-medium lg:block"
-        title={workspaceName}
+      <div
+        data-testid="agent-provider-identity"
+        aria-label={`${providerMetadata.label} agent`}
+        title={`${providerMetadata.label} agent`}
+        className="flex shrink-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-xs font-medium"
       >
-        {workspaceName}
+        <span
+          className={cn(
+            "flex size-6 items-center justify-center rounded-md border bg-background",
+            providerVisual.darkSurface && "bg-zinc-950",
+          )}
+          aria-hidden="true"
+        >
+          <Image
+            src={providerVisual.icon}
+            alt=""
+            className="size-4 object-contain"
+          />
+        </span>
+        <span className="hidden sm:inline">{providerMetadata.label}</span>
+      </div>
+      <span className="hidden h-4 w-px bg-border sm:block" aria-hidden="true" />
+      <span
+        className="hidden max-w-40 truncate px-1 font-mono text-xs text-muted-foreground md:block"
+        title={workspacePath}
+      >
+        ~/{workspaceName}
       </span>
       <WorkspaceGitSummary status={gitStatus} />
       <div className="ml-auto flex shrink-0 items-center gap-0.5">

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -30,7 +30,6 @@ import { toast } from "@/components/ui/toast";
 export function AgentSessionHeader({
   provider,
   workspaceId,
-  workspaceName,
   workspacePath,
   stats,
   running,
@@ -41,7 +40,6 @@ export function AgentSessionHeader({
 }: {
   provider: AgentProviderId;
   workspaceId: string;
-  workspaceName: string;
   workspacePath: string;
   stats: AgentSessionStats;
   running: boolean;
@@ -96,10 +94,11 @@ export function AgentSessionHeader({
       </div>
       <span className="hidden h-4 w-px bg-border sm:block" aria-hidden="true" />
       <span
-        className="hidden max-w-40 truncate px-1 font-mono text-xs text-muted-foreground md:block"
+        data-testid="agent-workspace-path"
+        className="hidden max-w-40 truncate px-1 font-mono text-xs text-muted-foreground md:block lg:max-w-64 xl:max-w-96"
         title={workspacePath}
       >
-        ~/{workspaceName}
+        {workspacePath}
       </span>
       <WorkspaceGitSummary status={gitStatus} />
       <div className="ml-auto flex shrink-0 items-center gap-0.5">

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -391,6 +391,7 @@ export function AgentSessionView({
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <AgentSessionHeader
+        provider={provider}
         workspaceId={workspaceId}
         workspaceName={workspaceName}
         workspacePath={workspacePath}

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -393,7 +393,6 @@ export function AgentSessionView({
       <AgentSessionHeader
         provider={provider}
         workspaceId={workspaceId}
-        workspaceName={workspaceName}
         workspacePath={workspacePath}
         stats={snapshot.stats}
         running={running}

--- a/apps/web/components/agents/AgentWorkspaceLink.tsx
+++ b/apps/web/components/agents/AgentWorkspaceLink.tsx
@@ -1,0 +1,36 @@
+function positiveLine(value: unknown): number | undefined {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function AgentWorkspaceLink({
+  children,
+  path,
+  linestart,
+  lineend,
+}: {
+  children?: React.ReactNode;
+  path?: unknown;
+  linestart?: unknown;
+  lineend?: unknown;
+}) {
+  const workspacePath = typeof path === "string" ? path : "Workspace file";
+  const lineStart = positiveLine(linestart);
+  const lineEnd = positiveLine(lineend);
+  const location = lineStart
+    ? `${workspacePath}:L${lineStart}${lineEnd ? `-L${lineEnd}` : ""}`
+    : workspacePath;
+
+  return (
+    <span
+      data-testid="agent-workspace-link"
+      data-workspace-path={workspacePath}
+      data-line-start={lineStart}
+      data-line-end={lineEnd}
+      title={location}
+      className="inline-flex max-w-full items-baseline font-medium text-primary no-underline"
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -773,6 +773,13 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(
     agentHeader.getByTestId("agent-provider-identity"),
   ).toHaveAccessibleName("Codex agent");
+  await expect(agentHeader.getByTestId("agent-workspace-path")).toHaveText(
+    "/tmp/runtime-test",
+  );
+  await expect(agentHeader.getByTestId("agent-workspace-path")).toHaveAttribute(
+    "title",
+    "/tmp/runtime-test",
+  );
   await expect(
     page.getByRole("button", { name: /overtchat\/overtchat PR #232/u }),
   ).toBeVisible();

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -181,7 +181,8 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
           {
             id: "answer",
             type: "text",
-            text: "I will inspect the runtime.",
+            text:
+              "I will inspect the runtime. https://github.com/overtchat/overtchat/pull/232\n\nReview [the agent view](apps/web/components/agents/AgentSessionView.tsx#L391), [the docs](https://docs.example.com/guide/start), and [the fixture](./fixtures/custom.xyz).",
           },
         ],
         timestamp: 2.2,
@@ -193,7 +194,7 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
         role: "turnFooter",
         messageId: "turn-1:assistant",
         content:
-          "I'm auditing the release state before merging anything.\n\nI will inspect the runtime.",
+          "I'm auditing the release state before merging anything.\n\nI will inspect the runtime. https://github.com/overtchat/overtchat/pull/232\n\nReview [the agent view](apps/web/components/agents/AgentSessionView.tsx#L391), [the docs](https://docs.example.com/guide/start), and [the fixture](./fixtures/custom.xyz).",
         durationMs: 246_000,
         timestamp: 2.3,
       },
@@ -770,6 +771,33 @@ test("shows durable turn activity without changing completed tool status", async
   const agentHeader = page.getByTestId("agent-session-header");
   const agentComposer = page.getByTestId("agent-composer");
   await expect(
+    agentHeader.getByTestId("agent-provider-identity"),
+  ).toHaveAccessibleName("Codex agent");
+  await expect(
+    page.getByRole("button", { name: /overtchat\/overtchat PR #232/u }),
+  ).toBeVisible();
+  await expect(page.getByTestId("agent-link-icon-github")).toBeVisible();
+  await expect(page.getByTestId("agent-link-icon-typescript")).toBeVisible();
+  await expect(page.getByTestId("agent-link-icon-web")).toBeVisible();
+  await expect(page.getByTestId("agent-link-icon-file")).toBeVisible();
+  const agentViewLink = page
+    .getByTestId("agent-workspace-link")
+    .filter({ hasText: "the agent view" });
+  await expect(agentViewLink).toBeVisible();
+  await expect(agentViewLink).toHaveAttribute(
+    "data-workspace-path",
+    "apps/web/components/agents/AgentSessionView.tsx",
+  );
+  await expect(agentViewLink).toHaveAttribute("data-line-start", "391");
+  await expect(
+    page.getByRole("button", { name: "the docs", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByTestId("agent-workspace-link")
+      .filter({ hasText: "the fixture" }),
+  ).toBeVisible();
+  await expect(
     agentHeader.getByTestId("agent-model-effort-trigger"),
   ).toHaveCount(0);
   await expect(
@@ -898,7 +926,9 @@ test("shows durable turn activity without changing completed tool status", async
     page.getByText("I should inspect the runtime before responding."),
   ).toBeVisible();
   await expect(
-    page.getByText("I will inspect the runtime.", { exact: true }),
+    page
+      .getByRole("paragraph")
+      .filter({ hasText: "I will inspect the runtime." }),
   ).toBeVisible();
   await expect(page.getByTestId("agent-plan-card")).toContainText(
     "Finish parity",

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -182,7 +182,7 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
             id: "answer",
             type: "text",
             text:
-              "I will inspect the runtime. https://github.com/overtchat/overtchat/pull/232\n\nReview [the agent view](apps/web/components/agents/AgentSessionView.tsx#L391), [the docs](https://docs.example.com/guide/start), and [the fixture](./fixtures/custom.xyz).",
+              "I will inspect the runtime. https://github.com/overtchat/overtchat/pull/232\n\nReview [the agent view](apps/web/components/agents/AgentSessionView.tsx#L391), [the docs](https://docs.example.com/guide/start), [the config](./fixtures/config.json), [the native app](./fixtures/App.cs), and [the fixture](./fixtures/custom.xyz).",
           },
         ],
         timestamp: 2.2,
@@ -194,7 +194,7 @@ function runtimeSnapshot(startedAt: number): AgentRuntimeSnapshot {
         role: "turnFooter",
         messageId: "turn-1:assistant",
         content:
-          "I'm auditing the release state before merging anything.\n\nI will inspect the runtime. https://github.com/overtchat/overtchat/pull/232\n\nReview [the agent view](apps/web/components/agents/AgentSessionView.tsx#L391), [the docs](https://docs.example.com/guide/start), and [the fixture](./fixtures/custom.xyz).",
+          "I'm auditing the release state before merging anything.\n\nI will inspect the runtime. https://github.com/overtchat/overtchat/pull/232\n\nReview [the agent view](apps/web/components/agents/AgentSessionView.tsx#L391), [the docs](https://docs.example.com/guide/start), [the config](./fixtures/config.json), [the native app](./fixtures/App.cs), and [the fixture](./fixtures/custom.xyz).",
         durationMs: 246_000,
         timestamp: 2.3,
       },
@@ -779,6 +779,8 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(page.getByTestId("agent-link-icon-github")).toBeVisible();
   await expect(page.getByTestId("agent-link-icon-typescript")).toBeVisible();
   await expect(page.getByTestId("agent-link-icon-web")).toBeVisible();
+  await expect(page.getByTestId("agent-link-icon-json")).toBeVisible();
+  await expect(page.getByTestId("agent-link-icon-csharp")).toBeVisible();
   await expect(page.getByTestId("agent-link-icon-file")).toBeVisible();
   const agentViewLink = page
     .getByTestId("agent-workspace-link")

--- a/apps/web/lib/agents/links.test.ts
+++ b/apps/web/lib/agents/links.test.ts
@@ -68,7 +68,12 @@ describe("agentLinkIconKind", () => {
     ["config/settings.json", "json"],
     ["docs/README.md", "markdown"],
     ["scripts/release.py", "python"],
-    ["src/main.rs", "code"],
+    ["src/main.c", "c"],
+    ["src/main.cpp", "cplusplus"],
+    ["src/App.cs", "csharp"],
+    ["cmd/server.go", "go"],
+    ["src/main.rs", "rust"],
+    ["src/Main.java", "code"],
     ["./fixtures/custom.xyz", "file"],
   ] as const)("maps %s to the %s icon", (href, icon) => {
     expect(agentLinkIconKind(classifyAgentLink({ href }))).toBe(icon);

--- a/apps/web/lib/agents/links.test.ts
+++ b/apps/web/lib/agents/links.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentLinkIconKind,
+  classifyAgentLink,
+  compactExternalLinkLabel,
+  remarkAgentLinks,
+} from "./links";
+
+describe("classifyAgentLink", () => {
+  it("separates external URLs from GitHub lookalikes", () => {
+    const github = classifyAgentLink({
+      href: "https://github.com/overtchat/overtchat/pull/232",
+    });
+    const lookalike = classifyAgentLink({
+      href: "https://github.com.example.com/unsafe/file.ts",
+    });
+
+    expect(github).toEqual({
+      kind: "external",
+      url: "https://github.com/overtchat/overtchat/pull/232",
+    });
+    expect(agentLinkIconKind(github)).toBe("github");
+    expect(agentLinkIconKind(lookalike)).toBe("web");
+  });
+
+  it("parses workspace files and line ranges without binding a workspace id", () => {
+    expect(
+      classifyAgentLink({ href: "apps/web/components/App.tsx#L12-L20" }),
+    ).toEqual({
+      kind: "workspace-file",
+      raw: "apps/web/components/App.tsx#L12-L20",
+      path: "apps/web/components/App.tsx",
+      lineStart: 12,
+      lineEnd: 20,
+    });
+    expect(classifyAgentLink({ href: "src/server.ts:42:7" })).toEqual({
+      kind: "workspace-file",
+      raw: "src/server.ts:42:7",
+      path: "src/server.ts",
+      lineStart: 42,
+    });
+    expect(classifyAgentLink({ href: "file:///tmp/project/main.py#L8" })).toEqual({
+      kind: "workspace-file",
+      raw: "file:///tmp/project/main.py#L8",
+      path: "/tmp/project/main.py",
+      lineStart: 8,
+    });
+  });
+
+  it("uses conservative file heuristics with a generic explicit-path fallback", () => {
+    expect(classifyAgentLink({ href: "docs.example.com/file.ts" })).toEqual({
+      kind: "unknown",
+      href: "docs.example.com/file.ts",
+    });
+    const generic = classifyAgentLink({ href: "./fixtures/custom.xyz" });
+    expect(generic).toMatchObject({
+      kind: "workspace-file",
+      path: "./fixtures/custom.xyz",
+    });
+    expect(agentLinkIconKind(generic)).toBe("file");
+  });
+});
+
+describe("agentLinkIconKind", () => {
+  it.each([
+    ["src/app.ts", "typescript"],
+    ["src/app.jsx", "javascript"],
+    ["config/settings.json", "json"],
+    ["docs/README.md", "markdown"],
+    ["scripts/release.py", "python"],
+    ["src/main.rs", "code"],
+    ["./fixtures/custom.xyz", "file"],
+  ] as const)("maps %s to the %s icon", (href, icon) => {
+    expect(agentLinkIconKind(classifyAgentLink({ href }))).toBe(icon);
+  });
+});
+
+describe("compactExternalLinkLabel", () => {
+  it("formats raw GitHub pull requests and ordinary web URLs", () => {
+    expect(
+      compactExternalLinkLabel("https://github.com/overtchat/overtchat/pull/232"),
+    ).toBe("overtchat/overtchat PR #232");
+    expect(compactExternalLinkLabel("https://docs.example.com/guide/start"))
+      .toBe("docs.example.com/guide/start");
+    expect(compactExternalLinkLabel("javascript:alert(1)"))
+      .toBeNull();
+  });
+});
+
+describe("remarkAgentLinks", () => {
+  it("decorates external and workspace links without replacing authored labels", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "link",
+          url: "https://github.com/overtchat/overtchat/pull/232",
+          children: [
+            {
+              type: "text",
+              value: "https://github.com/overtchat/overtchat/pull/232",
+            },
+          ],
+        },
+        {
+          type: "link",
+          url: "apps/web/src/app.ts#L12",
+          children: [{ type: "text", value: "the app entrypoint" }],
+        },
+      ],
+    };
+
+    remarkAgentLinks()(tree);
+
+    expect(tree.children[0].children).toEqual([
+      {
+        type: "agent-link-icon",
+        data: {
+          hName: "agent-link-icon",
+          hProperties: { kind: "github" },
+        },
+      },
+      { type: "text", value: "overtchat/overtchat PR #232" },
+    ]);
+    expect(tree.children[1].children).toEqual([
+      {
+        type: "agent-link-icon",
+        data: {
+          hName: "agent-link-icon",
+          hProperties: { kind: "typescript" },
+        },
+      },
+      { type: "text", value: "the app entrypoint" },
+    ]);
+    expect(
+      (tree.children[1] as (typeof tree.children)[number] & { data?: unknown })
+        .data,
+    ).toEqual({
+      hName: "agent-workspace-link",
+      hProperties: {
+        path: "apps/web/src/app.ts",
+        linestart: 12,
+      },
+    });
+  });
+});

--- a/apps/web/lib/agents/links.ts
+++ b/apps/web/lib/agents/links.ts
@@ -1,0 +1,402 @@
+export type AgentLinkSource = {
+  href: string;
+  text?: string;
+  sourceType?: "markdown" | "autolink" | "inline-code";
+};
+
+export type AgentWorkspaceFileTarget = {
+  kind: "workspace-file";
+  raw: string;
+  path: string;
+  lineStart?: number;
+  lineEnd?: number;
+};
+
+export type AgentLinkTarget =
+  | { kind: "external"; url: string }
+  | AgentWorkspaceFileTarget
+  | { kind: "unknown"; href: string };
+
+export const AGENT_LINK_ICON_KINDS = [
+  "github",
+  "web",
+  "typescript",
+  "javascript",
+  "json",
+  "markdown",
+  "python",
+  "code",
+  "file",
+  "link",
+] as const;
+
+export type AgentLinkIconKind = (typeof AGENT_LINK_ICON_KINDS)[number];
+
+type MarkdownNode = {
+  type?: string;
+  url?: unknown;
+  value?: unknown;
+  children?: MarkdownNode[];
+  data?: {
+    hName?: string;
+    hProperties?: Record<string, string | number>;
+  };
+};
+
+const MAX_LINK_LABEL_LENGTH = 64;
+const LINK_ICON_TAG = "agent-link-icon";
+const WORKSPACE_LINK_TAG = "agent-workspace-link";
+const LINE_FRAGMENT = /^L([0-9]+)(?:C[0-9]+)?(?:-L?([0-9]+)(?:C[0-9]+)?)?$/iu;
+const COLON_LINE_SUFFIX = /^(.+?):([0-9]+)(?::[0-9]+)?(?:-([0-9]+)(?::[0-9]+)?)?$/u;
+const PAREN_LINE_SUFFIX = /^(.+?)\(([0-9]+)(?:,[0-9]+)?(?:-([0-9]+)(?:,[0-9]+)?)?\)$/u;
+const WORD_LINE_SUFFIX = /^(.+?)\s+lines?\s+([0-9]+)(?:-([0-9]+))?$/iu;
+const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:[\\/]/u;
+const EXTERNAL_SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/u;
+const DOMAIN_LIKE_SEGMENT = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/u;
+
+const CODING_FILE_EXTENSIONS = new Set([
+  "astro",
+  "bash",
+  "c",
+  "cc",
+  "cjs",
+  "cpp",
+  "cs",
+  "css",
+  "cts",
+  "cxx",
+  "env",
+  "fish",
+  "go",
+  "gql",
+  "gradle",
+  "graphql",
+  "h",
+  "hpp",
+  "htm",
+  "html",
+  "ini",
+  "java",
+  "js",
+  "json",
+  "jsonc",
+  "jsx",
+  "kt",
+  "kts",
+  "less",
+  "lock",
+  "lua",
+  "md",
+  "mdx",
+  "mjs",
+  "mts",
+  "php",
+  "proto",
+  "py",
+  "rb",
+  "rs",
+  "sass",
+  "scss",
+  "sh",
+  "sql",
+  "svelte",
+  "swift",
+  "toml",
+  "ts",
+  "tsx",
+  "txt",
+  "vue",
+  "xml",
+  "yaml",
+  "yml",
+  "zsh",
+]);
+
+const CODE_FILE_NAMES = new Set([
+  "dockerfile",
+  "gemfile",
+  "justfile",
+  "makefile",
+  "procfile",
+]);
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function parseHttpUrl(href: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+}
+
+function positiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function validLines(
+  lineStart: number | undefined,
+  lineEnd: number | undefined,
+): Pick<AgentWorkspaceFileTarget, "lineStart" | "lineEnd"> | null {
+  if (lineEnd !== undefined && (lineStart === undefined || lineEnd < lineStart)) {
+    return null;
+  }
+  return {
+    ...(lineStart !== undefined ? { lineStart } : {}),
+    ...(lineEnd !== undefined ? { lineEnd } : {}),
+  };
+}
+
+function splitPathAndLines(
+  rawValue: string,
+): { path: string; lineStart?: number; lineEnd?: number } | null {
+  const trimmed = rawValue.trim().replace(/^['"`]|['"`]$/gu, "");
+  if (!trimmed || trimmed.includes("?")) return null;
+
+  if (trimmed.toLowerCase().startsWith("file://")) {
+    let url: URL;
+    try {
+      url = new URL(trimmed);
+    } catch {
+      return null;
+    }
+    let path = safeDecodeURIComponent(url.pathname).replace(/\\/gu, "/");
+    if (/^\/[A-Za-z]:\//u.test(path)) path = path.slice(1);
+    if (!path) return null;
+    const fragment = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+    if (!fragment) return { path };
+    const match = fragment.match(LINE_FRAGMENT);
+    if (!match) return null;
+    const lines = validLines(positiveInteger(match[1]), positiveInteger(match[2]));
+    return lines ? { path, ...lines } : null;
+  }
+
+  const hashIndex = trimmed.indexOf("#");
+  const withoutHash = hashIndex >= 0 ? trimmed.slice(0, hashIndex) : trimmed;
+  const fragment = hashIndex >= 0 ? trimmed.slice(hashIndex + 1) : "";
+  let fragmentLines: Pick<AgentWorkspaceFileTarget, "lineStart" | "lineEnd"> = {};
+  if (fragment) {
+    const match = fragment.match(LINE_FRAGMENT);
+    if (!match) return null;
+    const lines = validLines(positiveInteger(match[1]), positiveInteger(match[2]));
+    if (!lines) return null;
+    fragmentLines = lines;
+  }
+
+  const inlineMatch =
+    withoutHash.match(COLON_LINE_SUFFIX) ??
+    withoutHash.match(PAREN_LINE_SUFFIX) ??
+    withoutHash.match(WORD_LINE_SUFFIX);
+  if (inlineMatch) {
+    const lines = validLines(
+      positiveInteger(inlineMatch[2]),
+      positiveInteger(inlineMatch[3]),
+    );
+    if (!lines) return null;
+    return {
+      path: safeDecodeURIComponent(inlineMatch[1]).replace(/\\/gu, "/"),
+      ...lines,
+    };
+  }
+
+  return {
+    path: safeDecodeURIComponent(withoutHash).replace(/\\/gu, "/"),
+    ...fragmentLines,
+  };
+}
+
+function fileExtension(path: string): string | null {
+  const name = path.split("/").filter(Boolean).at(-1)?.toLowerCase();
+  if (!name) return null;
+  const lastDot = name.lastIndexOf(".");
+  return lastDot >= 0 && lastDot < name.length - 1
+    ? name.slice(lastDot + 1)
+    : null;
+}
+
+function looksLikeWorkspacePath(path: string): boolean {
+  if (
+    path.startsWith("/") ||
+    path.startsWith("./") ||
+    path.startsWith("../") ||
+    path.startsWith("~/") ||
+    WINDOWS_ABSOLUTE_PATH.test(path)
+  ) {
+    return true;
+  }
+
+  const segments = path.split("/").filter(Boolean);
+  const fileName = segments.at(-1)?.toLowerCase();
+  if (!fileName) return false;
+  if (CODE_FILE_NAMES.has(fileName) || (fileName.startsWith(".") && fileName.length > 1)) {
+    return true;
+  }
+
+  const extension = fileExtension(path);
+  if (segments.length === 1) {
+    return extension !== null && CODING_FILE_EXTENSIONS.has(extension);
+  }
+
+  return !DOMAIN_LIKE_SEGMENT.test(segments[0]) && extension !== null;
+}
+
+function workspaceFileTarget(href: string): AgentWorkspaceFileTarget | null {
+  const parsed = splitPathAndLines(href);
+  if (!parsed || !looksLikeWorkspacePath(parsed.path)) return null;
+  return {
+    kind: "workspace-file",
+    raw: href,
+    path: parsed.path,
+    ...(parsed.lineStart !== undefined ? { lineStart: parsed.lineStart } : {}),
+    ...(parsed.lineEnd !== undefined ? { lineEnd: parsed.lineEnd } : {}),
+  };
+}
+
+export function classifyAgentLink(source: AgentLinkSource): AgentLinkTarget {
+  const href = source.href.trim();
+  if (!href) return { kind: "unknown", href };
+
+  const httpUrl = parseHttpUrl(href);
+  if (httpUrl) return { kind: "external", url: href };
+
+  const fileTarget = workspaceFileTarget(href);
+  if (fileTarget) return fileTarget;
+
+  if (EXTERNAL_SCHEME.test(href) && !WINDOWS_ABSOLUTE_PATH.test(href)) {
+    return { kind: "external", url: href };
+  }
+
+  return { kind: "unknown", href };
+}
+
+export function agentLinkIconKind(target: AgentLinkTarget): AgentLinkIconKind {
+  if (target.kind === "external") {
+    const url = parseHttpUrl(target.url);
+    const hostname = url?.hostname.toLowerCase();
+    return hostname === "github.com" || hostname?.endsWith(".github.com")
+      ? "github"
+      : "web";
+  }
+  if (target.kind === "unknown") return "link";
+
+  const extension = fileExtension(target.path);
+  if (["ts", "tsx", "cts", "mts"].includes(extension ?? "")) {
+    return "typescript";
+  }
+  if (["js", "jsx", "cjs", "mjs"].includes(extension ?? "")) {
+    return "javascript";
+  }
+  if (extension === "json" || extension === "jsonc") return "json";
+  if (extension === "md" || extension === "mdx") return "markdown";
+  if (extension === "py") return "python";
+  if (extension && CODING_FILE_EXTENSIONS.has(extension)) return "code";
+  return "file";
+}
+
+export function compactExternalLinkLabel(href: string): string | null {
+  const url = parseHttpUrl(href);
+  if (!url) return null;
+
+  const hostname = url.hostname.replace(/^www\./u, "");
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (
+    hostname === "github.com" &&
+    segments.length >= 4 &&
+    /^\d+$/u.test(segments[3])
+  ) {
+    const [owner, repository, kind, number] = segments;
+    if (kind === "pull") return `${owner}/${repository} PR #${number}`;
+    if (kind === "issues") return `${owner}/${repository} #${number}`;
+  }
+
+  const path = url.pathname === "/" ? "" : url.pathname.replace(/\/$/u, "");
+  const display = `${hostname}${path}${url.search}${url.hash}`;
+  return display.length <= MAX_LINK_LABEL_LENGTH
+    ? display
+    : `${display.slice(0, MAX_LINK_LABEL_LENGTH - 1)}…`;
+}
+
+function markdownText(node: MarkdownNode): string {
+  if (node.type === "text" && typeof node.value === "string") return node.value;
+  return node.children?.map(markdownText).join("") ?? "";
+}
+
+function rawTextMatchesHref(text: string, href: string): boolean {
+  const normalizedText = text.trim().replace(/\/$/u, "");
+  const normalizedHref = href.trim().replace(/\/$/u, "");
+  return (
+    normalizedText === normalizedHref ||
+    normalizedHref === `https://${normalizedText}` ||
+    normalizedHref === `http://${normalizedText}`
+  );
+}
+
+function containsImage(node: MarkdownNode): boolean {
+  return node.type === "image" || node.children?.some(containsImage) === true;
+}
+
+function decorateAgentLinks(node: MarkdownNode): void {
+  if (node.type === "link" && typeof node.url === "string" && !containsImage(node)) {
+    const text = markdownText(node);
+    const source: AgentLinkSource = {
+      href: node.url,
+      text,
+      sourceType: rawTextMatchesHref(text, node.url) ? "autolink" : "markdown",
+    };
+    const target = classifyAgentLink(source);
+
+    if (source.sourceType === "autolink" && target.kind === "external") {
+      const label = compactExternalLinkLabel(target.url);
+      if (
+        label &&
+        node.children?.length === 1 &&
+        node.children[0]?.type === "text"
+      ) {
+        node.children[0].value = label;
+      }
+    }
+
+    const iconKind = agentLinkIconKind(target);
+    node.children = [
+      {
+        type: "agent-link-icon",
+        data: {
+          hName: LINK_ICON_TAG,
+          hProperties: { kind: iconKind },
+        },
+      },
+      ...(node.children ?? []),
+    ];
+
+    if (target.kind === "workspace-file") {
+      node.data = {
+        hName: WORKSPACE_LINK_TAG,
+        hProperties: {
+          path: target.path,
+          ...(target.lineStart !== undefined
+            ? { linestart: target.lineStart }
+            : {}),
+          ...(target.lineEnd !== undefined ? { lineend: target.lineEnd } : {}),
+        },
+      };
+    }
+  }
+
+  node.children?.forEach(decorateAgentLinks);
+}
+
+/** Adds compact labels and semantic icon markers to coding-agent links. */
+export function remarkAgentLinks() {
+  return decorateAgentLinks;
+}

--- a/apps/web/lib/agents/links.ts
+++ b/apps/web/lib/agents/links.ts
@@ -25,6 +25,11 @@ export const AGENT_LINK_ICON_KINDS = [
   "json",
   "markdown",
   "python",
+  "c",
+  "cplusplus",
+  "csharp",
+  "go",
+  "rust",
   "code",
   "file",
   "link",
@@ -300,6 +305,11 @@ export function agentLinkIconKind(target: AgentLinkTarget): AgentLinkIconKind {
   if (extension === "json" || extension === "jsonc") return "json";
   if (extension === "md" || extension === "mdx") return "markdown";
   if (extension === "py") return "python";
+  if (extension === "c") return "c";
+  if (["cc", "cpp", "cxx"].includes(extension ?? "")) return "cplusplus";
+  if (extension === "cs") return "csharp";
+  if (extension === "go") return "go";
+  if (extension === "rs") return "rust";
   if (extension && CODING_FILE_EXTENSIONS.has(extension)) return "code";
   return "file";
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "class-variance-authority": "^0.7.1",
     "clipboard-polyfill": "^4.1.1",
     "clsx": "^2.1.1",
+    "devicons-react": "^1.5.0",
     "drizzle-orm": "^0.45.2",
     "fflate": "^0.8.2",
     "katex": "^0.16.45",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,6 +64,7 @@
     "resumable-stream": "^2.2.12",
     "server-only": "^0.0.1",
     "shadcn": "^4.7.0",
+    "simple-icons": "^16.29.0",
     "streamdown": "^2.5.0",
     "strip-markdown": "^6.0.0",
     "tailwind-merge": "^3.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,6 +2356,7 @@
         "class-variance-authority": "^0.7.1",
         "clipboard-polyfill": "^4.1.1",
         "clsx": "^2.1.1",
+        "devicons-react": "^1.5.0",
         "drizzle-orm": "^0.45.2",
         "fflate": "^0.8.2",
         "katex": "^0.16.45",
@@ -14747,6 +14748,15 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devicons-react": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/devicons-react/-/devicons-react-1.5.0.tgz",
+      "integrity": "sha512-8DYsWpgdbwI7ENDyC6Z9eqV72H01zUIAeRRo+UxBAq4clpPWcFhtqDrWSm0i5GUqbn/iNyiIfT1K69y0XLsscg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/devlop": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,6 +2374,7 @@
         "resumable-stream": "^2.2.12",
         "server-only": "^0.0.1",
         "shadcn": "^4.7.0",
+        "simple-icons": "^16.29.0",
         "streamdown": "^2.5.0",
         "strip-markdown": "^6.0.0",
         "tailwind-merge": "^3.5.0",
@@ -25613,6 +25614,25 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-icons": {
+      "version": "16.29.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.29.0.tgz",
+      "integrity": "sha512-4H94f5ZgcCcgJroc902TFlFdgPu2IU2eD7+WebN2Z14xKYrKHeJ4UQcZwzgSuH4Rgzw+jp7sbHl40NefuIEYsg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
       }
     },
     "node_modules/simple-plist": {


### PR DESCRIPTION
## Summary

- show the active coding-agent provider and the exact workspace path in the session header
- render compact external links with tinted GitHub, common-language, file-format, and web icons
- distinguish workspace file references from external URLs while preserving path and line metadata
- use structured Markdown AST nodes so the renderer can evolve without reparsing transcript content

## Icon system

Recognizable brand and language marks come from Simple Icons, with a deep-imported Devicon mark for C# because Simple Icons does not provide one. The common-language mapping covers TypeScript, JavaScript, Python, C, C++, C#, Go, and Rust.

Semantic concepts continue to use Lucide: JSON uses braces rather than the low-legibility JSON brand swirl, while generic code, files, links, and web destinations retain their corresponding UI symbols. Every icon inherits the app theme rather than using its original brand color.

## Scope

This keeps the current change UI-only and provider-neutral. Workspace file references are intentionally inert until a follow-up adds connector-side resolution and the right-side file or diff viewer. The structured target metadata added here is the handoff point for that work.

The header renders the persisted workspace path verbatim. It does not synthesize a home-relative path because the web app does not know the local or SSH target home directory.

## Validation

- `npm test -w apps/web -- --run`
- `npm run typecheck -w apps/web --`
- `npm run lint -w apps/web --`
- `npm run build -w apps/web --`
- `E2E_PORT=4729 npm run test:e2e -w apps/web -- --project=chromium --grep "shows durable turn activity without changing completed tool status"`