### PR TITLE
feat(agents): add read-only workspace browser

### DIFF
--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -26,8 +26,8 @@ const mocks = vi.hoisted(() => ({
   snapshot: vi.fn(),
   observe: vi.fn(),
   acquireLease: vi.fn(),
-  listAgentWorkspaceDirectory: vi.fn(),
-  readAgentWorkspaceFile: vi.fn(),
+  listWorkspaceDirectory: vi.fn(),
+  readWorkspaceFile: vi.fn(),
   registryOptions: null as {
     runtimeExited?: (sessionId: string, runtime: unknown) => void | Promise<void>;
     saveQueuedMessages?: (
@@ -44,8 +44,10 @@ vi.mock("@overtchat/agent-runtime", async (importOriginal) => {
   return {
     ...original,
     configureProcessSpawner: mocks.configureProcessSpawner,
-    listAgentWorkspaceDirectory: mocks.listAgentWorkspaceDirectory,
-    readAgentWorkspaceFile: mocks.readAgentWorkspaceFile,
+    workspaceFilesService: {
+      listDirectory: mocks.listWorkspaceDirectory,
+      readFile: mocks.readWorkspaceFile,
+    },
     AgentRuntimeRegistry: class {
       constructor(options: NonNullable<typeof mocks.registryOptions>) {
         mocks.registryOptions = options;
@@ -214,12 +216,14 @@ beforeEach(() => {
   mocks.stopSession.mockResolvedValue(undefined);
   mocks.stopWorkspace.mockResolvedValue(undefined);
   mocks.stopConnection.mockResolvedValue(undefined);
-  mocks.listAgentWorkspaceDirectory.mockResolvedValue({
+  mocks.listWorkspaceDirectory.mockResolvedValue({
     path: ".",
     entries: [],
     truncated: false,
   });
-  mocks.readAgentWorkspaceFile.mockResolvedValue({
+  mocks.readWorkspaceFile.mockResolvedValue({
+    kind: "text",
+    encoding: "utf-8",
     path: "README.md",
     content: "OvertChat",
     size: 8,
@@ -268,12 +272,12 @@ describe("connector daemon command identity", () => {
       },
     });
 
-    expect(mocks.listAgentWorkspaceDirectory).toHaveBeenCalledWith(
+    expect(mocks.listWorkspaceDirectory).toHaveBeenCalledWith(
       { transport: "ssh", alias: "workstation" },
       "/srv/project",
       "src",
     );
-    expect(mocks.readAgentWorkspaceFile).toHaveBeenCalledWith(
+    expect(mocks.readWorkspaceFile).toHaveBeenCalledWith(
       { transport: "local" },
       "/srv/project",
       "README.md",

--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -26,6 +26,8 @@ const mocks = vi.hoisted(() => ({
   snapshot: vi.fn(),
   observe: vi.fn(),
   acquireLease: vi.fn(),
+  listAgentWorkspaceDirectory: vi.fn(),
+  readAgentWorkspaceFile: vi.fn(),
   registryOptions: null as {
     runtimeExited?: (sessionId: string, runtime: unknown) => void | Promise<void>;
     saveQueuedMessages?: (
@@ -42,6 +44,8 @@ vi.mock("@overtchat/agent-runtime", async (importOriginal) => {
   return {
     ...original,
     configureProcessSpawner: mocks.configureProcessSpawner,
+    listAgentWorkspaceDirectory: mocks.listAgentWorkspaceDirectory,
+    readAgentWorkspaceFile: mocks.readAgentWorkspaceFile,
     AgentRuntimeRegistry: class {
       constructor(options: NonNullable<typeof mocks.registryOptions>) {
         mocks.registryOptions = options;
@@ -210,6 +214,17 @@ beforeEach(() => {
   mocks.stopSession.mockResolvedValue(undefined);
   mocks.stopWorkspace.mockResolvedValue(undefined);
   mocks.stopConnection.mockResolvedValue(undefined);
+  mocks.listAgentWorkspaceDirectory.mockResolvedValue({
+    path: ".",
+    entries: [],
+    truncated: false,
+  });
+  mocks.readAgentWorkspaceFile.mockResolvedValue({
+    path: "README.md",
+    content: "OvertChat",
+    size: 8,
+    modifiedAt: 1,
+  });
   mocks.registryOptions = null;
 });
 
@@ -222,6 +237,64 @@ afterEach(async () => {
 });
 
 describe("connector daemon command identity", () => {
+  it("dispatches provider-neutral workspace file operations", async () => {
+    const { journal, timelines } = await openJournal();
+    const events: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => events.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+
+    await daemon.handle({
+      type: "request",
+      requestId: "list-files",
+      request: {
+        type: "list_workspace_directory",
+        target: { transport: "ssh", alias: "workstation" },
+        root: "/srv/project",
+        path: "src",
+      },
+    });
+    await daemon.handle({
+      type: "request",
+      requestId: "read-file",
+      request: {
+        type: "read_workspace_file",
+        target: { transport: "local" },
+        root: "/srv/project",
+        path: "README.md",
+      },
+    });
+
+    expect(mocks.listAgentWorkspaceDirectory).toHaveBeenCalledWith(
+      { transport: "ssh", alias: "workstation" },
+      "/srv/project",
+      "src",
+    );
+    expect(mocks.readAgentWorkspaceFile).toHaveBeenCalledWith(
+      { transport: "local" },
+      "/srv/project",
+      "README.md",
+    );
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "response",
+        requestId: "list-files",
+        success: true,
+      }),
+      expect.objectContaining({
+        type: "response",
+        requestId: "read-file",
+        success: true,
+      }),
+    ]);
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
   it("reads usage without entering the durable provider-command ledger", async () => {
     const { journal, timelines } = await openJournal();
     const events: HostConnectorEventPayload[] = [];

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -22,9 +22,8 @@ import {
   configureTcpTunnelOpener,
   inspectAgentWorkspaceGitStatus,
   listAgentDirectories,
-  listAgentWorkspaceDirectory,
   probeAgentWorkspace,
-  readAgentWorkspaceFile,
+  workspaceFilesService,
   type AgentSessionRuntime,
   type HostTarget,
   type ResolvedAgentImage,
@@ -375,13 +374,13 @@ export class ConnectorDaemon {
           request.path,
         );
       case "list_workspace_directory":
-        return listAgentWorkspaceDirectory(
+        return workspaceFilesService.listDirectory(
           hostTarget(request.target),
           request.root,
           request.path,
         );
       case "read_workspace_file":
-        return readAgentWorkspaceFile(
+        return workspaceFilesService.readFile(
           hostTarget(request.target),
           request.root,
           request.path,

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -22,7 +22,9 @@ import {
   configureTcpTunnelOpener,
   inspectAgentWorkspaceGitStatus,
   listAgentDirectories,
+  listAgentWorkspaceDirectory,
   probeAgentWorkspace,
+  readAgentWorkspaceFile,
   type AgentSessionRuntime,
   type HostTarget,
   type ResolvedAgentImage,
@@ -370,6 +372,18 @@ export class ConnectorDaemon {
       case "git_status":
         return inspectAgentWorkspaceGitStatus(
           hostTarget(request.target),
+          request.path,
+        );
+      case "list_workspace_directory":
+        return listAgentWorkspaceDirectory(
+          hostTarget(request.target),
+          request.root,
+          request.path,
+        );
+      case "read_workspace_file":
+        return readAgentWorkspaceFile(
+          hostTarget(request.target),
+          request.root,
           request.path,
         );
       case "create_session": {

--- a/apps/web/app/api/agent-workspaces/[id]/file/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/file/route.test.ts
@@ -46,6 +46,8 @@ describe("agent workspace file route", () => {
     mocks.isOnline.mockReturnValue(true);
     mocks.supports.mockReturnValue(true);
     mocks.daemonRequest.mockResolvedValue({
+      kind: "text",
+      encoding: "utf-8",
       path: "src/index.ts",
       content: "export {};",
       size: 10,

--- a/apps/web/app/api/agent-workspaces/[id]/file/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/file/route.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getOwnedAgentWorkspace: vi.fn(),
+  daemonRequest: vi.fn(),
+  isOnline: vi.fn(),
+  supports: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/agentConnections", () => ({
+  getOwnedAgentWorkspace: mocks.getOwnedAgentWorkspace,
+}));
+vi.mock("@/lib/agents/connector/broker", () => ({
+  hostConnectorBroker: {
+    request: mocks.daemonRequest,
+    isOnline: mocks.isOnline,
+    supports: mocks.supports,
+  },
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({ id: "workspace" }) };
+
+describe("agent workspace file route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "owner", role: "admin" },
+    });
+    mocks.getOwnedAgentWorkspace.mockResolvedValue({
+      host: {
+        connectorId: "connector",
+        transport: "ssh",
+        sshAlias: "workstation",
+        userId: "owner",
+      },
+      connection: { shellMode: "interactive" },
+      workspace: { id: "workspace", path: "/srv/project" },
+    });
+    mocks.isOnline.mockReturnValue(true);
+    mocks.supports.mockReturnValue(true);
+    mocks.daemonRequest.mockResolvedValue({
+      path: "src/index.ts",
+      content: "export {};",
+      size: 10,
+      modifiedAt: 100,
+    });
+  });
+
+  it("reads a workspace-confined file through local or SSH connectors", async () => {
+    const response = await GET(
+      new Request(
+        "http://server.test/api/agent-workspaces/workspace/file?path=src%2Findex.ts",
+      ),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.daemonRequest).toHaveBeenCalledWith("connector", {
+      type: "read_workspace_file",
+      target: {
+        transport: "ssh",
+        alias: "workstation",
+        shellMode: "interactive",
+      },
+      root: "/srv/project",
+      path: "src/index.ts",
+    });
+  });
+
+  it("rejects missing paths and incompatible connectors", async () => {
+    expect(
+      (
+        await GET(
+          new Request("http://server.test/api/agent-workspaces/workspace/file"),
+          context,
+        )
+      ).status,
+    ).toBe(400);
+
+    mocks.supports.mockReturnValueOnce(false);
+    const response = await GET(
+      new Request(
+        "http://server.test/api/agent-workspaces/workspace/file?path=README.md",
+      ),
+      context,
+    );
+    expect(response.status).toBe(426);
+    expect(mocks.daemonRequest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/agent-workspaces/[id]/file/route.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/file/route.ts
@@ -1,0 +1,60 @@
+import { auth } from "@/lib/auth/server";
+import { storedConnectionAccessError } from "@/lib/agents/access";
+import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import { daemonTarget } from "@/lib/agents/connector/descriptors";
+import { getOwnedAgentWorkspace } from "@/lib/db/agentConnections";
+
+export const maxDuration = 30;
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  const accessError = storedConnectionAccessError(session.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const owned = await getOwnedAgentWorkspace(id, session.user.id);
+  if (!owned) return new Response("Not found", { status: 404 });
+  if (
+    hostConnectorBroker.isOnline(owned.host.connectorId) &&
+    !hostConnectorBroker.supports(
+      owned.host.connectorId,
+      "workspace-files-v1",
+    )
+  ) {
+    return Response.json(
+      { error: "Update the OvertChat Host Connector to preview workspace files." },
+      { status: 426 },
+    );
+  }
+
+  const filePath = new URL(req.url).searchParams.get("path");
+  if (!filePath) {
+    return Response.json({ error: "File path is required." }, { status: 400 });
+  }
+  try {
+    const file = await hostConnectorBroker.request(
+      owned.host.connectorId,
+      {
+        type: "read_workspace_file",
+        target: daemonTarget(owned.host, owned.connection.shellMode),
+        root: owned.workspace.path,
+        path: filePath,
+      },
+    );
+    return Response.json(
+      { file },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/app/api/agent-workspaces/[id]/files/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/files/route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getOwnedAgentWorkspace: vi.fn(),
+  daemonRequest: vi.fn(),
+  isOnline: vi.fn(),
+  supports: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/agentConnections", () => ({
+  getOwnedAgentWorkspace: mocks.getOwnedAgentWorkspace,
+}));
+vi.mock("@/lib/agents/connector/broker", () => ({
+  hostConnectorBroker: {
+    request: mocks.daemonRequest,
+    isOnline: mocks.isOnline,
+    supports: mocks.supports,
+  },
+}));
+
+import { GET } from "./route";
+
+const context = { params: Promise.resolve({ id: "workspace" }) };
+
+describe("agent workspace directory route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "owner", role: "admin" },
+    });
+    mocks.getOwnedAgentWorkspace.mockResolvedValue({
+      host: { connectorId: "connector", transport: "local", userId: "owner" },
+      connection: { shellMode: "interactive" },
+      workspace: { id: "workspace", path: "/srv/project" },
+    });
+    mocks.isOnline.mockReturnValue(true);
+    mocks.supports.mockReturnValue(true);
+    mocks.daemonRequest.mockResolvedValue({
+      path: "src",
+      entries: [
+        {
+          name: "index.ts",
+          path: "src/index.ts",
+          kind: "file",
+          symlink: false,
+        },
+      ],
+      truncated: false,
+    });
+  });
+
+  it("lists a stored workspace directory through its connector", async () => {
+    const response = await GET(
+      new Request(
+        "http://server.test/api/agent-workspaces/workspace/files?path=src",
+      ),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.daemonRequest).toHaveBeenCalledWith("connector", {
+      type: "list_workspace_directory",
+      target: { transport: "local", shellMode: "interactive" },
+      root: "/srv/project",
+      path: "src",
+    });
+  });
+
+  it("requires ownership and a compatible connector", async () => {
+    mocks.getOwnedAgentWorkspace.mockResolvedValueOnce(null);
+    expect(
+      (
+        await GET(
+          new Request("http://server.test/api/agent-workspaces/missing/files"),
+          context,
+        )
+      ).status,
+    ).toBe(404);
+
+    mocks.supports.mockReturnValueOnce(false);
+    const response = await GET(
+      new Request("http://server.test/api/agent-workspaces/workspace/files"),
+      context,
+    );
+    expect(response.status).toBe(426);
+    expect(mocks.daemonRequest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/agent-workspaces/[id]/files/route.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/files/route.ts
@@ -1,0 +1,57 @@
+import { auth } from "@/lib/auth/server";
+import { storedConnectionAccessError } from "@/lib/agents/access";
+import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import { daemonTarget } from "@/lib/agents/connector/descriptors";
+import { getOwnedAgentWorkspace } from "@/lib/db/agentConnections";
+
+export const maxDuration = 30;
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  const accessError = storedConnectionAccessError(session.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const owned = await getOwnedAgentWorkspace(id, session.user.id);
+  if (!owned) return new Response("Not found", { status: 404 });
+  if (
+    hostConnectorBroker.isOnline(owned.host.connectorId) &&
+    !hostConnectorBroker.supports(
+      owned.host.connectorId,
+      "workspace-files-v1",
+    )
+  ) {
+    return Response.json(
+      { error: "Update the OvertChat Host Connector to browse workspace files." },
+      { status: 426 },
+    );
+  }
+
+  const directoryPath = new URL(req.url).searchParams.get("path") ?? ".";
+  try {
+    const listing = await hostConnectorBroker.request(
+      owned.host.connectorId,
+      {
+        type: "list_workspace_directory",
+        target: daemonTarget(owned.host, owned.connection.shellMode),
+        root: owned.workspace.path,
+        path: directoryPath,
+      },
+    );
+    return Response.json(
+      { listing },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/app/api/agent-workspaces/[id]/git-status/route.test.ts
+++ b/apps/web/app/api/agent-workspaces/[id]/git-status/route.test.ts
@@ -50,6 +50,14 @@ describe("agent workspace Git status route", () => {
       additions: 8,
       deletions: 3,
       lineStatsComplete: true,
+      files: [
+        {
+          path: "src/index.ts",
+          originalPath: null,
+          indexStatus: null,
+          worktreeStatus: "M",
+        },
+      ],
     });
   });
 

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -10,6 +10,7 @@ import {
   FileDiff,
   GitBranch,
   MoreHorizontal,
+  PanelRight,
   Pencil,
   Sparkles,
 } from "lucide-react";
@@ -37,6 +38,8 @@ export function AgentSessionHeader({
   readOnly,
   onRename,
   onCompact,
+  filesOpen,
+  onToggleFiles,
 }: {
   provider: AgentProviderId;
   workspaceId: string;
@@ -47,6 +50,8 @@ export function AgentSessionHeader({
   readOnly: boolean;
   onRename: () => void;
   onCompact: () => void;
+  filesOpen: boolean;
+  onToggleFiles: () => void;
 }) {
   const providerMetadata = agentProviderMetadata(provider);
   const providerVisual = AGENT_PROVIDER_VISUALS[provider];
@@ -102,6 +107,16 @@ export function AgentSessionHeader({
       </span>
       <WorkspaceGitSummary status={gitStatus} />
       <div className="ml-auto flex shrink-0 items-center gap-0.5">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={filesOpen ? "Close workspace files" : "Open workspace files"}
+          title={filesOpen ? "Close workspace files" : "Open workspace files"}
+          aria-pressed={filesOpen}
+          onClick={onToggleFiles}
+        >
+          <PanelRight />
+        </Button>
         <SessionStats stats={stats} />
         <Menu.Root>
           <Menu.Trigger

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { useRouter } from "next/navigation";
 import {
   AlertTriangle,
@@ -57,6 +66,12 @@ import {
 } from "./AgentWorkspaceNavigationContext";
 
 type UnknownRecord = Record<string, unknown>;
+
+const DEFAULT_WORKSPACE_PANE_WIDTH = 512;
+const MIN_WORKSPACE_PANE_WIDTH = 352;
+const MAX_WORKSPACE_PANE_WIDTH = 960;
+const MIN_TRANSCRIPT_WIDTH = 480;
+const WORKSPACE_PANE_WIDTH_KEY = "overtchat:agent-workspace-pane-width";
 
 function recordOf(value: unknown): UnknownRecord | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -175,6 +190,27 @@ function workspaceFileSelection(value: unknown): AgentWorkspaceFileSelection | n
   };
 }
 
+function workspaceFileSelections(value: unknown): AgentWorkspaceFileSelection[] {
+  if (!Array.isArray(value)) return [];
+  const selections = value.flatMap((entry) => {
+    const selection = workspaceFileSelection(entry);
+    return selection ? [selection] : [];
+  });
+  return selections.filter(
+    (selection, index) =>
+      selections.findIndex((candidate) => candidate.path === selection.path) ===
+      index,
+  );
+}
+
+function clampWorkspacePaneWidth(width: number, viewportWidth: number): number {
+  const maximum = Math.max(
+    MIN_WORKSPACE_PANE_WIDTH,
+    Math.min(MAX_WORKSPACE_PANE_WIDTH, viewportWidth - MIN_TRANSCRIPT_WIDTH),
+  );
+  return Math.min(maximum, Math.max(MIN_WORKSPACE_PANE_WIDTH, width));
+}
+
 export function AgentSessionView({
   sessionId,
   provider,
@@ -223,17 +259,140 @@ export function AgentSessionView({
       `overtchat:agent-workspace-file:${sessionId}`,
       null,
     );
+  const [storedOpenFiles, setStoredOpenFiles] = useLocalStorage<unknown>(
+    `overtchat:agent-workspace-tabs:${sessionId}`,
+    [],
+  );
+  const [storedPaneWidth, setStoredPaneWidth] = useLocalStorage<unknown>(
+    WORKSPACE_PANE_WIDTH_KEY,
+    DEFAULT_WORKSPACE_PANE_WIDTH,
+  );
   const selectedFile = useMemo(
     () => workspaceFileSelection(storedFileSelection),
     [storedFileSelection],
   );
+  const openFiles = useMemo(
+    () => workspaceFileSelections(storedOpenFiles),
+    [storedOpenFiles],
+  );
+  const [viewportWidth, setViewportWidth] = useState(1440);
+  const [dragPaneWidth, setDragPaneWidth] = useState<number | null>(null);
+  const [resizingPane, setResizingPane] = useState(false);
+  const resizeStart = useRef<{ pointerX: number; width: number } | null>(null);
+  const preferredPaneWidth =
+    typeof storedPaneWidth === "number" && Number.isFinite(storedPaneWidth)
+      ? storedPaneWidth
+      : DEFAULT_WORKSPACE_PANE_WIDTH;
+  const paneWidth =
+    dragPaneWidth ?? clampWorkspacePaneWidth(preferredPaneWidth, viewportWidth);
+
+  useEffect(() => {
+    const updateViewportWidth = () => setViewportWidth(window.innerWidth);
+    updateViewportWidth();
+    window.addEventListener("resize", updateViewportWidth);
+    return () => window.removeEventListener("resize", updateViewportWidth);
+  }, []);
+
+  useEffect(() => {
+    if (
+      !selectedFile ||
+      openFiles.some((candidate) => candidate.path === selectedFile.path)
+    ) {
+      return;
+    }
+    setStoredOpenFiles([...openFiles, selectedFile]);
+  }, [openFiles, selectedFile, setStoredOpenFiles]);
+
   const openWorkspaceFile = useCallback(
     (selection: AgentWorkspaceFileSelection) => {
+      const existing = openFiles.findIndex(
+        (candidate) => candidate.path === selection.path,
+      );
+      const next = [...openFiles];
+      if (existing >= 0) next[existing] = selection;
+      else next.push(selection);
+      setStoredOpenFiles(next);
       setStoredFileSelection(selection);
       setFilesOpen(true);
     },
-    [setFilesOpen, setStoredFileSelection],
+    [openFiles, setFilesOpen, setStoredFileSelection, setStoredOpenFiles],
   );
+  const activateWorkspaceFile = useCallback(
+    (path: string) => {
+      const selection = openFiles.find((candidate) => candidate.path === path);
+      if (selection) setStoredFileSelection(selection);
+    },
+    [openFiles, setStoredFileSelection],
+  );
+  const closeWorkspaceFile = useCallback(
+    (path: string) => {
+      const index = openFiles.findIndex((candidate) => candidate.path === path);
+      if (index < 0) return;
+      const next = openFiles.filter((candidate) => candidate.path !== path);
+      setStoredOpenFiles(next);
+      if (selectedFile?.path === path) {
+        setStoredFileSelection(next[index] ?? next[index - 1] ?? null);
+      }
+    },
+    [openFiles, selectedFile?.path, setStoredFileSelection, setStoredOpenFiles],
+  );
+
+  function paneWidthFromPointer(pointerX: number): number {
+    const start = resizeStart.current;
+    if (!start) return paneWidth;
+    return clampWorkspacePaneWidth(
+      start.width + start.pointerX - pointerX,
+      viewportWidth,
+    );
+  }
+
+  function startPaneResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    resizeStart.current = { pointerX: event.clientX, width: paneWidth };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setDragPaneWidth(paneWidth);
+    setResizingPane(true);
+  }
+
+  function movePaneResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (!resizeStart.current) return;
+    event.preventDefault();
+    setDragPaneWidth(paneWidthFromPointer(event.clientX));
+  }
+
+  function finishPaneResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (!resizeStart.current) return;
+    const width = paneWidthFromPointer(event.clientX);
+    resizeStart.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setStoredPaneWidth(width);
+    setDragPaneWidth(null);
+    setResizingPane(false);
+  }
+
+  function cancelPaneResize(event: ReactPointerEvent<HTMLDivElement>) {
+    resizeStart.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setDragPaneWidth(null);
+    setResizingPane(false);
+  }
+
+  function resizePaneWithKeyboard(event: ReactKeyboardEvent<HTMLDivElement>) {
+    const step = event.shiftKey ? 64 : 24;
+    let width: number | null = null;
+    if (event.key === "ArrowLeft") width = paneWidth + step;
+    if (event.key === "ArrowRight") width = paneWidth - step;
+    if (event.key === "Home") width = MIN_WORKSPACE_PANE_WIDTH;
+    if (event.key === "End") width = MAX_WORKSPACE_PANE_WIDTH;
+    if (width === null) return;
+    event.preventDefault();
+    setStoredPaneWidth(clampWorkspacePaneWidth(width, viewportWidth));
+  }
   const workspaceNavigation = useMemo(
     () => ({ openFile: openWorkspaceFile }),
     [openWorkspaceFile],
@@ -716,16 +875,54 @@ export function AgentSessionView({
         <div
           aria-hidden={!filesOpen}
           inert={!filesOpen}
+          style={
+            {
+              "--workspace-pane-width": `${paneWidth}px`,
+            } as CSSProperties
+          }
           className={cn(
-            "absolute inset-y-0 right-0 z-30 w-[min(34rem,calc(100%-1rem))] overflow-hidden xl:relative xl:z-auto xl:w-0 xl:shrink-0 xl:shadow-none xl:motion-width",
+            "absolute inset-y-0 right-0 z-30 w-[min(34rem,calc(100%-1rem))] overflow-hidden xl:relative xl:z-auto xl:w-0 xl:shrink-0 xl:shadow-none",
+            !resizingPane && "xl:motion-width",
             filesOpen
-              ? "pointer-events-auto xl:w-[32rem]"
+              ? "pointer-events-auto xl:w-(--workspace-pane-width)"
               : "pointer-events-none xl:w-0",
           )}
         >
           <div
+            role="separator"
+            aria-label="Resize workspace files"
+            aria-orientation="vertical"
+            aria-valuemin={MIN_WORKSPACE_PANE_WIDTH}
+            aria-valuemax={clampWorkspacePaneWidth(
+              MAX_WORKSPACE_PANE_WIDTH,
+              viewportWidth,
+            )}
+            aria-valuenow={Math.round(paneWidth)}
+            tabIndex={filesOpen ? 0 : -1}
+            data-testid="agent-workspace-resize-handle"
+            onPointerDown={startPaneResize}
+            onPointerMove={movePaneResize}
+            onPointerUp={finishPaneResize}
+            onPointerCancel={cancelPaneResize}
+            onDoubleClick={() =>
+              setStoredPaneWidth(DEFAULT_WORKSPACE_PANE_WIDTH)
+            }
+            onKeyDown={resizePaneWithKeyboard}
             className={cn(
-              "absolute inset-y-0 right-0 h-full w-full bg-background shadow-xl motion-transform xl:w-[32rem] xl:shadow-none",
+              "group absolute inset-y-0 left-0 z-40 hidden w-2 touch-none cursor-col-resize outline-none select-none xl:block",
+              resizingPane && "cursor-col-resize",
+            )}
+          >
+            <span
+              className={cn(
+                "absolute inset-y-0 left-0 w-px bg-border motion-colors group-hover:bg-primary/70 group-focus-visible:w-0.5 group-focus-visible:bg-primary",
+                resizingPane && "w-0.5 bg-primary",
+              )}
+            />
+          </div>
+          <div
+            className={cn(
+              "absolute inset-y-0 right-0 h-full w-full bg-background shadow-xl motion-transform xl:w-(--workspace-pane-width) xl:shadow-none",
               filesOpen ? "translate-x-0" : "translate-x-full",
             )}
           >
@@ -733,9 +930,12 @@ export function AgentSessionView({
               workspaceId={workspaceId}
               workspaceName={workspaceName}
               selection={selectedFile}
+              openFiles={openFiles}
               running={running}
               onSelect={openWorkspaceFile}
-              onCloseFile={() => setStoredFileSelection(null)}
+              onActivateFiles={() => setStoredFileSelection(null)}
+              onActivateFile={activateWorkspaceFile}
+              onCloseFile={closeWorkspaceFile}
               onClose={() => setFilesOpen(false)}
             />
           </div>

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   AlertTriangle,
@@ -22,9 +22,7 @@ import type {
   AgentSessionCommand,
   AgentUsageSnapshot,
 } from "@overtchat/agent-bridge";
-import {
-  agentProviderMetadata,
-} from "@overtchat/agent-bridge";
+import { agentProviderMetadata } from "@overtchat/agent-bridge";
 import {
   useAgentSession,
   useAgentSessionCommand,
@@ -40,6 +38,7 @@ import {
 } from "@/lib/agents/createPreferences";
 import { motionClasses } from "@/lib/motion";
 import { useLocalStorage } from "@/lib/useLocalStorage";
+import { cn } from "@/lib/utils";
 import { AgentComposer } from "./AgentComposer";
 import {
   AgentInteractionDialog,
@@ -51,6 +50,11 @@ import { AgentMessageList } from "./AgentMessageList";
 import type { AgentRunActivity } from "./AgentActivity";
 import { AgentSessionContext } from "./AgentSessionContext";
 import { AgentSessionHeader } from "./AgentSessionHeader";
+import { AgentWorkspacePane } from "./AgentWorkspacePane";
+import {
+  AgentWorkspaceNavigationProvider,
+  type AgentWorkspaceFileSelection,
+} from "./AgentWorkspaceNavigationContext";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -153,6 +157,24 @@ function forkDraftKey(sessionId: string): string {
   return `overtchat:agent-fork-draft:${sessionId}`;
 }
 
+function workspaceFileSelection(value: unknown): AgentWorkspaceFileSelection | null {
+  const record = recordOf(value);
+  if (!record || typeof record.path !== "string" || !record.path) return null;
+  const lineStart =
+    typeof record.lineStart === "number" && record.lineStart > 0
+      ? record.lineStart
+      : undefined;
+  const lineEnd =
+    typeof record.lineEnd === "number" && record.lineEnd >= (lineStart ?? 1)
+      ? record.lineEnd
+      : undefined;
+  return {
+    path: record.path,
+    ...(lineStart ? { lineStart } : {}),
+    ...(lineEnd ? { lineEnd } : {}),
+  };
+}
+
 export function AgentSessionView({
   sessionId,
   provider,
@@ -192,6 +214,30 @@ export function AgentSessionView({
     revision: number;
     text: string;
   } | null>(null);
+  const [filesOpen, setFilesOpen] = useLocalStorage<boolean>(
+    `overtchat:agent-workspace-pane:${sessionId}`,
+    false,
+  );
+  const [storedFileSelection, setStoredFileSelection] =
+    useLocalStorage<unknown>(
+      `overtchat:agent-workspace-file:${sessionId}`,
+      null,
+    );
+  const selectedFile = useMemo(
+    () => workspaceFileSelection(storedFileSelection),
+    [storedFileSelection],
+  );
+  const openWorkspaceFile = useCallback(
+    (selection: AgentWorkspaceFileSelection) => {
+      setStoredFileSelection(selection);
+      setFilesOpen(true);
+    },
+    [setFilesOpen, setStoredFileSelection],
+  );
+  const workspaceNavigation = useMemo(
+    () => ({ openFile: openWorkspaceFile }),
+    [openWorkspaceFile],
+  );
   const snapshot = session.data;
 
   useEffect(() => {
@@ -389,269 +435,313 @@ export function AgentSessionView({
   const controlsDisabled = composerDisabled || command.isPending;
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <AgentSessionHeader
-        provider={provider}
-        workspaceId={workspaceId}
-        workspacePath={workspacePath}
-        stats={snapshot.stats}
-        running={running}
-        commandPending={command.isPending}
-        readOnly={Boolean(readOnly)}
-        onRename={() => {
-          setDialogError("");
-          setRenameOpen(true);
-        }}
-        onCompact={() => {
-          setDialogError("");
-          setCompactOpen(true);
-        }}
-      />
+    <AgentWorkspaceNavigationProvider value={workspaceNavigation}>
+      <div className="relative flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <AgentSessionHeader
+            provider={provider}
+            workspaceId={workspaceId}
+            workspacePath={workspacePath}
+            stats={snapshot.stats}
+            running={running}
+            commandPending={command.isPending}
+            readOnly={Boolean(readOnly)}
+            filesOpen={filesOpen}
+            onToggleFiles={() => setFilesOpen(!filesOpen)}
+            onRename={() => {
+              setDialogError("");
+              setRenameOpen(true);
+            }}
+            onCompact={() => {
+              setDialogError("");
+              setCompactOpen(true);
+            }}
+          />
 
-      {readOnly && (
-        <section
-          aria-label={`Read-only ${providerLabel} session`}
-          className="border-b bg-muted/30 px-4 py-3"
-        >
-          <div className="mx-auto flex max-w-3xl items-start gap-3">
-            <LockKeyhole className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-            <p className="min-w-0 flex-1 text-sm text-muted-foreground">
-              {readOnly.reason}
-            </p>
-            {readOnly.retryable && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={command.isPending}
-                onClick={() => void run({ type: "retry_interactive" })}
-              >
-                <RefreshCw
-                  className={
-                    pendingCommand === "retry_interactive"
-                      ? motionClasses.spinner
-                      : undefined
-                  }
-                />
-                Retry
-              </Button>
-            )}
+          {readOnly && (
+            <section
+              aria-label={`Read-only ${providerLabel} session`}
+              className="border-b bg-muted/30 px-4 py-3"
+            >
+              <div className="mx-auto flex max-w-3xl items-start gap-3">
+                <LockKeyhole className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <p className="min-w-0 flex-1 text-sm text-muted-foreground">
+                  {readOnly.reason}
+                </p>
+                {readOnly.retryable && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={command.isPending}
+                    onClick={() => void run({ type: "retry_interactive" })}
+                  >
+                    <RefreshCw
+                      className={
+                        pendingCommand === "retry_interactive"
+                          ? motionClasses.spinner
+                          : undefined
+                      }
+                    />
+                    Retry
+                  </Button>
+                )}
+              </div>
+            </section>
+          )}
+
+          <AgentMessageList
+            providerLabel={providerLabel}
+            messages={snapshot.messages}
+            streaming={running}
+            activity={activity}
+            activityStartedAt={activityStartedAt}
+            error={runtimeError}
+            workspaceName={workspaceName}
+            canEditMessages={
+              snapshot.capabilities.editSentMessages === true
+            }
+            canForkMessages={snapshot.capabilities.forkMessages === true}
+            actionsDisabled={
+              running ||
+              exited ||
+              command.isPending ||
+              Boolean(snapshot.pendingInteraction)
+            }
+            suppressScrollButton={composerMenuOpen}
+            onEditMessage={(messageId) =>
+              void run({ type: "edit_message", messageId })
+            }
+            onForkMessage={(messageId) =>
+              void run({ type: "fork_message", messageId })
+            }
+            onImplementPlan={(plan) =>
+              void run({ type: "implement_plan", plan })
+            }
+          />
+
+          <div className="px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
+            <div className="mx-auto max-w-3xl">
+              <AgentSessionContext
+                goal={goal}
+                tasks={tasks}
+                goalActionsDisabled={Boolean(readOnly) || command.isPending}
+                onPauseGoal={() =>
+                  void run(
+                    { type: "update_goal", action: "pause" },
+                    { toastTitle: "Goal paused" },
+                  )
+                }
+                onResumeGoal={() =>
+                  void run(
+                    { type: "update_goal", action: "resume" },
+                    { toastTitle: "Goal resumed" },
+                  )
+                }
+                onClearGoal={() =>
+                  void run(
+                    { type: "update_goal", action: "clear" },
+                    { toastTitle: "Goal cleared" },
+                  )
+                }
+              />
+              <AgentComposer
+                key={sessionId}
+                providerLabel={providerLabel}
+                commands={snapshot.commands}
+                queuedMessages={snapshot.queuedMessages}
+                supportsSteer={snapshot.capabilities.steer}
+                supportsImages={selectedModel?.input.includes("image") === true}
+                running={running}
+                pending={command.isPending}
+                stopping={pendingCommand === "abort"}
+                disabled={composerDisabled}
+                controls={{
+                  providerLabel,
+                  models: snapshot.models,
+                  currentModel: model,
+                  thinkingLevel: thinking,
+                  thinkingOptions: selectedModel?.thinkingOptions ?? [],
+                  collaborationMode,
+                  collaborationModes: availableCollaborationModes,
+                  fastModeEnabled,
+                  fastModeAvailable,
+                  modeId,
+                  modes: availableModes,
+                  disabled: controlsDisabled,
+                  onSelectModel: (selected) => {
+                    void run({
+                      type: "set_model",
+                      modelId: selected.id,
+                    }).then((changed) => {
+                      if (!changed) return;
+                      setStoredPreferences(
+                        mergeAgentProviderPreferences({
+                          preferences,
+                          provider,
+                          updates: { model: selected.id },
+                        }),
+                      );
+                    });
+                  },
+                  onSelectThinking: (level) => {
+                    if (selectedModel) {
+                      setStoredPreferences(
+                        mergeAgentProviderPreferences({
+                          preferences,
+                          provider,
+                          updates: {
+                            model: selectedModel.id,
+                            thinkingByModel: { [selectedModel.id]: level },
+                          },
+                        }),
+                      );
+                    }
+                    void run({ type: "set_thinking_level", level });
+                  },
+                  onSelectCollaborationMode: (mode) =>
+                    void run({ type: "set_collaboration_mode", mode }),
+                  onToggleFastMode: (enabled) =>
+                    void run({ type: "set_fast_mode", enabled }),
+                  onSelectMode: (selectedModeId) => {
+                    setStoredPreferences(
+                      mergeAgentProviderPreferences({
+                        preferences,
+                        provider,
+                        updates: { mode: selectedModeId },
+                      }),
+                    );
+                    if (running && provider !== "omp") {
+                      toast.success("Permission mode applies next turn");
+                    }
+                    void run({ type: "set_mode", modeId: selectedModeId });
+                  },
+                  onMenuOpenChange: setComposerMenuOpen,
+                }}
+                contextUsage={snapshot.stats.contextUsage}
+                onSubmit={submit}
+                onStop={() => void run({ type: "abort" })}
+                onEditQueued={(id) =>
+                  run({ type: "remove_queued_message", id })
+                }
+                onDeleteQueued={(id) =>
+                  run({ type: "remove_queued_message", id })
+                }
+                onSteerQueued={(id) =>
+                  run({ type: "steer_queued_message", id })
+                }
+                restoreDraftKey={forkDraftKey(sessionId)}
+                restoredDraft={restoredDraft}
+              />
+            </div>
           </div>
-        </section>
-      )}
 
-      <AgentMessageList
-        providerLabel={providerLabel}
-        messages={snapshot.messages}
-        streaming={running}
-        activity={activity}
-        activityStartedAt={activityStartedAt}
-        error={runtimeError}
-        workspaceName={workspaceName}
-        canEditMessages={
-          snapshot.capabilities.editSentMessages === true
-        }
-        canForkMessages={snapshot.capabilities.forkMessages === true}
-        actionsDisabled={
-          running ||
-          exited ||
-          command.isPending ||
-          Boolean(snapshot.pendingInteraction)
-        }
-        suppressScrollButton={composerMenuOpen}
-        onEditMessage={(messageId) =>
-          void run({ type: "edit_message", messageId })
-        }
-        onForkMessage={(messageId) =>
-          void run({ type: "fork_message", messageId })
-        }
-        onImplementPlan={(plan) =>
-          void run({ type: "implement_plan", plan })
-        }
-      />
-
-      <div className="px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
-        <div className="mx-auto max-w-3xl">
-          <AgentSessionContext
-            goal={goal}
-            tasks={tasks}
-            goalActionsDisabled={Boolean(readOnly) || command.isPending}
-            onPauseGoal={() =>
+          <RenameAgentSessionDialog
+            providerLabel={providerLabel}
+            open={renameOpen}
+            initialName={currentName}
+            pending={command.isPending}
+            error={dialogError}
+            onOpenChange={(open) => {
+              setDialogError("");
+              setRenameOpen(open);
+            }}
+            onSubmit={(name) =>
               void run(
-                { type: "update_goal", action: "pause" },
-                { toastTitle: "Goal paused" },
-              )
-            }
-            onResumeGoal={() =>
-              void run(
-                { type: "update_goal", action: "resume" },
-                { toastTitle: "Goal resumed" },
-              )
-            }
-            onClearGoal={() =>
-              void run(
-                { type: "update_goal", action: "clear" },
-                { toastTitle: "Goal cleared" },
+                { type: "set_session_name", name },
+                { closeRename: true, toastTitle: "Session renamed" },
               )
             }
           />
-          <AgentComposer
-            key={sessionId}
+          <CompactAgentSessionDialog
             providerLabel={providerLabel}
-            commands={snapshot.commands}
-            queuedMessages={snapshot.queuedMessages}
-            supportsSteer={snapshot.capabilities.steer}
-            supportsImages={selectedModel?.input.includes("image") === true}
-            running={running}
+            supportsCustomInstructions={
+              snapshot.capabilities.customCompactionInstructions === true
+            }
+            open={compactOpen}
             pending={command.isPending}
-            stopping={pendingCommand === "abort"}
-            disabled={composerDisabled}
-            controls={{
-              providerLabel,
-              models: snapshot.models,
-              currentModel: model,
-              thinkingLevel: thinking,
-              thinkingOptions: selectedModel?.thinkingOptions ?? [],
-              collaborationMode,
-              collaborationModes: availableCollaborationModes,
-              fastModeEnabled,
-              fastModeAvailable,
-              modeId,
-              modes: availableModes,
-              disabled: controlsDisabled,
-              onSelectModel: (selected) => {
-                void run({
-                  type: "set_model",
-                  modelId: selected.id,
-                }).then((changed) => {
-                  if (!changed) return;
-                  setStoredPreferences(
-                    mergeAgentProviderPreferences({
-                      preferences,
-                      provider,
-                      updates: { model: selected.id },
-                    }),
-                  );
-                });
-              },
-              onSelectThinking: (level) => {
-                if (selectedModel) {
-                  setStoredPreferences(
-                    mergeAgentProviderPreferences({
-                      preferences,
-                      provider,
-                      updates: {
-                        model: selectedModel.id,
-                        thinkingByModel: { [selectedModel.id]: level },
-                      },
-                    }),
-                  );
-                }
-                void run({ type: "set_thinking_level", level });
-              },
-              onSelectCollaborationMode: (mode) =>
-                void run({ type: "set_collaboration_mode", mode }),
-              onToggleFastMode: (enabled) =>
-                void run({ type: "set_fast_mode", enabled }),
-              onSelectMode: (selectedModeId) => {
-                setStoredPreferences(
-                  mergeAgentProviderPreferences({
-                    preferences,
-                    provider,
-                    updates: { mode: selectedModeId },
-                  }),
-                );
-                if (running && provider !== "omp") {
-                  toast.success("Permission mode applies next turn");
-                }
-                void run({ type: "set_mode", modeId: selectedModeId });
-              },
-              onMenuOpenChange: setComposerMenuOpen,
+            error={dialogError}
+            onOpenChange={(open) => {
+              setDialogError("");
+              setCompactOpen(open);
             }}
-            contextUsage={snapshot.stats.contextUsage}
-            onSubmit={submit}
-            onStop={() => void run({ type: "abort" })}
-            onEditQueued={(id) =>
-              run({ type: "remove_queued_message", id })
+            onSubmit={(customInstructions) =>
+              void run(
+                {
+                  type: "compact",
+                  ...(customInstructions ? { customInstructions } : {}),
+                },
+                { closeCompact: true, toastTitle: "Compaction started" },
+              )
             }
-            onDeleteQueued={(id) =>
-              run({ type: "remove_queued_message", id })
+          />
+          <AgentInteractionDialog
+            providerLabel={providerLabel}
+            request={snapshot.pendingInteraction}
+            pending={command.isPending}
+            error={dialogError}
+            onRespond={(response) =>
+              void run({
+                type: "interaction_response",
+                id: snapshot.pendingInteraction!.id,
+                ...response,
+              })
             }
-            onSteerQueued={(id) =>
-              run({ type: "steer_queued_message", id })
-            }
-            restoreDraftKey={forkDraftKey(sessionId)}
-            restoredDraft={restoredDraft}
+          />
+          <AgentUsageDialog
+            open={usageOpen}
+            usage={usage}
+            pending={usageCommand.isPending}
+            error={usageError}
+            onOpenChange={(open) => {
+              setUsageOpen(open);
+              if (!open) {
+                setUsage(null);
+                setUsageError("");
+              }
+            }}
           />
         </div>
-      </div>
 
-      <RenameAgentSessionDialog
-        providerLabel={providerLabel}
-        open={renameOpen}
-        initialName={currentName}
-        pending={command.isPending}
-        error={dialogError}
-        onOpenChange={(open) => {
-          setDialogError("");
-          setRenameOpen(open);
-        }}
-        onSubmit={(name) =>
-          void run(
-            { type: "set_session_name", name },
-            { closeRename: true, toastTitle: "Session renamed" },
-          )
-        }
-      />
-      <CompactAgentSessionDialog
-        providerLabel={providerLabel}
-        supportsCustomInstructions={
-          snapshot.capabilities.customCompactionInstructions === true
-        }
-        open={compactOpen}
-        pending={command.isPending}
-        error={dialogError}
-        onOpenChange={(open) => {
-          setDialogError("");
-          setCompactOpen(open);
-        }}
-        onSubmit={(customInstructions) =>
-          void run(
-            {
-              type: "compact",
-              ...(customInstructions ? { customInstructions } : {}),
-            },
-            { closeCompact: true, toastTitle: "Compaction started" },
-          )
-        }
-      />
-      <AgentInteractionDialog
-        providerLabel={providerLabel}
-        request={snapshot.pendingInteraction}
-        pending={command.isPending}
-        error={dialogError}
-        onRespond={(response) =>
-          void run({
-            type: "interaction_response",
-            id: snapshot.pendingInteraction!.id,
-            ...response,
-          })
-        }
-      />
-      <AgentUsageDialog
-        open={usageOpen}
-        usage={usage}
-        pending={usageCommand.isPending}
-        error={usageError}
-        onOpenChange={(open) => {
-          setUsageOpen(open);
-          if (!open) {
-            setUsage(null);
-            setUsageError("");
-          }
-        }}
-      />
-    </div>
+        <button
+          type="button"
+          aria-label="Close workspace files"
+          tabIndex={filesOpen ? 0 : -1}
+          onClick={() => setFilesOpen(false)}
+          className={cn(
+            "absolute inset-0 z-20 bg-black/35 motion-overlay xl:hidden",
+            filesOpen ? "opacity-100" : "pointer-events-none opacity-0",
+          )}
+        />
+        <div
+          aria-hidden={!filesOpen}
+          inert={!filesOpen}
+          className={cn(
+            "absolute inset-y-0 right-0 z-30 w-[min(34rem,calc(100%-1rem))] overflow-hidden xl:relative xl:z-auto xl:w-0 xl:shrink-0 xl:shadow-none xl:motion-width",
+            filesOpen
+              ? "pointer-events-auto xl:w-[32rem]"
+              : "pointer-events-none xl:w-0",
+          )}
+        >
+          <div
+            className={cn(
+              "absolute inset-y-0 right-0 h-full w-full bg-background shadow-xl motion-transform xl:w-[32rem] xl:shadow-none",
+              filesOpen ? "translate-x-0" : "translate-x-full",
+            )}
+          >
+            <AgentWorkspacePane
+              workspaceId={workspaceId}
+              workspaceName={workspaceName}
+              selection={selectedFile}
+              running={running}
+              onSelect={openWorkspaceFile}
+              onCloseFile={() => setStoredFileSelection(null)}
+              onClose={() => setFilesOpen(false)}
+            />
+          </div>
+        </div>
+      </div>
+    </AgentWorkspaceNavigationProvider>
   );
 }
 

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -183,10 +183,12 @@ function workspaceFileSelection(value: unknown): AgentWorkspaceFileSelection | n
     typeof record.lineEnd === "number" && record.lineEnd >= (lineStart ?? 1)
       ? record.lineEnd
       : undefined;
+  const gitIgnored = record.gitIgnored === true;
   return {
     path: record.path,
     ...(lineStart ? { lineStart } : {}),
     ...(lineEnd ? { lineEnd } : {}),
+    ...(gitIgnored ? { gitIgnored: true } : {}),
   };
 }
 
@@ -309,10 +311,18 @@ export function AgentSessionView({
         (candidate) => candidate.path === selection.path,
       );
       const next = [...openFiles];
-      if (existing >= 0) next[existing] = selection;
-      else next.push(selection);
+      if (existing >= 0) {
+        next[existing] = {
+          ...selection,
+          ...(selection.gitIgnored === undefined &&
+            openFiles[existing]?.gitIgnored
+            ? { gitIgnored: true }
+            : {}),
+        };
+      } else next.push(selection);
+      const selected = existing >= 0 ? next[existing] : selection;
       setStoredOpenFiles(next);
-      setStoredFileSelection(selection);
+      setStoredFileSelection(selected);
       setFilesOpen(true);
     },
     [openFiles, setFilesOpen, setStoredFileSelection, setStoredOpenFiles],

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -939,6 +939,7 @@ export function AgentSessionView({
             <AgentWorkspacePane
               workspaceId={workspaceId}
               workspaceName={workspaceName}
+              active={filesOpen}
               selection={selectedFile}
               openFiles={openFiles}
               running={running}

--- a/apps/web/components/agents/AgentWorkspaceLink.tsx
+++ b/apps/web/components/agents/AgentWorkspaceLink.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useAgentWorkspaceNavigation } from "./AgentWorkspaceNavigationContext";
+
 function positiveLine(value: unknown): number | undefined {
   const parsed = typeof value === "number" ? value : Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
@@ -14,6 +18,7 @@ export function AgentWorkspaceLink({
   linestart?: unknown;
   lineend?: unknown;
 }) {
+  const navigation = useAgentWorkspaceNavigation();
   const workspacePath = typeof path === "string" ? path : "Workspace file";
   const lineStart = positiveLine(linestart);
   const lineEnd = positiveLine(lineend);
@@ -21,16 +26,39 @@ export function AgentWorkspaceLink({
     ? `${workspacePath}:L${lineStart}${lineEnd ? `-L${lineEnd}` : ""}`
     : workspacePath;
 
+  if (!navigation) {
+    return (
+      <span
+        data-testid="agent-workspace-link"
+        data-workspace-path={workspacePath}
+        data-line-start={lineStart}
+        data-line-end={lineEnd}
+        title={location}
+        className="inline-flex max-w-full items-baseline font-medium text-primary no-underline"
+      >
+        {children}
+      </span>
+    );
+  }
+
   return (
-    <span
+    <button
+      type="button"
+      onClick={() =>
+        navigation.openFile({
+          path: workspacePath,
+          ...(lineStart ? { lineStart } : {}),
+          ...(lineEnd ? { lineEnd } : {}),
+        })
+      }
       data-testid="agent-workspace-link"
       data-workspace-path={workspacePath}
       data-line-start={lineStart}
       data-line-end={lineEnd}
       title={location}
-      className="inline-flex max-w-full items-baseline font-medium text-primary no-underline"
+      className="inline-flex max-w-full cursor-pointer items-baseline font-medium text-primary no-underline hover:underline"
     >
       {children}
-    </span>
+    </button>
   );
 }

--- a/apps/web/components/agents/AgentWorkspaceNavigationContext.tsx
+++ b/apps/web/components/agents/AgentWorkspaceNavigationContext.tsx
@@ -6,6 +6,7 @@ export type AgentWorkspaceFileSelection = {
   path: string;
   lineStart?: number;
   lineEnd?: number;
+  gitIgnored?: boolean;
 };
 
 type AgentWorkspaceNavigation = {

--- a/apps/web/components/agents/AgentWorkspaceNavigationContext.tsx
+++ b/apps/web/components/agents/AgentWorkspaceNavigationContext.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export type AgentWorkspaceFileSelection = {
+  path: string;
+  lineStart?: number;
+  lineEnd?: number;
+};
+
+type AgentWorkspaceNavigation = {
+  openFile: (selection: AgentWorkspaceFileSelection) => void;
+};
+
+const AgentWorkspaceNavigationContext =
+  createContext<AgentWorkspaceNavigation | null>(null);
+
+export const AgentWorkspaceNavigationProvider =
+  AgentWorkspaceNavigationContext.Provider;
+
+export function useAgentWorkspaceNavigation(): AgentWorkspaceNavigation | null {
+  return useContext(AgentWorkspaceNavigationContext);
+}

--- a/apps/web/components/agents/AgentWorkspacePane.tsx
+++ b/apps/web/components/agents/AgentWorkspacePane.tsx
@@ -50,6 +50,7 @@ const EMPTY_CHANGED_FILES: AgentWorkspaceGitFile[] = [];
 export function AgentWorkspacePane({
   workspaceId,
   workspaceName,
+  active,
   selection,
   openFiles,
   running,
@@ -61,6 +62,7 @@ export function AgentWorkspacePane({
 }: {
   workspaceId: string;
   workspaceName: string;
+  active: boolean;
   selection: AgentWorkspaceFileSelection | null;
   openFiles: AgentWorkspaceFileSelection[];
   running: boolean;
@@ -99,6 +101,7 @@ export function AgentWorkspacePane({
         <WorkspaceFilePreview
           workspaceId={workspaceId}
           workspaceName={workspaceName}
+          active={active}
           selection={selection}
           decoration={
             gitDecorations.get(selection.path) ??
@@ -109,6 +112,7 @@ export function AgentWorkspacePane({
       ) : (
         <WorkspaceExplorer
           workspaceId={workspaceId}
+          active={active}
           isGit={gitStatus.data?.isGit === true}
           changedFiles={changedFiles}
           gitDecorations={gitDecorations}
@@ -277,12 +281,14 @@ function WorkspaceTabs({
 
 function WorkspaceExplorer({
   workspaceId,
+  active,
   isGit,
   changedFiles,
   gitDecorations,
   onSelect,
 }: {
   workspaceId: string;
+  active: boolean;
   isGit: boolean;
   changedFiles: AgentWorkspaceGitFile[];
   gitDecorations: Map<string, AgentWorkspaceGitDecoration>;
@@ -358,6 +364,7 @@ function WorkspaceExplorer({
         </div>
         <WorkspaceDirectory
           workspaceId={workspaceId}
+          active={active}
           path="."
           depth={0}
           expanded={expanded}
@@ -414,6 +421,7 @@ function ChangedFileRow({
 
 function WorkspaceDirectory({
   workspaceId,
+  active,
   path,
   depth,
   expanded,
@@ -422,6 +430,7 @@ function WorkspaceDirectory({
   onSelect,
 }: {
   workspaceId: string;
+  active: boolean;
   path: string;
   depth: number;
   expanded: Set<string>;
@@ -431,7 +440,7 @@ function WorkspaceDirectory({
 }) {
   const isExpanded = expanded.has(path);
   const directory = useAgentWorkspaceDirectory(workspaceId, path, {
-    enabled: isExpanded,
+    enabled: active && isExpanded,
   });
 
   if (!isExpanded) return null;
@@ -458,6 +467,7 @@ function WorkspaceDirectory({
           key={entry.path}
           entry={entry}
           workspaceId={workspaceId}
+          active={active}
           depth={depth}
           expanded={expanded}
           gitDecorations={gitDecorations}
@@ -482,6 +492,7 @@ function WorkspaceDirectory({
 function WorkspaceEntryRow({
   entry,
   workspaceId,
+  active,
   depth,
   expanded,
   gitDecorations,
@@ -490,6 +501,7 @@ function WorkspaceEntryRow({
 }: {
   entry: AgentWorkspaceDirectoryEntry;
   workspaceId: string;
+  active: boolean;
   depth: number;
   expanded: Set<string>;
   gitDecorations: Map<string, AgentWorkspaceGitDecoration>;
@@ -582,6 +594,7 @@ function WorkspaceEntryRow({
       {open && (
         <WorkspaceDirectory
           workspaceId={workspaceId}
+          active={active}
           path={entry.path}
           depth={depth + 1}
           expanded={expanded}
@@ -597,17 +610,22 @@ function WorkspaceEntryRow({
 function WorkspaceFilePreview({
   workspaceId,
   workspaceName,
+  active,
   selection,
   decoration,
   running,
 }: {
   workspaceId: string;
   workspaceName: string;
+  active: boolean;
   selection: AgentWorkspaceFileSelection;
   decoration?: AgentWorkspaceGitDecoration;
   running: boolean;
 }) {
-  const file = useAgentWorkspaceFile(workspaceId, selection.path, { running });
+  const file = useAgentWorkspaceFile(workspaceId, selection.path, {
+    enabled: active,
+    running,
+  });
   const displayPath = file.data?.path ?? selection.path;
 
   return (

--- a/apps/web/components/agents/AgentWorkspacePane.tsx
+++ b/apps/web/components/agents/AgentWorkspacePane.tsx
@@ -1,0 +1,570 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import { code, type HighlightResult } from "@streamdown/code";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  File,
+  FileCode2,
+  FileDiff,
+  Folder,
+  FolderOpen,
+  Link,
+  Loader2,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import type {
+  AgentWorkspaceDirectoryEntry,
+  AgentWorkspaceFilePreview,
+  AgentWorkspaceGitFile,
+} from "@overtchat/agent-bridge";
+import { Button } from "@/components/ui/button";
+import {
+  useAgentWorkspaceDirectory,
+  useAgentWorkspaceFile,
+  useAgentWorkspaceGitStatus,
+} from "@/lib/queries/agentWorkspaces";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+import type { AgentWorkspaceFileSelection } from "./AgentWorkspaceNavigationContext";
+
+export function AgentWorkspacePane({
+  workspaceId,
+  workspaceName,
+  selection,
+  running,
+  onSelect,
+  onCloseFile,
+  onClose,
+}: {
+  workspaceId: string;
+  workspaceName: string;
+  selection: AgentWorkspaceFileSelection | null;
+  running: boolean;
+  onSelect: (selection: AgentWorkspaceFileSelection) => void;
+  onCloseFile: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <aside
+      className="flex h-full w-full flex-col border-l bg-background"
+      data-testid="agent-workspace-pane"
+      aria-label="Workspace files"
+    >
+      <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3">
+        <div className="min-w-0 flex-1 truncate text-sm font-medium">
+          {workspaceName}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close workspace files"
+          title="Close workspace files"
+          onClick={onClose}
+        >
+          <X />
+        </Button>
+      </header>
+      {selection ? (
+        <WorkspaceFilePreview
+          workspaceId={workspaceId}
+          selection={selection}
+          running={running}
+          onBack={onCloseFile}
+        />
+      ) : (
+        <WorkspaceExplorer
+          workspaceId={workspaceId}
+          running={running}
+          onSelect={onSelect}
+        />
+      )}
+    </aside>
+  );
+}
+
+function WorkspaceExplorer({
+  workspaceId,
+  running,
+  onSelect,
+}: {
+  workspaceId: string;
+  running: boolean;
+  onSelect: (selection: AgentWorkspaceFileSelection) => void;
+}) {
+  const gitStatus = useAgentWorkspaceGitStatus(workspaceId, {
+    active: true,
+    running,
+  });
+  const changedFiles = gitStatus.data?.files ?? [];
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(["."]));
+
+  function toggle(path: string) {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-2">
+      {gitStatus.data?.isGit && changedFiles.length > 0 && (
+        <section className="pb-3" aria-labelledby="workspace-changes-heading">
+          <div className="flex h-8 items-center gap-2 px-3">
+            <FileDiff className="size-3.5 text-muted-foreground" />
+            <h2
+              id="workspace-changes-heading"
+              className="text-xs font-medium"
+            >
+              Changes
+            </h2>
+            <span className="text-[11px] tabular-nums text-muted-foreground">
+              {changedFiles.length}
+            </span>
+          </div>
+          <div className="px-1.5">
+            {changedFiles.map((file) => (
+              <ChangedFileRow
+                key={`${file.originalPath ?? ""}:${file.path}`}
+                file={file}
+                onSelect={() => onSelect({ path: file.path })}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section aria-labelledby="workspace-files-heading">
+        <div className="flex h-8 items-center gap-2 px-3">
+          <Folder className="size-3.5 text-muted-foreground" />
+          <h2 id="workspace-files-heading" className="text-xs font-medium">
+            Files
+          </h2>
+        </div>
+        <WorkspaceDirectory
+          workspaceId={workspaceId}
+          path="."
+          depth={0}
+          expanded={expanded}
+          running={running}
+          onToggle={toggle}
+          onSelect={onSelect}
+        />
+      </section>
+    </div>
+  );
+}
+
+function ChangedFileRow({
+  file,
+  onSelect,
+}: {
+  file: AgentWorkspaceGitFile;
+  onSelect: () => void;
+}) {
+  const status = file.worktreeStatus ?? file.indexStatus ?? "M";
+  const label =
+    status === "?" || status === "A"
+      ? "Added"
+      : status === "D"
+        ? "Deleted"
+        : status === "R"
+          ? "Renamed"
+          : status === "U"
+            ? "Conflicted"
+            : "Modified";
+  const deleted = status === "D";
+
+  return (
+    <button
+      type="button"
+      disabled={deleted}
+      onClick={onSelect}
+      title={deleted ? `${file.path} was deleted` : file.path}
+      className="group flex min-h-8 w-full items-center gap-2 rounded-md px-2 text-left text-xs outline-none motion-colors hover:bg-muted disabled:cursor-default disabled:opacity-60"
+    >
+      <FileCode2 className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate font-mono">{file.path}</span>
+      <span
+        className={cn(
+          "shrink-0 text-[10px] font-medium",
+          label === "Added" && "text-emerald-700 dark:text-emerald-300",
+          label === "Deleted" && "text-red-700 dark:text-red-300",
+          label === "Conflicted" && "text-amber-700 dark:text-amber-300",
+          (label === "Modified" || label === "Renamed") &&
+            "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+    </button>
+  );
+}
+
+function WorkspaceDirectory({
+  workspaceId,
+  path,
+  depth,
+  expanded,
+  running,
+  onToggle,
+  onSelect,
+}: {
+  workspaceId: string;
+  path: string;
+  depth: number;
+  expanded: Set<string>;
+  running: boolean;
+  onToggle: (path: string) => void;
+  onSelect: (selection: AgentWorkspaceFileSelection) => void;
+}) {
+  const isExpanded = expanded.has(path);
+  const directory = useAgentWorkspaceDirectory(workspaceId, path, {
+    enabled: isExpanded,
+    running,
+  });
+
+  if (!isExpanded) return null;
+  if (directory.isPending) {
+    return (
+      <div className="flex h-8 items-center gap-2 px-3 text-xs text-muted-foreground">
+        <Loader2 className={cn("size-3.5", motionClasses.spinner)} />
+        Loading files…
+      </div>
+    );
+  }
+  if (directory.error) {
+    return (
+      <div className="mx-3 my-1 rounded-md border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive">
+        {directory.error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {directory.data?.entries.map((entry) => (
+        <WorkspaceEntryRow
+          key={entry.path}
+          entry={entry}
+          workspaceId={workspaceId}
+          depth={depth}
+          expanded={expanded}
+          running={running}
+          onToggle={onToggle}
+          onSelect={onSelect}
+        />
+      ))}
+      {directory.data?.entries.length === 0 && depth === 0 && (
+        <p className="px-3 py-4 text-xs text-muted-foreground">
+          This workspace is empty.
+        </p>
+      )}
+      {directory.data?.truncated && (
+        <p className="px-3 py-2 text-[11px] text-muted-foreground">
+          Showing the first 1,000 entries.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function WorkspaceEntryRow({
+  entry,
+  workspaceId,
+  depth,
+  expanded,
+  running,
+  onToggle,
+  onSelect,
+}: {
+  entry: AgentWorkspaceDirectoryEntry;
+  workspaceId: string;
+  depth: number;
+  expanded: Set<string>;
+  running: boolean;
+  onToggle: (path: string) => void;
+  onSelect: (selection: AgentWorkspaceFileSelection) => void;
+}) {
+  const directory = entry.kind === "directory" && !entry.symlink;
+  const open = directory && expanded.has(entry.path);
+  const disabled = entry.kind === "symlink" || entry.symlink;
+
+  return (
+    <div>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() =>
+          directory
+            ? onToggle(entry.path)
+            : onSelect({ path: entry.path })
+        }
+        title={
+          disabled
+            ? `${entry.path} is a symbolic link and cannot be previewed`
+            : entry.path
+        }
+        className="flex min-h-8 w-full items-center gap-1.5 pr-2 text-left text-xs outline-none motion-colors hover:bg-muted disabled:cursor-default disabled:opacity-60"
+        style={{ paddingLeft: `${12 + depth * 16}px` }}
+      >
+        {directory ? (
+          open ? (
+            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+          )
+        ) : (
+          <span className="w-3.5 shrink-0" />
+        )}
+        {disabled ? (
+          <Link className="size-3.5 shrink-0 text-muted-foreground" />
+        ) : directory ? (
+          open ? (
+            <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+          )
+        ) : (
+          <File className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+      </button>
+      {open && (
+        <WorkspaceDirectory
+          workspaceId={workspaceId}
+          path={entry.path}
+          depth={depth + 1}
+          expanded={expanded}
+          running={running}
+          onToggle={onToggle}
+          onSelect={onSelect}
+        />
+      )}
+    </div>
+  );
+}
+
+function WorkspaceFilePreview({
+  workspaceId,
+  selection,
+  running,
+  onBack,
+}: {
+  workspaceId: string;
+  selection: AgentWorkspaceFileSelection;
+  running: boolean;
+  onBack: () => void;
+}) {
+  const file = useAgentWorkspaceFile(workspaceId, selection.path, { running });
+  const displayPath = file.data?.path ?? selection.path;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Back to workspace files"
+          title="Back to workspace files"
+          onClick={onBack}
+        >
+          <ArrowLeft />
+        </Button>
+        <div className="min-w-0 flex-1 truncate px-1 font-mono text-xs" title={displayPath}>
+          {displayPath}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Refresh file"
+          title="Refresh file"
+          disabled={file.isFetching}
+          onClick={() => void file.refetch()}
+        >
+          <RefreshCw className={file.isFetching ? motionClasses.spinner : undefined} />
+        </Button>
+      </div>
+      {file.isPending ? (
+        <div className="flex flex-1 items-center justify-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className={cn("size-4", motionClasses.spinner)} />
+          Loading file…
+        </div>
+      ) : file.error ? (
+        <div className="flex flex-1 items-center justify-center p-6 text-center">
+          <div className="max-w-xs">
+            <AlertTriangle className="mx-auto size-5 text-destructive" />
+            <p className="mt-3 text-sm font-medium">File cannot be previewed</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {file.error.message}
+            </p>
+          </div>
+        </div>
+      ) : file.data ? (
+        <HighlightedFile
+          file={file.data}
+          lineStart={selection.lineStart}
+          lineEnd={selection.lineEnd}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function languageForPath(filePath: string): string {
+  const name = filePath.split("/").at(-1)?.toLowerCase() ?? "";
+  const extension = name.includes(".") ? name.split(".").at(-1) ?? "" : "";
+  const aliases: Record<string, string> = {
+    cjs: "javascript",
+    cts: "typescript",
+    h: "c",
+    hpp: "cpp",
+    js: "javascript",
+    jsx: "jsx",
+    md: "markdown",
+    mdx: "mdx",
+    mjs: "javascript",
+    mts: "typescript",
+    py: "python",
+    rb: "ruby",
+    rs: "rust",
+    sh: "shellscript",
+    ts: "typescript",
+    tsx: "tsx",
+    yml: "yaml",
+  };
+  if (name === "dockerfile") return "dockerfile";
+  if (name === "makefile") return "makefile";
+  const language = aliases[extension] ?? extension;
+  return language && code.supportsLanguage(language as never) ? language : "text";
+}
+
+function HighlightedFile({
+  file,
+  lineStart,
+  lineEnd,
+}: {
+  file: AgentWorkspaceFilePreview;
+  lineStart?: number;
+  lineEnd?: number;
+}) {
+  const [highlighted, setHighlighted] = useState<HighlightResult | null>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const language = useMemo(() => languageForPath(file.path), [file.path]);
+
+  useEffect(() => {
+    let active = true;
+    const update = (result: HighlightResult) => {
+      if (active) setHighlighted(result);
+    };
+    const result = code.highlight(
+      {
+        code: file.content,
+        language: language as never,
+        themes: code.getThemes(),
+      },
+      update,
+    );
+    if (result) update(result);
+    return () => {
+      active = false;
+    };
+  }, [file.content, language]);
+
+  useEffect(() => {
+    if (!highlighted || !lineStart) return;
+    scrollerRef.current
+      ?.querySelector(`[data-line="${lineStart}"]`)
+      ?.scrollIntoView({ block: "center" });
+  }, [highlighted, lineStart]);
+
+  const fallbackLines = file.content.split("\n");
+  const lines: HighlightResult["tokens"] =
+    highlighted?.tokens ??
+    fallbackLines.map((content) => [{ content, offset: 0 }]);
+
+  return (
+    <div ref={scrollerRef} className="min-h-0 flex-1 overflow-auto bg-muted/10">
+      <pre className="min-w-max py-3 font-mono text-xs leading-5 text-foreground tab-size-4">
+        <code>
+          {lines.map((tokens, index) => {
+            const line = index + 1;
+            const selected =
+              lineStart !== undefined &&
+              line >= lineStart &&
+              line <= (lineEnd ?? lineStart);
+            return (
+              <span
+                key={line}
+                data-line={line}
+                className={cn(
+                  "flex min-h-5 px-3",
+                  selected && "bg-primary/10 ring-1 ring-inset ring-primary/15",
+                )}
+              >
+                <span
+                  aria-hidden="true"
+                  className="mr-4 w-8 shrink-0 select-none text-right text-muted-foreground/60"
+                >
+                  {line}
+                </span>
+                <span className="whitespace-pre">
+                  {tokens.map((token, tokenIndex) => {
+                    const {
+                      color: htmlColor,
+                      "background-color": htmlBackground,
+                      ...htmlStyle
+                    } = token.htmlStyle ?? {};
+                    return (
+                      <span
+                        key={`${line}:${tokenIndex}`}
+                        data-workspace-code-token
+                        className="text-[var(--workspace-token-color,inherit)] dark:text-[var(--shiki-dark,var(--workspace-token-color,inherit))] bg-[var(--workspace-token-background,transparent)] dark:bg-[var(--shiki-dark-bg,var(--workspace-token-background,transparent))]"
+                        style={{
+                          "--workspace-token-color":
+                            htmlColor ?? token.color ?? "inherit",
+                          "--workspace-token-background":
+                            htmlBackground ?? token.bgColor ?? "transparent",
+                          fontStyle:
+                            token.fontStyle && token.fontStyle & 1
+                              ? "italic"
+                              : undefined,
+                          fontWeight:
+                            token.fontStyle && token.fontStyle & 2
+                              ? "bold"
+                              : undefined,
+                          textDecoration:
+                            token.fontStyle && token.fontStyle & 4
+                              ? "underline"
+                              : undefined,
+                          ...htmlStyle,
+                        } as CSSProperties}
+                      >
+                        {token.content || " "}
+                      </span>
+                    );
+                  })}
+                </span>
+              </span>
+            );
+          })}
+        </code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/components/agents/AgentWorkspacePane.tsx
+++ b/apps/web/components/agents/AgentWorkspacePane.tsx
@@ -35,9 +35,17 @@ import {
   useAgentWorkspaceGitStatus,
 } from "@/lib/queries/agentWorkspaces";
 import { motionClasses } from "@/lib/motion";
+import {
+  agentWorkspaceGitDecorationMap,
+  agentWorkspaceGitFileDecoration,
+  ignoredGitDecoration,
+  type AgentWorkspaceGitDecoration,
+} from "@/lib/agents/workspaceGitDecorations";
 import { agentWorkspaceKeys } from "@/lib/queries/keys";
 import { cn } from "@/lib/utils";
 import type { AgentWorkspaceFileSelection } from "./AgentWorkspaceNavigationContext";
+
+const EMPTY_CHANGED_FILES: AgentWorkspaceGitFile[] = [];
 
 export function AgentWorkspacePane({
   workspaceId,
@@ -62,6 +70,16 @@ export function AgentWorkspacePane({
   onCloseFile: (path: string) => void;
   onClose: () => void;
 }) {
+  const gitStatus = useAgentWorkspaceGitStatus(workspaceId, {
+    active: true,
+    running,
+  });
+  const changedFiles = gitStatus.data?.files ?? EMPTY_CHANGED_FILES;
+  const gitDecorations = useMemo(
+    () => agentWorkspaceGitDecorationMap(changedFiles),
+    [changedFiles],
+  );
+
   return (
     <aside
       className="flex h-full w-full flex-col border-l bg-background"
@@ -71,6 +89,7 @@ export function AgentWorkspacePane({
       <WorkspaceTabs
         selection={selection}
         openFiles={openFiles}
+        gitDecorations={gitDecorations}
         onActivateFiles={onActivateFiles}
         onActivateFile={onActivateFile}
         onCloseFile={onCloseFile}
@@ -81,12 +100,18 @@ export function AgentWorkspacePane({
           workspaceId={workspaceId}
           workspaceName={workspaceName}
           selection={selection}
+          decoration={
+            gitDecorations.get(selection.path) ??
+            (selection.gitIgnored ? ignoredGitDecoration : undefined)
+          }
           running={running}
         />
       ) : (
         <WorkspaceExplorer
           workspaceId={workspaceId}
-          running={running}
+          isGit={gitStatus.data?.isGit === true}
+          changedFiles={changedFiles}
+          gitDecorations={gitDecorations}
           onSelect={onSelect}
         />
       )}
@@ -98,9 +123,36 @@ function fileName(filePath: string): string {
   return filePath.split("/").filter(Boolean).at(-1) ?? filePath;
 }
 
+function gitDecorationTextClass(
+  decoration: AgentWorkspaceGitDecoration | undefined,
+): string | undefined {
+  switch (decoration?.kind) {
+    case "added":
+      return "text-emerald-700 dark:text-emerald-300";
+    case "modified":
+    case "renamed":
+      return "text-amber-700 dark:text-amber-300";
+    case "conflicted":
+    case "deleted":
+      return "text-red-700 dark:text-red-300";
+    case "ignored":
+      return "text-muted-foreground/50";
+    default:
+      return undefined;
+  }
+}
+
+function gitDecoratedTitle(
+  path: string,
+  decoration: AgentWorkspaceGitDecoration | undefined,
+): string {
+  return decoration ? `${path} — ${decoration.label}` : path;
+}
+
 function WorkspaceTabs({
   selection,
   openFiles,
+  gitDecorations,
   onActivateFiles,
   onActivateFile,
   onCloseFile,
@@ -108,6 +160,7 @@ function WorkspaceTabs({
 }: {
   selection: AgentWorkspaceFileSelection | null;
   openFiles: AgentWorkspaceFileSelection[];
+  gitDecorations: Map<string, AgentWorkspaceGitDecoration>;
   onActivateFiles: () => void;
   onActivateFile: (path: string) => void;
   onCloseFile: (path: string) => void;
@@ -139,9 +192,13 @@ function WorkspaceTabs({
         {openFiles.map((file) => {
           const active = selection?.path === file.path;
           const name = fileName(file.path);
+          const decoration =
+            gitDecorations.get(file.path) ??
+            (file.gitIgnored ? ignoredGitDecoration : undefined);
           return (
             <div
               key={file.path}
+              data-git-status={decoration?.kind}
               className={cn(
                 "group relative flex h-full min-w-0 max-w-56 shrink-0 items-center border-r motion-colors hover:bg-muted/50 focus-within:bg-muted/60",
                 active
@@ -154,15 +211,35 @@ function WorkspaceTabs({
                 role="tab"
                 aria-selected={active}
                 aria-label={`Open ${file.path}`}
-                title={file.path}
+                title={gitDecoratedTitle(file.path, decoration)}
                 onClick={() => onActivateFile(file.path)}
                 className={cn(
                   "flex h-full min-w-0 items-center gap-2 py-0 pr-1 pl-3 text-xs outline-none",
                   active && "font-medium",
                 )}
               >
-                <FileCode2 className="size-3.5 shrink-0" />
-                <span className="truncate">{name}</span>
+                <FileCode2
+                  className={cn(
+                    "size-3.5 shrink-0",
+                    gitDecorationTextClass(decoration),
+                  )}
+                />
+                <span
+                  className={cn("truncate", gitDecorationTextClass(decoration))}
+                >
+                  {name}
+                </span>
+                {decoration?.code && (
+                  <span
+                    aria-label={decoration.label}
+                    className={cn(
+                      "shrink-0 text-[10px] font-semibold",
+                      gitDecorationTextClass(decoration),
+                    )}
+                  >
+                    {decoration.code}
+                  </span>
+                )}
               </button>
               <button
                 type="button"
@@ -200,18 +277,17 @@ function WorkspaceTabs({
 
 function WorkspaceExplorer({
   workspaceId,
-  running,
+  isGit,
+  changedFiles,
+  gitDecorations,
   onSelect,
 }: {
   workspaceId: string;
-  running: boolean;
+  isGit: boolean;
+  changedFiles: AgentWorkspaceGitFile[];
+  gitDecorations: Map<string, AgentWorkspaceGitDecoration>;
   onSelect: (selection: AgentWorkspaceFileSelection) => void;
 }) {
-  const gitStatus = useAgentWorkspaceGitStatus(workspaceId, {
-    active: true,
-    running,
-  });
-  const changedFiles = gitStatus.data?.files ?? [];
   const queryClient = useQueryClient();
   const directoryQueries = agentWorkspaceKeys.directories(workspaceId);
   const refreshingDirectories =
@@ -229,7 +305,7 @@ function WorkspaceExplorer({
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-2">
-      {gitStatus.data?.isGit && changedFiles.length > 0 && (
+      {isGit && changedFiles.length > 0 && (
         <section className="pb-3" aria-labelledby="workspace-changes-heading">
           <div className="flex h-8 items-center gap-2 px-3">
             <FileDiff className="size-3.5 text-muted-foreground" />
@@ -285,6 +361,7 @@ function WorkspaceExplorer({
           path="."
           depth={0}
           expanded={expanded}
+          gitDecorations={gitDecorations}
           onToggle={toggle}
           onSelect={onSelect}
         />
@@ -300,40 +377,36 @@ function ChangedFileRow({
   file: AgentWorkspaceGitFile;
   onSelect: () => void;
 }) {
-  const status = file.worktreeStatus ?? file.indexStatus ?? "M";
-  const label =
-    status === "?" || status === "A"
-      ? "Added"
-      : status === "D"
-        ? "Deleted"
-        : status === "R"
-          ? "Renamed"
-          : status === "U"
-            ? "Conflicted"
-            : "Modified";
-  const deleted = status === "D";
+  const decoration = agentWorkspaceGitFileDecoration(file);
+  const deleted = decoration.kind === "deleted";
 
   return (
     <button
       type="button"
       disabled={deleted}
       onClick={onSelect}
-      title={deleted ? `${file.path} was deleted` : file.path}
+      title={gitDecoratedTitle(file.path, decoration)}
+      data-git-status={decoration.kind}
       className="group flex min-h-8 w-full items-center gap-2 rounded-md px-2 text-left text-xs outline-none motion-colors hover:bg-muted disabled:cursor-default disabled:opacity-60"
     >
-      <FileCode2 className="size-3.5 shrink-0 text-muted-foreground" />
-      <span className="min-w-0 flex-1 truncate font-mono">{file.path}</span>
+      <FileCode2
+        className={cn("size-3.5 shrink-0", gitDecorationTextClass(decoration))}
+      />
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate font-mono",
+          gitDecorationTextClass(decoration),
+        )}
+      >
+        {file.path}
+      </span>
       <span
         className={cn(
           "shrink-0 text-[10px] font-medium",
-          label === "Added" && "text-emerald-700 dark:text-emerald-300",
-          label === "Deleted" && "text-red-700 dark:text-red-300",
-          label === "Conflicted" && "text-amber-700 dark:text-amber-300",
-          (label === "Modified" || label === "Renamed") &&
-            "text-muted-foreground",
+          gitDecorationTextClass(decoration),
         )}
       >
-        {label}
+        {decoration.label}
       </span>
     </button>
   );
@@ -344,6 +417,7 @@ function WorkspaceDirectory({
   path,
   depth,
   expanded,
+  gitDecorations,
   onToggle,
   onSelect,
 }: {
@@ -351,6 +425,7 @@ function WorkspaceDirectory({
   path: string;
   depth: number;
   expanded: Set<string>;
+  gitDecorations: Map<string, AgentWorkspaceGitDecoration>;
   onToggle: (path: string) => void;
   onSelect: (selection: AgentWorkspaceFileSelection) => void;
 }) {
@@ -385,6 +460,7 @@ function WorkspaceDirectory({
           workspaceId={workspaceId}
           depth={depth}
           expanded={expanded}
+          gitDecorations={gitDecorations}
           onToggle={onToggle}
           onSelect={onSelect}
         />
@@ -408,6 +484,7 @@ function WorkspaceEntryRow({
   workspaceId,
   depth,
   expanded,
+  gitDecorations,
   onToggle,
   onSelect,
 }: {
@@ -415,12 +492,19 @@ function WorkspaceEntryRow({
   workspaceId: string;
   depth: number;
   expanded: Set<string>;
+  gitDecorations: Map<string, AgentWorkspaceGitDecoration>;
   onToggle: (path: string) => void;
   onSelect: (selection: AgentWorkspaceFileSelection) => void;
 }) {
   const directory = entry.kind === "directory" && !entry.symlink;
   const open = directory && expanded.has(entry.path);
   const disabled = entry.kind === "symlink" || entry.symlink;
+  const decoration =
+    gitDecorations.get(entry.path) ??
+    (entry.ignored ? ignoredGitDecoration : undefined);
+  const title = disabled
+    ? `${entry.path} is a symbolic link and cannot be previewed`
+    : gitDecoratedTitle(entry.path, decoration);
 
   return (
     <div>
@@ -430,13 +514,13 @@ function WorkspaceEntryRow({
         onClick={() =>
           directory
             ? onToggle(entry.path)
-            : onSelect({ path: entry.path })
+            : onSelect({
+                path: entry.path,
+                ...(decoration?.kind === "ignored" ? { gitIgnored: true } : {}),
+              })
         }
-        title={
-          disabled
-            ? `${entry.path} is a symbolic link and cannot be previewed`
-            : entry.path
-        }
+        title={title}
+        data-git-status={decoration?.kind}
         className="flex min-h-8 w-full items-center gap-1.5 pr-2 text-left text-xs outline-none motion-colors hover:bg-muted disabled:cursor-default disabled:opacity-60"
         style={{ paddingLeft: `${12 + depth * 16}px` }}
       >
@@ -453,14 +537,47 @@ function WorkspaceEntryRow({
           <Link className="size-3.5 shrink-0 text-muted-foreground" />
         ) : directory ? (
           open ? (
-            <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
+            <FolderOpen
+              className={cn(
+                "size-3.5 shrink-0",
+                gitDecorationTextClass(decoration) ?? "text-muted-foreground",
+              )}
+            />
           ) : (
-            <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+            <Folder
+              className={cn(
+                "size-3.5 shrink-0",
+                gitDecorationTextClass(decoration) ?? "text-muted-foreground",
+              )}
+            />
           )
         ) : (
-          <File className="size-3.5 shrink-0 text-muted-foreground" />
+          <File
+            className={cn(
+              "size-3.5 shrink-0",
+              gitDecorationTextClass(decoration) ?? "text-muted-foreground",
+            )}
+          />
         )}
-        <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate",
+            gitDecorationTextClass(decoration),
+          )}
+        >
+          {entry.name}
+        </span>
+        {!directory && decoration?.code && (
+          <span
+            aria-label={decoration.label}
+            className={cn(
+              "shrink-0 text-[10px] font-semibold",
+              gitDecorationTextClass(decoration),
+            )}
+          >
+            {decoration.code}
+          </span>
+        )}
       </button>
       {open && (
         <WorkspaceDirectory
@@ -468,6 +585,7 @@ function WorkspaceEntryRow({
           path={entry.path}
           depth={depth + 1}
           expanded={expanded}
+          gitDecorations={gitDecorations}
           onToggle={onToggle}
           onSelect={onSelect}
         />
@@ -480,11 +598,13 @@ function WorkspaceFilePreview({
   workspaceId,
   workspaceName,
   selection,
+  decoration,
   running,
 }: {
   workspaceId: string;
   workspaceName: string;
   selection: AgentWorkspaceFileSelection;
+  decoration?: AgentWorkspaceGitDecoration;
   running: boolean;
 }) {
   const file = useAgentWorkspaceFile(workspaceId, selection.path, { running });
@@ -495,8 +615,12 @@ function WorkspaceFilePreview({
       <div className="flex h-10 shrink-0 items-center gap-1 border-b px-3">
         <div
           className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-xs text-muted-foreground"
-          title={`${workspaceName}/${displayPath}`}
+          title={gitDecoratedTitle(
+            `${workspaceName}/${displayPath}`,
+            decoration,
+          )}
           aria-label={`File path: ${workspaceName}/${displayPath}`}
+          data-git-status={decoration?.kind}
         >
           <span className="shrink-0 truncate">{workspaceName}</span>
           {displayPath.split("/").filter(Boolean).map((segment, index, parts) => (
@@ -509,11 +633,25 @@ function WorkspaceFilePreview({
                 className={cn(
                   "truncate",
                   index === parts.length - 1 &&
-                    "font-medium text-foreground",
+                    cn(
+                      "font-medium text-foreground",
+                      gitDecorationTextClass(decoration),
+                    ),
                 )}
               >
                 {segment}
               </span>
+              {index === parts.length - 1 && decoration?.code && (
+                <span
+                  aria-label={decoration.label}
+                  className={cn(
+                    "shrink-0 text-[10px] font-semibold",
+                    gitDecorationTextClass(decoration),
+                  )}
+                >
+                  {decoration.code}
+                </span>
+              )}
             </span>
           ))}
         </div>

--- a/apps/web/components/agents/AgentWorkspacePane.tsx
+++ b/apps/web/components/agents/AgentWorkspacePane.tsx
@@ -11,7 +11,6 @@ import { code, type HighlightResult } from "@streamdown/code";
 import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
-  ArrowLeft,
   ChevronDown,
   ChevronRight,
   File,
@@ -44,29 +43,146 @@ export function AgentWorkspacePane({
   workspaceId,
   workspaceName,
   selection,
+  openFiles,
   running,
   onSelect,
+  onActivateFiles,
+  onActivateFile,
   onCloseFile,
   onClose,
 }: {
   workspaceId: string;
   workspaceName: string;
   selection: AgentWorkspaceFileSelection | null;
+  openFiles: AgentWorkspaceFileSelection[];
   running: boolean;
   onSelect: (selection: AgentWorkspaceFileSelection) => void;
-  onCloseFile: () => void;
+  onActivateFiles: () => void;
+  onActivateFile: (path: string) => void;
+  onCloseFile: (path: string) => void;
   onClose: () => void;
 }) {
   return (
     <aside
       className="flex h-full w-full flex-col border-l bg-background"
       data-testid="agent-workspace-pane"
-      aria-label="Workspace files"
+      aria-label={`${workspaceName} workspace`}
     >
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3">
-        <div className="min-w-0 flex-1 truncate text-sm font-medium">
-          {workspaceName}
-        </div>
+      <WorkspaceTabs
+        selection={selection}
+        openFiles={openFiles}
+        onActivateFiles={onActivateFiles}
+        onActivateFile={onActivateFile}
+        onCloseFile={onCloseFile}
+        onClose={onClose}
+      />
+      {selection ? (
+        <WorkspaceFilePreview
+          workspaceId={workspaceId}
+          workspaceName={workspaceName}
+          selection={selection}
+          running={running}
+        />
+      ) : (
+        <WorkspaceExplorer
+          workspaceId={workspaceId}
+          running={running}
+          onSelect={onSelect}
+        />
+      )}
+    </aside>
+  );
+}
+
+function fileName(filePath: string): string {
+  return filePath.split("/").filter(Boolean).at(-1) ?? filePath;
+}
+
+function WorkspaceTabs({
+  selection,
+  openFiles,
+  onActivateFiles,
+  onActivateFile,
+  onCloseFile,
+  onClose,
+}: {
+  selection: AgentWorkspaceFileSelection | null;
+  openFiles: AgentWorkspaceFileSelection[];
+  onActivateFiles: () => void;
+  onActivateFile: (path: string) => void;
+  onCloseFile: (path: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <header className="flex h-12 shrink-0 border-b bg-muted/15">
+      <div
+        role="tablist"
+        aria-label="Workspace views"
+        className="flex min-w-0 flex-1 overflow-x-auto overscroll-x-contain"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={selection === null}
+          title="Browse workspace files"
+          onClick={onActivateFiles}
+          className={cn(
+            "relative flex h-full shrink-0 items-center gap-2 border-r px-3 text-xs outline-none motion-colors hover:bg-muted/50 focus-visible:bg-muted/60",
+            selection === null
+              ? "bg-background font-medium text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+              : "text-muted-foreground",
+          )}
+        >
+          <FolderOpen className="size-3.5" />
+          Files
+        </button>
+        {openFiles.map((file) => {
+          const active = selection?.path === file.path;
+          const name = fileName(file.path);
+          return (
+            <div
+              key={file.path}
+              className={cn(
+                "group relative flex h-full min-w-0 max-w-56 shrink-0 items-center border-r motion-colors hover:bg-muted/50 focus-within:bg-muted/60",
+                active
+                  ? "bg-background text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-primary"
+                  : "text-muted-foreground",
+              )}
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={active}
+                aria-label={`Open ${file.path}`}
+                title={file.path}
+                onClick={() => onActivateFile(file.path)}
+                className={cn(
+                  "flex h-full min-w-0 items-center gap-2 py-0 pr-1 pl-3 text-xs outline-none",
+                  active && "font-medium",
+                )}
+              >
+                <FileCode2 className="size-3.5 shrink-0" />
+                <span className="truncate">{name}</span>
+              </button>
+              <button
+                type="button"
+                aria-label={`Close ${file.path}`}
+                title={`Close ${file.path}`}
+                onClick={() => onCloseFile(file.path)}
+                className={cn(
+                  "mr-1 flex size-6 shrink-0 items-center justify-center rounded-md outline-none motion-colors hover:bg-muted focus-visible:bg-muted",
+                  active
+                    ? "text-muted-foreground"
+                    : "text-muted-foreground/0 group-hover:text-muted-foreground group-focus-within:text-muted-foreground [@media(hover:none)]:text-muted-foreground",
+                )}
+              >
+                <X className="size-3" />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex shrink-0 items-center border-l bg-background px-1">
         <Button
           type="button"
           variant="ghost"
@@ -77,22 +193,8 @@ export function AgentWorkspacePane({
         >
           <X />
         </Button>
-      </header>
-      {selection ? (
-        <WorkspaceFilePreview
-          workspaceId={workspaceId}
-          selection={selection}
-          running={running}
-          onBack={onCloseFile}
-        />
-      ) : (
-        <WorkspaceExplorer
-          workspaceId={workspaceId}
-          running={running}
-          onSelect={onSelect}
-        />
-      )}
-    </aside>
+      </div>
+    </header>
   );
 }
 
@@ -376,33 +478,44 @@ function WorkspaceEntryRow({
 
 function WorkspaceFilePreview({
   workspaceId,
+  workspaceName,
   selection,
   running,
-  onBack,
 }: {
   workspaceId: string;
+  workspaceName: string;
   selection: AgentWorkspaceFileSelection;
   running: boolean;
-  onBack: () => void;
 }) {
   const file = useAgentWorkspaceFile(workspaceId, selection.path, { running });
   const displayPath = file.data?.path ?? selection.path;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex h-10 shrink-0 items-center gap-1 border-b px-2">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          aria-label="Back to workspace files"
-          title="Back to workspace files"
-          onClick={onBack}
+      <div className="flex h-10 shrink-0 items-center gap-1 border-b px-3">
+        <div
+          className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-xs text-muted-foreground"
+          title={`${workspaceName}/${displayPath}`}
+          aria-label={`File path: ${workspaceName}/${displayPath}`}
         >
-          <ArrowLeft />
-        </Button>
-        <div className="min-w-0 flex-1 truncate px-1 font-mono text-xs" title={displayPath}>
-          {displayPath}
+          <span className="shrink-0 truncate">{workspaceName}</span>
+          {displayPath.split("/").filter(Boolean).map((segment, index, parts) => (
+            <span
+              key={`${index}:${segment}`}
+              className="flex min-w-0 items-center gap-1"
+            >
+              <ChevronRight className="size-3 shrink-0 opacity-60" />
+              <span
+                className={cn(
+                  "truncate",
+                  index === parts.length - 1 &&
+                    "font-medium text-foreground",
+                )}
+              >
+                {segment}
+              </span>
+            </span>
+          ))}
         </div>
         <Button
           type="button"

--- a/apps/web/components/agents/AgentWorkspacePane.tsx
+++ b/apps/web/components/agents/AgentWorkspacePane.tsx
@@ -8,6 +8,7 @@ import {
   type CSSProperties,
 } from "react";
 import { code, type HighlightResult } from "@streamdown/code";
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -35,6 +36,7 @@ import {
   useAgentWorkspaceGitStatus,
 } from "@/lib/queries/agentWorkspaces";
 import { motionClasses } from "@/lib/motion";
+import { agentWorkspaceKeys } from "@/lib/queries/keys";
 import { cn } from "@/lib/utils";
 import type { AgentWorkspaceFileSelection } from "./AgentWorkspaceNavigationContext";
 
@@ -108,6 +110,10 @@ function WorkspaceExplorer({
     running,
   });
   const changedFiles = gitStatus.data?.files ?? [];
+  const queryClient = useQueryClient();
+  const directoryQueries = agentWorkspaceKeys.directories(workspaceId);
+  const refreshingDirectories =
+    useIsFetching({ queryKey: directoryQueries }) > 0;
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(["."]));
 
   function toggle(path: string) {
@@ -153,13 +159,30 @@ function WorkspaceExplorer({
           <h2 id="workspace-files-heading" className="text-xs font-medium">
             Files
           </h2>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="ml-auto"
+            aria-label="Refresh workspace files"
+            title="Refresh workspace files"
+            disabled={refreshingDirectories}
+            onClick={() =>
+              void queryClient.invalidateQueries({ queryKey: directoryQueries })
+            }
+          >
+            <RefreshCw
+              className={
+                refreshingDirectories ? motionClasses.spinner : undefined
+              }
+            />
+          </Button>
         </div>
         <WorkspaceDirectory
           workspaceId={workspaceId}
           path="."
           depth={0}
           expanded={expanded}
-          running={running}
           onToggle={toggle}
           onSelect={onSelect}
         />
@@ -219,7 +242,6 @@ function WorkspaceDirectory({
   path,
   depth,
   expanded,
-  running,
   onToggle,
   onSelect,
 }: {
@@ -227,14 +249,12 @@ function WorkspaceDirectory({
   path: string;
   depth: number;
   expanded: Set<string>;
-  running: boolean;
   onToggle: (path: string) => void;
   onSelect: (selection: AgentWorkspaceFileSelection) => void;
 }) {
   const isExpanded = expanded.has(path);
   const directory = useAgentWorkspaceDirectory(workspaceId, path, {
     enabled: isExpanded,
-    running,
   });
 
   if (!isExpanded) return null;
@@ -263,7 +283,6 @@ function WorkspaceDirectory({
           workspaceId={workspaceId}
           depth={depth}
           expanded={expanded}
-          running={running}
           onToggle={onToggle}
           onSelect={onSelect}
         />
@@ -287,7 +306,6 @@ function WorkspaceEntryRow({
   workspaceId,
   depth,
   expanded,
-  running,
   onToggle,
   onSelect,
 }: {
@@ -295,7 +313,6 @@ function WorkspaceEntryRow({
   workspaceId: string;
   depth: number;
   expanded: Set<string>;
-  running: boolean;
   onToggle: (path: string) => void;
   onSelect: (selection: AgentWorkspaceFileSelection) => void;
 }) {
@@ -349,7 +366,6 @@ function WorkspaceEntryRow({
           path={entry.path}
           depth={depth + 1}
           expanded={expanded}
-          running={running}
           onToggle={onToggle}
           onSelect={onSelect}
         />

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -651,6 +651,75 @@ test("shows durable turn activity without changing completed tool status", async
             additions: 8,
             deletions: 3,
             lineStatsComplete: true,
+            files: [
+              {
+                path: "src/index.ts",
+                originalPath: null,
+                indexStatus: null,
+                worktreeStatus: "M",
+              },
+            ],
+          },
+        }),
+      });
+    },
+  );
+  await page.route(
+    new RegExp("/api/agent-workspaces/workspace/files(?:\\?.*)?$"),
+    async (route) => {
+      const directoryPath = new URL(route.request().url()).searchParams.get("path");
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          listing:
+            directoryPath === "src"
+              ? {
+                  path: "src",
+                  entries: [
+                    {
+                      name: "index.ts",
+                      path: "src/index.ts",
+                      kind: "file",
+                      symlink: false,
+                    },
+                  ],
+                  truncated: false,
+                }
+              : {
+                  path: ".",
+                  entries: [
+                    {
+                      name: "src",
+                      path: "src",
+                      kind: "directory",
+                      symlink: false,
+                    },
+                    {
+                      name: "README.md",
+                      path: "README.md",
+                      kind: "file",
+                      symlink: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+        }),
+      });
+    },
+  );
+  await page.route(
+    new RegExp("/api/agent-workspaces/workspace/file(?:\\?.*)?$"),
+    async (route) => {
+      const filePath =
+        new URL(route.request().url()).searchParams.get("path") ?? "README.md";
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          file: {
+            path: filePath,
+            content: "export function AgentSessionView() {\n  return null;\n}\n",
+            size: 56,
+            modifiedAt: 100,
           },
         }),
       });
@@ -798,6 +867,50 @@ test("shows durable turn activity without changing completed tool status", async
     "apps/web/components/agents/AgentSessionView.tsx",
   );
   await expect(agentViewLink).toHaveAttribute("data-line-start", "391");
+  await agentViewLink.click();
+  const workspacePane = page.getByTestId("agent-workspace-pane");
+  await expect(workspacePane).toBeVisible();
+  await expect(workspacePane).toContainText(
+    "apps/web/components/agents/AgentSessionView.tsx",
+  );
+  await expect(workspacePane).toContainText("AgentSessionView");
+  const codeToken = workspacePane.locator("[data-workspace-code-token]").first();
+  const themeWasDark = await page.evaluate(() =>
+    document.documentElement.classList.contains("dark"),
+  );
+  await page.evaluate(() => document.documentElement.classList.add("dark"));
+  await expect
+    .poll(() =>
+      codeToken.evaluate((element) => {
+        const styles = getComputedStyle(element);
+        const darkColor = styles.getPropertyValue("--shiki-dark").trim();
+        if (!darkColor) return false;
+        const probe = document.createElement("span");
+        probe.style.color = darkColor;
+        document.body.appendChild(probe);
+        const expected = getComputedStyle(probe).color;
+        probe.remove();
+        return styles.color === expected;
+      }),
+    )
+    .toBe(true);
+  if (!themeWasDark) {
+    await page.evaluate(() => document.documentElement.classList.remove("dark"));
+  }
+  await workspacePane.getByRole("button", { name: "Back to workspace files" }).click();
+  await expect(workspacePane.getByRole("heading", { name: "Changes" })).toBeVisible();
+  await expect(workspacePane.getByRole("heading", { name: "Files" })).toBeVisible();
+  await workspacePane.getByRole("button", { name: "src", exact: true }).click();
+  await workspacePane
+    .getByRole("button", { name: "index.ts", exact: true })
+    .click();
+  await expect(workspacePane).toContainText("src/index.ts");
+  await workspacePane
+    .getByRole("button", { name: "Close workspace files" })
+    .click();
+  await expect(
+    agentHeader.getByRole("button", { name: "Open workspace files" }),
+  ).toHaveAttribute("aria-pressed", "false");
   await expect(
     page.getByRole("button", { name: "the docs", exact: true }),
   ).toBeVisible();

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -703,6 +703,13 @@ test("shows durable turn activity without changing completed tool status", async
                       kind: "file",
                       symlink: false,
                     },
+                    {
+                      name: "generated.log",
+                      path: "generated.log",
+                      kind: "file",
+                      symlink: false,
+                      ignored: true,
+                    },
                   ],
                   truncated: false,
                 },
@@ -912,10 +919,27 @@ test("shows durable turn activity without changing completed tool status", async
   await workspacePane.getByRole("tab", { name: "Files" }).click();
   await expect(workspacePane.getByRole("heading", { name: "Changes" })).toBeVisible();
   await expect(workspacePane.getByRole("heading", { name: "Files" })).toBeVisible();
-  await workspacePane.getByRole("button", { name: "src", exact: true }).click();
   await expect(
-    workspacePane.getByRole("button", { name: "index.ts", exact: true }),
-  ).toBeVisible();
+    workspacePane.getByRole("button", {
+      name: "src/index.ts Modified",
+      exact: true,
+    }),
+  ).toHaveAttribute("data-git-status", "modified");
+  const sourceDirectory = workspacePane.getByRole("button", {
+    name: "src",
+    exact: true,
+  });
+  await expect(sourceDirectory).toHaveAttribute("data-git-status", "modified");
+  await expect(
+    workspacePane.getByRole("button", { name: "generated.log", exact: true }),
+  ).toHaveAttribute("data-git-status", "ignored");
+  await sourceDirectory.click();
+  await expect(
+    workspacePane.getByRole("button", {
+      name: "index.ts Modified",
+      exact: true,
+    }),
+  ).toHaveAttribute("data-git-status", "modified");
   const requestsBeforeIdle = [...workspaceDirectoryRequests];
   await page.waitForTimeout(3_200);
   expect(workspaceDirectoryRequests).toEqual(requestsBeforeIdle);
@@ -941,11 +965,11 @@ test("shows durable turn activity without changing completed tool status", async
     )
     .toBeGreaterThan(sourceRequestsBeforeRefresh);
   await workspacePane
-    .getByRole("button", { name: "index.ts", exact: true })
+    .getByRole("button", { name: "index.ts Modified", exact: true })
     .click();
   await expect(
     workspacePane.getByLabel("File path: Runtime test/src/index.ts"),
-  ).toBeVisible();
+  ).toHaveAttribute("data-git-status", "modified");
   await expect(
     workspacePane.getByRole("tab", {
       name: "Open apps/web/components/agents/AgentSessionView.tsx",
@@ -955,6 +979,10 @@ test("shows durable turn activity without changing completed tool status", async
     name: "Open src/index.ts",
   });
   await expect(indexTab).toHaveAttribute("aria-selected", "true");
+  await expect(indexTab.locator("..")).toHaveAttribute(
+    "data-git-status",
+    "modified",
+  );
   await page.screenshot({
     path: testInfo.outputPath("runtime-workspace-tabs.png"),
     fullPage: true,

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -457,6 +457,7 @@ test("shows durable turn activity without changing completed tool status", async
   let interactionResponse: Record<string, unknown> | null = null;
   let runtimeAvailable = true;
   const submittedCommands: Array<Record<string, unknown>> = [];
+  const workspaceDirectoryRequests: string[] = [];
   await page.exposeFunction(
     "__setAgentRuntimeAvailable",
     (available: boolean) => {
@@ -667,7 +668,9 @@ test("shows durable turn activity without changing completed tool status", async
   await page.route(
     new RegExp("/api/agent-workspaces/workspace/files(?:\\?.*)?$"),
     async (route) => {
-      const directoryPath = new URL(route.request().url()).searchParams.get("path");
+      const directoryPath =
+        new URL(route.request().url()).searchParams.get("path") ?? ".";
+      workspaceDirectoryRequests.push(directoryPath);
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({
@@ -716,6 +719,8 @@ test("shows durable turn activity without changing completed tool status", async
         contentType: "application/json",
         body: JSON.stringify({
           file: {
+            kind: "text",
+            encoding: "utf-8",
             path: filePath,
             content: "export function AgentSessionView() {\n  return null;\n}\n",
             size: 56,
@@ -901,6 +906,33 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(workspacePane.getByRole("heading", { name: "Changes" })).toBeVisible();
   await expect(workspacePane.getByRole("heading", { name: "Files" })).toBeVisible();
   await workspacePane.getByRole("button", { name: "src", exact: true }).click();
+  await expect(
+    workspacePane.getByRole("button", { name: "index.ts", exact: true }),
+  ).toBeVisible();
+  const requestsBeforeIdle = [...workspaceDirectoryRequests];
+  await page.waitForTimeout(3_200);
+  expect(workspaceDirectoryRequests).toEqual(requestsBeforeIdle);
+  const rootRequestsBeforeRefresh = workspaceDirectoryRequests.filter(
+    (path) => path === ".",
+  ).length;
+  const sourceRequestsBeforeRefresh = workspaceDirectoryRequests.filter(
+    (path) => path === "src",
+  ).length;
+  await workspacePane
+    .getByRole("button", { name: "Refresh workspace files" })
+    .click();
+  await expect
+    .poll(
+      () =>
+        workspaceDirectoryRequests.filter((path) => path === ".").length,
+    )
+    .toBeGreaterThan(rootRequestsBeforeRefresh);
+  await expect
+    .poll(
+      () =>
+        workspaceDirectoryRequests.filter((path) => path === "src").length,
+    )
+    .toBeGreaterThan(sourceRequestsBeforeRefresh);
   await workspacePane
     .getByRole("button", { name: "index.ts", exact: true })
     .click();

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -441,6 +441,7 @@ test("requires inspection before retrying an uncertain queued message", async ({
 test("shows durable turn activity without changing completed tool status", async ({
   page,
 }, testInfo) => {
+  test.setTimeout(60_000);
   await page.goto("/signup");
   await page.locator("#name").fill("Runtime E2E Admin");
   await page.locator("#email").fill("runtime-admin@overtchat-test.local");

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -458,6 +458,7 @@ test("shows durable turn activity without changing completed tool status", async
   let runtimeAvailable = true;
   const submittedCommands: Array<Record<string, unknown>> = [];
   const workspaceDirectoryRequests: string[] = [];
+  const workspaceFileRequests: string[] = [];
   await page.exposeFunction(
     "__setAgentRuntimeAvailable",
     (available: boolean) => {
@@ -722,6 +723,7 @@ test("shows durable turn activity without changing completed tool status", async
     async (route) => {
       const filePath =
         new URL(route.request().url()).searchParams.get("path") ?? "README.md";
+      workspaceFileRequests.push(filePath);
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({
@@ -879,6 +881,8 @@ test("shows durable turn activity without changing completed tool status", async
     "apps/web/components/agents/AgentSessionView.tsx",
   );
   await expect(agentViewLink).toHaveAttribute("data-line-start", "391");
+  expect(workspaceDirectoryRequests).toEqual([]);
+  expect(workspaceFileRequests).toEqual([]);
   await agentViewLink.click();
   const workspacePane = page.getByTestId("agent-workspace-pane");
   await expect(workspacePane).toBeVisible();
@@ -1046,6 +1050,10 @@ test("shows durable turn activity without changing completed tool status", async
   await workspacePane
     .getByRole("button", { name: "Close workspace files" })
     .click();
+  const fileRequestsAfterClose = [...workspaceFileRequests];
+  expect(fileRequestsAfterClose.length).toBeGreaterThan(0);
+  await page.waitForTimeout(2_200);
+  expect(workspaceFileRequests).toEqual(fileRequestsAfterClose);
   await expect(
     page.getByRole("button", { name: "the docs", exact: true }),
   ).toBeVisible();

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -875,9 +875,11 @@ test("shows durable turn activity without changing completed tool status", async
   await agentViewLink.click();
   const workspacePane = page.getByTestId("agent-workspace-pane");
   await expect(workspacePane).toBeVisible();
-  await expect(workspacePane).toContainText(
-    "apps/web/components/agents/AgentSessionView.tsx",
-  );
+  await expect(
+    workspacePane.getByLabel(
+      "File path: Runtime test/apps/web/components/agents/AgentSessionView.tsx",
+    ),
+  ).toBeVisible();
   await expect(workspacePane).toContainText("AgentSessionView");
   const codeToken = workspacePane.locator("[data-workspace-code-token]").first();
   const themeWasDark = await page.evaluate(() =>
@@ -902,7 +904,12 @@ test("shows durable turn activity without changing completed tool status", async
   if (!themeWasDark) {
     await page.evaluate(() => document.documentElement.classList.remove("dark"));
   }
-  await workspacePane.getByRole("button", { name: "Back to workspace files" }).click();
+  await expect(
+    workspacePane.getByRole("tab", {
+      name: "Open apps/web/components/agents/AgentSessionView.tsx",
+    }),
+  ).toHaveAttribute("aria-selected", "true");
+  await workspacePane.getByRole("tab", { name: "Files" }).click();
   await expect(workspacePane.getByRole("heading", { name: "Changes" })).toBeVisible();
   await expect(workspacePane.getByRole("heading", { name: "Files" })).toBeVisible();
   await workspacePane.getByRole("button", { name: "src", exact: true }).click();
@@ -936,13 +943,81 @@ test("shows durable turn activity without changing completed tool status", async
   await workspacePane
     .getByRole("button", { name: "index.ts", exact: true })
     .click();
-  await expect(workspacePane).toContainText("src/index.ts");
+  await expect(
+    workspacePane.getByLabel("File path: Runtime test/src/index.ts"),
+  ).toBeVisible();
+  await expect(
+    workspacePane.getByRole("tab", {
+      name: "Open apps/web/components/agents/AgentSessionView.tsx",
+    }),
+  ).toBeVisible();
+  const indexTab = workspacePane.getByRole("tab", {
+    name: "Open src/index.ts",
+  });
+  await expect(indexTab).toHaveAttribute("aria-selected", "true");
+  await page.screenshot({
+    path: testInfo.outputPath("runtime-workspace-tabs.png"),
+    fullPage: true,
+  });
+  await workspacePane
+    .getByRole("button", { name: "Close src/index.ts" })
+    .click();
+  await expect(indexTab).toHaveCount(0);
+  await expect(
+    workspacePane.getByRole("tab", {
+      name: "Open apps/web/components/agents/AgentSessionView.tsx",
+    }),
+  ).toHaveAttribute("aria-selected", "true");
+
+  const workspaceResizeHandle = page.getByRole("separator", {
+    name: "Resize workspace files",
+  });
+  const paneWidthBeforeResize = await workspacePane.evaluate(
+    (element) => element.getBoundingClientRect().width,
+  );
+  const resizeBox = await workspaceResizeHandle.boundingBox();
+  expect(resizeBox).not.toBeNull();
+  await page.mouse.move(resizeBox!.x + resizeBox!.width / 2, resizeBox!.y + 100);
+  await page.mouse.down();
+  await page.mouse.move(resizeBox!.x - 96, resizeBox!.y + 100, { steps: 4 });
+  await page.mouse.up();
+  await expect
+    .poll(() =>
+      workspacePane.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeGreaterThan(paneWidthBeforeResize + 70);
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        JSON.parse(
+          window.localStorage.getItem("overtchat:agent-workspace-pane-width") ??
+            "0",
+        ),
+      ),
+    )
+    .toBeGreaterThan(paneWidthBeforeResize + 70);
+
   await workspacePane
     .getByRole("button", { name: "Close workspace files" })
     .click();
   await expect(
     agentHeader.getByRole("button", { name: "Open workspace files" }),
   ).toHaveAttribute("aria-pressed", "false");
+  await agentHeader.getByRole("button", { name: "Open workspace files" }).click();
+  await expect
+    .poll(() =>
+      workspacePane.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeGreaterThan(paneWidthBeforeResize + 70);
+  await workspaceResizeHandle.dblclick();
+  await expect
+    .poll(() =>
+      workspacePane.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeCloseTo(512, 0);
+  await workspacePane
+    .getByRole("button", { name: "Close workspace files" })
+    .click();
   await expect(
     page.getByRole("button", { name: "the docs", exact: true }),
   ).toBeVisible();
@@ -1376,6 +1451,20 @@ test("shows durable turn activity without changing completed tool status", async
         document.documentElement.clientWidth,
     ),
   ).toBe(true);
+  await agentHeader.getByRole("button", { name: "Open workspace files" }).click();
+  await expect(workspacePane).toBeVisible();
+  await expect(workspacePane.getByRole("tab", { name: "Files" })).toBeVisible();
+  await expect(workspaceResizeHandle).not.toBeVisible();
+  expect(
+    await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth <=
+        document.documentElement.clientWidth,
+    ),
+  ).toBe(true);
+  await workspacePane
+    .getByRole("button", { name: "Close workspace files" })
+    .click();
   await page.screenshot({
     path: testInfo.outputPath("runtime-activity-mobile-main.png"),
     fullPage: true,

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -62,6 +62,17 @@ function response(
 }
 
 describe("host connector daemon broker", () => {
+  it("reports negotiated connector capabilities", () => {
+    const broker = new HostConnectorBroker();
+    expect(broker.supports("connector", "workspace-files-v1")).toBe(false);
+
+    broker.register("connector", [], vi.fn(), ["workspace-files-v1"]);
+
+    expect(broker.isOnline("connector")).toBe(true);
+    expect(broker.supports("connector", "workspace-files-v1")).toBe(true);
+    expect(broker.supports("connector", "command-wal-v1")).toBe(false);
+  });
+
   it("projects the global session directory without a detail subscription", async () => {
     const listener = vi.fn();
     const broker = new HostConnectorBroker(0);

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -98,6 +98,13 @@ export class HostConnectorBroker {
     return this.channels.has(connectorId);
   }
 
+  supports(
+    connectorId: string,
+    capability: HostConnectorCapability,
+  ): boolean {
+    return this.channels.get(connectorId)?.capabilities.has(capability) ?? false;
+  }
+
   runtimeStatusForSession(
     sessionId: string,
   ): AgentSessionDirectoryEntry["runtimeStatus"] {

--- a/apps/web/lib/agents/workspaceGitDecorations.test.ts
+++ b/apps/web/lib/agents/workspaceGitDecorations.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { AgentWorkspaceGitFile } from "@overtchat/agent-bridge";
+import {
+  agentWorkspaceGitDecorationMap,
+  agentWorkspaceGitFileDecoration,
+} from "./workspaceGitDecorations";
+
+function file(
+  path: string,
+  indexStatus: string | null,
+  worktreeStatus: string | null,
+): AgentWorkspaceGitFile {
+  return { path, originalPath: null, indexStatus, worktreeStatus };
+}
+
+describe("agent workspace Git decorations", () => {
+  it("maps porcelain status combinations to familiar editor decorations", () => {
+    expect(
+      agentWorkspaceGitFileDecoration(file("new.ts", null, "?")),
+    ).toMatchObject({
+      kind: "added",
+      code: "U",
+    });
+    expect(
+      agentWorkspaceGitFileDecoration(file("staged.ts", "A", null)),
+    ).toMatchObject({
+      kind: "added",
+      code: "A",
+    });
+    expect(
+      agentWorkspaceGitFileDecoration(file("changed.ts", null, "M")),
+    ).toMatchObject({
+      kind: "modified",
+      code: "M",
+    });
+    expect(
+      agentWorkspaceGitFileDecoration(file("gone.ts", "D", null)),
+    ).toMatchObject({
+      kind: "deleted",
+      code: "D",
+    });
+    expect(
+      agentWorkspaceGitFileDecoration(file("moved.ts", "R", null)),
+    ).toMatchObject({
+      kind: "renamed",
+      code: "R",
+    });
+    expect(
+      agentWorkspaceGitFileDecoration(file("conflict.ts", "U", "U")),
+    ).toMatchObject({
+      kind: "conflicted",
+      code: "!",
+    });
+  });
+
+  it("decorates parent directories with their strongest descendant status", () => {
+    const decorations = agentWorkspaceGitDecorationMap([
+      file("src/new.ts", null, "?"),
+      file("src/components/changed.tsx", null, "M"),
+      file("src/components/conflict.tsx", "U", "U"),
+    ]);
+
+    expect(decorations.get("src/new.ts")?.kind).toBe("added");
+    expect(decorations.get("src/components/changed.tsx")?.kind).toBe(
+      "modified",
+    );
+    expect(decorations.get("src/components")?.kind).toBe("conflicted");
+    expect(decorations.get("src")?.kind).toBe("conflicted");
+  });
+});

--- a/apps/web/lib/agents/workspaceGitDecorations.ts
+++ b/apps/web/lib/agents/workspaceGitDecorations.ts
@@ -1,0 +1,95 @@
+import type { AgentWorkspaceGitFile } from "@overtchat/agent-bridge";
+
+export type AgentWorkspaceGitDecorationKind =
+  "added" | "conflicted" | "deleted" | "ignored" | "modified" | "renamed";
+
+export type AgentWorkspaceGitDecoration = {
+  kind: AgentWorkspaceGitDecorationKind;
+  code: string;
+  label: string;
+};
+
+export const ignoredGitDecoration: AgentWorkspaceGitDecoration = {
+  kind: "ignored",
+  code: "",
+  label: "Ignored",
+};
+
+const decorationPriority: Record<AgentWorkspaceGitDecorationKind, number> = {
+  ignored: 0,
+  added: 1,
+  modified: 2,
+  renamed: 2,
+  deleted: 3,
+  conflicted: 4,
+};
+
+function hasStatus(file: AgentWorkspaceGitFile, status: string): boolean {
+  return file.indexStatus === status || file.worktreeStatus === status;
+}
+
+export function agentWorkspaceGitFileDecoration(
+  file: AgentWorkspaceGitFile,
+): AgentWorkspaceGitDecoration {
+  const conflicted =
+    hasStatus(file, "U") ||
+    (file.indexStatus === "A" && file.worktreeStatus === "A") ||
+    (file.indexStatus === "D" && file.worktreeStatus === "D");
+  if (conflicted) {
+    return { kind: "conflicted", code: "!", label: "Conflicted" };
+  }
+  if (hasStatus(file, "D")) {
+    return { kind: "deleted", code: "D", label: "Deleted" };
+  }
+  if (hasStatus(file, "R") || hasStatus(file, "C")) {
+    return { kind: "renamed", code: "R", label: "Renamed" };
+  }
+  if (file.worktreeStatus === "?") {
+    return { kind: "added", code: "U", label: "Untracked" };
+  }
+  if (hasStatus(file, "A")) {
+    return { kind: "added", code: "A", label: "Added" };
+  }
+  return { kind: "modified", code: "M", label: "Modified" };
+}
+
+function normalizedPath(value: string): string {
+  return value.replace(/^\.\//u, "").replace(/\/+$/u, "");
+}
+
+function parentPath(value: string): string | null {
+  const separator = value.lastIndexOf("/");
+  return separator > 0 ? value.slice(0, separator) : null;
+}
+
+function setStrongestDecoration(
+  decorations: Map<string, AgentWorkspaceGitDecoration>,
+  path: string,
+  decoration: AgentWorkspaceGitDecoration,
+): void {
+  const current = decorations.get(path);
+  if (
+    !current ||
+    decorationPriority[decoration.kind] > decorationPriority[current.kind]
+  ) {
+    decorations.set(path, decoration);
+  }
+}
+
+export function agentWorkspaceGitDecorationMap(
+  files: AgentWorkspaceGitFile[],
+): Map<string, AgentWorkspaceGitDecoration> {
+  const decorations = new Map<string, AgentWorkspaceGitDecoration>();
+  for (const file of files) {
+    const path = normalizedPath(file.path);
+    if (!path) continue;
+    const decoration = agentWorkspaceGitFileDecoration(file);
+    setStrongestDecoration(decorations, path, decoration);
+    let parent = parentPath(path);
+    while (parent) {
+      setStrongestDecoration(decorations, parent, decoration);
+      parent = parentPath(parent);
+    }
+  }
+  return decorations;
+}

--- a/apps/web/lib/queries/agentWorkspaces.ts
+++ b/apps/web/lib/queries/agentWorkspaces.ts
@@ -86,14 +86,14 @@ async function fetchAgentWorkspaceFile(
 export function useAgentWorkspaceFile(
   id: string,
   path: string | null,
-  { running = false } = {},
+  { enabled = true, running = false } = {},
 ) {
   return useQuery({
     queryKey: agentWorkspaceKeys.file(id, path ?? ""),
     queryFn: () => fetchAgentWorkspaceFile(id, path!),
-    enabled: Boolean(id && path),
+    enabled: Boolean(id && path) && enabled,
     retry: false,
     staleTime: running ? 1_000 : 4_000,
-    refetchInterval: running && path ? 2_000 : false,
+    refetchInterval: enabled && running && path ? 2_000 : false,
   });
 }

--- a/apps/web/lib/queries/agentWorkspaces.ts
+++ b/apps/web/lib/queries/agentWorkspaces.ts
@@ -60,7 +60,7 @@ async function fetchAgentWorkspaceDirectory(
 export function useAgentWorkspaceDirectory(
   id: string,
   path: string,
-  { enabled = true, running = false } = {},
+  { enabled = true } = {},
 ) {
   return useQuery({
     queryKey: agentWorkspaceKeys.directory(id, path),
@@ -68,7 +68,6 @@ export function useAgentWorkspaceDirectory(
     enabled: Boolean(id) && enabled,
     retry: false,
     staleTime: 4_000,
-    refetchInterval: running && enabled ? 3_000 : false,
   });
 }
 

--- a/apps/web/lib/queries/agentWorkspaces.ts
+++ b/apps/web/lib/queries/agentWorkspaces.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import type { AgentWorkspaceGitStatus } from "@overtchat/agent-bridge";
+import type {
+  AgentWorkspaceDirectoryListing,
+  AgentWorkspaceFilePreview,
+  AgentWorkspaceGitStatus,
+} from "@overtchat/agent-bridge";
 import { agentWorkspaceKeys } from "@/lib/queries/keys";
 
 async function responseError(response: Response): Promise<Error> {
@@ -36,5 +40,61 @@ export function useAgentWorkspaceGitStatus(
     retry: false,
     staleTime: 4_000,
     refetchInterval: running ? 2_000 : active ? 5_000 : false,
+  });
+}
+
+async function fetchAgentWorkspaceDirectory(
+  id: string,
+  path: string,
+): Promise<AgentWorkspaceDirectoryListing> {
+  const params = new URLSearchParams({ path });
+  const response = await fetch(
+    `/api/agent-workspaces/${encodeURIComponent(id)}/files?${params}`,
+  );
+  if (!response.ok) throw await responseError(response);
+  return ((await response.json()) as {
+    listing: AgentWorkspaceDirectoryListing;
+  }).listing;
+}
+
+export function useAgentWorkspaceDirectory(
+  id: string,
+  path: string,
+  { enabled = true, running = false } = {},
+) {
+  return useQuery({
+    queryKey: agentWorkspaceKeys.directory(id, path),
+    queryFn: () => fetchAgentWorkspaceDirectory(id, path),
+    enabled: Boolean(id) && enabled,
+    retry: false,
+    staleTime: 4_000,
+    refetchInterval: running && enabled ? 3_000 : false,
+  });
+}
+
+async function fetchAgentWorkspaceFile(
+  id: string,
+  path: string,
+): Promise<AgentWorkspaceFilePreview> {
+  const params = new URLSearchParams({ path });
+  const response = await fetch(
+    `/api/agent-workspaces/${encodeURIComponent(id)}/file?${params}`,
+  );
+  if (!response.ok) throw await responseError(response);
+  return ((await response.json()) as { file: AgentWorkspaceFilePreview }).file;
+}
+
+export function useAgentWorkspaceFile(
+  id: string,
+  path: string | null,
+  { running = false } = {},
+) {
+  return useQuery({
+    queryKey: agentWorkspaceKeys.file(id, path ?? ""),
+    queryFn: () => fetchAgentWorkspaceFile(id, path!),
+    enabled: Boolean(id && path),
+    retry: false,
+    staleTime: running ? 1_000 : 4_000,
+    refetchInterval: running && path ? 2_000 : false,
   });
 }

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -69,6 +69,10 @@ export const agentWorkspaceKeys = {
   all: () => ["agentWorkspaces"] as const,
   gitStatus: (id: string) =>
     [...agentWorkspaceKeys.all(), "gitStatus", id] as const,
+  directory: (id: string, path: string) =>
+    [...agentWorkspaceKeys.all(), "directory", id, path] as const,
+  file: (id: string, path: string) =>
+    [...agentWorkspaceKeys.all(), "file", id, path] as const,
 };
 
 export const modelConfigKeys = {

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -69,8 +69,10 @@ export const agentWorkspaceKeys = {
   all: () => ["agentWorkspaces"] as const,
   gitStatus: (id: string) =>
     [...agentWorkspaceKeys.all(), "gitStatus", id] as const,
+  directories: (id: string) =>
+    [...agentWorkspaceKeys.all(), "directory", id] as const,
   directory: (id: string, path: string) =>
-    [...agentWorkspaceKeys.all(), "directory", id, path] as const,
+    [...agentWorkspaceKeys.directories(id), path] as const,
   file: (id: string, path: string) =>
     [...agentWorkspaceKeys.all(), "file", id, path] as const,
 };

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -199,12 +199,17 @@ export type AgentWorkspaceDirectoryListing = {
   truncated: boolean;
 };
 
-export type AgentWorkspaceFilePreview = {
+export type AgentWorkspaceTextFilePreview = {
+  kind: "text";
+  encoding: "utf-8";
   path: string;
   content: string;
   size: number;
   modifiedAt: number;
 };
+
+/** Extensible read-only preview payload; future content kinds add union members. */
+export type AgentWorkspaceFilePreview = AgentWorkspaceTextFilePreview;
 
 export type AgentConnectionListItem = {
   id: string;

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -175,6 +175,35 @@ export type AgentWorkspaceGitStatus = {
   additions: number;
   deletions: number;
   lineStatsComplete: boolean;
+  /** Present when the connector supports workspace-files-v1. */
+  files?: AgentWorkspaceGitFile[];
+};
+
+export type AgentWorkspaceGitFile = {
+  path: string;
+  originalPath: string | null;
+  indexStatus: string | null;
+  worktreeStatus: string | null;
+};
+
+export type AgentWorkspaceDirectoryEntry = {
+  name: string;
+  path: string;
+  kind: "file" | "directory" | "symlink";
+  symlink: boolean;
+};
+
+export type AgentWorkspaceDirectoryListing = {
+  path: string;
+  entries: AgentWorkspaceDirectoryEntry[];
+  truncated: boolean;
+};
+
+export type AgentWorkspaceFilePreview = {
+  path: string;
+  content: string;
+  size: number;
+  modifiedAt: number;
 };
 
 export type AgentConnectionListItem = {

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -191,6 +191,8 @@ export type AgentWorkspaceDirectoryEntry = {
   path: string;
   kind: "file" | "directory" | "symlink";
   symlink: boolean;
+  /** True when Git ignores this visible workspace entry. */
+  ignored?: boolean;
 };
 
 export type AgentWorkspaceDirectoryListing = {

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -28,6 +28,7 @@ export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 export const HOST_CONNECTOR_CAPABILITIES = [
   "session-sync-v1",
   "command-wal-v1",
+  "workspace-files-v1",
 ] as const;
 export type HostConnectorCapability =
   (typeof HOST_CONNECTOR_CAPABILITIES)[number];
@@ -98,6 +99,18 @@ export type AgentDaemonRequest =
   | { type: "list_directories"; target: AgentDaemonTarget; path?: string }
   | { type: "probe_workspace"; target: AgentDaemonTarget; path: string }
   | { type: "git_status"; target: AgentDaemonTarget; path: string }
+  | {
+      type: "list_workspace_directory";
+      target: AgentDaemonTarget;
+      root: string;
+      path: string;
+    }
+  | {
+      type: "read_workspace_file";
+      target: AgentDaemonTarget;
+      root: string;
+      path: string;
+    }
   | {
       type: "create_session";
       sessionId: string;
@@ -315,6 +328,14 @@ function isAgentDaemonRequest(value: unknown): value is AgentDaemonRequest {
       return isAgentDaemonTarget(value.target) && typeof value.path === "string";
     case "git_status":
       return isAgentDaemonTarget(value.target) && typeof value.path === "string";
+    case "list_workspace_directory":
+    case "read_workspace_file":
+      return (
+        isAgentDaemonTarget(value.target) &&
+        typeof value.root === "string" &&
+        value.root.length > 0 &&
+        typeof value.path === "string"
+      );
     case "create_session":
       return (
         isNonEmptyString(value.sessionId) &&

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -46,6 +46,26 @@ describe("Host Connector protocol compatibility", () => {
     ).toBe(true);
   });
 
+  it("validates provider-neutral workspace file requests", () => {
+    for (const type of [
+      "list_workspace_directory",
+      "read_workspace_file",
+    ] as const) {
+      expect(
+        isHostConnectorCommand({
+          type: "request",
+          requestId: "request",
+          request: {
+            type,
+            target: { transport: "ssh", alias: "workstation" },
+            root: "/srv/project",
+            path: "apps/web",
+          },
+        }),
+      ).toBe(true);
+    }
+  });
+
   it("accepts a session-directory snapshot and provider-independent upserts", () => {
     expect(
       isHostConnectorEvent({

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -9,3 +9,7 @@ export * from "./runtime/git";
 export * from "./runtime/process";
 export * from "./runtime/provider-snapshots";
 export * from "./runtime/registry";
+export {
+  workspaceFilesService,
+  type WorkspaceFilesService,
+} from "./runtime/workspace-files";

--- a/packages/agent-runtime/src/runtime/filesystem.test.ts
+++ b/packages/agent-runtime/src/runtime/filesystem.test.ts
@@ -1,3 +1,12 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -8,7 +17,12 @@ vi.mock("@overtchat/agent-runtime/runtime/process", () => ({
   executeOnHost: mocks.executeOnHost,
 }));
 
-import { listAgentDirectories } from "./filesystem";
+import {
+  AGENT_WORKSPACE_FILES_SCRIPT,
+  listAgentDirectories,
+  listAgentWorkspaceDirectory,
+  readAgentWorkspaceFile,
+} from "./filesystem";
 
 const connectorId = "11111111-1111-4111-8111-111111111111";
 
@@ -63,5 +77,97 @@ describe("agent directory browsing", () => {
         "/srv/project",
       ),
     ).rejects.toThrow("invalid directory list");
+  });
+});
+
+function runWorkspaceFiles(
+  action: "list" | "read",
+  root: string,
+  requestedPath: string,
+): unknown {
+  return JSON.parse(
+    execFileSync(
+      process.execPath,
+      ["-e", AGENT_WORKSPACE_FILES_SCRIPT, action, root, requestedPath],
+      { encoding: "utf8" },
+    ),
+  ) as unknown;
+}
+
+describe("workspace-confined file browsing", () => {
+  it("lists directories and reads UTF-8 files relative to the workspace", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "overtchat-files-"));
+    mkdirSync(path.join(root, "src"));
+    writeFileSync(path.join(root, "src", "index.ts"), "export const ok = true;\n");
+    mkdirSync(path.join(root, ".git"));
+
+    expect(runWorkspaceFiles("list", root, ".")).toEqual({
+      path: ".",
+      entries: [
+        { name: "src", path: "src", kind: "directory", symlink: false },
+      ],
+      truncated: false,
+    });
+    expect(runWorkspaceFiles("read", root, "src/index.ts")).toMatchObject({
+      path: "src/index.ts",
+      content: "export const ok = true;\n",
+      size: 24,
+    });
+  });
+
+  it("rejects traversal, escaping symlinks, binary files, and oversized files", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "overtchat-files-"));
+    const outside = mkdtempSync(path.join(tmpdir(), "overtchat-outside-"));
+    writeFileSync(path.join(outside, "secret.txt"), "secret");
+    symlinkSync(path.join(outside, "secret.txt"), path.join(root, "escape"));
+    writeFileSync(path.join(root, "binary"), Buffer.from([0, 1, 2]));
+    writeFileSync(path.join(root, "large"), Buffer.alloc(512 * 1024 + 1, 65));
+
+    for (const requestedPath of ["../secret.txt", "escape", "binary", "large"]) {
+      const result = spawnSync(
+        process.execPath,
+        ["-e", AGENT_WORKSPACE_FILES_SCRIPT, "read", root, requestedPath],
+        { encoding: "utf8" },
+      );
+      expect(result.status).toBe(1);
+    }
+  });
+
+  it("normalizes and validates connector responses", async () => {
+    mocks.executeOnHost
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          path: ".",
+          entries: [
+            { name: "src", path: "src", kind: "directory", symlink: false },
+          ],
+          truncated: false,
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          path: "src/index.ts",
+          content: "export {};",
+          size: 10,
+          modifiedAt: 100,
+        }),
+        stderr: "",
+      });
+
+    await expect(
+      listAgentWorkspaceDirectory(
+        { transport: "ssh", alias: "workstation" },
+        "/srv/project",
+        "src",
+      ),
+    ).resolves.toMatchObject({ path: ".", truncated: false });
+    await expect(
+      readAgentWorkspaceFile(
+        { transport: "ssh", alias: "workstation" },
+        "/srv/project",
+        "src/index.ts",
+      ),
+    ).resolves.toMatchObject({ path: "src/index.ts", content: "export {};" });
   });
 });

--- a/packages/agent-runtime/src/runtime/filesystem.test.ts
+++ b/packages/agent-runtime/src/runtime/filesystem.test.ts
@@ -1,12 +1,3 @@
-import { execFileSync, spawnSync } from "node:child_process";
-import {
-  mkdirSync,
-  mkdtempSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -17,14 +8,7 @@ vi.mock("@overtchat/agent-runtime/runtime/process", () => ({
   executeOnHost: mocks.executeOnHost,
 }));
 
-import {
-  AGENT_WORKSPACE_FILES_SCRIPT,
-  listAgentDirectories,
-  listAgentWorkspaceDirectory,
-  readAgentWorkspaceFile,
-} from "./filesystem";
-
-const connectorId = "11111111-1111-4111-8111-111111111111";
+import { listAgentDirectories } from "./filesystem";
 
 describe("agent directory browsing", () => {
   beforeEach(() => {
@@ -77,97 +61,5 @@ describe("agent directory browsing", () => {
         "/srv/project",
       ),
     ).rejects.toThrow("invalid directory list");
-  });
-});
-
-function runWorkspaceFiles(
-  action: "list" | "read",
-  root: string,
-  requestedPath: string,
-): unknown {
-  return JSON.parse(
-    execFileSync(
-      process.execPath,
-      ["-e", AGENT_WORKSPACE_FILES_SCRIPT, action, root, requestedPath],
-      { encoding: "utf8" },
-    ),
-  ) as unknown;
-}
-
-describe("workspace-confined file browsing", () => {
-  it("lists directories and reads UTF-8 files relative to the workspace", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "overtchat-files-"));
-    mkdirSync(path.join(root, "src"));
-    writeFileSync(path.join(root, "src", "index.ts"), "export const ok = true;\n");
-    mkdirSync(path.join(root, ".git"));
-
-    expect(runWorkspaceFiles("list", root, ".")).toEqual({
-      path: ".",
-      entries: [
-        { name: "src", path: "src", kind: "directory", symlink: false },
-      ],
-      truncated: false,
-    });
-    expect(runWorkspaceFiles("read", root, "src/index.ts")).toMatchObject({
-      path: "src/index.ts",
-      content: "export const ok = true;\n",
-      size: 24,
-    });
-  });
-
-  it("rejects traversal, escaping symlinks, binary files, and oversized files", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "overtchat-files-"));
-    const outside = mkdtempSync(path.join(tmpdir(), "overtchat-outside-"));
-    writeFileSync(path.join(outside, "secret.txt"), "secret");
-    symlinkSync(path.join(outside, "secret.txt"), path.join(root, "escape"));
-    writeFileSync(path.join(root, "binary"), Buffer.from([0, 1, 2]));
-    writeFileSync(path.join(root, "large"), Buffer.alloc(512 * 1024 + 1, 65));
-
-    for (const requestedPath of ["../secret.txt", "escape", "binary", "large"]) {
-      const result = spawnSync(
-        process.execPath,
-        ["-e", AGENT_WORKSPACE_FILES_SCRIPT, "read", root, requestedPath],
-        { encoding: "utf8" },
-      );
-      expect(result.status).toBe(1);
-    }
-  });
-
-  it("normalizes and validates connector responses", async () => {
-    mocks.executeOnHost
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          path: ".",
-          entries: [
-            { name: "src", path: "src", kind: "directory", symlink: false },
-          ],
-          truncated: false,
-        }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          path: "src/index.ts",
-          content: "export {};",
-          size: 10,
-          modifiedAt: 100,
-        }),
-        stderr: "",
-      });
-
-    await expect(
-      listAgentWorkspaceDirectory(
-        { transport: "ssh", alias: "workstation" },
-        "/srv/project",
-        "src",
-      ),
-    ).resolves.toMatchObject({ path: ".", truncated: false });
-    await expect(
-      readAgentWorkspaceFile(
-        { transport: "ssh", alias: "workstation" },
-        "/srv/project",
-        "src/index.ts",
-      ),
-    ).resolves.toMatchObject({ path: "src/index.ts", content: "export {};" });
   });
 });

--- a/packages/agent-runtime/src/runtime/filesystem.ts
+++ b/packages/agent-runtime/src/runtime/filesystem.ts
@@ -1,8 +1,4 @@
 import path from "node:path";
-import type {
-  AgentWorkspaceDirectoryListing,
-  AgentWorkspaceFilePreview,
-} from "@overtchat/agent-bridge";
 import {
   executeOnHost,
   type HostTarget,
@@ -46,127 +42,6 @@ process.stdout.write(JSON.stringify({
 }));
 `.trim();
 
-export const AGENT_WORKSPACE_FILES_SCRIPT = `
-const fs = require("node:fs");
-const path = require("node:path");
-
-const MAX_DIRECTORY_ENTRIES = 1000;
-const MAX_PREVIEW_BYTES = 512 * 1024;
-const action = process.argv[1];
-const workspaceRoot = process.argv[2];
-const requestedPath = process.argv[3] || ".";
-
-function fail(message) {
-  throw new Error(message);
-}
-
-function inside(root, candidate) {
-  const relative = path.relative(root, candidate);
-  return relative === "" || (!relative.startsWith(".." + path.sep) && relative !== "..");
-}
-
-function canonicalRoot() {
-  const root = fs.realpathSync(workspaceRoot);
-  if (!fs.statSync(root).isDirectory()) fail("Workspace root is not a directory.");
-  return root;
-}
-
-function resolveTarget(root) {
-  const lexical = path.isAbsolute(requestedPath)
-    ? path.resolve(requestedPath)
-    : path.resolve(root, requestedPath);
-  if (!inside(root, lexical)) fail("Path is outside the workspace.");
-  const resolved = fs.realpathSync(lexical);
-  if (!inside(root, resolved)) fail("Path resolves outside the workspace.");
-  return { lexical, resolved };
-}
-
-function relativePath(root, candidate) {
-  const relative = path.relative(root, candidate);
-  return relative ? relative.split(path.sep).join("/") : ".";
-}
-
-function list(root, target) {
-  if (!fs.statSync(target.resolved).isDirectory()) fail("Path is not a directory.");
-  const names = fs.readdirSync(target.resolved).filter((name) => name !== ".git");
-  const truncated = names.length > MAX_DIRECTORY_ENTRIES;
-  const entries = [];
-  for (const name of names.slice(0, MAX_DIRECTORY_ENTRIES)) {
-    const lexical = path.join(target.lexical, name);
-    const relative = relativePath(root, lexical);
-    try {
-      const linkStat = fs.lstatSync(lexical);
-      const symlink = linkStat.isSymbolicLink();
-      if (!symlink) {
-        entries.push({
-          name,
-          path: relative,
-          kind: linkStat.isDirectory() ? "directory" : linkStat.isFile() ? "file" : "symlink",
-          symlink: false,
-        });
-        continue;
-      }
-      const resolved = fs.realpathSync(lexical);
-      if (!inside(root, resolved)) {
-        entries.push({ name, path: relative, kind: "symlink", symlink: true });
-        continue;
-      }
-      const stat = fs.statSync(resolved);
-      entries.push({
-        name,
-        path: relative,
-        kind: stat.isDirectory() ? "directory" : stat.isFile() ? "file" : "symlink",
-        symlink: true,
-      });
-    } catch {
-      entries.push({ name, path: relative, kind: "symlink", symlink: true });
-    }
-  }
-  entries.sort((left, right) => {
-    const leftDirectory = left.kind === "directory" ? 0 : 1;
-    const rightDirectory = right.kind === "directory" ? 0 : 1;
-    return leftDirectory - rightDirectory || left.name.localeCompare(right.name);
-  });
-  return { path: relativePath(root, target.lexical), entries, truncated };
-}
-
-function read(root, target) {
-  const stat = fs.statSync(target.resolved);
-  if (!stat.isFile()) fail("Path is not a regular file.");
-  if (stat.size > MAX_PREVIEW_BYTES) {
-    fail("File is too large to preview (maximum 512 KB).");
-  }
-  const bytes = fs.readFileSync(target.resolved);
-  if (bytes.includes(0)) fail("Binary files cannot be previewed.");
-  let content;
-  try {
-    content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  } catch {
-    fail("File is not valid UTF-8 text.");
-  }
-  return {
-    path: relativePath(root, target.lexical),
-    content,
-    size: stat.size,
-    modifiedAt: stat.mtimeMs,
-  };
-}
-
-try {
-  const root = canonicalRoot();
-  const target = resolveTarget(root);
-  const result = action === "list"
-    ? list(root, target)
-    : action === "read"
-      ? read(root, target)
-      : fail("Unknown workspace file operation.");
-  process.stdout.write(JSON.stringify(result));
-} catch (error) {
-  process.stderr.write(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-}
-`.trim();
-
 export type ProbedWorkspace = {
   path: string;
   name: string;
@@ -177,42 +52,6 @@ export type ProbedDirectoryListing = {
   parent: string | null;
   directories: Array<{ name: string; path: string }>;
 };
-
-function isWorkspaceDirectoryListing(
-  value: unknown,
-): value is AgentWorkspaceDirectoryListing {
-  if (!value || typeof value !== "object") return false;
-  const entries = Reflect.get(value, "entries");
-  return (
-    typeof Reflect.get(value, "path") === "string" &&
-    typeof Reflect.get(value, "truncated") === "boolean" &&
-    Array.isArray(entries) &&
-    entries.every(
-      (entry) =>
-        entry &&
-        typeof entry === "object" &&
-        typeof Reflect.get(entry, "name") === "string" &&
-        typeof Reflect.get(entry, "path") === "string" &&
-        ["file", "directory", "symlink"].includes(
-          String(Reflect.get(entry, "kind")),
-        ) &&
-        typeof Reflect.get(entry, "symlink") === "boolean",
-    )
-  );
-}
-
-function isWorkspaceFilePreview(
-  value: unknown,
-): value is AgentWorkspaceFilePreview {
-  return Boolean(
-    value &&
-      typeof value === "object" &&
-      typeof Reflect.get(value, "path") === "string" &&
-      typeof Reflect.get(value, "content") === "string" &&
-      typeof Reflect.get(value, "size") === "number" &&
-      typeof Reflect.get(value, "modifiedAt") === "number",
-  );
-}
 
 export async function probeAgentWorkspace(
   target: HostTarget,
@@ -276,48 +115,4 @@ export async function listAgentDirectories(
       path: Reflect.get(entry, "path") as string,
     })),
   };
-}
-
-export async function listAgentWorkspaceDirectory(
-  target: HostTarget,
-  workspaceRoot: string,
-  directoryPath: string,
-): Promise<AgentWorkspaceDirectoryListing> {
-  const result = await executeOnHost(target, {
-    command: "node",
-    args: [
-      "-e",
-      AGENT_WORKSPACE_FILES_SCRIPT,
-      "list",
-      workspaceRoot,
-      directoryPath,
-    ],
-  });
-  const parsed = JSON.parse(result.stdout) as unknown;
-  if (!isWorkspaceDirectoryListing(parsed)) {
-    throw new Error("The remote machine returned an invalid workspace directory.");
-  }
-  return parsed;
-}
-
-export async function readAgentWorkspaceFile(
-  target: HostTarget,
-  workspaceRoot: string,
-  filePath: string,
-): Promise<AgentWorkspaceFilePreview> {
-  const result = await executeOnHost(target, {
-    command: "node",
-    args: [
-      "-e",
-      AGENT_WORKSPACE_FILES_SCRIPT,
-      "read",
-      workspaceRoot,
-      filePath,
-    ],
-  });
-  const parsed = JSON.parse(result.stdout) as unknown;
-  if (!isWorkspaceFilePreview(parsed)) {
-    throw new Error("The remote machine returned an invalid workspace file.");
-  }
-  return parsed;
 }

--- a/packages/agent-runtime/src/runtime/filesystem.ts
+++ b/packages/agent-runtime/src/runtime/filesystem.ts
@@ -1,4 +1,8 @@
 import path from "node:path";
+import type {
+  AgentWorkspaceDirectoryListing,
+  AgentWorkspaceFilePreview,
+} from "@overtchat/agent-bridge";
 import {
   executeOnHost,
   type HostTarget,
@@ -42,6 +46,127 @@ process.stdout.write(JSON.stringify({
 }));
 `.trim();
 
+export const AGENT_WORKSPACE_FILES_SCRIPT = `
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MAX_DIRECTORY_ENTRIES = 1000;
+const MAX_PREVIEW_BYTES = 512 * 1024;
+const action = process.argv[1];
+const workspaceRoot = process.argv[2];
+const requestedPath = process.argv[3] || ".";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function inside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(".." + path.sep) && relative !== "..");
+}
+
+function canonicalRoot() {
+  const root = fs.realpathSync(workspaceRoot);
+  if (!fs.statSync(root).isDirectory()) fail("Workspace root is not a directory.");
+  return root;
+}
+
+function resolveTarget(root) {
+  const lexical = path.isAbsolute(requestedPath)
+    ? path.resolve(requestedPath)
+    : path.resolve(root, requestedPath);
+  if (!inside(root, lexical)) fail("Path is outside the workspace.");
+  const resolved = fs.realpathSync(lexical);
+  if (!inside(root, resolved)) fail("Path resolves outside the workspace.");
+  return { lexical, resolved };
+}
+
+function relativePath(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative ? relative.split(path.sep).join("/") : ".";
+}
+
+function list(root, target) {
+  if (!fs.statSync(target.resolved).isDirectory()) fail("Path is not a directory.");
+  const names = fs.readdirSync(target.resolved).filter((name) => name !== ".git");
+  const truncated = names.length > MAX_DIRECTORY_ENTRIES;
+  const entries = [];
+  for (const name of names.slice(0, MAX_DIRECTORY_ENTRIES)) {
+    const lexical = path.join(target.lexical, name);
+    const relative = relativePath(root, lexical);
+    try {
+      const linkStat = fs.lstatSync(lexical);
+      const symlink = linkStat.isSymbolicLink();
+      if (!symlink) {
+        entries.push({
+          name,
+          path: relative,
+          kind: linkStat.isDirectory() ? "directory" : linkStat.isFile() ? "file" : "symlink",
+          symlink: false,
+        });
+        continue;
+      }
+      const resolved = fs.realpathSync(lexical);
+      if (!inside(root, resolved)) {
+        entries.push({ name, path: relative, kind: "symlink", symlink: true });
+        continue;
+      }
+      const stat = fs.statSync(resolved);
+      entries.push({
+        name,
+        path: relative,
+        kind: stat.isDirectory() ? "directory" : stat.isFile() ? "file" : "symlink",
+        symlink: true,
+      });
+    } catch {
+      entries.push({ name, path: relative, kind: "symlink", symlink: true });
+    }
+  }
+  entries.sort((left, right) => {
+    const leftDirectory = left.kind === "directory" ? 0 : 1;
+    const rightDirectory = right.kind === "directory" ? 0 : 1;
+    return leftDirectory - rightDirectory || left.name.localeCompare(right.name);
+  });
+  return { path: relativePath(root, target.lexical), entries, truncated };
+}
+
+function read(root, target) {
+  const stat = fs.statSync(target.resolved);
+  if (!stat.isFile()) fail("Path is not a regular file.");
+  if (stat.size > MAX_PREVIEW_BYTES) {
+    fail("File is too large to preview (maximum 512 KB).");
+  }
+  const bytes = fs.readFileSync(target.resolved);
+  if (bytes.includes(0)) fail("Binary files cannot be previewed.");
+  let content;
+  try {
+    content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail("File is not valid UTF-8 text.");
+  }
+  return {
+    path: relativePath(root, target.lexical),
+    content,
+    size: stat.size,
+    modifiedAt: stat.mtimeMs,
+  };
+}
+
+try {
+  const root = canonicalRoot();
+  const target = resolveTarget(root);
+  const result = action === "list"
+    ? list(root, target)
+    : action === "read"
+      ? read(root, target)
+      : fail("Unknown workspace file operation.");
+  process.stdout.write(JSON.stringify(result));
+} catch (error) {
+  process.stderr.write(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+`.trim();
+
 export type ProbedWorkspace = {
   path: string;
   name: string;
@@ -52,6 +177,42 @@ export type ProbedDirectoryListing = {
   parent: string | null;
   directories: Array<{ name: string; path: string }>;
 };
+
+function isWorkspaceDirectoryListing(
+  value: unknown,
+): value is AgentWorkspaceDirectoryListing {
+  if (!value || typeof value !== "object") return false;
+  const entries = Reflect.get(value, "entries");
+  return (
+    typeof Reflect.get(value, "path") === "string" &&
+    typeof Reflect.get(value, "truncated") === "boolean" &&
+    Array.isArray(entries) &&
+    entries.every(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        typeof Reflect.get(entry, "name") === "string" &&
+        typeof Reflect.get(entry, "path") === "string" &&
+        ["file", "directory", "symlink"].includes(
+          String(Reflect.get(entry, "kind")),
+        ) &&
+        typeof Reflect.get(entry, "symlink") === "boolean",
+    )
+  );
+}
+
+function isWorkspaceFilePreview(
+  value: unknown,
+): value is AgentWorkspaceFilePreview {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      typeof Reflect.get(value, "path") === "string" &&
+      typeof Reflect.get(value, "content") === "string" &&
+      typeof Reflect.get(value, "size") === "number" &&
+      typeof Reflect.get(value, "modifiedAt") === "number",
+  );
+}
 
 export async function probeAgentWorkspace(
   target: HostTarget,
@@ -115,4 +276,48 @@ export async function listAgentDirectories(
       path: Reflect.get(entry, "path") as string,
     })),
   };
+}
+
+export async function listAgentWorkspaceDirectory(
+  target: HostTarget,
+  workspaceRoot: string,
+  directoryPath: string,
+): Promise<AgentWorkspaceDirectoryListing> {
+  const result = await executeOnHost(target, {
+    command: "node",
+    args: [
+      "-e",
+      AGENT_WORKSPACE_FILES_SCRIPT,
+      "list",
+      workspaceRoot,
+      directoryPath,
+    ],
+  });
+  const parsed = JSON.parse(result.stdout) as unknown;
+  if (!isWorkspaceDirectoryListing(parsed)) {
+    throw new Error("The remote machine returned an invalid workspace directory.");
+  }
+  return parsed;
+}
+
+export async function readAgentWorkspaceFile(
+  target: HostTarget,
+  workspaceRoot: string,
+  filePath: string,
+): Promise<AgentWorkspaceFilePreview> {
+  const result = await executeOnHost(target, {
+    command: "node",
+    args: [
+      "-e",
+      AGENT_WORKSPACE_FILES_SCRIPT,
+      "read",
+      workspaceRoot,
+      filePath,
+    ],
+  });
+  const parsed = JSON.parse(result.stdout) as unknown;
+  if (!isWorkspaceFilePreview(parsed)) {
+    throw new Error("The remote machine returned an invalid workspace file.");
+  }
+  return parsed;
 }

--- a/packages/agent-runtime/src/runtime/git.test.ts
+++ b/packages/agent-runtime/src/runtime/git.test.ts
@@ -72,6 +72,20 @@ describe("agent workspace Git status", () => {
       additions: 4,
       deletions: 1,
       lineStatsComplete: true,
+      files: expect.arrayContaining([
+        {
+          path: "tracked.txt",
+          originalPath: null,
+          indexStatus: null,
+          worktreeStatus: "M",
+        },
+        {
+          path: "new.txt",
+          originalPath: null,
+          indexStatus: null,
+          worktreeStatus: "?",
+        },
+      ]),
     });
   });
 
@@ -124,6 +138,14 @@ describe("agent workspace Git status", () => {
         additions: 12,
         deletions: 4,
         lineStatsComplete: true,
+        files: [
+          {
+            path: "src/index.ts",
+            originalPath: null,
+            indexStatus: null,
+            worktreeStatus: "M",
+          },
+        ],
       }),
       stderr: "",
     });
@@ -145,6 +167,14 @@ describe("agent workspace Git status", () => {
       additions: 12,
       deletions: 4,
       lineStatsComplete: true,
+      files: [
+        {
+          path: "src/index.ts",
+          originalPath: null,
+          indexStatus: null,
+          worktreeStatus: "M",
+        },
+      ],
     });
     expect(mocks.executeOnHost).toHaveBeenCalledWith(
       { transport: "local" },

--- a/packages/agent-runtime/src/runtime/git.ts
+++ b/packages/agent-runtime/src/runtime/git.ts
@@ -43,6 +43,22 @@ function parseStatus(value) {
   let initial = false;
   let changedFiles = 0;
   const untrackedPaths = [];
+  const files = [];
+
+  function statusValue(value) {
+    return value && value !== "." && value !== " " ? value : null;
+  }
+
+  function trackedFile(record, fieldCount, originalPath = null) {
+    const fields = record.split(" ");
+    const xy = fields[1] || "..";
+    return {
+      path: fields.slice(fieldCount).join(" "),
+      originalPath,
+      indexStatus: statusValue(xy[0]),
+      worktreeStatus: statusValue(xy[1]),
+    };
+  }
 
   for (let index = 0; index < records.length; index += 1) {
     const record = records[index];
@@ -70,18 +86,31 @@ function parseStatus(value) {
     }
     if (record.startsWith("2 ")) {
       changedFiles += 1;
+      const originalPath = records[index + 1] || null;
+      files.push(trackedFile(record, 9, originalPath));
       index += 1;
       continue;
     }
-    if (
-      record.startsWith("1 ") ||
-      record.startsWith("u ") ||
-      record.startsWith("? ")
-    ) {
+    if (record.startsWith("1 ")) {
       changedFiles += 1;
-      if (record.startsWith("? ")) {
-        untrackedPaths.push(record.slice(2));
-      }
+      files.push(trackedFile(record, 8));
+      continue;
+    }
+    if (record.startsWith("u ")) {
+      changedFiles += 1;
+      files.push(trackedFile(record, 10));
+      continue;
+    }
+    if (record.startsWith("? ")) {
+      changedFiles += 1;
+      const filePath = record.slice(2);
+      untrackedPaths.push(filePath);
+      files.push({
+        path: filePath,
+        originalPath: null,
+        indexStatus: null,
+        worktreeStatus: "?",
+      });
     }
   }
 
@@ -93,6 +122,7 @@ function parseStatus(value) {
     initial,
     changedFiles,
     untrackedPaths,
+    files,
   };
 }
 
@@ -190,6 +220,17 @@ try {
     throw error;
   }
 
+  const workspacePrefix = path
+    .relative(repositoryRoot, process.cwd())
+    .split(path.sep)
+    .join("/");
+  const workspacePathspec = workspacePrefix || ".";
+  const scopedPath = (filePath) => {
+    if (!workspacePrefix) return filePath;
+    const prefix = workspacePrefix + "/";
+    return filePath.startsWith(prefix) ? filePath.slice(prefix.length) : null;
+  };
+
   const rawStatus = runGit(
     [
       "status",
@@ -197,17 +238,31 @@ try {
       "--branch",
       "-z",
       "--untracked-files=all",
+      "--",
+      workspacePathspec,
     ],
     repositoryRoot,
   );
   const status = parseStatus(rawStatus);
+  status.files = status.files.flatMap((file) => {
+    const filePath = scopedPath(file.path);
+    if (filePath === null) return [];
+    const originalPath = file.originalPath === null
+      ? null
+      : scopedPath(file.originalPath);
+    return [{ ...file, path: filePath, originalPath }];
+  });
+  status.changedFiles = status.files.length;
   const rawNumstat = status.initial
     ? ""
-    : runGit(["diff", "--numstat", "-z", "HEAD", "--"], repositoryRoot);
+    : runGit(
+        ["diff", "--numstat", "-z", "HEAD", "--", workspacePathspec],
+        repositoryRoot,
+      );
   const numstat = parseNumstat(rawNumstat);
   const supplementalPaths = status.initial
     ? runGit(
-        ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        ["ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", workspacePathspec],
         repositoryRoot,
       )
         .split("\\0")
@@ -226,6 +281,7 @@ try {
     additions: numstat.additions + supplemental.additions,
     deletions: numstat.deletions,
     lineStatsComplete: numstat.complete && supplemental.complete,
+    files: status.files,
   });
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
@@ -272,6 +328,7 @@ function parseGitProbe(value: unknown): AgentWorkspaceGitStatus {
       additions: 0,
       deletions: 0,
       lineStatsComplete: true,
+      files: [],
     };
   }
 
@@ -284,6 +341,7 @@ function parseGitProbe(value: unknown): AgentWorkspaceGitStatus {
   const additions = Reflect.get(value, "additions");
   const deletions = Reflect.get(value, "deletions");
   const lineStatsComplete = Reflect.get(value, "lineStatsComplete");
+  const files = Reflect.get(value, "files");
   if (
     Reflect.get(value, "isGit") !== true ||
     typeof repositoryRoot !== "string" ||
@@ -295,7 +353,17 @@ function parseGitProbe(value: unknown): AgentWorkspaceGitStatus {
     !isCount(changedFiles) ||
     !isCount(additions) ||
     !isCount(deletions) ||
-    typeof lineStatsComplete !== "boolean"
+    typeof lineStatsComplete !== "boolean" ||
+    !Array.isArray(files) ||
+    !files.every(
+      (file) =>
+        file &&
+        typeof file === "object" &&
+        typeof Reflect.get(file, "path") === "string" &&
+        isNullableString(Reflect.get(file, "originalPath")) &&
+        isNullableString(Reflect.get(file, "indexStatus")) &&
+        isNullableString(Reflect.get(file, "worktreeStatus")),
+    )
   ) {
     throw new Error("The remote machine returned invalid Git metadata.");
   }
@@ -312,6 +380,12 @@ function parseGitProbe(value: unknown): AgentWorkspaceGitStatus {
     additions,
     deletions,
     lineStatsComplete,
+    files: files.map((file) => ({
+      path: Reflect.get(file, "path") as string,
+      originalPath: Reflect.get(file, "originalPath") as string | null,
+      indexStatus: Reflect.get(file, "indexStatus") as string | null,
+      worktreeStatus: Reflect.get(file, "worktreeStatus") as string | null,
+    })),
   };
 }
 

--- a/packages/agent-runtime/src/runtime/workspace-files.test.ts
+++ b/packages/agent-runtime/src/runtime/workspace-files.test.ts
@@ -101,6 +101,31 @@ describe("workspace-confined file service", () => {
     expect(listing.entries.some((entry) => entry.name === "zzzz-last")).toBe(false);
   });
 
+  it("marks only visible Git-ignored entries without enumerating ignored trees", () => {
+    const root = temporaryDirectory("overtchat-files-ignored-");
+    execFileSync("git", ["init", "--quiet", root]);
+    writeFileSync(path.join(root, ".gitignore"), "*.log\ncache/\n");
+    writeFileSync(path.join(root, "kept.ts"), "export {};\n");
+    writeFileSync(path.join(root, "debug.log"), "ignored\n");
+    writeFileSync(path.join(root, "tracked.log"), "tracked despite the pattern\n");
+    execFileSync("git", ["-C", root, "add", "-f", "tracked.log"]);
+    mkdirSync(path.join(root, "cache"));
+    writeFileSync(path.join(root, "cache", "artifact.txt"), "ignored\n");
+
+    const listing = runWorkspaceFiles("list", root, ".") as {
+      entries: Array<{ name: string; ignored?: boolean }>;
+    };
+
+    expect(listing.entries.find((entry) => entry.name === "debug.log")).toMatchObject({
+      ignored: true,
+    });
+    expect(listing.entries.find((entry) => entry.name === "cache")).toMatchObject({
+      ignored: true,
+    });
+    expect(listing.entries.find((entry) => entry.name === "kept.ts")?.ignored).toBeUndefined();
+    expect(listing.entries.find((entry) => entry.name === "tracked.log")?.ignored).toBeUndefined();
+  });
+
   it("rejects traversal, escaping symlinks, binary data, invalid UTF-8, and large files", () => {
     const root = temporaryDirectory("overtchat-files-");
     const outside = temporaryDirectory("overtchat-outside-");

--- a/packages/agent-runtime/src/runtime/workspace-files.test.ts
+++ b/packages/agent-runtime/src/runtime/workspace-files.test.ts
@@ -1,0 +1,213 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  executeOnHost: vi.fn(),
+}));
+
+vi.mock("@overtchat/agent-runtime/runtime/process", () => ({
+  executeOnHost: mocks.executeOnHost,
+}));
+
+import {
+  AGENT_WORKSPACE_FILES_SCRIPT,
+  workspaceFilesService,
+} from "./workspace-files";
+
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(path.join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function runWorkspaceFiles(
+  action: "list" | "read",
+  root: string,
+  requestedPath: string,
+): unknown {
+  return JSON.parse(
+    execFileSync(
+      process.execPath,
+      ["-e", AGENT_WORKSPACE_FILES_SCRIPT, action, root, requestedPath],
+      { encoding: "utf8" },
+    ),
+  ) as unknown;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("workspace-confined file service", () => {
+  it("lists directories and reads typed UTF-8 text payloads", () => {
+    const root = temporaryDirectory("overtchat-files-");
+    mkdirSync(path.join(root, "src"));
+    writeFileSync(path.join(root, "src", "index.ts"), "export const ok = true;\n");
+    mkdirSync(path.join(root, ".git"));
+
+    expect(runWorkspaceFiles("list", root, ".")).toEqual({
+      path: ".",
+      entries: [
+        { name: "src", path: "src", kind: "directory", symlink: false },
+      ],
+      truncated: false,
+    });
+    expect(runWorkspaceFiles("read", root, "src/index.ts")).toMatchObject({
+      kind: "text",
+      encoding: "utf-8",
+      path: "src/index.ts",
+      content: "export const ok = true;\n",
+      size: 24,
+    });
+  });
+
+  it("sorts the complete directory before applying its deterministic limit", () => {
+    const root = temporaryDirectory("overtchat-files-limit-");
+    mkdirSync(path.join(root, "aaa-directory"));
+    for (let index = 0; index < 1_000; index += 1) {
+      writeFileSync(
+        path.join(root, `file-${String(index).padStart(4, "0")}`),
+        "",
+      );
+    }
+    writeFileSync(path.join(root, "zzzz-last"), "");
+
+    const listing = runWorkspaceFiles("list", root, ".") as {
+      entries: Array<{ name: string }>;
+      truncated: boolean;
+    };
+
+    expect(listing.truncated).toBe(true);
+    expect(listing.entries).toHaveLength(1_000);
+    expect(listing.entries[0]?.name).toBe("aaa-directory");
+    expect(listing.entries.some((entry) => entry.name === "file-0000")).toBe(true);
+    expect(listing.entries.some((entry) => entry.name === "zzzz-last")).toBe(false);
+  });
+
+  it("rejects traversal, escaping symlinks, binary data, invalid UTF-8, and large files", () => {
+    const root = temporaryDirectory("overtchat-files-");
+    const outside = temporaryDirectory("overtchat-outside-");
+    writeFileSync(path.join(outside, "secret.txt"), "secret");
+    symlinkSync(path.join(outside, "secret.txt"), path.join(root, "escape"));
+    writeFileSync(path.join(root, "binary"), Buffer.from([0, 1, 2]));
+    writeFileSync(path.join(root, "invalid-utf8"), Buffer.from([0xc3, 0x28]));
+    writeFileSync(path.join(root, "large"), Buffer.alloc(512 * 1024 + 1, 65));
+
+    for (const requestedPath of [
+      "../secret.txt",
+      "escape",
+      "binary",
+      "invalid-utf8",
+      "large",
+    ]) {
+      const result = spawnSync(
+        process.execPath,
+        ["-e", AGENT_WORKSPACE_FILES_SCRIPT, "read", root, requestedPath],
+        { encoding: "utf8" },
+      );
+      expect(result.status, requestedPath).toBe(1);
+    }
+  });
+
+  it("uses one typed service boundary for local and SSH host execution", async () => {
+    mocks.executeOnHost
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          path: ".",
+          entries: [
+            { name: "src", path: "src", kind: "directory", symlink: false },
+          ],
+          truncated: false,
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          kind: "text",
+          encoding: "utf-8",
+          path: "src/index.ts",
+          content: "export {};",
+          size: 10,
+          modifiedAt: 100,
+        }),
+        stderr: "",
+      });
+
+    await expect(
+      workspaceFilesService.listDirectory(
+        { transport: "ssh", alias: "workstation" },
+        "/srv/project",
+        "src",
+      ),
+    ).resolves.toMatchObject({ path: ".", truncated: false });
+    await expect(
+      workspaceFilesService.readFile(
+        { transport: "local" },
+        "/srv/project",
+        "src/index.ts",
+      ),
+    ).resolves.toMatchObject({
+      kind: "text",
+      encoding: "utf-8",
+      path: "src/index.ts",
+      content: "export {};",
+    });
+    expect(mocks.executeOnHost).toHaveBeenNthCalledWith(
+      1,
+      { transport: "ssh", alias: "workstation" },
+      expect.objectContaining({
+        command: "node",
+        args: expect.arrayContaining(["list", "/srv/project", "src"]),
+      }),
+    );
+    expect(mocks.executeOnHost).toHaveBeenNthCalledWith(
+      2,
+      { transport: "local" },
+      expect.objectContaining({
+        command: "node",
+        args: expect.arrayContaining([
+          "read",
+          "/srv/project",
+          "src/index.ts",
+        ]),
+      }),
+    );
+  });
+
+  it("rejects malformed host responses at the service boundary", async () => {
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: JSON.stringify({
+        path: "README.md",
+        content: "missing kind and encoding",
+        size: 25,
+        modifiedAt: 100,
+      }),
+      stderr: "",
+    });
+
+    await expect(
+      workspaceFilesService.readFile(
+        { transport: "local" },
+        "/srv/project",
+        "README.md",
+      ),
+    ).rejects.toThrow("invalid workspace file");
+  });
+});

--- a/packages/agent-runtime/src/runtime/workspace-files.ts
+++ b/packages/agent-runtime/src/runtime/workspace-files.ts
@@ -15,9 +15,11 @@ const INVALID_FILE_MESSAGE =
 export const AGENT_WORKSPACE_FILES_SCRIPT = `
 const fs = require("node:fs");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 
 const MAX_DIRECTORY_ENTRIES = 1000;
 const MAX_PREVIEW_BYTES = 512 * 1024;
+const MAX_GIT_OUTPUT_BYTES = 1024 * 1024;
 const READ_FLAGS = process.platform === "win32"
   ? fs.constants.O_RDONLY
   : fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW;
@@ -53,6 +55,20 @@ function resolveTarget(root) {
 function relativePath(root, candidate) {
   const relative = path.relative(root, candidate);
   return relative ? relative.split(path.sep).join("/") : ".";
+}
+
+function ignoredPaths(root, entries) {
+  if (entries.length === 0) return new Set();
+  const result = spawnSync("git", ["check-ignore", "-z", "--stdin"], {
+    cwd: root,
+    input: entries.map((entry) => entry.path).join("\\0") + "\\0",
+    encoding: "utf8",
+    maxBuffer: MAX_GIT_OUTPUT_BYTES,
+  });
+  if (result.error || (result.status !== 0 && result.status !== 1)) {
+    return new Set();
+  }
+  return new Set(String(result.stdout || "").split("\\0").filter(Boolean));
 }
 
 function list(root, target) {
@@ -95,9 +111,13 @@ function list(root, target) {
     const rightDirectory = right.kind === "directory" ? 0 : 1;
     return leftDirectory - rightDirectory || left.name.localeCompare(right.name);
   });
+  const visibleEntries = entries.slice(0, MAX_DIRECTORY_ENTRIES);
+  const ignored = ignoredPaths(root, visibleEntries);
   return {
     path: relativePath(root, target.lexical),
-    entries: entries.slice(0, MAX_DIRECTORY_ENTRIES),
+    entries: visibleEntries.map((entry) =>
+      ignored.has(entry.path) ? { ...entry, ignored: true } : entry
+    ),
     truncated: entries.length > MAX_DIRECTORY_ENTRIES,
   };
 }
@@ -173,7 +193,9 @@ function isWorkspaceDirectoryListing(
         ["file", "directory", "symlink"].includes(
           String(Reflect.get(entry, "kind")),
         ) &&
-        typeof Reflect.get(entry, "symlink") === "boolean",
+        typeof Reflect.get(entry, "symlink") === "boolean" &&
+        (Reflect.get(entry, "ignored") === undefined ||
+          typeof Reflect.get(entry, "ignored") === "boolean"),
     )
   );
 }

--- a/packages/agent-runtime/src/runtime/workspace-files.ts
+++ b/packages/agent-runtime/src/runtime/workspace-files.ts
@@ -1,0 +1,265 @@
+import type {
+  AgentWorkspaceDirectoryListing,
+  AgentWorkspaceFilePreview,
+} from "@overtchat/agent-bridge";
+import {
+  executeOnHost,
+  type HostTarget,
+} from "@overtchat/agent-runtime/runtime/process";
+
+const INVALID_DIRECTORY_MESSAGE =
+  "The remote machine returned an invalid workspace directory.";
+const INVALID_FILE_MESSAGE =
+  "The remote machine returned an invalid workspace file.";
+
+export const AGENT_WORKSPACE_FILES_SCRIPT = `
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MAX_DIRECTORY_ENTRIES = 1000;
+const MAX_PREVIEW_BYTES = 512 * 1024;
+const READ_FLAGS = process.platform === "win32"
+  ? fs.constants.O_RDONLY
+  : fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW;
+const action = process.argv[1];
+const workspaceRoot = process.argv[2];
+const requestedPath = process.argv[3] || ".";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function inside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(".." + path.sep) && relative !== "..");
+}
+
+function canonicalRoot() {
+  const root = fs.realpathSync(workspaceRoot);
+  if (!fs.statSync(root).isDirectory()) fail("Workspace root is not a directory.");
+  return root;
+}
+
+function resolveTarget(root) {
+  const lexical = path.isAbsolute(requestedPath)
+    ? path.resolve(requestedPath)
+    : path.resolve(root, requestedPath);
+  if (!inside(root, lexical)) fail("Path is outside the workspace.");
+  const resolved = fs.realpathSync(lexical);
+  if (!inside(root, resolved)) fail("Path resolves outside the workspace.");
+  return { lexical, resolved };
+}
+
+function relativePath(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative ? relative.split(path.sep).join("/") : ".";
+}
+
+function list(root, target) {
+  if (!fs.statSync(target.resolved).isDirectory()) fail("Path is not a directory.");
+  const names = fs.readdirSync(target.resolved).filter((name) => name !== ".git");
+  const entries = [];
+  for (const name of names) {
+    const lexical = path.join(target.lexical, name);
+    const relative = relativePath(root, lexical);
+    try {
+      const linkStat = fs.lstatSync(lexical);
+      const symlink = linkStat.isSymbolicLink();
+      if (!symlink) {
+        entries.push({
+          name,
+          path: relative,
+          kind: linkStat.isDirectory() ? "directory" : linkStat.isFile() ? "file" : "symlink",
+          symlink: false,
+        });
+        continue;
+      }
+      const resolved = fs.realpathSync(lexical);
+      if (!inside(root, resolved)) {
+        entries.push({ name, path: relative, kind: "symlink", symlink: true });
+        continue;
+      }
+      const stat = fs.statSync(resolved);
+      entries.push({
+        name,
+        path: relative,
+        kind: stat.isDirectory() ? "directory" : stat.isFile() ? "file" : "symlink",
+        symlink: true,
+      });
+    } catch {
+      entries.push({ name, path: relative, kind: "symlink", symlink: true });
+    }
+  }
+  entries.sort((left, right) => {
+    const leftDirectory = left.kind === "directory" ? 0 : 1;
+    const rightDirectory = right.kind === "directory" ? 0 : 1;
+    return leftDirectory - rightDirectory || left.name.localeCompare(right.name);
+  });
+  return {
+    path: relativePath(root, target.lexical),
+    entries: entries.slice(0, MAX_DIRECTORY_ENTRIES),
+    truncated: entries.length > MAX_DIRECTORY_ENTRIES,
+  };
+}
+
+function read(root, target) {
+  let descriptor;
+  try {
+    descriptor = fs.openSync(target.resolved, READ_FLAGS);
+    const before = fs.fstatSync(descriptor);
+    if (!before.isFile()) fail("Path is not a regular file.");
+    if (before.size > MAX_PREVIEW_BYTES) {
+      fail("File is too large to preview (maximum 512 KB).");
+    }
+    const bytes = fs.readFileSync(descriptor);
+    const after = fs.fstatSync(descriptor);
+    if (
+      bytes.length !== before.size ||
+      after.size !== before.size ||
+      after.mtimeMs !== before.mtimeMs
+    ) {
+      fail("File changed while it was being read.");
+    }
+    if (bytes.includes(0)) fail("Binary files cannot be previewed.");
+    let content;
+    try {
+      content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch {
+      fail("File is not valid UTF-8 text.");
+    }
+    return {
+      kind: "text",
+      encoding: "utf-8",
+      path: relativePath(root, target.lexical),
+      content,
+      size: after.size,
+      modifiedAt: after.mtimeMs,
+    };
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+try {
+  const root = canonicalRoot();
+  const target = resolveTarget(root);
+  const result = action === "list"
+    ? list(root, target)
+    : action === "read"
+      ? read(root, target)
+      : fail("Unknown workspace file operation.");
+  process.stdout.write(JSON.stringify(result));
+} catch (error) {
+  process.stderr.write(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+`.trim();
+
+function isWorkspaceDirectoryListing(
+  value: unknown,
+): value is AgentWorkspaceDirectoryListing {
+  if (!value || typeof value !== "object") return false;
+  const entries = Reflect.get(value, "entries");
+  return (
+    typeof Reflect.get(value, "path") === "string" &&
+    typeof Reflect.get(value, "truncated") === "boolean" &&
+    Array.isArray(entries) &&
+    entries.every(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        typeof Reflect.get(entry, "name") === "string" &&
+        typeof Reflect.get(entry, "path") === "string" &&
+        ["file", "directory", "symlink"].includes(
+          String(Reflect.get(entry, "kind")),
+        ) &&
+        typeof Reflect.get(entry, "symlink") === "boolean",
+    )
+  );
+}
+
+function isWorkspaceFilePreview(
+  value: unknown,
+): value is AgentWorkspaceFilePreview {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      Reflect.get(value, "kind") === "text" &&
+      Reflect.get(value, "encoding") === "utf-8" &&
+      typeof Reflect.get(value, "path") === "string" &&
+      typeof Reflect.get(value, "content") === "string" &&
+      typeof Reflect.get(value, "size") === "number" &&
+      typeof Reflect.get(value, "modifiedAt") === "number",
+  );
+}
+
+async function executeWorkspaceFilesRequest(
+  target: HostTarget,
+  action: "list" | "read",
+  workspaceRoot: string,
+  requestedPath: string,
+): Promise<unknown> {
+  const result = await executeOnHost(target, {
+    command: "node",
+    args: [
+      "-e",
+      AGENT_WORKSPACE_FILES_SCRIPT,
+      action,
+      workspaceRoot,
+      requestedPath,
+    ],
+  });
+  return JSON.parse(result.stdout) as unknown;
+}
+
+export interface WorkspaceFilesService {
+  listDirectory(
+    target: HostTarget,
+    workspaceRoot: string,
+    directoryPath: string,
+  ): Promise<AgentWorkspaceDirectoryListing>;
+  readFile(
+    target: HostTarget,
+    workspaceRoot: string,
+    filePath: string,
+  ): Promise<AgentWorkspaceFilePreview>;
+}
+
+class HostWorkspaceFilesService implements WorkspaceFilesService {
+  async listDirectory(
+    target: HostTarget,
+    workspaceRoot: string,
+    directoryPath: string,
+  ): Promise<AgentWorkspaceDirectoryListing> {
+    const parsed = await executeWorkspaceFilesRequest(
+      target,
+      "list",
+      workspaceRoot,
+      directoryPath,
+    );
+    if (!isWorkspaceDirectoryListing(parsed)) {
+      throw new Error(INVALID_DIRECTORY_MESSAGE);
+    }
+    return parsed;
+  }
+
+  async readFile(
+    target: HostTarget,
+    workspaceRoot: string,
+    filePath: string,
+  ): Promise<AgentWorkspaceFilePreview> {
+    const parsed = await executeWorkspaceFilesRequest(
+      target,
+      "read",
+      workspaceRoot,
+      filePath,
+    );
+    if (!isWorkspaceFilePreview(parsed)) {
+      throw new Error(INVALID_FILE_MESSAGE);
+    }
+    return parsed;
+  }
+}
+
+export const workspaceFilesService: WorkspaceFilesService =
+  new HostWorkspaceFilesService();


### PR DESCRIPTION
## Summary

- add a read-only workspace browser for Agent Connections
- show Git changes and a lazy file tree with familiar status decorations
- preview syntax-highlighted text files in persistent, closable tabs
- open workspace file references from agent transcripts at the referenced line
- support local and SSH-backed workspaces

## Behavior

- resizable desktop pane and responsive mobile overlay
- persistent open tabs, active file, and pane width
- Git status colors for changed and ignored files
- manual directory refresh and live refresh for the active file while an agent runs
- workspace-confined reads with binary and oversized-file safeguards

## Validation

- lint and typechecks
- agent bridge, runtime, connector, and web test suites
- connector and web production builds
- focused Playwright coverage for browsing, tabs, resizing, themes, refresh behavior, Git decorations, and mobile layout