### PR TITLE
fix(mobile): stabilize theme values across renders

### DIFF
--- a/apps/mobile/src/lib/theme.ts
+++ b/apps/mobile/src/lib/theme.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useColorScheme } from "react-native";
 import { mobileFonts, radii, type ColorTokens } from "@overtchat/shared";
 import { darkTokensRgb, lightTokensRgb } from "@overtchat/shared/theme.rn";
@@ -19,10 +20,14 @@ export function useTheme(): Theme {
   const fontId = useFontPref();
   const system = useColorScheme() === "dark" ? "dark" : "light";
   const scheme = pref === "system" ? system : pref;
-  return {
-    colors: scheme === "dark" ? darkTokensRgb : lightTokensRgb,
-    radii,
-    fonts: { ...mobileFonts, ...FONT_SANS[fontId] },
-    scheme,
-  };
+  const colors = scheme === "dark" ? darkTokensRgb : lightTokensRgb;
+  const fonts = useMemo(
+    () => ({ ...mobileFonts, ...FONT_SANS[fontId] }),
+    [fontId],
+  );
+
+  return useMemo(
+    () => ({ colors, radii, fonts, scheme }),
+    [colors, fonts, scheme],
+  );
 }


### PR DESCRIPTION
## Summary

- keep mobile theme values stable between renders
- prevent the chat header effect from repeatedly updating navigation

## Test plan

- open new and existing chats without a maximum-update-depth error
- switch the app theme and font settings
- run the mobile typecheck
