### PR TITLE
fix(mobile): preserve scroll intent while streaming

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,7 +10,7 @@
     "ios": "expo start --ios --host=lan",
     "lint": "npm run typecheck",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"(no tests)\" && exit 0",
+    "test": "vitest run",
     "build": "echo \"(mobile is dev-only; no build step)\" && exit 0",
     "build:android:aab": "mkdir -p ../../dist/mobile && npx eas-cli@20 build --local --non-interactive --platform android --profile production --output ../../dist/mobile/overtchat.aab",
     "build:android:apk": "mkdir -p ../../dist/mobile && npx eas-cli@20 build --local --non-interactive --platform android --profile production-apk --output ../../dist/mobile/overtchat.apk",
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.2.2",
-    "typescript": "~6.0.3"
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.6"
   }
 }

--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -546,6 +546,7 @@ function ChatSurface({
         </View>
       ) : (
         <MessageList
+          key={chatId}
           messages={messages}
           streaming={streaming}
           status={status}

--- a/apps/mobile/src/components/chat/MessageList.tsx
+++ b/apps/mobile/src/components/chat/MessageList.tsx
@@ -1,12 +1,14 @@
+import { Ionicons } from "@expo/vector-icons";
 import type { ChatStatus, FileUIPart, UIMessage } from "ai";
-import { useEffect, useRef } from "react";
 import {
+  Pressable,
   RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
   View,
 } from "react-native";
+import { useScrollFollow } from "@/lib/chat/useScrollFollow";
 import { useTheme } from "@/lib/theme";
 import type { useSpeech } from "@/lib/useSpeech";
 import { MessageBubble } from "./MessageBubble";
@@ -41,85 +43,149 @@ export function MessageList({
   readOnly?: boolean;
 }) {
   const { colors, fonts } = useTheme();
-  const scrollRef = useRef<ScrollView>(null);
+  const latestMessage = messages.at(-1);
+  const latestMessageId = latestMessage?.id;
+  const latestMessageRole = latestMessage?.role;
+  const scrollFollow = useScrollFollow({
+    latestMessageId,
+    latestMessageRole,
+  });
 
-  useEffect(() => {
-    scrollRef.current?.scrollToEnd({ animated: true });
-  }, [messages, status]);
-
-  const lastIsUser = messages.at(-1)?.role === "user";
+  const lastIsUser = latestMessageRole === "user";
 
   return (
-    <ScrollView
-      ref={scrollRef}
-      style={styles.scroll}
-      contentContainerStyle={styles.content}
-      keyboardDismissMode="interactive"
-      keyboardShouldPersistTaps="handled"
-      refreshControl={
-        onRefresh ? (
-          <RefreshControl
-            refreshing={!!refreshing}
-            onRefresh={onRefresh}
-            tintColor={colors.mutedForeground}
-          />
-        ) : undefined
-      }
-    >
-      {messages.map((m, i) => {
-        const isLast = i === messages.length - 1;
-        return (
-          <MessageBubble
-            key={m.id}
-            message={m}
-            streaming={streaming && isLast}
-            editing={editingId === m.id}
-            speech={speech}
-            onStartEdit={onStartEdit}
-            onCancelEdit={onCancelEdit}
-            onSaveEdit={onSaveEdit}
-            onRegenerate={onRegenerate}
-            readOnly={readOnly}
-          />
-        );
-      })}
-      {!error && status === "submitted" && lastIsUser && (
-        <Text
-          accessibilityLabel="Assistant is responding"
-          accessibilityLiveRegion="polite"
-          style={[
-            styles.pending,
-            { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
-          ]}
-        >
-          …
-        </Text>
-      )}
-      {error && (
-        <View
-          style={[
-            styles.error,
-            { borderColor: colors.destructive, backgroundColor: colors.muted },
-          ]}
-        >
+    <View style={styles.root}>
+      <ScrollView
+        ref={scrollFollow.scrollRef}
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        keyboardDismissMode="interactive"
+        keyboardShouldPersistTaps="handled"
+        onLayout={scrollFollow.handleLayout}
+        onScroll={scrollFollow.handleScroll}
+        onScrollBeginDrag={scrollFollow.handleScrollBeginDrag}
+        onScrollEndDrag={scrollFollow.handleScrollEndDrag}
+        onMomentumScrollBegin={scrollFollow.handleMomentumScrollBegin}
+        onMomentumScrollEnd={scrollFollow.handleMomentumScrollEnd}
+        onContentSizeChange={scrollFollow.handleContentSizeChange}
+        scrollEventThrottle={16}
+        refreshControl={
+          onRefresh ? (
+            <RefreshControl
+              refreshing={!!refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.mutedForeground}
+            />
+          ) : undefined
+        }
+      >
+        {messages.map((m, i) => {
+          const isLast = i === messages.length - 1;
+          return (
+            <MessageBubble
+              key={m.id}
+              message={m}
+              streaming={streaming && isLast}
+              editing={editingId === m.id}
+              speech={speech}
+              onStartEdit={onStartEdit}
+              onCancelEdit={onCancelEdit}
+              onSaveEdit={onSaveEdit}
+              onRegenerate={onRegenerate}
+              readOnly={readOnly}
+            />
+          );
+        })}
+        {!error && status === "submitted" && lastIsUser && (
           <Text
+            accessibilityLabel="Assistant is responding"
+            accessibilityLiveRegion="polite"
             style={[
-              styles.errorText,
-              { color: colors.destructive, fontFamily: fonts.sansRegular },
+              styles.pending,
+              { color: colors.mutedForeground, fontFamily: fonts.sansRegular },
             ]}
           >
-            {error.message || "Something went wrong."}
+            …
           </Text>
+        )}
+        {error && (
+          <View
+            style={[
+              styles.error,
+              {
+                borderColor: colors.destructive,
+                backgroundColor: colors.muted,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.errorText,
+                {
+                  color: colors.destructive,
+                  fontFamily: fonts.sansRegular,
+                },
+              ]}
+            >
+              {error.message || "Something went wrong."}
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {!scrollFollow.isFollowing && (
+        <View style={styles.scrollToBottomContainer} pointerEvents="box-none">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Scroll to bottom"
+            hitSlop={8}
+            onPress={scrollFollow.scrollToLatest}
+            style={({ pressed }) => [
+              styles.scrollToBottomButton,
+              {
+                backgroundColor: colors.card,
+                borderColor: colors.border,
+                opacity: pressed ? 0.75 : 1,
+              },
+            ]}
+          >
+            <Ionicons
+              name="chevron-down"
+              size={22}
+              color={colors.foreground}
+            />
+          </Pressable>
         </View>
       )}
-    </ScrollView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  root: { flex: 1 },
   scroll: { flex: 1 },
   content: { paddingHorizontal: 16, paddingVertical: 16, gap: 16 },
   pending: { fontSize: 18, paddingVertical: 4 },
   error: { borderWidth: StyleSheet.hairlineWidth, borderRadius: 12, padding: 12 },
   errorText: { fontSize: 14 },
+  scrollToBottomContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 12,
+    alignItems: "center",
+  },
+  scrollToBottomButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 4,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.16,
+    shadowRadius: 5,
+  },
 });

--- a/apps/mobile/src/lib/chat/scroll-follow.test.ts
+++ b/apps/mobile/src/lib/chat/scroll-follow.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialChatScrollFollowState,
+  isChatScrollNearBottom,
+  reduceChatScrollFollow,
+  shouldPinChatToBottom,
+} from "./scroll-follow";
+
+describe("chat scroll following", () => {
+  it("treats content within the bottom threshold as attached", () => {
+    expect(
+      isChatScrollNearBottom({
+        contentHeight: 1_200,
+        viewportHeight: 500,
+        offsetY: 620,
+      }),
+    ).toBe(true);
+    expect(
+      isChatScrollNearBottom({
+        contentHeight: 1_200,
+        viewportHeight: 500,
+        offsetY: 619,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps short transcripts attached", () => {
+    expect(
+      isChatScrollNearBottom({
+        contentHeight: 320,
+        viewportHeight: 500,
+        offsetY: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("detaches as soon as an active user scroll moves away", () => {
+    const dragging = reduceChatScrollFollow(initialChatScrollFollowState, {
+      type: "user-scroll-begin",
+    });
+    const detached = reduceChatScrollFollow(dragging, {
+      type: "user-scroll-position",
+      nearBottom: false,
+    });
+
+    expect(detached).toEqual({ mode: "detached", userScrollActive: true });
+    expect(shouldPinChatToBottom(detached)).toBe(false);
+  });
+
+  it("ignores scroll-away events that were not initiated by the user", () => {
+    const next = reduceChatScrollFollow(initialChatScrollFollowState, {
+      type: "user-scroll-position",
+      nearBottom: false,
+    });
+
+    expect(next).toBe(initialChatScrollFollowState);
+  });
+
+  it("reattaches when a user scroll ends near the bottom", () => {
+    const next = reduceChatScrollFollow(
+      { mode: "detached", userScrollActive: true },
+      { type: "user-scroll-end", nearBottom: true },
+    );
+
+    expect(next).toEqual(initialChatScrollFollowState);
+    expect(shouldPinChatToBottom(next)).toBe(true);
+  });
+
+  it("stays detached when a user scroll ends away from the bottom", () => {
+    const next = reduceChatScrollFollow(
+      { mode: "detached", userScrollActive: true },
+      { type: "user-scroll-end", nearBottom: false },
+    );
+
+    expect(next).toEqual({ mode: "detached", userScrollActive: false });
+    expect(shouldPinChatToBottom(next)).toBe(false);
+  });
+
+  it("reattaches for an explicit follow request", () => {
+    const next = reduceChatScrollFollow(
+      { mode: "detached", userScrollActive: false },
+      { type: "follow-requested" },
+    );
+
+    expect(next).toEqual(initialChatScrollFollowState);
+  });
+});

--- a/apps/mobile/src/lib/chat/scroll-follow.ts
+++ b/apps/mobile/src/lib/chat/scroll-follow.ts
@@ -1,0 +1,63 @@
+export const CHAT_BOTTOM_THRESHOLD = 80;
+
+export type ChatScrollFollowMode = "following" | "detached";
+
+export type ChatScrollFollowState = {
+  mode: ChatScrollFollowMode;
+  userScrollActive: boolean;
+};
+
+export type ChatScrollFollowEvent =
+  | { type: "user-scroll-begin" }
+  | { type: "user-scroll-position"; nearBottom: boolean }
+  | { type: "user-scroll-end"; nearBottom: boolean }
+  | { type: "follow-requested" };
+
+export const initialChatScrollFollowState: ChatScrollFollowState = {
+  mode: "following",
+  userScrollActive: false,
+};
+
+export function isChatScrollNearBottom({
+  contentHeight,
+  viewportHeight,
+  offsetY,
+  threshold = CHAT_BOTTOM_THRESHOLD,
+}: {
+  contentHeight: number;
+  viewportHeight: number;
+  offsetY: number;
+  threshold?: number;
+}) {
+  return contentHeight - viewportHeight - offsetY <= threshold;
+}
+
+export function reduceChatScrollFollow(
+  state: ChatScrollFollowState,
+  event: ChatScrollFollowEvent,
+): ChatScrollFollowState {
+  if (event.type === "follow-requested") {
+    return initialChatScrollFollowState;
+  }
+
+  if (event.type === "user-scroll-begin") {
+    return { ...state, userScrollActive: true };
+  }
+
+  if (event.type === "user-scroll-position") {
+    if (!state.userScrollActive) return state;
+    return {
+      ...state,
+      mode: event.nearBottom ? "following" : "detached",
+    };
+  }
+
+  return {
+    mode: event.nearBottom ? "following" : "detached",
+    userScrollActive: false,
+  };
+}
+
+export function shouldPinChatToBottom(state: ChatScrollFollowState) {
+  return state.mode === "following" && !state.userScrollActive;
+}

--- a/apps/mobile/src/lib/chat/useScrollFollow.ts
+++ b/apps/mobile/src/lib/chat/useScrollFollow.ts
@@ -1,0 +1,191 @@
+import type { UIMessage } from "ai";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+} from "react-native";
+import {
+  type ChatScrollFollowEvent,
+  initialChatScrollFollowState,
+  isChatScrollNearBottom,
+  reduceChatScrollFollow,
+  shouldPinChatToBottom,
+} from "./scroll-follow";
+
+export function useScrollFollow({
+  latestMessageId,
+  latestMessageRole,
+}: {
+  latestMessageId: string | undefined;
+  latestMessageRole: UIMessage["role"] | undefined;
+}) {
+  const scrollRef = useRef<ScrollView>(null);
+  const followStateRef = useRef(initialChatScrollFollowState);
+  const latestMessageIdRef = useRef(latestMessageId);
+  const scrollFrameRef = useRef<number | null>(null);
+  const pendingScrollAnimatedRef = useRef(false);
+  const userScrollEndFrameRef = useRef<number | null>(null);
+  const [isFollowing, setIsFollowing] = useState(true);
+
+  const applyFollowEvent = useCallback((event: ChatScrollFollowEvent) => {
+    const next = reduceChatScrollFollow(followStateRef.current, event);
+    followStateRef.current = next;
+    const following = next.mode === "following";
+    setIsFollowing((current) =>
+      current === following ? current : following,
+    );
+    return next;
+  }, []);
+
+  const clearScheduledScroll = useCallback(() => {
+    if (scrollFrameRef.current === null) return;
+    cancelAnimationFrame(scrollFrameRef.current);
+    scrollFrameRef.current = null;
+    pendingScrollAnimatedRef.current = false;
+  }, []);
+
+  const scheduleScrollToEnd = useCallback((animated: boolean) => {
+    pendingScrollAnimatedRef.current ||= animated;
+    if (scrollFrameRef.current !== null) return;
+    scrollFrameRef.current = requestAnimationFrame(() => {
+      scrollFrameRef.current = null;
+      const shouldAnimate = pendingScrollAnimatedRef.current;
+      pendingScrollAnimatedRef.current = false;
+      scrollRef.current?.scrollToEnd({ animated: shouldAnimate });
+    });
+  }, []);
+
+  const clearPendingUserScrollEnd = useCallback(() => {
+    if (userScrollEndFrameRef.current === null) return;
+    cancelAnimationFrame(userScrollEndFrameRef.current);
+    userScrollEndFrameRef.current = null;
+  }, []);
+
+  const nearBottomFromEvent = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      return isChatScrollNearBottom({
+        contentHeight: contentSize.height,
+        viewportHeight: layoutMeasurement.height,
+        offsetY: contentOffset.y,
+      });
+    },
+    [],
+  );
+
+  const finishUserScroll = useCallback(
+    (nearBottom: boolean) => {
+      const next = applyFollowEvent({
+        type: "user-scroll-end",
+        nearBottom,
+      });
+      if (shouldPinChatToBottom(next)) {
+        scheduleScrollToEnd(false);
+      }
+    },
+    [applyFollowEvent, scheduleScrollToEnd],
+  );
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      applyFollowEvent({
+        type: "user-scroll-position",
+        nearBottom: nearBottomFromEvent(event),
+      });
+    },
+    [applyFollowEvent, nearBottomFromEvent],
+  );
+
+  const handleScrollBeginDrag = useCallback(() => {
+    clearPendingUserScrollEnd();
+    clearScheduledScroll();
+    applyFollowEvent({ type: "user-scroll-begin" });
+  }, [applyFollowEvent, clearPendingUserScrollEnd, clearScheduledScroll]);
+
+  const handleScrollEndDrag = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const nearBottom = nearBottomFromEvent(event);
+      clearPendingUserScrollEnd();
+      userScrollEndFrameRef.current = requestAnimationFrame(() => {
+        userScrollEndFrameRef.current = null;
+        finishUserScroll(nearBottom);
+      });
+    },
+    [clearPendingUserScrollEnd, finishUserScroll, nearBottomFromEvent],
+  );
+
+  const handleMomentumScrollBegin = useCallback(() => {
+    clearPendingUserScrollEnd();
+  }, [clearPendingUserScrollEnd]);
+
+  const handleMomentumScrollEnd = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      clearPendingUserScrollEnd();
+      finishUserScroll(nearBottomFromEvent(event));
+    },
+    [clearPendingUserScrollEnd, finishUserScroll, nearBottomFromEvent],
+  );
+
+  const handleContentSizeChange = useCallback(() => {
+    if (shouldPinChatToBottom(followStateRef.current)) {
+      scheduleScrollToEnd(false);
+    }
+  }, [scheduleScrollToEnd]);
+
+  const handleLayout = useCallback(
+    (_event: LayoutChangeEvent) => {
+      if (shouldPinChatToBottom(followStateRef.current)) {
+        scheduleScrollToEnd(false);
+      }
+    },
+    [scheduleScrollToEnd],
+  );
+
+  const scrollToLatest = useCallback(() => {
+    clearPendingUserScrollEnd();
+    applyFollowEvent({ type: "follow-requested" });
+    scheduleScrollToEnd(true);
+  }, [applyFollowEvent, clearPendingUserScrollEnd, scheduleScrollToEnd]);
+
+  useEffect(() => {
+    const previousLatestMessageId = latestMessageIdRef.current;
+    latestMessageIdRef.current = latestMessageId;
+    if (
+      latestMessageRole !== "user" ||
+      latestMessageId === previousLatestMessageId
+    ) {
+      return;
+    }
+    applyFollowEvent({ type: "follow-requested" });
+    scheduleScrollToEnd(false);
+  }, [
+    applyFollowEvent,
+    latestMessageId,
+    latestMessageRole,
+    scheduleScrollToEnd,
+  ]);
+
+  useEffect(
+    () => () => {
+      clearScheduledScroll();
+      clearPendingUserScrollEnd();
+    },
+    [clearPendingUserScrollEnd, clearScheduledScroll],
+  );
+
+  return {
+    scrollRef,
+    isFollowing,
+    scrollToLatest,
+    handleLayout,
+    handleScroll,
+    handleScrollBeginDrag,
+    handleScrollEndDrag,
+    handleMomentumScrollBegin,
+    handleMomentumScrollEnd,
+    handleContentSizeChange,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,7 +1143,8 @@
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
-        "typescript": "~6.0.3"
+        "typescript": "~6.0.3",
+        "vitest": "^4.1.6"
       }
     },
     "apps/mobile/node_modules/@better-auth/core": {


### PR DESCRIPTION
## Summary

- replace unconditional animated scrolling with measured, frame-coalesced sticky-bottom following
- pause following during drag and momentum, detach when the reader scrolls away, and reattach at the bottom or after an explicit send
- add a jump-to-latest affordance and reset follow state when switching chats
- add mobile unit coverage for the follow-state contract

## Testing

- npm test -w apps/mobile --
- npm run lint -w apps/mobile --
- npm run deps:check
- npx expo export --platform android --output-dir <temporary-directory>

## Draft follow-up

- verify drag, momentum, keyboard resize, and streaming behavior on physical Android and iOS devices