### PR TITLE
fix(mobile): make streaming chat responsive

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -222,6 +222,9 @@ function ChatSurface({
     error,
   } = useChat({
     id: chatId,
+    // Rendering every provider delta makes the React Native tree contend with
+    // scrolling and touch handling. The AI SDK coalesces subscriber updates.
+    throttle: 60,
     resume: !isNew,
     transport,
     messages: initialMessages,
@@ -409,6 +412,7 @@ function ChatSurface({
   const isNewRef = useRef(isNew);
 
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [localAnchorRequestKey, setLocalAnchorRequestKey] = useState(0);
 
   const lastErrorRef = useRef<Error | undefined>(undefined);
   useEffect(() => {
@@ -459,6 +463,7 @@ function ChatSurface({
         return [next, ...prev];
       });
     }
+    setLocalAnchorRequestKey((key) => key + 1);
     sendMessage(
       { text, files },
       { body: requestBody({ type: "submit" }, searchRequested) },
@@ -469,6 +474,7 @@ function ChatSurface({
 
   function handleRegenerate(messageId: string) {
     if (streaming || !configured) return;
+    setLocalAnchorRequestKey((key) => key + 1);
     regenerate({
       messageId,
       body: requestBody({
@@ -488,6 +494,7 @@ function ChatSurface({
     const trimmed = text.trim();
     if (!trimmed && files.length === 0) return;
     Keyboard.dismiss();
+    setLocalAnchorRequestKey((key) => key + 1);
     sendMessage(
       { text: trimmed, files, messageId },
       {
@@ -558,6 +565,7 @@ function ChatSurface({
           onCancelEdit={() => setEditingId(null)}
           onSaveEdit={handleSaveEdit}
           onRegenerate={handleRegenerate}
+          localAnchorRequestKey={localAnchorRequestKey}
           readOnly={voiceReadOnly}
         />
       )}

--- a/apps/mobile/src/components/chat/ChainOfThought.tsx
+++ b/apps/mobile/src/components/chat/ChainOfThought.tsx
@@ -3,12 +3,12 @@ import {
   Ionicons,
   MaterialCommunityIcons,
 } from "@expo/vector-icons";
+import { useLayoutState } from "@shopify/flash-list";
 import { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Animated,
   Image,
-  LayoutAnimation,
   Linking,
   Pressable,
   StyleSheet,
@@ -67,7 +67,7 @@ export function ChainOfThought({
   active: boolean;
 }) {
   const { colors, fonts } = useTheme();
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useLayoutState(false);
   const [duration, setDuration] = useState(0);
   const startedAtRef = useRef<number | null>(null);
   const settledRef = useRef(false);
@@ -106,9 +106,6 @@ export function ChainOfThought({
   const label = active ? activeLabel(last) : settledLabel(parts, duration);
 
   function toggle() {
-    LayoutAnimation.configureNext(
-      LayoutAnimation.create(180, "easeInEaseOut", "opacity"),
-    );
     setOpen((o) => !o);
   }
 
@@ -400,7 +397,7 @@ const RESULTS_PREVIEW = 5;
 
 function SearchStep({ part }: { part: WebSearchPart }) {
   const { colors, fonts } = useTheme();
-  const [showAll, setShowAll] = useState(false);
+  const [showAll, setShowAll] = useLayoutState(false);
   const query = part.input?.query?.trim();
   const results = webSearchResults(part.output);
   const provider = webSearchProviderLabel(part.output);
@@ -412,9 +409,6 @@ function SearchStep({ part }: { part: WebSearchPart }) {
   const hidden = results.length - visible.length;
 
   function toggleShowAll() {
-    LayoutAnimation.configureNext(
-      LayoutAnimation.create(180, "easeInEaseOut", "opacity"),
-    );
     setShowAll((s) => !s);
   }
 

--- a/apps/mobile/src/components/chat/MemoryArtifact.tsx
+++ b/apps/mobile/src/components/chat/MemoryArtifact.tsx
@@ -6,8 +6,8 @@ import {
   type MemoryToolDisplay,
   type MemoryToolPart,
 } from "@overtchat/shared";
+import { useLayoutState } from "@shopify/flash-list";
 import { router } from "expo-router";
-import { useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -19,7 +19,7 @@ import { useTheme } from "@/lib/theme";
 
 export function MemoryArtifact({ parts }: { parts: MemoryToolPart[] }) {
   const { colors, fonts, radii } = useTheme();
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useLayoutState(false);
   const details = parts.map(describeMemoryToolPart);
   const running = details.some((detail) => detail.status === "running");
   const failed = details.some(

--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -43,6 +43,7 @@ export function MessageBubble({
   const [copied, setCopied] = useState(false);
   const menu = useMeasuredPopoverAnchor();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sourceLookup = useMemo(() => buildSourceLookup(message), [message]);
 
   useEffect(() => {
     return () => {
@@ -152,8 +153,6 @@ export function MessageBubble({
         ? ["copy"]
         : ["copy", "regenerate"]
       : [];
-  const sourceLookup = useMemo(() => buildSourceLookup(message), [message]);
-
   function onAssistantMenuSelect(action: MessageAction) {
     if (action === "copy") copyText(text);
     else if (action === "regenerate") onRegenerate(message.id);

--- a/apps/mobile/src/components/chat/MessageList.tsx
+++ b/apps/mobile/src/components/chat/MessageList.tsx
@@ -1,8 +1,12 @@
+import { Ionicons } from "@expo/vector-icons";
+import { FlashList, type FlashListRef } from "@shopify/flash-list";
 import type { ChatStatus, FileUIPart, UIMessage } from "ai";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
   RefreshControl,
-  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -10,6 +14,14 @@ import {
 import { useTheme } from "@/lib/theme";
 import type { useSpeech } from "@/lib/useSpeech";
 import { MessageBubble } from "./MessageBubble";
+
+const CHAT_MAINTAIN_VISIBLE_POSITION = {
+  startRenderingFromBottom: true,
+  autoscrollToBottomThreshold: 0.05,
+  animateAutoScrollToBottom: false,
+} as const;
+
+const CHAT_BOTTOM_THRESHOLD_PX = 32;
 
 export function MessageList({
   messages,
@@ -24,6 +36,7 @@ export function MessageList({
   onCancelEdit,
   onSaveEdit,
   onRegenerate,
+  localAnchorRequestKey,
   readOnly = false,
 }: {
   messages: UIMessage[];
@@ -38,51 +51,48 @@ export function MessageList({
   onCancelEdit: () => void;
   onSaveEdit: (id: string, text: string, files: FileUIPart[]) => void;
   onRegenerate: (id: string) => void;
+  localAnchorRequestKey: number;
   readOnly?: boolean;
 }) {
   const { colors, fonts } = useTheme();
-  const scrollRef = useRef<ScrollView>(null);
+  const latestMessage = messages.at(-1);
+  const latestMessageId = latestMessage?.id;
+  const latestMessageRole = latestMessage?.role;
+  const listRef = useRef<FlashListRef<UIMessage>>(null);
+  const nearBottomRef = useRef(true);
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  const lastIsUser = latestMessageRole === "user";
+  const listExtraData = useMemo(
+    () => ({
+      editingId,
+      readOnly,
+      speechActiveId: speech.activeId,
+      speechStatus: speech.status,
+      streaming,
+    }),
+    [editingId, readOnly, speech.activeId, speech.status, streaming],
+  );
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const next =
+        contentSize.height - layoutMeasurement.height - contentOffset.y <=
+        CHAT_BOTTOM_THRESHOLD_PX;
+      if (next === nearBottomRef.current) return;
+      nearBottomRef.current = next;
+      setIsNearBottom(next);
+    },
+    [],
+  );
 
   useEffect(() => {
-    scrollRef.current?.scrollToEnd({ animated: true });
-  }, [messages, status]);
+    listRef.current?.scrollToEnd({ animated: false });
+  }, [localAnchorRequestKey]);
 
-  const lastIsUser = messages.at(-1)?.role === "user";
-
-  return (
-    <ScrollView
-      ref={scrollRef}
-      style={styles.scroll}
-      contentContainerStyle={styles.content}
-      keyboardDismissMode="interactive"
-      keyboardShouldPersistTaps="handled"
-      refreshControl={
-        onRefresh ? (
-          <RefreshControl
-            refreshing={!!refreshing}
-            onRefresh={onRefresh}
-            tintColor={colors.mutedForeground}
-          />
-        ) : undefined
-      }
-    >
-      {messages.map((m, i) => {
-        const isLast = i === messages.length - 1;
-        return (
-          <MessageBubble
-            key={m.id}
-            message={m}
-            streaming={streaming && isLast}
-            editing={editingId === m.id}
-            speech={speech}
-            onStartEdit={onStartEdit}
-            onCancelEdit={onCancelEdit}
-            onSaveEdit={onSaveEdit}
-            onRegenerate={onRegenerate}
-            readOnly={readOnly}
-          />
-        );
-      })}
+  const footer = (
+    <>
       {!error && status === "submitted" && lastIsUser && (
         <Text
           accessibilityLabel="Assistant is responding"
@@ -105,21 +115,114 @@ export function MessageList({
           <Text
             style={[
               styles.errorText,
-              { color: colors.destructive, fontFamily: fonts.sansRegular },
+              {
+                color: colors.destructive,
+                fontFamily: fonts.sansRegular,
+              },
             ]}
           >
             {error.message || "Something went wrong."}
           </Text>
         </View>
       )}
-    </ScrollView>
+    </>
+  );
+
+  return (
+    <View style={styles.root}>
+      <FlashList
+        ref={listRef}
+        data={messages}
+        extraData={listExtraData}
+        keyExtractor={(message) => message.id}
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        keyboardDismissMode="interactive"
+        keyboardShouldPersistTaps="handled"
+        maintainVisibleContentPosition={CHAT_MAINTAIN_VISIBLE_POSITION}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        refreshControl={
+          onRefresh ? (
+            <RefreshControl
+              refreshing={!!refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.mutedForeground}
+            />
+          ) : undefined
+        }
+        renderItem={({ item: message }) => (
+          <View style={styles.messageRow}>
+            <MessageBubble
+              message={message}
+              streaming={streaming && message.id === latestMessageId}
+              editing={editingId === message.id}
+              speech={speech}
+              onStartEdit={onStartEdit}
+              onCancelEdit={onCancelEdit}
+              onSaveEdit={onSaveEdit}
+              onRegenerate={onRegenerate}
+              readOnly={readOnly}
+            />
+          </View>
+        )}
+        ListFooterComponent={footer}
+      />
+
+      {!isNearBottom && (
+        <View style={styles.scrollToBottomContainer} pointerEvents="box-none">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Scroll to bottom"
+            hitSlop={8}
+            onPress={() => listRef.current?.scrollToEnd({ animated: true })}
+            style={({ pressed }) => [
+              styles.scrollToBottomButton,
+              {
+                backgroundColor: colors.card,
+                borderColor: colors.border,
+                opacity: pressed ? 0.75 : 1,
+              },
+            ]}
+          >
+            <Ionicons name="chevron-down" size={22} color={colors.foreground} />
+          </Pressable>
+        </View>
+      )}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  root: { flex: 1 },
   scroll: { flex: 1 },
-  content: { paddingHorizontal: 16, paddingVertical: 16, gap: 16 },
+  content: { paddingHorizontal: 16, paddingVertical: 16 },
+  messageRow: { marginBottom: 16 },
   pending: { fontSize: 18, paddingVertical: 4 },
-  error: { borderWidth: StyleSheet.hairlineWidth, borderRadius: 12, padding: 12 },
+  error: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    padding: 12,
+  },
   errorText: { fontSize: 14 },
+  scrollToBottomContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 12,
+    alignItems: "center",
+  },
+  scrollToBottomButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    elevation: 4,
+  },
 });

--- a/apps/mobile/src/components/chat/Sources.tsx
+++ b/apps/mobile/src/components/chat/Sources.tsx
@@ -1,8 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useState } from "react";
+import { useLayoutState } from "@shopify/flash-list";
 import {
   Image,
-  LayoutAnimation,
   Linking,
   Pressable,
   StyleSheet,
@@ -20,15 +19,12 @@ import { useTheme } from "@/lib/theme";
 
 export function Sources({ message }: { message: UIMessage }) {
   const { colors, fonts } = useTheme();
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useLayoutState(false);
 
   const all: WebSearchResult[] = buildWebCitationIndex(message.parts).sources;
   if (all.length === 0) return null;
 
   function toggle() {
-    LayoutAnimation.configureNext(
-      LayoutAnimation.create(180, "easeInEaseOut", "opacity"),
-    );
     setOpen((o) => !o);
   }
 


### PR DESCRIPTION
## Summary

- throttle streamed chat renders to keep interactions responsive
- use FlashList's built-in bottom anchoring and detach when the user scrolls away
- keep expandable message rows synchronized with list layout

## Test plan

- stream with Thoughts expanded and confirm controls remain responsive
- scroll away during streaming, then use the down arrow to return
- open an older chat and expand or collapse Thoughts, tools, and Sources
- run the mobile typecheck and Android/iOS production exports

Depends on #244.
