### PR TITLE
feat(agents): add workspace terminal

### DIFF
--- a/.github/workflows/connector-release.yml
+++ b/.github/workflows/connector-release.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        with:
+          platforms: arm64
+
       - name: Build Linux binaries
         run: |
           mkdir -p dist/connector-release
@@ -76,6 +80,11 @@ jobs:
             --compile \
             --target=bun-linux-arm64 \
             --outfile dist/connector-release/overtchat-connector-linux-arm64
+          dist/connector-release/overtchat-connector-linux-amd64 terminal-smoke
+          docker run --rm --platform linux/arm64 \
+            --volume "$PWD/dist/connector-release/overtchat-connector-linux-arm64:/usr/local/bin/overtchat-connector:ro" \
+            debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171 \
+            /usr/local/bin/overtchat-connector terminal-smoke
           cp scripts/install-connector.sh dist/connector-release/
           (
             cd dist/connector-release

--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -8,15 +8,18 @@
   },
   "scripts": {
     "dev": "tsx src/cli.ts",
-    "build": "esbuild src/cli.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/overtchat-connector.mjs",
+    "build": "esbuild src/cli.ts --bundle --platform=node --target=node22 --format=esm --external:node-pty --external:node-pty/* --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\" --outfile=dist/overtchat-connector.mjs",
     "build:binary": "bun build src/cli.ts --compile --outfile dist/overtchat-connector",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
+    "@xterm/addon-serialize": "0.14.0",
+    "@xterm/headless": "6.0.0",
     "@overtchat/agent-bridge": "*",
-    "@overtchat/agent-runtime": "*"
+    "@overtchat/agent-runtime": "*",
+    "node-pty": "1.2.0-beta.15"
   },
   "devDependencies": {
     "@eslint/js": "^9",

--- a/apps/connector/src/cli.ts
+++ b/apps/connector/src/cli.ts
@@ -11,6 +11,7 @@ import {
   installUserService,
 } from "./service.js";
 import { CONNECTOR_VERSION } from "./version.js";
+import { runConnectorTerminalSmoke } from "./terminal.js";
 
 type ParsedArgs = {
   command: string;
@@ -187,9 +188,16 @@ async function main(): Promise<void> {
       }
       console.log(CONNECTOR_VERSION);
       return;
+    case "terminal-smoke":
+      if (parsed.values.size > 0) {
+        throw new Error("The terminal-smoke command does not accept arguments.");
+      }
+      await runConnectorTerminalSmoke();
+      console.log("Terminal PTY smoke test passed.");
+      return;
     default:
       throw new Error(
-        "Usage: overtchat-connector <install|install-managed|pair|preflight|run|version>",
+        "Usage: overtchat-connector <install|install-managed|pair|preflight|run|terminal-smoke|version>",
       );
   }
 }

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -40,6 +40,7 @@ afterEach(async () => {
   delete process.env.OVERTCHAT_CONNECTOR_STATE;
   delete process.env.OVERTCHAT_CONNECTOR_TIMELINES;
   delete process.env.OVERTCHAT_CONNECTOR_LOCK;
+  delete process.env.OVERTCHAT_DISABLE_AGENT_TERMINAL;
   await Promise.all(
     directories.splice(0).map((directory) =>
       rm(directory, { recursive: true, force: true }),
@@ -140,6 +141,31 @@ describe.sequential("connector client compatibility", () => {
     expect(headers.get("x-overtchat-connector-capabilities")).toBe(
       HOST_CONNECTOR_CAPABILITIES.join(","),
     );
+    await client.stop();
+    await running;
+  });
+
+  it("keeps ordinary connector capabilities when terminals are disabled", async () => {
+    process.env.OVERTCHAT_DISABLE_AGENT_TERMINAL = "1";
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input), init });
+        return emptyChannel();
+      }),
+    );
+    const client = await ConnectorClient.create(await config());
+    const running = client.run();
+    await vi.waitFor(() => expect(requests.length).toBeGreaterThan(0));
+
+    const headers = new Headers(requests[0]!.init?.headers);
+    expect(headers.get("x-overtchat-connector-capabilities")?.split(","))
+      .toEqual(
+        HOST_CONNECTOR_CAPABILITIES.filter(
+          (capability) => capability !== "workspace-terminal-v1",
+        ),
+      );
     await client.stop();
     await running;
   });

--- a/apps/connector/src/client.ts
+++ b/apps/connector/src/client.ts
@@ -8,6 +8,7 @@ import {
   type HostConnectorEventAck,
   type HostConnectorEventBatch,
   type HostConnectorEventPayload,
+  type HostConnectorCapability,
 } from "@overtchat/agent-bridge";
 import type { ResolvedAgentImage } from "@overtchat/agent-runtime";
 import {
@@ -20,6 +21,7 @@ import { ConnectorDaemon } from "./daemon.js";
 import { ConnectorInstanceLock } from "./lock.js";
 import { ConnectorStateJournal } from "./state.js";
 import { ConnectorTimelineStore } from "./timeline.js";
+import { connectorTerminalSupport } from "./terminal.js";
 import { CONNECTOR_VERSION } from "./version.js";
 
 const RECONNECT_BASE_DELAY_MS = 1_000;
@@ -63,8 +65,17 @@ function waitForRetry(milliseconds: number, signal: AbortSignal): Promise<void> 
   });
 }
 
+function availableCapabilities(): HostConnectorCapability[] {
+  const terminalSupport = connectorTerminalSupport();
+  return HOST_CONNECTOR_CAPABILITIES.filter(
+    (capability) =>
+      capability !== "workspace-terminal-v1" || terminalSupport.available,
+  );
+}
+
 export class ConnectorClient {
   private readonly daemon: ConnectorDaemon;
+  private readonly capabilities = availableCapabilities();
   private readonly stopAbort = new AbortController();
   private commandStreamAbort: AbortController | undefined;
   private eventRequestAbort: AbortController | undefined;
@@ -200,8 +211,7 @@ export class ConnectorClient {
         headers: {
           Authorization: `Bearer ${this.config.token}`,
           "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
-          "X-OvertChat-Connector-Capabilities":
-            HOST_CONNECTOR_CAPABILITIES.join(","),
+          "X-OvertChat-Connector-Capabilities": this.capabilities.join(","),
           "X-OvertChat-Connector-Protocol": String(
             HOST_CONNECTOR_PROTOCOL_VERSION,
           ),
@@ -315,8 +325,7 @@ export class ConnectorClient {
             Authorization: `Bearer ${this.config.token}`,
             "Content-Type": "application/json",
             "X-OvertChat-Connector-Build-Version": CONNECTOR_VERSION,
-            "X-OvertChat-Connector-Capabilities":
-              HOST_CONNECTOR_CAPABILITIES.join(","),
+            "X-OvertChat-Connector-Capabilities": this.capabilities.join(","),
             "X-OvertChat-Connector-Protocol": String(
               HOST_CONNECTOR_PROTOCOL_VERSION,
             ),

--- a/apps/connector/src/client.ts
+++ b/apps/connector/src/client.ts
@@ -29,7 +29,7 @@ const MAX_BUFFERED_LIVE_EVENTS = 2_048;
 
 type LiveEventPayload = Extract<
   HostConnectorEventPayload,
-  { type: "session_event" }
+  { type: "session_event" | "terminal_event" }
 >;
 
 type LiveEventBatch = {
@@ -247,12 +247,13 @@ export class ConnectorClient {
   }
 
   private enqueue(payload: HostConnectorEventPayload): void {
-    if (payload.type === "session_event") {
+    if (payload.type === "session_event" || payload.type === "terminal_event") {
       if (this.stopped) return;
-      // The per-session timeline is already synced to disk before the daemon
-      // emits this live hint. Keeping a second durable copy here caused stale
-      // connectors to accumulate hundreds of megabytes. A lost/bounded hint is
-      // recovered through the authoritative session sync.
+      // Session events are recovered through authoritative timeline sync. A
+      // terminal event carries its own revision, so a lost/bounded hint makes
+      // the browser reattach from the connector's headless terminal snapshot.
+      // Keeping either high-volume stream in the durable journal would let an
+      // offline server grow connector state without bound.
       this.liveEvents.push(payload);
       if (this.liveEvents.length > MAX_BUFFERED_LIVE_EVENTS) {
         const displaced = this.liveEvents.splice(

--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -241,6 +241,74 @@ afterEach(async () => {
 });
 
 describe("connector daemon command identity", () => {
+  it("routes terminal subscriptions, input, and output through the daemon", async () => {
+    const { journal, timelines } = await openJournal();
+    const events: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => events.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+    const terminalSession = {
+      ...session,
+      cwd: process.cwd(),
+      sessionId: "terminal-daemon",
+    };
+    const marker = `terminal-daemon-${process.pid}`;
+
+    await daemon.handle({
+      type: "request",
+      requestId: "subscribe-terminal",
+      request: {
+        type: "subscribe_terminal",
+        subscriptionId: "terminal-subscription",
+        session: terminalSession,
+        size: { cols: 80, rows: 24 },
+      },
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "subscribe-terminal",
+        success: true,
+        data: expect.objectContaining({
+          subscribed: true,
+          snapshot: expect.objectContaining({
+            sessionId: "terminal-daemon",
+            cols: 80,
+            rows: 24,
+          }),
+        }),
+      }),
+    );
+
+    await daemon.handle({
+      type: "terminal_input",
+      sessionId: "terminal-daemon",
+      data: `printf '${marker}\\n'; exit\r`,
+    });
+    await vi.waitFor(
+      () => {
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            type: "terminal_event",
+            subscriptionId: "terminal-subscription",
+            sessionId: "terminal-daemon",
+            event: expect.objectContaining({
+              type: "output",
+              data: expect.stringContaining(marker),
+            }),
+          }),
+        );
+      },
+      { timeout: 5_000 },
+    );
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
   it("dispatches provider-neutral workspace file operations", async () => {
     const { journal, timelines } = await openJournal();
     const events: HostConnectorEventPayload[] = [];

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -32,6 +32,7 @@ import { listSshHosts } from "./ssh.js";
 import { ConnectorProcessHost } from "./runtime.js";
 import { ConnectorStateJournal } from "./state.js";
 import { ConnectorTimelineStore } from "./timeline.js";
+import { ConnectorTerminalManager } from "./terminal.js";
 
 type Emit = (event: HostConnectorEventPayload) => void;
 type ResolveImages = (
@@ -126,6 +127,7 @@ function sessionDescriptor(descriptor: AgentDaemonSessionDescriptor) {
 export class ConnectorDaemon {
   private readonly processHost = new ConnectorProcessHost();
   private readonly providerSnapshots = new AgentProviderSnapshotManager();
+  private readonly terminals = new ConnectorTerminalManager();
   private readonly registry: AgentRuntimeRegistry;
   private readonly subscriptions = new Map<string, SessionSubscription>();
   private readonly captures = new Map<string, TimelineCapture>();
@@ -203,6 +205,14 @@ export class ConnectorDaemon {
       );
       return;
     }
+    if (command.type === "terminal_input") {
+      this.terminals.write(command.sessionId, command.data);
+      return;
+    }
+    if (command.type === "terminal_resize") {
+      this.terminals.resize(command.sessionId, command.size);
+      return;
+    }
     try {
       const data = await this.handleRequest(command.request);
       this.emit({
@@ -236,6 +246,7 @@ export class ConnectorDaemon {
     // or timeline operation. The stores are closed by the client immediately
     // after this method returns.
     this.storesClosing = true;
+    this.terminals.stopAll();
     for (const subscription of this.subscriptions.values()) {
       this.closeSubscription(subscription);
     }
@@ -316,6 +327,7 @@ export class ConnectorDaemon {
         this.closeSubscription(subscription);
       }
       this.subscriptions.clear();
+      this.terminals.disconnectSubscribers();
     }
     const active = new Set(activeSessionIds);
     const removed = this.journal
@@ -324,6 +336,7 @@ export class ConnectorDaemon {
     await Promise.all(
       removed.map((sessionId) => this.registry.stopSession(sessionId)),
     );
+    for (const sessionId of removed) this.terminals.stopSession(sessionId);
     this.assertAccepting();
     await Promise.all(
       removed.map((sessionId) => this.finishCapture(sessionId, true)),
@@ -385,6 +398,31 @@ export class ConnectorDaemon {
           request.root,
           request.path,
         );
+      case "subscribe_terminal": {
+        const snapshot = await this.terminals.subscribe(
+          request.subscriptionId,
+          request.session,
+          request.size,
+          (event) => {
+            this.emit({
+              type: "terminal_event",
+              subscriptionId: request.subscriptionId,
+              sessionId: request.session.sessionId,
+              event,
+            });
+          },
+        );
+        return { subscribed: true, snapshot };
+      }
+      case "unsubscribe_terminal":
+        this.terminals.unsubscribe(request.subscriptionId);
+        return { subscribed: false };
+      case "restart_terminal":
+        return {
+          snapshot: await this.terminals.restart(request.session, request.size),
+        };
+      case "kill_terminal":
+        return { killed: this.terminals.kill(request.sessionId) };
       case "create_session": {
         const created = await this.serializeSession(request.sessionId, async () => {
           const result = await this.registry.create(
@@ -485,6 +523,7 @@ export class ConnectorDaemon {
         this.subscriptions.delete(request.subscriptionId);
         return { subscribed: false };
       case "stop_session":
+        this.terminals.stopSession(request.sessionId);
         await this.registry.stopSession(request.sessionId);
         this.assertAccepting();
         await this.finishCapture(request.sessionId, true);
@@ -492,6 +531,7 @@ export class ConnectorDaemon {
         await this.journal.deleteSession(request.sessionId);
         return { stopped: true };
       case "stop_workspace": {
+        this.terminals.stopWorkspace(request.workspaceId);
         const removed = this.journal.sessionIdsForWorkspace(request.workspaceId);
         await this.registry.stopWorkspace(request.workspaceId);
         this.assertAccepting();
@@ -503,6 +543,7 @@ export class ConnectorDaemon {
         return { stopped: true };
       }
       case "stop_connection": {
+        this.terminals.stopConnection(request.connectionId);
         const removed = this.journal.sessionIdsForConnection(request.connectionId);
         await this.registry.stopConnection(request.connectionId);
         this.assertAccepting();
@@ -514,6 +555,7 @@ export class ConnectorDaemon {
         return { stopped: true };
       }
       case "stop_all": {
+        this.terminals.stopAll();
         const removed = this.journal.sessionIds();
         await this.registry.stopAll();
         this.assertAccepting();

--- a/apps/connector/src/ssh.test.ts
+++ b/apps/connector/src/ssh.test.ts
@@ -7,6 +7,7 @@ import {
   listSshHosts,
   parseSshExpansion,
   sshSpawnArgs,
+  sshTerminalArgs,
   sshTunnelArgs,
 } from "./ssh.js";
 
@@ -103,6 +104,21 @@ describe("SSH process launching", () => {
     expect(() => sshTunnelArgs("macbook", 0, 4096)).toThrow(
       "Invalid SSH tunnel port",
     );
+  });
+
+  it("allocates a remote login terminal in the workspace", () => {
+    const args = sshTerminalArgs("macbook", "/Users/yash/project's files");
+
+    expect(args).toEqual([
+      "-tt",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "macbook",
+      expect.stringContaining('exec "${SHELL:-/bin/sh}" -il'),
+    ]);
+    expect(args.at(-1)).toContain("cd -- '/Users/yash/project'\\''s files'");
   });
 });
 

--- a/apps/connector/src/ssh.ts
+++ b/apps/connector/src/ssh.ts
@@ -50,6 +50,23 @@ export function sshSpawnArgs(
   ];
 }
 
+export function sshTerminalArgs(alias: string, cwd: string): string[] {
+  if (!SAFE_ALIAS.test(alias)) throw new Error("Invalid SSH host alias.");
+  const remote = [
+    `cd -- ${shellQuote(cwd)}`,
+    'exec "${SHELL:-/bin/sh}" -il',
+  ].join(" && ");
+  return [
+    "-tt",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ConnectTimeout=10",
+    alias,
+    remote,
+  ];
+}
+
 export function sshTunnelArgs(
   alias: string,
   localPort: number,

--- a/apps/connector/src/terminal.test.ts
+++ b/apps/connector/src/terminal.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { AgentDaemonSessionDescriptor } from "@overtchat/agent-bridge";
+import { AGENT_TERMINAL_MAX_OUTPUT_CHARS } from "@overtchat/agent-bridge";
 import {
+  connectorTerminalSupport,
   ConnectorTerminalManager,
   runConnectorTerminalSmoke,
 } from "./terminal.js";
@@ -63,6 +65,106 @@ describe("connector terminal manager", () => {
       manager.stopSession(descriptor.sessionId);
       expect(manager.write(descriptor.sessionId, "pwd\r")).toBe(false);
     } finally {
+      manager.stopAll();
+    }
+  });
+
+  it("cleans up a terminal after its final subscriber remains idle", async () => {
+    const manager = new ConnectorTerminalManager(10);
+    try {
+      await manager.subscribe(
+        "idle",
+        descriptor,
+        { cols: 80, rows: 24 },
+        () => {},
+      );
+      manager.unsubscribe("idle");
+
+      await expect
+        .poll(
+          () =>
+            (Reflect.get(manager, "terminals") as Map<string, unknown>).has(
+              descriptor.sessionId,
+            ),
+          { timeout: 1_000 },
+        )
+        .toBe(false);
+    } finally {
+      manager.stopAll();
+    }
+  });
+
+  it("bounds coalesced output and forces snapshot recovery after truncation", async () => {
+    const manager = new ConnectorTerminalManager();
+    const events: Array<{ revision: number }> = [];
+    try {
+      await manager.subscribe(
+        "bounded-output",
+        descriptor,
+        { cols: 80, rows: 24 },
+        (event) => events.push(event),
+      );
+      const terminals = Reflect.get(manager, "terminals") as Map<
+        string,
+        {
+          revision: number;
+          pendingOutput: string;
+          outputTimer: NodeJS.Timeout | null;
+          parseTail: Promise<void>;
+        }
+      >;
+      const terminal = terminals.get(descriptor.sessionId)!;
+      const queueOutput = Reflect.get(manager, "queueOutput") as (
+        terminal: unknown,
+        data: string,
+      ) => void;
+      const flushOutputWindow = Reflect.get(
+        manager,
+        "flushOutputWindow",
+      ) as (terminal: unknown) => void;
+
+      queueOutput.call(manager, terminal, "seed");
+      if (terminal.outputTimer) clearTimeout(terminal.outputTimer);
+      const revisionBeforeOverflow = terminal.revision;
+      events.splice(0);
+      queueOutput.call(
+        manager,
+        terminal,
+        "x".repeat(AGENT_TERMINAL_MAX_OUTPUT_CHARS * 3),
+      );
+
+      expect(terminal.pendingOutput.length).toBeLessThanOrEqual(
+        AGENT_TERMINAL_MAX_OUTPUT_CHARS * 2,
+      );
+      terminal.outputTimer = null;
+      flushOutputWindow.call(manager, terminal);
+      await terminal.parseTail;
+      expect(events[0]!.revision).toBeGreaterThan(
+        revisionBeforeOverflow + 1,
+      );
+    } finally {
+      manager.stopAll();
+    }
+  });
+
+  it("rejects terminals without affecting connector startup when disabled", async () => {
+    process.env.OVERTCHAT_DISABLE_AGENT_TERMINAL = "true";
+    const manager = new ConnectorTerminalManager();
+    try {
+      expect(connectorTerminalSupport()).toEqual({
+        available: false,
+        reason: "Workspace terminals are disabled on this Host Connector.",
+      });
+      await expect(
+        manager.subscribe(
+          "disabled",
+          descriptor,
+          { cols: 80, rows: 24 },
+          () => {},
+        ),
+      ).rejects.toThrow("Workspace terminal unavailable");
+    } finally {
+      delete process.env.OVERTCHAT_DISABLE_AGENT_TERMINAL;
       manager.stopAll();
     }
   });

--- a/apps/connector/src/terminal.test.ts
+++ b/apps/connector/src/terminal.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { AgentDaemonSessionDescriptor } from "@overtchat/agent-bridge";
+import {
+  ConnectorTerminalManager,
+  runConnectorTerminalSmoke,
+} from "./terminal.js";
+
+const descriptor: AgentDaemonSessionDescriptor = {
+  connectionId: "connection",
+  workspaceId: "workspace",
+  provider: "codex",
+  target: { transport: "local", shellMode: "login" },
+  executable: "codex",
+  cwd: process.cwd(),
+  sessionId: "terminal-test",
+  providerSessionId: "provider-session",
+  providerSessionPath: "/provider-session",
+  launchConfig: {},
+};
+
+describe("connector terminal manager", () => {
+  it("runs a real local PTY in the connector workspace", async () => {
+    await runConnectorTerminalSmoke();
+  });
+
+  it("reattaches with a serialized snapshot and survives unsubscribe", async () => {
+    const manager = new ConnectorTerminalManager();
+    const marker = `terminal-reattach-${process.pid}`;
+    try {
+      await manager.subscribe(
+        "first",
+        descriptor,
+        { cols: 80, rows: 24 },
+        () => {},
+      );
+      manager.unsubscribe("first");
+      expect(
+        manager.write(descriptor.sessionId, `printf '${marker}\\n'\r`),
+      ).toBe(true);
+      await expect
+        .poll(
+          async () =>
+            (
+              await manager.subscribe(
+                "second",
+                descriptor,
+                { cols: 100, rows: 30 },
+                () => {},
+              )
+            ).data.includes(marker),
+          { timeout: 5_000 },
+        )
+        .toBe(true);
+
+      const snapshot = await manager.subscribe(
+        "third",
+        descriptor,
+        { cols: 100, rows: 30 },
+        () => {},
+      );
+      expect(snapshot.data).toContain(marker);
+      expect(snapshot).toMatchObject({ cols: 100, rows: 30, exited: false });
+      manager.stopSession(descriptor.sessionId);
+      expect(manager.write(descriptor.sessionId, "pwd\r")).toBe(false);
+    } finally {
+      manager.stopAll();
+    }
+  });
+});

--- a/apps/connector/src/terminal.ts
+++ b/apps/connector/src/terminal.ts
@@ -1,0 +1,483 @@
+import type { IPty } from "node-pty";
+import { createRequire as createNodeRequire } from "node:module";
+import headlessRuntime from "@xterm/headless/lib-headless/xterm-headless.js";
+import type { Terminal as HeadlessTerminal } from "@xterm/headless";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import {
+  AGENT_TERMINAL_MAX_OUTPUT_CHARS,
+  AGENT_TERMINAL_MAX_SNAPSHOT_CHARS,
+  type AgentDaemonSessionDescriptor,
+  type AgentTerminalEvent,
+  type AgentTerminalSize,
+  type AgentTerminalSnapshot,
+} from "@overtchat/agent-bridge";
+import { sshTerminalArgs } from "./ssh.js";
+
+/* eslint-disable @typescript-eslint/no-require-imports -- Bun only embeds the
+ * architecture-specific N-API addon when these paths remain static requires. */
+
+const { Terminal } = headlessRuntime as unknown as {
+  Terminal: typeof HeadlessTerminal;
+};
+
+type NodePtyModule = typeof import("node-pty");
+type NodePtyNativeModule = {
+  fork: (...args: unknown[]) => unknown;
+};
+
+const nodeRequire = createNodeRequire(import.meta.url);
+const isBunRuntime = "bun" in process.versions;
+
+function loadNodePtyNative(): NodePtyNativeModule {
+  if (process.arch === "arm64") {
+    return isBunRuntime
+      ? require("node-pty/prebuilds/linux-arm64/pty.node")
+      : (nodeRequire(
+          "node-pty/prebuilds/linux-arm64/pty.node",
+        ) as NodePtyNativeModule);
+  }
+  return isBunRuntime
+    ? require("node-pty/prebuilds/linux-x64/pty.node")
+    : (nodeRequire(
+        "node-pty/prebuilds/linux-x64/pty.node",
+      ) as NodePtyNativeModule);
+}
+
+function loadNodePty(): NodePtyModule {
+  if (process.platform === "linux") {
+    const native = loadNodePtyNative();
+    const utils = (isBunRuntime
+      ? require("node-pty/lib/utils.js")
+      : nodeRequire("node-pty/lib/utils.js")) as {
+      loadNativeModule(name: string): {
+        dir: string;
+        module: NodePtyNativeModule;
+      };
+    };
+    utils.loadNativeModule = (name) => {
+      if (name !== "pty") throw new Error(`Unsupported PTY module ${name}.`);
+      return {
+        dir: `../prebuilds/linux-${process.arch}`,
+        module: native,
+      };
+    };
+  }
+  return (isBunRuntime
+    ? require("node-pty")
+    : nodeRequire("node-pty")) as NodePtyModule;
+}
+
+const pty = loadNodePty();
+
+const OUTPUT_COALESCE_MS = 5;
+const TERMINAL_SCROLLBACK_LINES = 2_000;
+
+type TerminalSubscriber = {
+  sessionId: string;
+  listener: (event: AgentTerminalEvent) => void;
+};
+
+type ManagedTerminal = {
+  descriptor: AgentDaemonSessionDescriptor;
+  pty: IPty;
+  emulator: HeadlessTerminal;
+  serializer: SerializeAddon;
+  revision: number;
+  exited: boolean;
+  exitCode: number | null;
+  signal: number | null;
+  parseTail: Promise<void>;
+  pendingOutput: string;
+  outputTimer: NodeJS.Timeout | null;
+  disposables: Array<{ dispose(): void }>;
+};
+
+function processEnvironment(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).flatMap(([key, value]) =>
+      value === undefined ? [] : [[key, value]],
+    ),
+  );
+}
+
+function sameTerminalOwner(
+  left: AgentDaemonSessionDescriptor,
+  right: AgentDaemonSessionDescriptor,
+): boolean {
+  return (
+    left.sessionId === right.sessionId &&
+    left.workspaceId === right.workspaceId &&
+    left.connectionId === right.connectionId &&
+    left.cwd === right.cwd &&
+    left.target.transport === right.target.transport &&
+    (left.target.transport === "local" ||
+      (right.target.transport === "ssh" &&
+        left.target.alias === right.target.alias))
+  );
+}
+
+function terminalLaunch(descriptor: AgentDaemonSessionDescriptor): {
+  command: string;
+  args: string[];
+  cwd: string;
+} {
+  if (descriptor.target.transport === "ssh") {
+    return {
+      command: "ssh",
+      args: sshTerminalArgs(descriptor.target.alias, descriptor.cwd),
+      cwd: process.cwd(),
+    };
+  }
+  return {
+    command: process.env.SHELL?.trim() || "/bin/sh",
+    args: ["-il"],
+    cwd: descriptor.cwd,
+  };
+}
+
+function writeToEmulator(
+  terminal: ManagedTerminal,
+  data: string,
+): Promise<void> {
+  terminal.parseTail = terminal.parseTail.then(
+    () =>
+      new Promise<void>((resolve) => {
+        terminal.emulator.write(data, resolve);
+      }),
+  );
+  return terminal.parseTail;
+}
+
+export class ConnectorTerminalManager {
+  private readonly terminals = new Map<string, ManagedTerminal>();
+  private readonly subscribers = new Map<string, TerminalSubscriber>();
+
+  async subscribe(
+    subscriptionId: string,
+    descriptor: AgentDaemonSessionDescriptor,
+    size: AgentTerminalSize,
+    listener: (event: AgentTerminalEvent) => void,
+  ): Promise<AgentTerminalSnapshot> {
+    this.subscribers.set(subscriptionId, {
+      sessionId: descriptor.sessionId,
+      listener,
+    });
+    try {
+      const terminal = this.getOrCreate(descriptor, size);
+      this.resize(descriptor.sessionId, size);
+      return await this.snapshot(terminal);
+    } catch (error) {
+      this.subscribers.delete(subscriptionId);
+      throw error;
+    }
+  }
+
+  unsubscribe(subscriptionId: string): void {
+    this.subscribers.delete(subscriptionId);
+  }
+
+  write(sessionId: string, data: string): boolean {
+    const terminal = this.terminals.get(sessionId);
+    if (!terminal || terminal.exited) return false;
+    terminal.pty.write(data);
+    return true;
+  }
+
+  resize(sessionId: string, size: AgentTerminalSize): boolean {
+    const terminal = this.terminals.get(sessionId);
+    if (!terminal || terminal.exited) return false;
+    if (
+      terminal.emulator.cols === size.cols &&
+      terminal.emulator.rows === size.rows
+    ) {
+      return true;
+    }
+    terminal.emulator.resize(size.cols, size.rows);
+    try {
+      terminal.pty.resize(size.cols, size.rows);
+    } catch {
+      return false;
+    }
+    return true;
+  }
+
+  async restart(
+    descriptor: AgentDaemonSessionDescriptor,
+    size: AgentTerminalSize,
+  ): Promise<AgentTerminalSnapshot> {
+    this.disposeTerminal(descriptor.sessionId, true);
+    return this.snapshot(this.create(descriptor, size));
+  }
+
+  kill(sessionId: string): boolean {
+    const terminal = this.terminals.get(sessionId);
+    if (!terminal || terminal.exited) return false;
+    terminal.pty.kill();
+    return true;
+  }
+
+  stopSession(sessionId: string): void {
+    this.disposeTerminal(sessionId, true);
+    for (const [subscriptionId, subscriber] of this.subscribers) {
+      if (subscriber.sessionId === sessionId) {
+        this.subscribers.delete(subscriptionId);
+      }
+    }
+  }
+
+  stopWorkspace(workspaceId: string): void {
+    for (const terminal of [...this.terminals.values()]) {
+      if (terminal.descriptor.workspaceId === workspaceId) {
+        this.stopSession(terminal.descriptor.sessionId);
+      }
+    }
+  }
+
+  stopConnection(connectionId: string): void {
+    for (const terminal of [...this.terminals.values()]) {
+      if (terminal.descriptor.connectionId === connectionId) {
+        this.stopSession(terminal.descriptor.sessionId);
+      }
+    }
+  }
+
+  stopAll(): void {
+    for (const sessionId of [...this.terminals.keys()]) {
+      this.stopSession(sessionId);
+    }
+    this.subscribers.clear();
+  }
+
+  disconnectSubscribers(): void {
+    this.subscribers.clear();
+  }
+
+  private getOrCreate(
+    descriptor: AgentDaemonSessionDescriptor,
+    size: AgentTerminalSize,
+  ): ManagedTerminal {
+    const existing = this.terminals.get(descriptor.sessionId);
+    if (!existing) return this.create(descriptor, size);
+    if (!sameTerminalOwner(existing.descriptor, descriptor)) {
+      throw new Error("The terminal session belongs to a different workspace.");
+    }
+    return existing;
+  }
+
+  private create(
+    descriptor: AgentDaemonSessionDescriptor,
+    size: AgentTerminalSize,
+  ): ManagedTerminal {
+    const launch = terminalLaunch(descriptor);
+    const emulator = new Terminal({
+      cols: size.cols,
+      rows: size.rows,
+      scrollback: TERMINAL_SCROLLBACK_LINES,
+      allowProposedApi: true,
+    });
+    const serializer = new SerializeAddon();
+    emulator.loadAddon(serializer);
+    const processHandle = pty.spawn(launch.command, launch.args, {
+      name: "xterm-256color",
+      cols: size.cols,
+      rows: size.rows,
+      cwd: launch.cwd,
+      env: {
+        ...processEnvironment(),
+        TERM: "xterm-256color",
+        COLORTERM: "truecolor",
+        OVERTCHAT_AGENT_SESSION_ID: descriptor.sessionId,
+        OVERTCHAT_AGENT_WORKSPACE_ID: descriptor.workspaceId,
+      },
+    });
+    const terminal: ManagedTerminal = {
+      descriptor,
+      pty: processHandle,
+      emulator,
+      serializer,
+      revision: 0,
+      exited: false,
+      exitCode: null,
+      signal: null,
+      parseTail: Promise.resolve(),
+      pendingOutput: "",
+      outputTimer: null,
+      disposables: [],
+    };
+    terminal.disposables.push(
+      processHandle.onData((data) => this.queueOutput(terminal, data)),
+      processHandle.onExit(({ exitCode, signal }) => {
+        void this.finishExit(terminal, exitCode, signal);
+      }),
+    );
+    this.terminals.set(descriptor.sessionId, terminal);
+    return terminal;
+  }
+
+  private queueOutput(terminal: ManagedTerminal, data: string): void {
+    if (this.terminals.get(terminal.descriptor.sessionId) !== terminal) return;
+    void writeToEmulator(terminal, data);
+    if (!terminal.outputTimer && terminal.pendingOutput.length === 0) {
+      this.publishOutput(terminal, data);
+      terminal.outputTimer = setTimeout(
+        () => this.flushOutputWindow(terminal),
+        OUTPUT_COALESCE_MS,
+      );
+      terminal.outputTimer.unref();
+      return;
+    }
+    terminal.pendingOutput += data;
+  }
+
+  private flushOutputWindow(terminal: ManagedTerminal): void {
+    terminal.outputTimer = null;
+    if (this.terminals.get(terminal.descriptor.sessionId) !== terminal) return;
+    const output = terminal.pendingOutput;
+    terminal.pendingOutput = "";
+    if (!output) return;
+    this.publishOutput(terminal, output);
+    terminal.outputTimer = setTimeout(
+      () => this.flushOutputWindow(terminal),
+      OUTPUT_COALESCE_MS,
+    );
+    terminal.outputTimer.unref();
+  }
+
+  private publishOutput(terminal: ManagedTerminal, output: string): void {
+    for (
+      let offset = 0;
+      offset < output.length;
+      offset += AGENT_TERMINAL_MAX_OUTPUT_CHARS
+    ) {
+      const data = output.slice(
+        offset,
+        offset + AGENT_TERMINAL_MAX_OUTPUT_CHARS,
+      );
+      const event: AgentTerminalEvent = {
+        type: "output",
+        revision: ++terminal.revision,
+        data,
+      };
+      this.emit(terminal.descriptor.sessionId, event);
+    }
+  }
+
+  private async finishExit(
+    terminal: ManagedTerminal,
+    exitCode: number,
+    signal: number | undefined,
+  ): Promise<void> {
+    if (this.terminals.get(terminal.descriptor.sessionId) !== terminal) return;
+    if (terminal.outputTimer) clearTimeout(terminal.outputTimer);
+    terminal.outputTimer = null;
+    if (terminal.pendingOutput) {
+      this.publishOutput(terminal, terminal.pendingOutput);
+      terminal.pendingOutput = "";
+    }
+    await terminal.parseTail;
+    terminal.exited = true;
+    terminal.exitCode = exitCode;
+    terminal.signal = signal ?? null;
+    this.emit(terminal.descriptor.sessionId, {
+      type: "exit",
+      revision: ++terminal.revision,
+      exitCode,
+      signal: signal ?? null,
+    });
+  }
+
+  private emit(sessionId: string, event: AgentTerminalEvent): void {
+    for (const subscriber of this.subscribers.values()) {
+      if (subscriber.sessionId === sessionId) subscriber.listener(event);
+    }
+  }
+
+  private async snapshot(
+    terminal: ManagedTerminal,
+  ): Promise<AgentTerminalSnapshot> {
+    await terminal.parseTail;
+    let data = "";
+    for (const scrollback of [2_000, 1_000, 500, 200, 0]) {
+      data = terminal.serializer.serialize({ scrollback });
+      if (data.length <= AGENT_TERMINAL_MAX_SNAPSHOT_CHARS) break;
+    }
+    if (data.length > AGENT_TERMINAL_MAX_SNAPSHOT_CHARS) {
+      throw new Error("The terminal snapshot is too large to reconnect.");
+    }
+    return {
+      sessionId: terminal.descriptor.sessionId,
+      revision: terminal.revision,
+      data,
+      cols: terminal.emulator.cols,
+      rows: terminal.emulator.rows,
+      exited: terminal.exited,
+      exitCode: terminal.exitCode,
+      signal: terminal.signal,
+    };
+  }
+
+  private disposeTerminal(sessionId: string, kill: boolean): void {
+    const terminal = this.terminals.get(sessionId);
+    if (!terminal) return;
+    this.terminals.delete(sessionId);
+    if (terminal.outputTimer) clearTimeout(terminal.outputTimer);
+    terminal.outputTimer = null;
+    for (const disposable of terminal.disposables) disposable.dispose();
+    terminal.serializer.dispose();
+    terminal.emulator.dispose();
+    if (kill && !terminal.exited) {
+      try {
+        terminal.pty.kill();
+      } catch {
+        // The PTY may have exited between the state check and cleanup.
+      }
+    }
+  }
+}
+
+export async function runConnectorTerminalSmoke(): Promise<void> {
+  const manager = new ConnectorTerminalManager();
+  const sessionId = `terminal-smoke-${process.pid}`;
+  const marker = `overtchat-terminal-smoke-${process.pid}`;
+  let output = "";
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    const exited = new Promise<void>((resolve, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for terminal smoke test.")),
+        10_000,
+      );
+      manager
+        .subscribe(
+          "terminal-smoke",
+          {
+            connectionId: "terminal-smoke",
+            workspaceId: "terminal-smoke",
+            provider: "codex",
+            target: { transport: "local", shellMode: "login" },
+            executable: "codex",
+            cwd: process.cwd(),
+            sessionId,
+            providerSessionId: "terminal-smoke",
+            providerSessionPath: "/terminal-smoke",
+            launchConfig: {},
+          },
+          { cols: 80, rows: 24 },
+          (event) => {
+            if (event.type === "output") output += event.data;
+            else resolve();
+          },
+        )
+        .then(() => {
+          manager.write(sessionId, `printf '${marker}\\n'; exit\r`);
+        }, reject);
+    });
+    await exited;
+    if (!output.includes(marker)) {
+      throw new Error("Terminal smoke test did not receive shell output.");
+    }
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    manager.stopAll();
+  }
+}

--- a/apps/connector/src/terminal.ts
+++ b/apps/connector/src/terminal.ts
@@ -25,10 +25,19 @@ type NodePtyNativeModule = {
   fork: (...args: unknown[]) => unknown;
 };
 
+export type ConnectorTerminalSupport =
+  | { available: true }
+  | { available: false; reason: string };
+
 const nodeRequire = createNodeRequire(import.meta.url);
 const isBunRuntime = "bun" in process.versions;
 
 function loadNodePtyNative(): NodePtyNativeModule {
+  if (process.arch !== "x64" && process.arch !== "arm64") {
+    throw new Error(
+      `Workspace terminals do not support Linux ${process.arch}.`,
+    );
+  }
   if (process.arch === "arm64") {
     return isBunRuntime
       ? require("node-pty/prebuilds/linux-arm64/pty.node")
@@ -67,10 +76,47 @@ function loadNodePty(): NodePtyModule {
     : nodeRequire("node-pty")) as NodePtyModule;
 }
 
-const pty = loadNodePty();
-
 const OUTPUT_COALESCE_MS = 5;
+const MAX_PENDING_OUTPUT_CHARS = AGENT_TERMINAL_MAX_OUTPUT_CHARS * 2;
 const TERMINAL_SCROLLBACK_LINES = 2_000;
+const DEFAULT_TERMINAL_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
+
+let loadedNodePty: NodePtyModule | Error | undefined;
+
+function terminalDisabled(): boolean {
+  return /^(?:1|true)$/iu.test(
+    process.env.OVERTCHAT_DISABLE_AGENT_TERMINAL?.trim() ?? "",
+  );
+}
+
+export function connectorTerminalSupport(): ConnectorTerminalSupport {
+  if (terminalDisabled()) {
+    return {
+      available: false,
+      reason: "Workspace terminals are disabled on this Host Connector.",
+    };
+  }
+  if (loadedNodePty instanceof Error) {
+    return { available: false, reason: loadedNodePty.message };
+  }
+  if (loadedNodePty) return { available: true };
+  try {
+    loadedNodePty = loadNodePty();
+    return { available: true };
+  } catch (error) {
+    loadedNodePty =
+      error instanceof Error ? error : new Error(String(error));
+    return { available: false, reason: loadedNodePty.message };
+  }
+}
+
+function requireNodePty(): NodePtyModule {
+  const support = connectorTerminalSupport();
+  if (!support.available) {
+    throw new Error(`Workspace terminal unavailable: ${support.reason}`);
+  }
+  return loadedNodePty as NodePtyModule;
+}
 
 type TerminalSubscriber = {
   sessionId: string;
@@ -88,7 +134,9 @@ type ManagedTerminal = {
   signal: number | null;
   parseTail: Promise<void>;
   pendingOutput: string;
+  outputTruncated: boolean;
   outputTimer: NodeJS.Timeout | null;
+  idleTimer: NodeJS.Timeout | null;
   disposables: Array<{ dispose(): void }>;
 };
 
@@ -152,6 +200,10 @@ export class ConnectorTerminalManager {
   private readonly terminals = new Map<string, ManagedTerminal>();
   private readonly subscribers = new Map<string, TerminalSubscriber>();
 
+  constructor(
+    private readonly idleTimeoutMs = DEFAULT_TERMINAL_IDLE_TIMEOUT_MS,
+  ) {}
+
   async subscribe(
     subscriptionId: string,
     descriptor: AgentDaemonSessionDescriptor,
@@ -164,16 +216,21 @@ export class ConnectorTerminalManager {
     });
     try {
       const terminal = this.getOrCreate(descriptor, size);
+      this.cancelIdleCleanup(terminal);
       this.resize(descriptor.sessionId, size);
       return await this.snapshot(terminal);
     } catch (error) {
       this.subscribers.delete(subscriptionId);
+      this.scheduleIdleCleanup(descriptor.sessionId);
       throw error;
     }
   }
 
   unsubscribe(subscriptionId: string): void {
+    const subscriber = this.subscribers.get(subscriptionId);
+    if (!subscriber) return;
     this.subscribers.delete(subscriptionId);
+    this.scheduleIdleCleanup(subscriber.sessionId);
   }
 
   write(sessionId: string, data: string): boolean {
@@ -206,7 +263,9 @@ export class ConnectorTerminalManager {
     size: AgentTerminalSize,
   ): Promise<AgentTerminalSnapshot> {
     this.disposeTerminal(descriptor.sessionId, true);
-    return this.snapshot(this.create(descriptor, size));
+    const terminal = this.create(descriptor, size);
+    this.scheduleIdleCleanup(descriptor.sessionId);
+    return this.snapshot(terminal);
   }
 
   kill(sessionId: string): boolean {
@@ -250,6 +309,9 @@ export class ConnectorTerminalManager {
 
   disconnectSubscribers(): void {
     this.subscribers.clear();
+    for (const sessionId of this.terminals.keys()) {
+      this.scheduleIdleCleanup(sessionId);
+    }
   }
 
   private getOrCreate(
@@ -269,6 +331,7 @@ export class ConnectorTerminalManager {
     size: AgentTerminalSize,
   ): ManagedTerminal {
     const launch = terminalLaunch(descriptor);
+    const pty = requireNodePty();
     const emulator = new Terminal({
       cols: size.cols,
       rows: size.rows,
@@ -301,7 +364,9 @@ export class ConnectorTerminalManager {
       signal: null,
       parseTail: Promise.resolve(),
       pendingOutput: "",
+      outputTruncated: false,
       outputTimer: null,
+      idleTimer: null,
       disposables: [],
     };
     terminal.disposables.push(
@@ -327,6 +392,17 @@ export class ConnectorTerminalManager {
       return;
     }
     terminal.pendingOutput += data;
+    if (terminal.pendingOutput.length > MAX_PENDING_OUTPUT_CHARS) {
+      terminal.pendingOutput = terminal.pendingOutput.slice(
+        -MAX_PENDING_OUTPUT_CHARS,
+      );
+      if (!terminal.outputTruncated) {
+        // Deliberately leave a revision gap. The web broker will close the
+        // stream and the browser will recover from the headless snapshot.
+        terminal.revision += 1;
+        terminal.outputTruncated = true;
+      }
+    }
   }
 
   private flushOutputWindow(terminal: ManagedTerminal): void {
@@ -334,6 +410,7 @@ export class ConnectorTerminalManager {
     if (this.terminals.get(terminal.descriptor.sessionId) !== terminal) return;
     const output = terminal.pendingOutput;
     terminal.pendingOutput = "";
+    terminal.outputTruncated = false;
     if (!output) return;
     this.publishOutput(terminal, output);
     terminal.outputTimer = setTimeout(
@@ -384,6 +461,7 @@ export class ConnectorTerminalManager {
       exitCode,
       signal: signal ?? null,
     });
+    this.scheduleIdleCleanup(terminal.descriptor.sessionId);
   }
 
   private emit(sessionId: string, event: AgentTerminalEvent): void {
@@ -422,6 +500,8 @@ export class ConnectorTerminalManager {
     this.terminals.delete(sessionId);
     if (terminal.outputTimer) clearTimeout(terminal.outputTimer);
     terminal.outputTimer = null;
+    if (terminal.idleTimer) clearTimeout(terminal.idleTimer);
+    terminal.idleTimer = null;
     for (const disposable of terminal.disposables) disposable.dispose();
     terminal.serializer.dispose();
     terminal.emulator.dispose();
@@ -432,6 +512,36 @@ export class ConnectorTerminalManager {
         // The PTY may have exited between the state check and cleanup.
       }
     }
+  }
+
+  private hasSubscribers(sessionId: string): boolean {
+    for (const subscriber of this.subscribers.values()) {
+      if (subscriber.sessionId === sessionId) return true;
+    }
+    return false;
+  }
+
+  private cancelIdleCleanup(terminal: ManagedTerminal): void {
+    if (!terminal.idleTimer) return;
+    clearTimeout(terminal.idleTimer);
+    terminal.idleTimer = null;
+  }
+
+  private scheduleIdleCleanup(sessionId: string): void {
+    const terminal = this.terminals.get(sessionId);
+    if (!terminal || terminal.idleTimer || this.hasSubscribers(sessionId)) {
+      return;
+    }
+    terminal.idleTimer = setTimeout(() => {
+      terminal.idleTimer = null;
+      if (
+        this.terminals.get(sessionId) === terminal &&
+        !this.hasSubscribers(sessionId)
+      ) {
+        this.disposeTerminal(sessionId, true);
+      }
+    }, this.idleTimeoutMs);
+    terminal.idleTimer.unref();
   }
 }
 

--- a/apps/connector/src/xterm-headless-runtime.d.ts
+++ b/apps/connector/src/xterm-headless-runtime.d.ts
@@ -1,0 +1,3 @@
+declare module "@xterm/headless/lib-headless/xterm-headless.js" {
+  export { Terminal } from "@xterm/headless";
+}

--- a/apps/web/app/api/agent-sessions/[id]/terminal/events/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/events/route.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getOwnedAgentSession: vi.fn(),
+  isOnline: vi.fn(),
+  supports: vi.fn(),
+  subscribeTerminal: vi.fn(),
+  unsubscribe: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/agentConnections", () => ({
+  getOwnedAgentSession: mocks.getOwnedAgentSession,
+}));
+vi.mock("@/lib/agents/connector/broker", () => ({
+  hostConnectorBroker: {
+    isOnline: mocks.isOnline,
+    supports: mocks.supports,
+    subscribeTerminal: mocks.subscribeTerminal,
+  },
+}));
+
+import { GET } from "./route";
+
+const owned = {
+  host: {
+    connectorId: "connector",
+    transport: "local",
+    sshAlias: null,
+    userId: "owner",
+  },
+  connection: {
+    id: "connection",
+    provider: "pi",
+    shellMode: "interactive",
+    executable: "pi",
+    detectedVersion: "0.55.0",
+  },
+  workspace: { id: "workspace", path: "/workspace" },
+  agentSession: {
+    id: "session",
+    providerSessionId: "provider-session",
+    providerSessionPath: "/sessions/provider-session.jsonl",
+  },
+};
+
+const context = { params: Promise.resolve({ id: "session" }) };
+
+describe("agent terminal event stream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "owner", role: "admin" },
+    });
+    mocks.getOwnedAgentSession.mockResolvedValue(owned);
+    mocks.isOnline.mockReturnValue(true);
+    mocks.supports.mockReturnValue(true);
+    mocks.subscribeTerminal.mockImplementation(
+      async (
+        _connectorId: string,
+        _session: unknown,
+        _size: unknown,
+        listener: (event: unknown) => void,
+      ) => {
+        listener({ type: "output", revision: 4, data: "live" });
+        return {
+          snapshot: {
+            sessionId: "session",
+            revision: 3,
+            data: "snapshot",
+            cols: 90,
+            rows: 28,
+            exited: false,
+            exitCode: null,
+            signal: null,
+          },
+          unsubscribe: mocks.unsubscribe,
+        };
+      },
+    );
+  });
+
+  it("emits the snapshot before buffered terminal output", async () => {
+    const response = await GET(
+      new Request("http://server.test/events?cols=90&rows=28"),
+      context,
+    );
+    expect(response.status).toBe(200);
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    const snapshot = decoder.decode((await reader.read()).value);
+    const output = decoder.decode((await reader.read()).value);
+
+    expect(snapshot).toContain("event: terminal-snapshot");
+    expect(snapshot).toContain("id: 3");
+    expect(output).toContain("event: terminal-output");
+    expect(output).toContain("id: 4");
+    expect(mocks.subscribeTerminal).toHaveBeenCalledWith(
+      "connector",
+      expect.objectContaining({ sessionId: "session", cwd: "/workspace" }),
+      { cols: 90, rows: 28 },
+      expect.any(Function),
+      expect.any(Function),
+    );
+    await reader.cancel();
+    expect(mocks.unsubscribe).toHaveBeenCalled();
+  });
+
+  it("requires an updated connector capability", async () => {
+    mocks.supports.mockReturnValue(false);
+
+    const response = await GET(
+      new Request("http://server.test/events"),
+      context,
+    );
+
+    expect(response.status).toBe(426);
+    await expect(response.json()).resolves.toEqual({
+      error: "Update the OvertChat Host Connector to use workspace terminals.",
+    });
+    expect(mocks.subscribeTerminal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/agent-sessions/[id]/terminal/events/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/events/route.test.ts
@@ -63,6 +63,7 @@ describe("agent terminal event stream", () => {
       async (
         _connectorId: string,
         _session: unknown,
+        _controlId: string,
         _size: unknown,
         listener: (event: unknown) => void,
       ) => {
@@ -86,7 +87,9 @@ describe("agent terminal event stream", () => {
 
   it("emits the snapshot before buffered terminal output", async () => {
     const response = await GET(
-      new Request("http://server.test/events?cols=90&rows=28"),
+      new Request(
+        "http://server.test/events?cols=90&rows=28&controlId=control-one",
+      ),
       context,
     );
     expect(response.status).toBe(200);
@@ -102,6 +105,7 @@ describe("agent terminal event stream", () => {
     expect(mocks.subscribeTerminal).toHaveBeenCalledWith(
       "connector",
       expect.objectContaining({ sessionId: "session", cwd: "/workspace" }),
+      "control-one",
       { cols: 90, rows: 28 },
       expect.any(Function),
       expect.any(Function),
@@ -114,7 +118,7 @@ describe("agent terminal event stream", () => {
     mocks.supports.mockReturnValue(false);
 
     const response = await GET(
-      new Request("http://server.test/events"),
+      new Request("http://server.test/events?controlId=control-one"),
       context,
     );
 
@@ -123,5 +127,58 @@ describe("agent terminal event stream", () => {
       error: "Update the OvertChat Host Connector to use workspace terminals.",
     });
     expect(mocks.subscribeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing terminal control identifier", async () => {
+    const response = await GET(
+      new Request("http://server.test/events?cols=90&rows=28"),
+      context,
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.subscribeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("bounds output buffered before the terminal snapshot", async () => {
+    mocks.subscribeTerminal.mockImplementationOnce(
+      async (
+        _connectorId: string,
+        _session: unknown,
+        _controlId: string,
+        _size: unknown,
+        listener: (event: unknown) => void,
+      ) => {
+        for (let revision = 1; revision <= 20; revision += 1) {
+          listener({
+            type: "output",
+            revision,
+            data: "x".repeat(256 * 1_024),
+          });
+        }
+        return {
+          snapshot: {
+            sessionId: "session",
+            revision: 0,
+            data: "",
+            cols: 90,
+            rows: 28,
+            exited: false,
+            exitCode: null,
+            signal: null,
+          },
+          unsubscribe: mocks.unsubscribe,
+        };
+      },
+    );
+
+    const response = await GET(
+      new Request(
+        "http://server.test/events?cols=90&rows=28&controlId=control-one",
+      ),
+      context,
+    );
+
+    expect(response.status).toBe(503);
+    expect(mocks.unsubscribe).toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/agent-sessions/[id]/terminal/events/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/events/route.ts
@@ -1,0 +1,158 @@
+import { auth } from "@/lib/auth/server";
+import { storedConnectionAccessError } from "@/lib/agents/access";
+import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import { daemonSession } from "@/lib/agents/connector/descriptors";
+import { getOwnedAgentSession } from "@/lib/db/agentConnections";
+import {
+  isAgentTerminalSize,
+  type AgentTerminalEvent,
+  type AgentTerminalSnapshot,
+} from "@overtchat/agent-bridge";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+type StreamItem =
+  | { type: "snapshot"; snapshot: AgentTerminalSnapshot }
+  | { type: "event"; event: AgentTerminalEvent };
+
+function encode(item: StreamItem): Uint8Array {
+  const revision =
+    item.type === "snapshot" ? item.snapshot.revision : item.event.revision;
+  const eventName =
+    item.type === "snapshot"
+      ? "terminal-snapshot"
+      : `terminal-${item.event.type}`;
+  const data = item.type === "snapshot" ? item.snapshot : item.event;
+  return new TextEncoder().encode(
+    `id: ${revision}\nevent: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`,
+  );
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const authSession = await auth.api.getSession({ headers: req.headers });
+  if (!authSession) return new Response("Unauthorized", { status: 401 });
+  const accessError = storedConnectionAccessError(authSession.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+  const { id } = await params;
+  const owned = await getOwnedAgentSession(id, authSession.user.id);
+  if (!owned) return new Response("Not found", { status: 404 });
+  if (
+    hostConnectorBroker.isOnline(owned.host.connectorId) &&
+    !hostConnectorBroker.supports(
+      owned.host.connectorId,
+      "workspace-terminal-v1",
+    )
+  ) {
+    return Response.json(
+      {
+        error:
+          "Update the OvertChat Host Connector to use workspace terminals.",
+      },
+      { status: 426 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const size = {
+    cols: Number(url.searchParams.get("cols") ?? 80),
+    rows: Number(url.searchParams.get("rows") ?? 24),
+  };
+  if (!isAgentTerminalSize(size)) {
+    return Response.json({ error: "Invalid terminal size." }, { status: 400 });
+  }
+
+  const pending: StreamItem[] = [];
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let closed = false;
+  let closeRequested = req.signal.aborted;
+  let closeStream = () => {
+    closeRequested = true;
+  };
+  const handleAbort = () => closeStream();
+  req.signal.addEventListener("abort", handleAbort, { once: true });
+
+  try {
+    const enqueue = (item: StreamItem) => {
+      if (closed) return;
+      if (!controller) {
+        pending.push(item);
+        return;
+      }
+      try {
+        controller.enqueue(encode(item));
+      } catch {
+        closeStream();
+      }
+    };
+    const subscription = await hostConnectorBroker.subscribeTerminal(
+      owned.host.connectorId,
+      daemonSession(owned),
+      size,
+      (event) => enqueue({ type: "event", event }),
+      () => closeStream(),
+    );
+    if (closeRequested) {
+      subscription.unsubscribe();
+      req.signal.removeEventListener("abort", handleAbort);
+      return new Response(null, { status: 503 });
+    }
+
+    const body = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+        streamController.enqueue(
+          encode({ type: "snapshot", snapshot: subscription.snapshot }),
+        );
+        for (const item of pending.splice(0)) {
+          streamController.enqueue(encode(item));
+        }
+        const keepAlive = setInterval(() => {
+          if (closed) return;
+          try {
+            streamController.enqueue(
+              new TextEncoder().encode(": keepalive\n\n"),
+            );
+          } catch {
+            closeStream();
+          }
+        }, 15_000);
+        closeStream = () => {
+          if (closed) return;
+          closed = true;
+          clearInterval(keepAlive);
+          req.signal.removeEventListener("abort", handleAbort);
+          subscription.unsubscribe();
+          try {
+            streamController.close();
+          } catch {
+            // The browser may already have closed the stream.
+          }
+        };
+      },
+      cancel() {
+        closeStream();
+      },
+    });
+    return new Response(body, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  } catch (error) {
+    closed = true;
+    req.signal.removeEventListener("abort", handleAbort);
+    return Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/app/api/agent-sessions/[id]/terminal/events/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/events/route.ts
@@ -4,6 +4,7 @@ import { hostConnectorBroker } from "@/lib/agents/connector/broker";
 import { daemonSession } from "@/lib/agents/connector/descriptors";
 import { getOwnedAgentSession } from "@/lib/db/agentConnections";
 import {
+  AGENT_TERMINAL_MAX_SNAPSHOT_CHARS,
   isAgentTerminalSize,
   type AgentTerminalEvent,
   type AgentTerminalSnapshot,
@@ -11,6 +12,9 @@ import {
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
+
+const MAX_TERMINAL_STREAM_BUFFER_BYTES =
+  AGENT_TERMINAL_MAX_SNAPSHOT_CHARS + 512 * 1_024;
 
 type StreamItem =
   | { type: "snapshot"; snapshot: AgentTerminalSnapshot }
@@ -59,6 +63,13 @@ export async function GET(
   }
 
   const url = new URL(req.url);
+  const controlId = url.searchParams.get("controlId")?.trim() ?? "";
+  if (!controlId || controlId.length > 128) {
+    return Response.json(
+      { error: "Invalid terminal control identifier." },
+      { status: 400 },
+    );
+  }
   const size = {
     cols: Number(url.searchParams.get("cols") ?? 80),
     rows: Number(url.searchParams.get("rows") ?? 24),
@@ -67,7 +78,8 @@ export async function GET(
     return Response.json({ error: "Invalid terminal size." }, { status: 400 });
   }
 
-  const pending: StreamItem[] = [];
+  const pending: Uint8Array[] = [];
+  let pendingBytes = 0;
   let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
   let closed = false;
   let closeRequested = req.signal.aborted;
@@ -80,12 +92,26 @@ export async function GET(
   try {
     const enqueue = (item: StreamItem) => {
       if (closed) return;
+      const encoded = encode(item);
       if (!controller) {
-        pending.push(item);
+        if (
+          pendingBytes + encoded.byteLength >
+          MAX_TERMINAL_STREAM_BUFFER_BYTES
+        ) {
+          closeStream();
+          return;
+        }
+        pending.push(encoded);
+        pendingBytes += encoded.byteLength;
         return;
       }
       try {
-        controller.enqueue(encode(item));
+        const capacity = controller.desiredSize;
+        if (capacity !== null && capacity < encoded.byteLength) {
+          closeStream();
+          return;
+        }
+        controller.enqueue(encoded);
       } catch {
         closeStream();
       }
@@ -93,6 +119,7 @@ export async function GET(
     const subscription = await hostConnectorBroker.subscribeTerminal(
       owned.host.connectorId,
       daemonSession(owned),
+      controlId,
       size,
       (event) => enqueue({ type: "event", event }),
       () => closeStream(),
@@ -103,42 +130,52 @@ export async function GET(
       return new Response(null, { status: 503 });
     }
 
-    const body = new ReadableStream<Uint8Array>({
-      start(streamController) {
-        controller = streamController;
-        streamController.enqueue(
-          encode({ type: "snapshot", snapshot: subscription.snapshot }),
-        );
-        for (const item of pending.splice(0)) {
-          streamController.enqueue(encode(item));
-        }
-        const keepAlive = setInterval(() => {
-          if (closed) return;
-          try {
-            streamController.enqueue(
-              new TextEncoder().encode(": keepalive\n\n"),
-            );
-          } catch {
-            closeStream();
+    const body = new ReadableStream<Uint8Array>(
+      {
+        start(streamController) {
+          controller = streamController;
+          streamController.enqueue(
+            encode({ type: "snapshot", snapshot: subscription.snapshot }),
+          );
+          for (const item of pending.splice(0)) {
+            streamController.enqueue(item);
           }
-        }, 15_000);
-        closeStream = () => {
-          if (closed) return;
-          closed = true;
-          clearInterval(keepAlive);
-          req.signal.removeEventListener("abort", handleAbort);
-          subscription.unsubscribe();
-          try {
-            streamController.close();
-          } catch {
-            // The browser may already have closed the stream.
-          }
-        };
+          pendingBytes = 0;
+          const keepAlive = setInterval(() => {
+            if (closed) return;
+            try {
+              const keepAliveFrame = new TextEncoder().encode(": keepalive\n\n");
+              const capacity = streamController.desiredSize;
+              if (capacity !== null && capacity < keepAliveFrame.byteLength) {
+                closeStream();
+                return;
+              }
+              streamController.enqueue(keepAliveFrame);
+            } catch {
+              closeStream();
+            }
+          }, 15_000);
+          closeStream = () => {
+            if (closed) return;
+            closed = true;
+            clearInterval(keepAlive);
+            req.signal.removeEventListener("abort", handleAbort);
+            subscription.unsubscribe();
+            try {
+              streamController.close();
+            } catch {
+              // The browser may already have closed the stream.
+            }
+          };
+        },
+        cancel() {
+          closeStream();
+        },
       },
-      cancel() {
-        closeStream();
-      },
-    });
+      new ByteLengthQueuingStrategy({
+        highWaterMark: MAX_TERMINAL_STREAM_BUFFER_BYTES,
+      }),
+    );
     return new Response(body, {
       headers: {
         "Content-Type": "text/event-stream",

--- a/apps/web/app/api/agent-sessions/[id]/terminal/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/route.test.ts
@@ -83,7 +83,11 @@ describe("agent terminal controls", () => {
       context,
     );
     const resize = await POST(
-      request({ type: "resize", size: { cols: 100, rows: 32 } }),
+      request({
+        type: "resize",
+        controlId: "control-one",
+        size: { cols: 100, rows: 32 },
+      }),
       context,
     );
 
@@ -94,10 +98,12 @@ describe("agent terminal controls", () => {
       "session",
       "pwd\r",
     );
-    expect(mocks.resizeTerminal).toHaveBeenCalledWith("connector", "session", {
-      cols: 100,
-      rows: 32,
-    });
+    expect(mocks.resizeTerminal).toHaveBeenCalledWith(
+      "connector",
+      "session",
+      "control-one",
+      { cols: 100, rows: 32 },
+    );
   });
 
   it("restarts the workspace terminal with the session descriptor", async () => {
@@ -136,5 +142,35 @@ describe("agent terminal controls", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Update the OvertChat Host Connector to use workspace terminals.",
     });
+  });
+
+  it("does not expose terminal controls for an unowned session", async () => {
+    mocks.getOwnedAgentSession.mockResolvedValue(null);
+
+    const response = await POST(
+      request({ type: "input", data: "pwd\r" }),
+      context,
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.sendTerminalInput).not.toHaveBeenCalled();
+    expect(mocks.resizeTerminal).not.toHaveBeenCalled();
+    expect(mocks.restartTerminal).not.toHaveBeenCalled();
+    expect(mocks.killTerminal).not.toHaveBeenCalled();
+  });
+
+  it("keeps terminal controls admin-only", async () => {
+    mocks.getSession.mockResolvedValue({
+      user: { id: "owner", role: "user" },
+    });
+
+    const response = await POST(
+      request({ type: "input", data: "pwd\r" }),
+      context,
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.getOwnedAgentSession).not.toHaveBeenCalled();
+    expect(mocks.sendTerminalInput).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/agent-sessions/[id]/terminal/route.test.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getOwnedAgentSession: vi.fn(),
+  isOnline: vi.fn(),
+  supports: vi.fn(),
+  sendTerminalInput: vi.fn(),
+  resizeTerminal: vi.fn(),
+  restartTerminal: vi.fn(),
+  killTerminal: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/agentConnections", () => ({
+  getOwnedAgentSession: mocks.getOwnedAgentSession,
+}));
+vi.mock("@/lib/agents/connector/broker", () => ({
+  hostConnectorBroker: mocks,
+}));
+
+import { GET, POST } from "./route";
+
+const owned = {
+  host: {
+    connectorId: "connector",
+    transport: "local",
+    sshAlias: null,
+    userId: "owner",
+  },
+  connection: {
+    id: "connection",
+    provider: "pi",
+    shellMode: "interactive",
+    executable: "pi",
+    detectedVersion: "0.55.0",
+  },
+  workspace: { id: "workspace", path: "/workspace" },
+  agentSession: {
+    id: "session",
+    providerSessionId: "provider-session",
+    providerSessionPath: "/sessions/provider-session.jsonl",
+  },
+};
+
+const context = { params: Promise.resolve({ id: "session" }) };
+
+function request(body: unknown) {
+  return new Request("http://server.test/terminal", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("agent terminal controls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({
+      user: { id: "owner", role: "admin" },
+    });
+    mocks.getOwnedAgentSession.mockResolvedValue(owned);
+    mocks.isOnline.mockReturnValue(true);
+    mocks.supports.mockReturnValue(true);
+    mocks.restartTerminal.mockResolvedValue({
+      sessionId: "session",
+      revision: 0,
+      data: "",
+      cols: 80,
+      rows: 24,
+      exited: false,
+      exitCode: null,
+      signal: null,
+    });
+  });
+
+  it("relays input and resize only to the owned session", async () => {
+    const input = await POST(
+      request({ type: "input", data: "pwd\r" }),
+      context,
+    );
+    const resize = await POST(
+      request({ type: "resize", size: { cols: 100, rows: 32 } }),
+      context,
+    );
+
+    expect(input.status).toBe(204);
+    expect(resize.status).toBe(204);
+    expect(mocks.sendTerminalInput).toHaveBeenCalledWith(
+      "connector",
+      "session",
+      "pwd\r",
+    );
+    expect(mocks.resizeTerminal).toHaveBeenCalledWith("connector", "session", {
+      cols: 100,
+      rows: 32,
+    });
+  });
+
+  it("restarts the workspace terminal with the session descriptor", async () => {
+    const response = await POST(
+      request({ type: "restart", size: { cols: 80, rows: 24 } }),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.restartTerminal).toHaveBeenCalledWith(
+      "connector",
+      expect.objectContaining({ sessionId: "session", cwd: "/workspace" }),
+      { cols: 80, rows: 24 },
+    );
+  });
+
+  it("rejects invalid and oversized input", async () => {
+    const response = await POST(
+      request({ type: "input", data: "x".repeat(65 * 1_024) }),
+      context,
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.sendTerminalInput).not.toHaveBeenCalled();
+  });
+
+  it("reports when the installed connector needs an upgrade", async () => {
+    mocks.supports.mockReturnValue(false);
+
+    const response = await GET(
+      new Request("http://server.test/terminal"),
+      context,
+    );
+
+    expect(response.status).toBe(426);
+    await expect(response.json()).resolves.toEqual({
+      error: "Update the OvertChat Host Connector to use workspace terminals.",
+    });
+  });
+});

--- a/apps/web/app/api/agent-sessions/[id]/terminal/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/route.ts
@@ -11,7 +11,7 @@ import {
 
 type TerminalControl =
   | { type: "input"; data: string }
-  | { type: "resize"; size: AgentTerminalSize }
+  | { type: "resize"; controlId: string; size: AgentTerminalSize }
   | { type: "restart"; size: AgentTerminalSize }
   | { type: "kill" };
 
@@ -27,10 +27,20 @@ function parseControl(value: unknown): TerminalControl | null {
     return { type: "input", data: record.data };
   }
   if (
-    (record.type === "resize" || record.type === "restart") &&
+    record.type === "resize" &&
+    typeof record.controlId === "string" &&
+    record.controlId.length > 0 &&
+    record.controlId.length <= 128 &&
     isAgentTerminalSize(record.size)
   ) {
-    return { type: record.type, size: record.size };
+    return {
+      type: "resize",
+      controlId: record.controlId,
+      size: record.size,
+    };
+  }
+  if (record.type === "restart" && isAgentTerminalSize(record.size)) {
+    return { type: "restart", size: record.size };
   }
   return record.type === "kill" ? { type: "kill" } : null;
 }
@@ -123,6 +133,7 @@ export async function POST(
       hostConnectorBroker.resizeTerminal(
         owned.host.connectorId,
         id,
+        control.controlId,
         control.size,
       );
       return new Response(null, { status: 204 });

--- a/apps/web/app/api/agent-sessions/[id]/terminal/route.ts
+++ b/apps/web/app/api/agent-sessions/[id]/terminal/route.ts
@@ -1,0 +1,146 @@
+import { auth } from "@/lib/auth/server";
+import { storedConnectionAccessError } from "@/lib/agents/access";
+import { hostConnectorBroker } from "@/lib/agents/connector/broker";
+import { daemonSession } from "@/lib/agents/connector/descriptors";
+import { getOwnedAgentSession } from "@/lib/db/agentConnections";
+import {
+  AGENT_TERMINAL_MAX_INPUT_CHARS,
+  isAgentTerminalSize,
+  type AgentTerminalSize,
+} from "@overtchat/agent-bridge";
+
+type TerminalControl =
+  | { type: "input"; data: string }
+  | { type: "resize"; size: AgentTerminalSize }
+  | { type: "restart"; size: AgentTerminalSize }
+  | { type: "kill" };
+
+function parseControl(value: unknown): TerminalControl | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    record.type === "input" &&
+    typeof record.data === "string" &&
+    record.data.length > 0 &&
+    record.data.length <= AGENT_TERMINAL_MAX_INPUT_CHARS
+  ) {
+    return { type: "input", data: record.data };
+  }
+  if (
+    (record.type === "resize" || record.type === "restart") &&
+    isAgentTerminalSize(record.size)
+  ) {
+    return { type: record.type, size: record.size };
+  }
+  return record.type === "kill" ? { type: "kill" } : null;
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const authSession = await auth.api.getSession({ headers: req.headers });
+  if (!authSession) return new Response("Unauthorized", { status: 401 });
+  const accessError = storedConnectionAccessError(authSession.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+  const { id } = await params;
+  const owned = await getOwnedAgentSession(id, authSession.user.id);
+  if (!owned) return new Response("Not found", { status: 404 });
+  if (!hostConnectorBroker.isOnline(owned.host.connectorId)) {
+    return Response.json(
+      { error: "The OvertChat Host Connector is offline." },
+      { status: 503 },
+    );
+  }
+  if (
+    !hostConnectorBroker.supports(
+      owned.host.connectorId,
+      "workspace-terminal-v1",
+    )
+  ) {
+    return Response.json(
+      {
+        error:
+          "Update the OvertChat Host Connector to use workspace terminals.",
+      },
+      { status: 426 },
+    );
+  }
+  return Response.json(
+    { available: true },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const authSession = await auth.api.getSession({ headers: req.headers });
+  if (!authSession) return new Response("Unauthorized", { status: 401 });
+  const accessError = storedConnectionAccessError(authSession.user.role);
+  if (accessError) {
+    return Response.json({ error: accessError }, { status: 403 });
+  }
+  const { id } = await params;
+  const owned = await getOwnedAgentSession(id, authSession.user.id);
+  if (!owned) return new Response("Not found", { status: 404 });
+  if (
+    hostConnectorBroker.isOnline(owned.host.connectorId) &&
+    !hostConnectorBroker.supports(
+      owned.host.connectorId,
+      "workspace-terminal-v1",
+    )
+  ) {
+    return Response.json(
+      {
+        error:
+          "Update the OvertChat Host Connector to use workspace terminals.",
+      },
+      { status: 426 },
+    );
+  }
+  const control = parseControl(await req.json().catch(() => null));
+  if (!control) {
+    return Response.json(
+      { error: "Invalid terminal command." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    if (control.type === "input") {
+      hostConnectorBroker.sendTerminalInput(
+        owned.host.connectorId,
+        id,
+        control.data,
+      );
+      return new Response(null, { status: 204 });
+    }
+    if (control.type === "resize") {
+      hostConnectorBroker.resizeTerminal(
+        owned.host.connectorId,
+        id,
+        control.size,
+      );
+      return new Response(null, { status: 204 });
+    }
+    if (control.type === "restart") {
+      const snapshot = await hostConnectorBroker.restartTerminal(
+        owned.host.connectorId,
+        daemonSession(owned),
+        control.size,
+      );
+      return Response.json({ snapshot });
+    }
+    await hostConnectorBroker.killTerminal(owned.host.connectorId, id);
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3,6 +3,7 @@
 @import "shadcn/tailwind.css";
 @import "streamdown/styles.css";
 @import "katex/dist/katex.min.css";
+@import "@xterm/xterm/css/xterm.css";
 
 @source "../../../node_modules/streamdown/dist/*.js";
 @source "../../../node_modules/@streamdown/code/dist/*.js";

--- a/apps/web/components/agents/AgentSessionHeader.tsx
+++ b/apps/web/components/agents/AgentSessionHeader.tsx
@@ -13,6 +13,7 @@ import {
   PanelRight,
   Pencil,
   Sparkles,
+  SquareTerminal,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SidebarToggle } from "@/components/SidebarToggle";
@@ -40,6 +41,8 @@ export function AgentSessionHeader({
   onCompact,
   filesOpen,
   onToggleFiles,
+  terminalOpen,
+  onToggleTerminal,
 }: {
   provider: AgentProviderId;
   workspaceId: string;
@@ -52,6 +55,8 @@ export function AgentSessionHeader({
   onCompact: () => void;
   filesOpen: boolean;
   onToggleFiles: () => void;
+  terminalOpen: boolean;
+  onToggleTerminal: () => void;
 }) {
   const providerMetadata = agentProviderMetadata(provider);
   const providerVisual = AGENT_PROVIDER_VISUALS[provider];
@@ -107,6 +112,24 @@ export function AgentSessionHeader({
       </span>
       <WorkspaceGitSummary status={gitStatus} />
       <div className="ml-auto flex shrink-0 items-center gap-0.5">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={
+            terminalOpen
+              ? "Close workspace terminal"
+              : "Open workspace terminal"
+          }
+          title={
+            terminalOpen
+              ? "Close workspace terminal"
+              : "Open workspace terminal"
+          }
+          aria-pressed={terminalOpen}
+          onClick={onToggleTerminal}
+        >
+          <SquareTerminal />
+        </Button>
         <Button
           variant="ghost"
           size="icon-sm"

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -11,6 +11,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import {
   AlertTriangle,
   Loader2,
@@ -72,6 +73,17 @@ const MIN_WORKSPACE_PANE_WIDTH = 352;
 const MAX_WORKSPACE_PANE_WIDTH = 960;
 const MIN_TRANSCRIPT_WIDTH = 480;
 const WORKSPACE_PANE_WIDTH_KEY = "overtchat:agent-workspace-pane-width";
+const DEFAULT_TERMINAL_PANE_HEIGHT = 288;
+const MIN_TERMINAL_PANE_HEIGHT = 160;
+const MAX_TERMINAL_PANE_HEIGHT = 720;
+const MIN_TRANSCRIPT_HEIGHT = 240;
+const TERMINAL_PANE_HEIGHT_KEY = "overtchat:agent-terminal-pane-height";
+
+const AgentTerminalPane = dynamic(
+  () =>
+    import("./AgentTerminalPane").then((module) => module.AgentTerminalPane),
+  { ssr: false },
+);
 
 function recordOf(value: unknown): UnknownRecord | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -213,6 +225,17 @@ function clampWorkspacePaneWidth(width: number, viewportWidth: number): number {
   return Math.min(maximum, Math.max(MIN_WORKSPACE_PANE_WIDTH, width));
 }
 
+function clampTerminalPaneHeight(
+  height: number,
+  viewportHeight: number,
+): number {
+  const maximum = Math.max(
+    MIN_TERMINAL_PANE_HEIGHT,
+    Math.min(MAX_TERMINAL_PANE_HEIGHT, viewportHeight - MIN_TRANSCRIPT_HEIGHT),
+  );
+  return Math.min(maximum, Math.max(MIN_TERMINAL_PANE_HEIGHT, height));
+}
+
 export function AgentSessionView({
   sessionId,
   provider,
@@ -256,6 +279,15 @@ export function AgentSessionView({
     `overtchat:agent-workspace-pane:${sessionId}`,
     false,
   );
+  const [terminalOpen, setTerminalOpen] = useLocalStorage<boolean>(
+    `overtchat:agent-terminal-pane:${sessionId}`,
+    false,
+  );
+  const [storedTerminalHeight, setStoredTerminalHeight] =
+    useLocalStorage<unknown>(
+      TERMINAL_PANE_HEIGHT_KEY,
+      DEFAULT_TERMINAL_PANE_HEIGHT,
+    );
   const [storedFileSelection, setStoredFileSelection] =
     useLocalStorage<unknown>(
       `overtchat:agent-workspace-file:${sessionId}`,
@@ -278,21 +310,41 @@ export function AgentSessionView({
     [storedOpenFiles],
   );
   const [viewportWidth, setViewportWidth] = useState(1440);
+  const [viewportHeight, setViewportHeight] = useState(900);
   const [dragPaneWidth, setDragPaneWidth] = useState<number | null>(null);
   const [resizingPane, setResizingPane] = useState(false);
   const resizeStart = useRef<{ pointerX: number; width: number } | null>(null);
+  const [dragTerminalHeight, setDragTerminalHeight] = useState<number | null>(
+    null,
+  );
+  const [resizingTerminal, setResizingTerminal] = useState(false);
+  const terminalResizeStart = useRef<{
+    pointerY: number;
+    height: number;
+  } | null>(null);
   const preferredPaneWidth =
     typeof storedPaneWidth === "number" && Number.isFinite(storedPaneWidth)
       ? storedPaneWidth
       : DEFAULT_WORKSPACE_PANE_WIDTH;
   const paneWidth =
     dragPaneWidth ?? clampWorkspacePaneWidth(preferredPaneWidth, viewportWidth);
+  const preferredTerminalHeight =
+    typeof storedTerminalHeight === "number" &&
+    Number.isFinite(storedTerminalHeight)
+      ? storedTerminalHeight
+      : DEFAULT_TERMINAL_PANE_HEIGHT;
+  const terminalHeight =
+    dragTerminalHeight ??
+    clampTerminalPaneHeight(preferredTerminalHeight, viewportHeight);
 
   useEffect(() => {
-    const updateViewportWidth = () => setViewportWidth(window.innerWidth);
-    updateViewportWidth();
-    window.addEventListener("resize", updateViewportWidth);
-    return () => window.removeEventListener("resize", updateViewportWidth);
+    const updateViewport = () => {
+      setViewportWidth(window.innerWidth);
+      setViewportHeight(window.innerHeight);
+    };
+    updateViewport();
+    window.addEventListener("resize", updateViewport);
+    return () => window.removeEventListener("resize", updateViewport);
   }, []);
 
   useEffect(() => {
@@ -402,6 +454,68 @@ export function AgentSessionView({
     if (width === null) return;
     event.preventDefault();
     setStoredPaneWidth(clampWorkspacePaneWidth(width, viewportWidth));
+  }
+
+  function terminalHeightFromPointer(pointerY: number): number {
+    const start = terminalResizeStart.current;
+    if (!start) return terminalHeight;
+    return clampTerminalPaneHeight(
+      start.height + start.pointerY - pointerY,
+      viewportHeight,
+    );
+  }
+
+  function startTerminalResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    terminalResizeStart.current = {
+      pointerY: event.clientY,
+      height: terminalHeight,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setDragTerminalHeight(terminalHeight);
+    setResizingTerminal(true);
+  }
+
+  function moveTerminalResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (!terminalResizeStart.current) return;
+    event.preventDefault();
+    setDragTerminalHeight(terminalHeightFromPointer(event.clientY));
+  }
+
+  function finishTerminalResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (!terminalResizeStart.current) return;
+    const height = terminalHeightFromPointer(event.clientY);
+    terminalResizeStart.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setStoredTerminalHeight(height);
+    setDragTerminalHeight(null);
+    setResizingTerminal(false);
+  }
+
+  function cancelTerminalResize(event: ReactPointerEvent<HTMLDivElement>) {
+    terminalResizeStart.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setDragTerminalHeight(null);
+    setResizingTerminal(false);
+  }
+
+  function resizeTerminalWithKeyboard(
+    event: ReactKeyboardEvent<HTMLDivElement>,
+  ) {
+    const step = event.shiftKey ? 64 : 24;
+    let height: number | null = null;
+    if (event.key === "ArrowUp") height = terminalHeight + step;
+    if (event.key === "ArrowDown") height = terminalHeight - step;
+    if (event.key === "Home") height = MIN_TERMINAL_PANE_HEIGHT;
+    if (event.key === "End") height = MAX_TERMINAL_PANE_HEIGHT;
+    if (height === null) return;
+    event.preventDefault();
+    setStoredTerminalHeight(clampTerminalPaneHeight(height, viewportHeight));
   }
   const workspaceNavigation = useMemo(
     () => ({ openFile: openWorkspaceFile }),
@@ -606,7 +720,7 @@ export function AgentSessionView({
   return (
     <AgentWorkspaceNavigationProvider value={workspaceNavigation}>
       <div className="relative flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
           <AgentSessionHeader
             provider={provider}
             workspaceId={workspaceId}
@@ -617,6 +731,8 @@ export function AgentSessionView({
             readOnly={Boolean(readOnly)}
             filesOpen={filesOpen}
             onToggleFiles={() => setFilesOpen(!filesOpen)}
+            terminalOpen={terminalOpen}
+            onToggleTerminal={() => setTerminalOpen(!terminalOpen)}
             onRename={() => {
               setDialogError("");
               setRenameOpen(true);
@@ -804,6 +920,51 @@ export function AgentSessionView({
               />
             </div>
           </div>
+
+          {terminalOpen && (
+            <div
+              data-testid="agent-terminal-pane"
+              style={{ height: `${terminalHeight}px` }}
+              className="relative shrink-0 border-t bg-background"
+            >
+              <div
+                role="separator"
+                aria-label="Resize workspace terminal"
+                aria-orientation="horizontal"
+                aria-valuemin={MIN_TERMINAL_PANE_HEIGHT}
+                aria-valuemax={clampTerminalPaneHeight(
+                  MAX_TERMINAL_PANE_HEIGHT,
+                  viewportHeight,
+                )}
+                aria-valuenow={Math.round(terminalHeight)}
+                tabIndex={0}
+                onPointerDown={startTerminalResize}
+                onPointerMove={moveTerminalResize}
+                onPointerUp={finishTerminalResize}
+                onPointerCancel={cancelTerminalResize}
+                onDoubleClick={() =>
+                  setStoredTerminalHeight(DEFAULT_TERMINAL_PANE_HEIGHT)
+                }
+                onKeyDown={resizeTerminalWithKeyboard}
+                className={cn(
+                  "group absolute inset-x-0 top-0 z-10 h-2 -translate-y-1/2 touch-none cursor-row-resize outline-none select-none",
+                  resizingTerminal && "cursor-row-resize",
+                )}
+              >
+                <span
+                  className={cn(
+                    "absolute inset-x-0 top-1/2 h-px bg-border motion-colors group-hover:bg-primary/70 group-focus-visible:h-0.5 group-focus-visible:bg-primary",
+                    resizingTerminal && "h-0.5 bg-primary",
+                  )}
+                />
+              </div>
+              <AgentTerminalPane
+                sessionId={sessionId}
+                active={terminalOpen}
+                onClose={() => setTerminalOpen(false)}
+              />
+            </div>
+          )}
 
           <RenameAgentSessionDialog
             providerLabel={providerLabel}

--- a/apps/web/components/agents/AgentTerminalPane.tsx
+++ b/apps/web/components/agents/AgentTerminalPane.tsx
@@ -15,6 +15,13 @@ import { cn } from "@/lib/utils";
 
 type ConnectionStatus = "connecting" | "connected" | "reconnecting" | "error";
 
+let terminalControlSequence = 0;
+
+function createTerminalControlId(): string {
+  terminalControlSequence += 1;
+  return `${Date.now().toString(36)}-${terminalControlSequence.toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 function terminalTheme(element: HTMLElement) {
   const styles = getComputedStyle(element);
   return {
@@ -145,7 +152,7 @@ export function AgentTerminalPane({
     let inputBuffer = "";
     let inputChain = Promise.resolve();
     let lastSize = sizeRef.current;
-    const controlId = crypto.randomUUID();
+    const controlId = createTerminalControlId();
 
     const post = async (body: unknown) => {
       const response = await fetch(controlUrl, {

--- a/apps/web/components/agents/AgentTerminalPane.tsx
+++ b/apps/web/components/agents/AgentTerminalPane.tsx
@@ -145,12 +145,17 @@ export function AgentTerminalPane({
     let inputBuffer = "";
     let inputChain = Promise.resolve();
     let lastSize = sizeRef.current;
+    const controlId = crypto.randomUUID();
 
     const post = async (body: unknown) => {
       const response = await fetch(controlUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
+        body: JSON.stringify(
+          body && typeof body === "object"
+            ? { ...body, controlId }
+            : body,
+        ),
       });
       if (!response.ok) throw new Error(await responseError(response));
       return response;
@@ -250,7 +255,7 @@ export function AgentTerminalPane({
       lastSize = size;
       sizeRef.current = size;
       source = new EventSource(
-        `${controlUrl}/events?cols=${size.cols}&rows=${size.rows}`,
+        `${controlUrl}/events?cols=${size.cols}&rows=${size.rows}&controlId=${encodeURIComponent(controlId)}`,
       );
       source.onopen = () => {
         if (!disposed) setStatus(hasSnapshot ? "connected" : "connecting");

--- a/apps/web/components/agents/AgentTerminalPane.tsx
+++ b/apps/web/components/agents/AgentTerminalPane.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import { RotateCcw, Square, X } from "lucide-react";
+import {
+  AGENT_TERMINAL_MAX_INPUT_CHARS,
+  type AgentTerminalEvent,
+  type AgentTerminalSize,
+  type AgentTerminalSnapshot,
+} from "@overtchat/agent-bridge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ConnectionStatus = "connecting" | "connected" | "reconnecting" | "error";
+
+function terminalTheme(element: HTMLElement) {
+  const styles = getComputedStyle(element);
+  return {
+    background: styles.getPropertyValue("--background").trim(),
+    foreground: styles.getPropertyValue("--foreground").trim(),
+    cursor: styles.getPropertyValue("--foreground").trim(),
+    cursorAccent: styles.getPropertyValue("--background").trim(),
+    selectionBackground: styles.getPropertyValue("--accent").trim(),
+    black: "#18181b",
+    brightBlack: "#71717a",
+    red: "#ef4444",
+    brightRed: "#f87171",
+    green: "#84a75b",
+    brightGreen: "#a3c778",
+    yellow: "#d6a84b",
+    brightYellow: "#f0c96b",
+    blue: "#60a5fa",
+    brightBlue: "#93c5fd",
+    magenta: "#c084fc",
+    brightMagenta: "#d8b4fe",
+    cyan: "#22d3ee",
+    brightCyan: "#67e8f9",
+    white: "#d4d4d8",
+    brightWhite: "#fafafa",
+  };
+}
+
+function readSnapshot(value: unknown): AgentTerminalSnapshot | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const snapshot = value as Partial<AgentTerminalSnapshot>;
+  return typeof snapshot.sessionId === "string" &&
+    Number.isSafeInteger(snapshot.revision) &&
+    typeof snapshot.data === "string" &&
+    Number.isSafeInteger(snapshot.cols) &&
+    Number.isSafeInteger(snapshot.rows) &&
+    typeof snapshot.exited === "boolean" &&
+    (snapshot.exitCode === null || Number.isSafeInteger(snapshot.exitCode)) &&
+    (snapshot.signal === null || Number.isSafeInteger(snapshot.signal))
+    ? (snapshot as AgentTerminalSnapshot)
+    : null;
+}
+
+function readEvent(
+  value: unknown,
+  type: "output" | "exit",
+): AgentTerminalEvent | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const event = value as Record<string, unknown>;
+  if (event.type !== type || !Number.isSafeInteger(event.revision)) return null;
+  if (type === "output") {
+    return typeof event.data === "string"
+      ? { type, revision: Number(event.revision), data: event.data }
+      : null;
+  }
+  return (event.exitCode === null || Number.isSafeInteger(event.exitCode)) &&
+    (event.signal === null || Number.isSafeInteger(event.signal))
+    ? {
+        type,
+        revision: Number(event.revision),
+        exitCode: event.exitCode === null ? null : Number(event.exitCode),
+        signal: event.signal === null ? null : Number(event.signal),
+      }
+    : null;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+async function responseError(response: Response): Promise<string> {
+  const value = (await response.json().catch(() => null)) as {
+    error?: unknown;
+  } | null;
+  return typeof value?.error === "string"
+    ? value.error
+    : `Terminal request failed (${response.status}).`;
+}
+
+export function AgentTerminalPane({
+  sessionId,
+  active,
+  onClose,
+}: {
+  sessionId: string;
+  active: boolean;
+  onClose: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sizeRef = useRef<AgentTerminalSize>({ cols: 80, rows: 24 });
+  const [status, setStatus] = useState<ConnectionStatus>("connecting");
+  const [error, setError] = useState("");
+  const [exited, setExited] = useState(false);
+  const [exitLabel, setExitLabel] = useState("");
+  const controlUrl = `/api/agent-sessions/${encodeURIComponent(sessionId)}/terminal`;
+
+  useEffect(() => {
+    if (!active || !containerRef.current) return;
+    const container = containerRef.current;
+    const terminal = new Terminal({
+      allowProposedApi: false,
+      convertEol: false,
+      cursorBlink: true,
+      cursorStyle: "block",
+      fontFamily:
+        getComputedStyle(container)
+          .getPropertyValue("--font-geist-mono")
+          .trim() || "ui-monospace, monospace",
+      fontSize: 13,
+      lineHeight: 1.15,
+      scrollback: 10_000,
+      theme: terminalTheme(container),
+    });
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.open(container);
+    let disposed = false;
+    let source: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let preflightTimer: ReturnType<typeof setTimeout> | undefined;
+    let resizeTimer: ReturnType<typeof setTimeout> | undefined;
+    let inputTimer: ReturnType<typeof setTimeout> | undefined;
+    let revision = 0;
+    let hasSnapshot = false;
+    let inputBuffer = "";
+    let inputChain = Promise.resolve();
+    let lastSize = sizeRef.current;
+
+    const post = async (body: unknown) => {
+      const response = await fetch(controlUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) throw new Error(await responseError(response));
+      return response;
+    };
+
+    const flushInput = () => {
+      inputTimer = undefined;
+      const data = inputBuffer;
+      inputBuffer = "";
+      if (!data) return;
+      for (
+        let offset = 0;
+        offset < data.length;
+        offset += AGENT_TERMINAL_MAX_INPUT_CHARS
+      ) {
+        const chunk = data.slice(
+          offset,
+          offset + AGENT_TERMINAL_MAX_INPUT_CHARS,
+        );
+        inputChain = inputChain.then(() =>
+          post({ type: "input", data: chunk }).then(() => undefined),
+        );
+      }
+      inputChain = inputChain.catch((cause) => {
+        if (disposed) return;
+        setStatus("error");
+        setError(cause instanceof Error ? cause.message : String(cause));
+      });
+    };
+
+    const dataDisposable = terminal.onData((data) => {
+      inputBuffer += data;
+      if (!inputTimer) inputTimer = setTimeout(flushInput, 8);
+    });
+
+    const dimensions = () => ({
+      cols: Math.max(2, terminal.cols || 80),
+      rows: Math.max(1, terminal.rows || 24),
+    });
+
+    const applyFit = (notify: boolean) => {
+      try {
+        fitAddon.fit();
+      } catch {
+        return;
+      }
+      const next = dimensions();
+      if (next.cols === lastSize.cols && next.rows === lastSize.rows) return;
+      lastSize = next;
+      sizeRef.current = next;
+      if (!notify || !hasSnapshot) return;
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        void post({ type: "resize", size: lastSize }).catch((cause) => {
+          if (!disposed)
+            setError(cause instanceof Error ? cause.message : String(cause));
+        });
+      }, 60);
+    };
+
+    const reconnect = () => {
+      if (disposed || reconnectTimer) return;
+      source?.close();
+      setStatus("reconnecting");
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
+        connect();
+      }, 250);
+    };
+
+    const acceptEvent = (event: AgentTerminalEvent) => {
+      if (!hasSnapshot || event.revision !== revision + 1) {
+        reconnect();
+        return;
+      }
+      revision = event.revision;
+      if (event.type === "output") {
+        terminal.write(event.data);
+        return;
+      }
+      setExited(true);
+      setExitLabel(
+        event.signal !== null
+          ? `Exited from signal ${event.signal}`
+          : `Exited with code ${event.exitCode ?? "unknown"}`,
+      );
+    };
+
+    const connect = () => {
+      if (disposed) return;
+      source?.close();
+      hasSnapshot = false;
+      revision = 0;
+      setStatus("connecting");
+      setError("");
+      const size = dimensions();
+      lastSize = size;
+      sizeRef.current = size;
+      source = new EventSource(
+        `${controlUrl}/events?cols=${size.cols}&rows=${size.rows}`,
+      );
+      source.onopen = () => {
+        if (!disposed) setStatus(hasSnapshot ? "connected" : "connecting");
+      };
+      source.addEventListener("terminal-snapshot", (message) => {
+        const snapshot = readSnapshot(
+          parseJson((message as MessageEvent<string>).data),
+        );
+        if (!snapshot || snapshot.sessionId !== sessionId) {
+          reconnect();
+          return;
+        }
+        revision = snapshot.revision;
+        hasSnapshot = true;
+        setExited(snapshot.exited);
+        setExitLabel(
+          snapshot.exited
+            ? snapshot.signal !== null
+              ? `Exited from signal ${snapshot.signal}`
+              : `Exited with code ${snapshot.exitCode ?? "unknown"}`
+            : "",
+        );
+        terminal.reset();
+        terminal.write(snapshot.data, () => {
+          if (disposed) return;
+          applyFit(true);
+          terminal.focus();
+        });
+        setStatus("connected");
+      });
+      source.addEventListener("terminal-output", (message) => {
+        const event = readEvent(
+          parseJson((message as MessageEvent<string>).data),
+          "output",
+        );
+        if (event) acceptEvent(event);
+        else reconnect();
+      });
+      source.addEventListener("terminal-exit", (message) => {
+        const event = readEvent(
+          parseJson((message as MessageEvent<string>).data),
+          "exit",
+        );
+        if (event) acceptEvent(event);
+        else reconnect();
+      });
+      source.onerror = () => {
+        if (!disposed) setStatus("reconnecting");
+      };
+    };
+
+    const resizeObserver = new ResizeObserver(() => applyFit(true));
+    resizeObserver.observe(container);
+    const themeObserver = new MutationObserver(() => {
+      terminal.options.theme = terminalTheme(container);
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+    applyFit(false);
+    const preflight = async () => {
+      try {
+        const response = await fetch(controlUrl, { cache: "no-store" });
+        if (!response.ok) {
+          const message = await responseError(response);
+          if (response.status === 503 && !disposed) {
+            setStatus("reconnecting");
+            setError(message);
+            preflightTimer = setTimeout(() => void preflight(), 1_000);
+            return;
+          }
+          throw new Error(message);
+        }
+        if (!disposed) connect();
+      } catch (cause) {
+        if (disposed) return;
+        setStatus("error");
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+    };
+    void preflight();
+
+    return () => {
+      disposed = true;
+      source?.close();
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (preflightTimer) clearTimeout(preflightTimer);
+      if (resizeTimer) clearTimeout(resizeTimer);
+      if (inputTimer) clearTimeout(inputTimer);
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      dataDisposable.dispose();
+      terminal.dispose();
+    };
+  }, [active, controlUrl, sessionId]);
+
+  async function runControl(type: "restart" | "kill") {
+    setError("");
+    try {
+      const response = await fetch(controlUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          type === "restart" ? { type, size: sizeRef.current } : { type },
+        ),
+      });
+      if (!response.ok) throw new Error(await responseError(response));
+      if (type === "restart") {
+        setExited(false);
+        setExitLabel("");
+        setStatus("reconnecting");
+      }
+    } catch (cause) {
+      setStatus("error");
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }
+
+  return (
+    <section
+      className="flex h-full min-h-0 flex-col bg-background"
+      aria-label="Workspace terminal"
+    >
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b px-2">
+        <span className="text-xs font-medium">Terminal</span>
+        <span
+          className={cn(
+            "size-1.5 rounded-full",
+            status === "connected" && !exited
+              ? "bg-emerald-500"
+              : status === "error"
+                ? "bg-destructive"
+                : "bg-muted-foreground/60",
+          )}
+          aria-hidden="true"
+        />
+        <span className="truncate text-[11px] text-muted-foreground">
+          {error ||
+            exitLabel ||
+            (status === "connected" ? "Connected" : "Reconnecting…")}
+        </span>
+        <div className="ml-auto flex items-center gap-0.5">
+          {!exited && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Stop terminal"
+              title="Stop terminal"
+              onClick={() => void runControl("kill")}
+            >
+              <Square className="size-3.5" />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Restart terminal"
+            title="Restart terminal"
+            onClick={() => void runControl("restart")}
+          >
+            <RotateCcw className="size-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Close terminal panel"
+            title="Close terminal panel"
+            onClick={onClose}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+      <div
+        ref={containerRef}
+        className="min-h-0 flex-1 overflow-hidden bg-background p-2"
+      />
+    </section>
+  );
+}

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -87,6 +87,7 @@ describe("host connector daemon broker", () => {
     const subscribing = broker.subscribeTerminal(
       "connector",
       session,
+      "control-one",
       { cols: 80, rows: 24 },
       received,
       disconnected,
@@ -160,7 +161,7 @@ describe("host connector daemon broker", () => {
     subscription.unsubscribe();
   });
 
-  it("sends terminal input and resize as volatile connector commands", () => {
+  it("sends terminal input and owner resize as volatile connector commands", async () => {
     const commands: HostConnectorCommand[] = [];
     const broker = new HostConnectorBroker();
     broker.register(
@@ -169,9 +170,43 @@ describe("host connector daemon broker", () => {
       (command) => commands.push(command),
       ["workspace-terminal-v1"],
     );
+    const subscribing = broker.subscribeTerminal(
+      "connector",
+      session,
+      "control-one",
+      { cols: 80, rows: 24 },
+      vi.fn(),
+      vi.fn(),
+    );
+    const subscribe = commands.at(-1);
+    if (
+      subscribe?.type !== "request" ||
+      subscribe.request.type !== "subscribe_terminal"
+    ) {
+      throw new Error("missing terminal subscription");
+    }
+    await broker.acceptBatch("connector", "durable", [
+      response(1, subscribe.requestId, {
+        subscribed: true,
+        snapshot: {
+          sessionId: "session",
+          revision: 0,
+          data: "",
+          cols: 80,
+          rows: 24,
+          exited: false,
+          exitCode: null,
+          signal: null,
+        },
+      }),
+    ]);
+    const subscription = await subscribing;
 
     broker.sendTerminalInput("connector", "session", "echo hello\r");
-    broker.resizeTerminal("connector", "session", { cols: 120, rows: 40 });
+    broker.resizeTerminal("connector", "session", "control-one", {
+      cols: 120,
+      rows: 40,
+    });
 
     expect(commands.slice(-2)).toEqual([
       { type: "terminal_input", sessionId: "session", data: "echo hello\r" },
@@ -181,6 +216,80 @@ describe("host connector daemon broker", () => {
         size: { cols: 120, rows: 40 },
       },
     ]);
+    subscription.unsubscribe();
+  });
+
+  it("gives the newest terminal view deterministic resize ownership", async () => {
+    const commands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["workspace-terminal-v1"],
+    );
+
+    const attach = async (controlId: string, cols: number) => {
+      const subscribing = broker.subscribeTerminal(
+        "connector",
+        session,
+        controlId,
+        { cols, rows: 24 },
+        vi.fn(),
+        vi.fn(),
+      );
+      const request = commands.at(-1);
+      if (
+        request?.type !== "request" ||
+        request.request.type !== "subscribe_terminal"
+      ) {
+        throw new Error("missing terminal subscription");
+      }
+      await broker.acceptBatch("connector", crypto.randomUUID(), [
+        response(1, request.requestId, {
+          subscribed: true,
+          snapshot: {
+            sessionId: "session",
+            revision: 0,
+            data: "",
+            cols,
+            rows: 24,
+            exited: false,
+            exitCode: null,
+            signal: null,
+          },
+        }),
+      ]);
+      return subscribing;
+    };
+
+    const first = await attach("first", 80);
+    const second = await attach("second", 100);
+
+    expect(() =>
+      broker.resizeTerminal("connector", "session", "first", {
+        cols: 90,
+        rows: 24,
+      }),
+    ).toThrow("Another open terminal view");
+    broker.resizeTerminal("connector", "session", "second", {
+      cols: 120,
+      rows: 40,
+    });
+    second.unsubscribe();
+
+    expect(commands.at(-1)).toEqual({
+      type: "terminal_resize",
+      sessionId: "session",
+      size: { cols: 80, rows: 24 },
+    });
+    expect(() =>
+      broker.resizeTerminal("connector", "session", "first", {
+        cols: 90,
+        rows: 24,
+      }),
+    ).not.toThrow();
+    first.unsubscribe();
   });
 
   it("rejects terminal use when the connector lacks the capability", async () => {
@@ -191,6 +300,7 @@ describe("host connector daemon broker", () => {
       broker.subscribeTerminal(
         "connector",
         session,
+        "control-one",
         { cols: 80, rows: 24 },
         vi.fn(),
         vi.fn(),

--- a/apps/web/lib/agents/connector/broker.test.ts
+++ b/apps/web/lib/agents/connector/broker.test.ts
@@ -73,6 +73,134 @@ describe("host connector daemon broker", () => {
     expect(broker.supports("connector", "command-wal-v1")).toBe(false);
   });
 
+  it("streams terminal snapshots and contiguous live output", async () => {
+    const commands: HostConnectorCommand[] = [];
+    const received = vi.fn();
+    const disconnected = vi.fn();
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["workspace-terminal-v1"],
+    );
+    const subscribing = broker.subscribeTerminal(
+      "connector",
+      session,
+      { cols: 80, rows: 24 },
+      received,
+      disconnected,
+    );
+    const request = commands.at(-1);
+    if (
+      request?.type !== "request" ||
+      request.request.type !== "subscribe_terminal"
+    ) {
+      throw new Error("missing terminal subscription");
+    }
+
+    await broker.acceptBatch("connector", "live", [
+      {
+        sequence: 1,
+        payload: {
+          type: "terminal_event",
+          subscriptionId: request.request.subscriptionId,
+          sessionId: "session",
+          event: { type: "output", revision: 2, data: "after snapshot" },
+        },
+      },
+    ]);
+    await broker.acceptBatch("connector", "durable", [
+      response(1, request.requestId, {
+        subscribed: true,
+        snapshot: {
+          sessionId: "session",
+          revision: 1,
+          data: "snapshot",
+          cols: 80,
+          rows: 24,
+          exited: false,
+          exitCode: null,
+          signal: null,
+        },
+      }),
+    ]);
+    const subscription = await subscribing;
+
+    expect(subscription.snapshot.data).toBe("snapshot");
+    expect(received).toHaveBeenCalledWith({
+      type: "output",
+      revision: 2,
+      data: "after snapshot",
+    });
+    await broker.acceptBatch("connector", "live", [
+      {
+        sequence: 2,
+        payload: {
+          type: "terminal_event",
+          subscriptionId: request.request.subscriptionId,
+          sessionId: "session",
+          event: { type: "output", revision: 2, data: "duplicate" },
+        },
+      },
+      {
+        sequence: 3,
+        payload: {
+          type: "terminal_event",
+          subscriptionId: request.request.subscriptionId,
+          sessionId: "session",
+          event: { type: "output", revision: 4, data: "gap" },
+        },
+      },
+    ]);
+    expect(received).toHaveBeenCalledTimes(1);
+    expect(disconnected).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("snapshot") }),
+    );
+    subscription.unsubscribe();
+  });
+
+  it("sends terminal input and resize as volatile connector commands", () => {
+    const commands: HostConnectorCommand[] = [];
+    const broker = new HostConnectorBroker();
+    broker.register(
+      "connector",
+      ["session"],
+      (command) => commands.push(command),
+      ["workspace-terminal-v1"],
+    );
+
+    broker.sendTerminalInput("connector", "session", "echo hello\r");
+    broker.resizeTerminal("connector", "session", { cols: 120, rows: 40 });
+
+    expect(commands.slice(-2)).toEqual([
+      { type: "terminal_input", sessionId: "session", data: "echo hello\r" },
+      {
+        type: "terminal_resize",
+        sessionId: "session",
+        size: { cols: 120, rows: 40 },
+      },
+    ]);
+  });
+
+  it("rejects terminal use when the connector lacks the capability", async () => {
+    const broker = new HostConnectorBroker();
+    broker.register("connector", ["session"], vi.fn());
+
+    await expect(
+      broker.subscribeTerminal(
+        "connector",
+        session,
+        { cols: 80, rows: 24 },
+        vi.fn(),
+        vi.fn(),
+      ),
+    ).rejects.toThrow("Update the OvertChat Host Connector");
+    expect(() =>
+      broker.sendTerminalInput("connector", "session", "pwd\r"),
+    ).toThrow("Update the OvertChat Host Connector");
+  });
+
   it("projects the global session directory without a detail subscription", async () => {
     const listener = vi.fn();
     const broker = new HostConnectorBroker(0);

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -76,6 +76,8 @@ type SessionSubscription = {
 type TerminalSubscription = {
   connectorId: string;
   session: AgentDaemonSessionDescriptor;
+  controlId: string;
+  size: AgentTerminalSize;
   revision: number;
   subscriber: (event: AgentTerminalEvent) => void;
   disconnect: (error: Error) => void;
@@ -99,6 +101,7 @@ export class HostConnectorBroker {
     string,
     TerminalSubscription
   >();
+  private readonly terminalControlOwners = new Map<string, string>();
   private readonly sessionDirectory = new Map<
     string,
     { connectorId: string; session: AgentSessionDirectoryEntry }
@@ -382,6 +385,7 @@ export class HostConnectorBroker {
   async subscribeTerminal(
     connectorId: string,
     session: AgentDaemonSessionDescriptor,
+    controlId: string,
     size: AgentTerminalSize,
     subscriber: (event: AgentTerminalEvent) => void,
     disconnect: (error: Error) => void,
@@ -395,6 +399,8 @@ export class HostConnectorBroker {
     const subscription: TerminalSubscription = {
       connectorId,
       session,
+      controlId,
+      size,
       revision: 0,
       subscriber,
       disconnect,
@@ -436,6 +442,10 @@ export class HostConnectorBroker {
       throw error;
     }
 
+    this.terminalControlOwners.set(
+      this.terminalControlKey(connectorId, session.sessionId),
+      subscriptionId,
+    );
     subscription.replayBuffer = null;
     for (const event of replayBuffer) {
       if (!this.deliverTerminalEvent(subscriptionId, subscription, event)) {
@@ -447,6 +457,7 @@ export class HostConnectorBroker {
       unsubscribe: () => {
         if (!this.terminalSubscriptions.delete(subscriptionId)) return;
         this.sendTerminalUnsubscribe(connectorId, subscriptionId);
+        this.releaseTerminalControl(subscriptionId, subscription);
       },
     };
   }
@@ -463,9 +474,22 @@ export class HostConnectorBroker {
   resizeTerminal(
     connectorId: string,
     sessionId: string,
+    controlId: string,
     size: AgentTerminalSize,
   ): void {
     const channel = this.requireTerminalChannel(connectorId);
+    const ownerId = this.terminalControlOwners.get(
+      this.terminalControlKey(connectorId, sessionId),
+    );
+    const owner = ownerId
+      ? this.terminalSubscriptions.get(ownerId)
+      : undefined;
+    if (!owner || owner.controlId !== controlId) {
+      throw new Error(
+        "Another open terminal view currently controls the terminal size.",
+      );
+    }
+    owner.size = size;
     channel.send({ type: "terminal_resize", sessionId, size });
   }
 
@@ -784,6 +808,7 @@ export class HostConnectorBroker {
       if (this.terminalSubscriptions.get(subscriptionId) === subscription) {
         this.terminalSubscriptions.delete(subscriptionId);
         this.sendTerminalUnsubscribe(subscription.connectorId, subscriptionId);
+        this.releaseTerminalControl(subscriptionId, subscription);
       }
       subscription.disconnect(
         new Error(
@@ -811,6 +836,7 @@ export class HostConnectorBroker {
       }
       this.terminalSubscriptions.delete(subscriptionId);
       this.sendTerminalUnsubscribe(connectorId, subscriptionId);
+      this.releaseTerminalControl(subscriptionId, subscription);
       subscription.disconnect(error);
     }
   }
@@ -823,7 +849,47 @@ export class HostConnectorBroker {
       if (subscription.connectorId !== connectorId) continue;
       this.terminalSubscriptions.delete(subscriptionId);
       this.sendTerminalUnsubscribe(connectorId, subscriptionId);
+      this.releaseTerminalControl(subscriptionId, subscription);
       subscription.disconnect(error);
+    }
+  }
+
+  private terminalControlKey(connectorId: string, sessionId: string): string {
+    return `${connectorId}\u0000${sessionId}`;
+  }
+
+  private releaseTerminalControl(
+    subscriptionId: string,
+    subscription: TerminalSubscription,
+  ): void {
+    const key = this.terminalControlKey(
+      subscription.connectorId,
+      subscription.session.sessionId,
+    );
+    if (this.terminalControlOwners.get(key) !== subscriptionId) return;
+    const fallback = [...this.terminalSubscriptions.entries()]
+      .filter(
+        ([, candidate]) =>
+          candidate.connectorId === subscription.connectorId &&
+          candidate.session.sessionId === subscription.session.sessionId,
+      )
+      .at(-1);
+    if (!fallback) {
+      this.terminalControlOwners.delete(key);
+      return;
+    }
+    const [fallbackId, candidate] = fallback;
+    this.terminalControlOwners.set(key, fallbackId);
+    const channel = this.channels.get(candidate.connectorId);
+    if (!channel?.capabilities.has("workspace-terminal-v1")) return;
+    try {
+      channel.send({
+        type: "terminal_resize",
+        sessionId: candidate.session.sessionId,
+        size: candidate.size,
+      });
+    } catch {
+      // A reconnect will establish a fresh terminal size owner.
     }
   }
 

--- a/apps/web/lib/agents/connector/broker.ts
+++ b/apps/web/lib/agents/connector/broker.ts
@@ -3,12 +3,16 @@ import {
   HOST_CONNECTOR_CAPABILITIES,
   HOST_CONNECTOR_PROTOCOL_VERSION,
   isAgentSessionSync,
+  isAgentTerminalSnapshot,
   isConnectorSshHost,
   type AgentDaemonRequest,
   type AgentDaemonSessionDescriptor,
   type AgentRuntimeEnvelope,
   type AgentSessionDirectoryEntry,
   type AgentSessionSync,
+  type AgentTerminalEvent,
+  type AgentTerminalSize,
+  type AgentTerminalSnapshot,
   type ConnectorSshHost,
   type HostConnectorCommand,
   type HostConnectorCapability,
@@ -69,6 +73,15 @@ type SessionSubscription = {
   replayBuffer: AgentRuntimeEnvelope[] | null;
 };
 
+type TerminalSubscription = {
+  connectorId: string;
+  session: AgentDaemonSessionDescriptor;
+  revision: number;
+  subscriber: (event: AgentTerminalEvent) => void;
+  disconnect: (error: Error) => void;
+  replayBuffer: AgentTerminalEvent[] | null;
+};
+
 export type AgentSessionDirectoryEvent =
   | { type: "snapshot"; sessions: AgentSessionDirectoryEntry[] }
   | { type: "update"; session: AgentSessionDirectoryEntry };
@@ -82,6 +95,10 @@ export class HostConnectorBroker {
   private readonly channels = new Map<string, Channel>();
   private readonly pending = new Map<string, PendingRequest>();
   private readonly subscriptions = new Map<string, SessionSubscription>();
+  private readonly terminalSubscriptions = new Map<
+    string,
+    TerminalSubscription
+  >();
   private readonly sessionDirectory = new Map<
     string,
     { connectorId: string; session: AgentSessionDirectoryEntry }
@@ -163,6 +180,10 @@ export class HostConnectorBroker {
     connectorCapabilities: readonly HostConnectorCapability[] = [],
   ): () => void {
     this.clearDisconnectTimer(connectorId);
+    this.disconnectTerminalSubscriptions(
+      connectorId,
+      new Error("The OvertChat Host Connector reconnected."),
+    );
     const supported = new Set<string>(HOST_CONNECTOR_CAPABILITIES);
     const capabilities = new Set(
       connectorCapabilities.filter((capability) => supported.has(capability)),
@@ -358,6 +379,128 @@ export class HostConnectorBroker {
     };
   }
 
+  async subscribeTerminal(
+    connectorId: string,
+    session: AgentDaemonSessionDescriptor,
+    size: AgentTerminalSize,
+    subscriber: (event: AgentTerminalEvent) => void,
+    disconnect: (error: Error) => void,
+  ): Promise<{
+    unsubscribe: () => void;
+    snapshot: AgentTerminalSnapshot;
+  }> {
+    const channel = this.requireTerminalChannel(connectorId);
+    const subscriptionId = crypto.randomUUID();
+    const replayBuffer: AgentTerminalEvent[] = [];
+    const subscription: TerminalSubscription = {
+      connectorId,
+      session,
+      revision: 0,
+      subscriber,
+      disconnect,
+      replayBuffer,
+    };
+    this.terminalSubscriptions.set(subscriptionId, subscription);
+    let snapshot: AgentTerminalSnapshot;
+    try {
+      const result = await this.request<{ snapshot?: unknown }>(connectorId, {
+        type: "subscribe_terminal",
+        subscriptionId,
+        session,
+        size,
+      });
+      if (
+        this.channels.get(connectorId) !== channel ||
+        this.terminalSubscriptions.get(subscriptionId) !== subscription ||
+        subscription.replayBuffer !== replayBuffer
+      ) {
+        throw new Error(
+          "The Host Connector channel changed while subscribing.",
+        );
+      }
+      if (
+        !isAgentTerminalSnapshot(result?.snapshot) ||
+        result.snapshot.sessionId !== session.sessionId
+      ) {
+        throw new Error(
+          "The Host Connector returned an invalid terminal snapshot.",
+        );
+      }
+      snapshot = result.snapshot;
+      subscription.revision = snapshot.revision;
+    } catch (error) {
+      if (this.terminalSubscriptions.get(subscriptionId) === subscription) {
+        this.terminalSubscriptions.delete(subscriptionId);
+        this.sendTerminalUnsubscribe(connectorId, subscriptionId);
+      }
+      throw error;
+    }
+
+    subscription.replayBuffer = null;
+    for (const event of replayBuffer) {
+      if (!this.deliverTerminalEvent(subscriptionId, subscription, event)) {
+        break;
+      }
+    }
+    return {
+      snapshot,
+      unsubscribe: () => {
+        if (!this.terminalSubscriptions.delete(subscriptionId)) return;
+        this.sendTerminalUnsubscribe(connectorId, subscriptionId);
+      },
+    };
+  }
+
+  sendTerminalInput(
+    connectorId: string,
+    sessionId: string,
+    data: string,
+  ): void {
+    const channel = this.requireTerminalChannel(connectorId);
+    channel.send({ type: "terminal_input", sessionId, data });
+  }
+
+  resizeTerminal(
+    connectorId: string,
+    sessionId: string,
+    size: AgentTerminalSize,
+  ): void {
+    const channel = this.requireTerminalChannel(connectorId);
+    channel.send({ type: "terminal_resize", sessionId, size });
+  }
+
+  async restartTerminal(
+    connectorId: string,
+    session: AgentDaemonSessionDescriptor,
+    size: AgentTerminalSize,
+  ): Promise<AgentTerminalSnapshot> {
+    this.requireTerminalChannel(connectorId);
+    this.disconnectTerminalSession(
+      connectorId,
+      session.sessionId,
+      new Error("The terminal restarted."),
+    );
+    const result = await this.request<{ snapshot?: unknown }>(connectorId, {
+      type: "restart_terminal",
+      session,
+      size,
+    });
+    if (
+      !isAgentTerminalSnapshot(result?.snapshot) ||
+      result.snapshot.sessionId !== session.sessionId
+    ) {
+      throw new Error(
+        "The Host Connector returned an invalid terminal snapshot.",
+      );
+    }
+    return result.snapshot;
+  }
+
+  async killTerminal(connectorId: string, sessionId: string): Promise<void> {
+    this.requireTerminalChannel(connectorId);
+    await this.request(connectorId, { type: "kill_terminal", sessionId });
+  }
+
   async acceptBatch(
     connectorId: string,
     connectorEpoch: string,
@@ -417,6 +560,26 @@ export class HostConnectorBroker {
           ? { providerModifiedAt: new Date(providerModifiedAt) }
           : {}),
       });
+      return;
+    }
+    if (event.type === "terminal_event") {
+      const subscription = this.terminalSubscriptions.get(event.subscriptionId);
+      if (
+        !subscription ||
+        subscription.connectorId !== connectorId ||
+        subscription.session.sessionId !== event.sessionId
+      ) {
+        return;
+      }
+      if (subscription.replayBuffer) {
+        subscription.replayBuffer.push(event.event);
+        return;
+      }
+      this.deliverTerminalEvent(
+        event.subscriptionId,
+        subscription,
+        event.event,
+      );
       return;
     }
     const subscription = this.subscriptions.get(event.subscriptionId);
@@ -581,6 +744,89 @@ export class HostConnectorBroker {
     }
   }
 
+  private requireTerminalChannel(connectorId: string): Channel {
+    const channel = this.channels.get(connectorId);
+    if (!channel) {
+      throw new Error("The OvertChat Host Connector is offline.");
+    }
+    if (!channel.capabilities.has("workspace-terminal-v1")) {
+      throw new Error(
+        "Update the OvertChat Host Connector to use workspace terminals.",
+      );
+    }
+    return channel;
+  }
+
+  private sendTerminalUnsubscribe(
+    connectorId: string,
+    subscriptionId: string,
+  ): void {
+    const channel = this.channels.get(connectorId);
+    if (!channel?.capabilities.has("workspace-terminal-v1")) return;
+    try {
+      channel.send({
+        type: "request",
+        requestId: crypto.randomUUID(),
+        request: { type: "unsubscribe_terminal", subscriptionId },
+      });
+    } catch {
+      // The connector may have gone offline before the lease could be released.
+    }
+  }
+
+  private deliverTerminalEvent(
+    subscriptionId: string,
+    subscription: TerminalSubscription,
+    event: AgentTerminalEvent,
+  ): boolean {
+    if (event.revision <= subscription.revision) return true;
+    if (event.revision !== subscription.revision + 1) {
+      if (this.terminalSubscriptions.get(subscriptionId) === subscription) {
+        this.terminalSubscriptions.delete(subscriptionId);
+        this.sendTerminalUnsubscribe(subscription.connectorId, subscriptionId);
+      }
+      subscription.disconnect(
+        new Error(
+          "Terminal output was interrupted; reconnecting from a snapshot.",
+        ),
+      );
+      return false;
+    }
+    subscription.revision = event.revision;
+    subscription.subscriber(event);
+    return true;
+  }
+
+  private disconnectTerminalSession(
+    connectorId: string,
+    sessionId: string,
+    error: Error,
+  ): void {
+    for (const [subscriptionId, subscription] of this.terminalSubscriptions) {
+      if (
+        subscription.connectorId !== connectorId ||
+        subscription.session.sessionId !== sessionId
+      ) {
+        continue;
+      }
+      this.terminalSubscriptions.delete(subscriptionId);
+      this.sendTerminalUnsubscribe(connectorId, subscriptionId);
+      subscription.disconnect(error);
+    }
+  }
+
+  private disconnectTerminalSubscriptions(
+    connectorId: string,
+    error: Error,
+  ): void {
+    for (const [subscriptionId, subscription] of this.terminalSubscriptions) {
+      if (subscription.connectorId !== connectorId) continue;
+      this.terminalSubscriptions.delete(subscriptionId);
+      this.sendTerminalUnsubscribe(connectorId, subscriptionId);
+      subscription.disconnect(error);
+    }
+  }
+
   private readSessionSync(
     connectorId: string,
     session: AgentDaemonSessionDescriptor,
@@ -661,6 +907,7 @@ export class HostConnectorBroker {
         this.subscriptions.delete(subscriptionId);
         subscription.disconnect(error);
       }
+      this.disconnectTerminalSubscriptions(connectorId, error);
       for (const entry of this.sessionDirectory.values()) {
         if (entry.connectorId !== connectorId) continue;
         this.upsertSessionDirectory(connectorId, {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,8 @@
     "@tanstack/react-query": "^5.100.10",
     "@tanstack/react-query-devtools": "^5.100.10",
     "@tanstack/react-virtual": "^3.14.10",
+    "@xterm/addon-fit": "0.11.0",
+    "@xterm/xterm": "6.0.0",
     "@yoloyash/web-basics": "0.5.0",
     "ai": "^7.0.84",
     "better-auth": "1.6.23",

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,7 +16,7 @@ stable channel used by both `overtchat setup` and `overtchat update`.
 ## Version map
 
 | Component | Change | Tag |
-| --- | --- | --- |
+| -------------- | -------------------------------------------------------------------------------------------------------------- | ------------------ |
 | App | Manifest `appVersion`; `compose.yml` default | `vX.Y.Z` |
 | Realtime voice | Manifest `voiceVersion`; `compose.yml` default | `voice-vX.Y.Z` |
 | CLI | `apps/cli/package.json`; lockfile; `CLI_VERSION`; site installer; manifest `cliVersion` | `cli-vX.Y.Z` |
@@ -118,6 +118,23 @@ For a CLI release, build the CLI workspace and then verify the bundled version:
 ```bash
 npm run build -w apps/cli --
 node apps/cli/dist/overtchat.mjs version
+```
+
+For a connector release, compile each native Bun target on a runner with arm64
+emulation enabled and execute the PTY smoke test in both artifacts. This gate is
+required because the terminal support embeds an architecture-specific native
+`node-pty` addon:
+
+```bash
+bun build apps/connector/src/cli.ts --compile --target=bun-linux-x64-baseline \
+  --outfile dist/overtchat-connector-linux-amd64
+bun build apps/connector/src/cli.ts --compile --target=bun-linux-arm64 \
+  --outfile dist/overtchat-connector-linux-arm64
+dist/overtchat-connector-linux-amd64 terminal-smoke
+docker run --rm --platform linux/arm64 \
+  --volume "$PWD/dist/overtchat-connector-linux-arm64:/usr/local/bin/overtchat-connector:ro" \
+  debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171 \
+  /usr/local/bin/overtchat-connector terminal-smoke
 ```
 
 `promote-release.yml` is the only CI production deploy path. It verifies CLI

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,7 +16,7 @@ stable channel used by both `overtchat setup` and `overtchat update`.
 ## Version map
 
 | Component | Change | Tag |
-| -------------- | -------------------------------------------------------------------------------------------------------------- | ------------------ |
+| --- | --- | --- |
 | App | Manifest `appVersion`; `compose.yml` default | `vX.Y.Z` |
 | Realtime voice | Manifest `voiceVersion`; `compose.yml` default | `voice-vX.Y.Z` |
 | CLI | `apps/cli/package.json`; lockfile; `CLI_VERSION`; site installer; manifest `cliVersion` | `cli-vX.Y.Z` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,7 +555,10 @@
       "version": "0.9.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
-        "@overtchat/agent-runtime": "*"
+        "@overtchat/agent-runtime": "*",
+        "@xterm/addon-serialize": "0.14.0",
+        "@xterm/headless": "6.0.0",
+        "node-pty": "1.2.0-beta.15"
       },
       "bin": {
         "overtchat-connector": "dist/overtchat-connector.mjs"
@@ -2349,6 +2352,8 @@
         "@tanstack/react-query": "^5.100.10",
         "@tanstack/react-query-devtools": "^5.100.10",
         "@tanstack/react-virtual": "^3.14.10",
+        "@xterm/addon-fit": "0.11.0",
+        "@xterm/xterm": "6.0.0",
         "@yoloyash/web-basics": "0.5.0",
         "ai": "^7.0.84",
         "better-auth": "1.6.23",
@@ -12095,6 +12100,36 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/@yoloyash/web-basics": {
       "version": "0.5.0",
@@ -22094,6 +22129,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -22182,6 +22223,16 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.15.tgz",
+      "integrity": "sha512-vORSzHXi4Ofl7HemVWpuudLqCPdaQb4LfpRCUpE5HPxhp4JYscl8zZwxh11p26v2wvW24WMwnMfLjhRLixrfxA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.46",

--- a/packages/agent-bridge/src/agents.ts
+++ b/packages/agent-bridge/src/agents.ts
@@ -213,6 +213,41 @@ export type AgentWorkspaceTextFilePreview = {
 /** Extensible read-only preview payload; future content kinds add union members. */
 export type AgentWorkspaceFilePreview = AgentWorkspaceTextFilePreview;
 
+export const AGENT_TERMINAL_MIN_COLUMNS = 2;
+export const AGENT_TERMINAL_MAX_COLUMNS = 1_000;
+export const AGENT_TERMINAL_MIN_ROWS = 1;
+export const AGENT_TERMINAL_MAX_ROWS = 1_000;
+export const AGENT_TERMINAL_MAX_INPUT_CHARS = 64 * 1_024;
+export const AGENT_TERMINAL_MAX_OUTPUT_CHARS = 256 * 1_024;
+export const AGENT_TERMINAL_MAX_SNAPSHOT_CHARS = 4 * 1_024 * 1_024;
+
+export type AgentTerminalSize = {
+  cols: number;
+  rows: number;
+};
+
+export type AgentTerminalSnapshot = AgentTerminalSize & {
+  sessionId: string;
+  revision: number;
+  data: string;
+  exited: boolean;
+  exitCode: number | null;
+  signal: number | null;
+};
+
+export type AgentTerminalEvent =
+  | {
+      type: "output";
+      revision: number;
+      data: string;
+    }
+  | {
+      type: "exit";
+      revision: number;
+      exitCode: number | null;
+      signal: number | null;
+    };
+
 export type AgentConnectionListItem = {
   id: string;
   provider: AgentProviderId;

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -8,9 +8,19 @@ import type {
   AgentSessionSync,
   AgentSessionCommand,
   AgentSessionLaunchConfig,
+  AgentTerminalEvent,
+  AgentTerminalSize,
+  AgentTerminalSnapshot,
   ConnectorShellMode,
 } from "./agents";
 import {
+  AGENT_TERMINAL_MAX_COLUMNS,
+  AGENT_TERMINAL_MAX_INPUT_CHARS,
+  AGENT_TERMINAL_MAX_OUTPUT_CHARS,
+  AGENT_TERMINAL_MAX_SNAPSHOT_CHARS,
+  AGENT_TERMINAL_MIN_COLUMNS,
+  AGENT_TERMINAL_MAX_ROWS,
+  AGENT_TERMINAL_MIN_ROWS,
   CONNECTOR_SHELL_MODES,
   AGENT_PROVIDER_IDS,
   agentConnectionDraftSchema,
@@ -29,6 +39,7 @@ export const HOST_CONNECTOR_CAPABILITIES = [
   "session-sync-v1",
   "command-wal-v1",
   "workspace-files-v1",
+  "workspace-terminal-v1",
 ] as const;
 export type HostConnectorCapability =
   (typeof HOST_CONNECTOR_CAPABILITIES)[number];
@@ -112,6 +123,19 @@ export type AgentDaemonRequest =
       path: string;
     }
   | {
+      type: "subscribe_terminal";
+      subscriptionId: string;
+      session: AgentDaemonSessionDescriptor;
+      size: AgentTerminalSize;
+    }
+  | { type: "unsubscribe_terminal"; subscriptionId: string }
+  | {
+      type: "restart_terminal";
+      session: AgentDaemonSessionDescriptor;
+      size: AgentTerminalSize;
+    }
+  | { type: "kill_terminal"; sessionId: string }
+  | {
       type: "create_session";
       sessionId: string;
       workspace: AgentDaemonWorkspaceDescriptor;
@@ -152,6 +176,12 @@ export type HostConnectorCommand =
       type: "request";
       requestId: string;
       request: AgentDaemonRequest;
+    }
+  | { type: "terminal_input"; sessionId: string; data: string }
+  | {
+      type: "terminal_resize";
+      sessionId: string;
+      size: AgentTerminalSize;
     };
 
 export type HostConnectorEventPayload =
@@ -183,6 +213,12 @@ export type HostConnectorEventPayload =
         providerModifiedAt?: number;
         launchConfig?: AgentSessionLaunchConfig;
       };
+    }
+  | {
+      type: "terminal_event";
+      subscriptionId: string;
+      sessionId: string;
+      event: AgentTerminalEvent;
     }
   | { type: "session_directory"; sessions: AgentSessionDirectoryEntry[] }
   | { type: "session_update"; session: AgentSessionDirectoryEntry };
@@ -271,6 +307,37 @@ function isAgentDaemonTarget(value: unknown): value is AgentDaemonTarget {
   );
 }
 
+export function isAgentTerminalSize(
+  value: unknown,
+): value is AgentTerminalSize {
+  if (!isRecord(value)) return false;
+  return (
+    Number.isSafeInteger(value.cols) &&
+    Number(value.cols) >= AGENT_TERMINAL_MIN_COLUMNS &&
+    Number(value.cols) <= AGENT_TERMINAL_MAX_COLUMNS &&
+    Number.isSafeInteger(value.rows) &&
+    Number(value.rows) >= AGENT_TERMINAL_MIN_ROWS &&
+    Number(value.rows) <= AGENT_TERMINAL_MAX_ROWS
+  );
+}
+
+export function isAgentTerminalSnapshot(
+  value: unknown,
+): value is AgentTerminalSnapshot {
+  if (!isRecord(value) || !isAgentTerminalSize(value)) return false;
+  const snapshot = value as Record<string, unknown>;
+  return (
+    isNonEmptyString(snapshot.sessionId) &&
+    Number.isSafeInteger(snapshot.revision) &&
+    Number(snapshot.revision) >= 0 &&
+    typeof snapshot.data === "string" &&
+    snapshot.data.length <= AGENT_TERMINAL_MAX_SNAPSHOT_CHARS &&
+    typeof snapshot.exited === "boolean" &&
+    (snapshot.exitCode === null || Number.isSafeInteger(snapshot.exitCode)) &&
+    (snapshot.signal === null || Number.isSafeInteger(snapshot.signal))
+  );
+}
+
 export function isAgentDaemonWorkspaceDescriptor(
   value: unknown,
 ): value is AgentDaemonWorkspaceDescriptor {
@@ -336,6 +403,21 @@ function isAgentDaemonRequest(value: unknown): value is AgentDaemonRequest {
         value.root.length > 0 &&
         typeof value.path === "string"
       );
+    case "subscribe_terminal":
+      return (
+        isNonEmptyString(value.subscriptionId) &&
+        isAgentDaemonSessionDescriptor(value.session) &&
+        isAgentTerminalSize(value.size)
+      );
+    case "unsubscribe_terminal":
+      return isNonEmptyString(value.subscriptionId);
+    case "restart_terminal":
+      return (
+        isAgentDaemonSessionDescriptor(value.session) &&
+        isAgentTerminalSize(value.size)
+      );
+    case "kill_terminal":
+      return isNonEmptyString(value.sessionId);
     case "create_session":
       return (
         isNonEmptyString(value.sessionId) &&
@@ -399,6 +481,17 @@ export function isHostConnectorCommand(
       return (
         isNonEmptyString(value.requestId) &&
         isAgentDaemonRequest(value.request)
+      );
+    case "terminal_input":
+      return (
+        isNonEmptyString(value.sessionId) &&
+        typeof value.data === "string" &&
+        value.data.length > 0 &&
+        value.data.length <= AGENT_TERMINAL_MAX_INPUT_CHARS
+      );
+    case "terminal_resize":
+      return (
+        isNonEmptyString(value.sessionId) && isAgentTerminalSize(value.size)
       );
     default:
       return false;
@@ -520,6 +613,31 @@ export function isHostConnectorEvent(
       isAgentRuntimeEnvelope(payload.envelope) &&
       (payload.envelope.type !== "snapshot" ||
         payload.envelope.data.sessionId === payload.sessionId)
+    );
+  }
+  if (payload.type === "terminal_event") {
+    if (
+      !isNonEmptyString(payload.subscriptionId) ||
+      !isNonEmptyString(payload.sessionId) ||
+      !isRecord(payload.event) ||
+      !Number.isSafeInteger(payload.event.revision) ||
+      Number(payload.event.revision) < 1
+    ) {
+      return false;
+    }
+    if (payload.event.type === "output") {
+      return (
+        typeof payload.event.data === "string" &&
+        payload.event.data.length > 0 &&
+        payload.event.data.length <= AGENT_TERMINAL_MAX_OUTPUT_CHARS
+      );
+    }
+    return (
+      payload.event.type === "exit" &&
+      (payload.event.exitCode === null ||
+        Number.isSafeInteger(payload.event.exitCode)) &&
+      (payload.event.signal === null ||
+        Number.isSafeInteger(payload.event.signal))
     );
   }
   if (payload.type === "session_metadata") {

--- a/packages/agent-bridge/src/protocol.test.ts
+++ b/packages/agent-bridge/src/protocol.test.ts
@@ -66,6 +66,58 @@ describe("Host Connector protocol compatibility", () => {
     }
   });
 
+  it("validates additive workspace terminal commands and live events", () => {
+    const session = {
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/srv/project",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+      launchConfig: {},
+    } as const;
+    expect(
+      isHostConnectorCommand({
+        type: "request",
+        requestId: "request",
+        request: {
+          type: "subscribe_terminal",
+          subscriptionId: "terminal-subscription",
+          session,
+          size: { cols: 120, rows: 30 },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isHostConnectorCommand({
+        type: "terminal_input",
+        sessionId: "session",
+        data: "npm test\r",
+      }),
+    ).toBe(true);
+    expect(
+      isHostConnectorCommand({
+        type: "terminal_resize",
+        sessionId: "session",
+        size: { cols: 0, rows: 30 },
+      }),
+    ).toBe(false);
+    expect(
+      isHostConnectorEvent({
+        sequence: 1,
+        payload: {
+          type: "terminal_event",
+          subscriptionId: "terminal-subscription",
+          sessionId: "session",
+          event: { type: "output", revision: 1, data: "ready\r\n" },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("accepts a session-directory snapshot and provider-independent upserts", () => {
     expect(
       isHostConnectorEvent({


### PR DESCRIPTION
## Summary

- Add a terminal button to coding-agent session headers.
- Open the workspace terminal in a resizable bottom pane without leaving the active session.
- Support both local workspaces and workspaces connected over SSH.
- Preserve terminal output across pane closes and reconnect from an authoritative snapshot when needed.

## Implementation

- The Host Connector owns each PTY and launches the shell in the session workspace.
- The web app relays authenticated terminal output and control requests through the existing connector protocol.
- Terminal events are revisioned so interrupted or slow clients can detect gaps and recover safely.
- The most recently opened terminal view controls the shared PTY dimensions, with automatic fallback when that view closes.

## Reliability and security

- Terminal routes enforce administrator access and session ownership.
- Input, terminal dimensions, snapshots, and buffered output are bounded and validated.
- PTYs are stopped with their owning session, workspace, connection, or connector and are reaped after a detached idle period.
- Terminal support is capability-gated. If the native PTY dependency is unavailable, only the terminal feature is disabled; agent sessions and workspace files continue to work.

## Deployment notes

- Requires a Host Connector release advertising `workspace-terminal-v1`.
- No database migration is required.
- Connector release CI smoke-tests the compiled Linux x64 and arm64 binaries against a real PTY.

## Validation

- Agent bridge typecheck and tests
- Host Connector typecheck, lint, tests, production build, and source/bundled PTY smoke tests
- Web typecheck, lint, tests, and production build
- Workspace dependency consistency check
