### PR TITLE
fix(mobile): preserve iOS auth cookies

### DIFF
--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,10 +1,7 @@
-import { getCookie } from "@better-auth/expo/client";
 import { File as FsFile } from "expo-file-system";
-import * as SecureStore from "expo-secure-store";
 import { fetch as expoFetch } from "expo/fetch";
+import { getAuthClient } from "@/lib/auth/client";
 import { getServerUrl } from "@/lib/server-url";
-
-const COOKIE_STORAGE_KEY = "overtchat_cookie";
 
 export function getApiBase(): string {
   const url = getServerUrl();
@@ -13,7 +10,7 @@ export function getApiBase(): string {
 }
 
 export function getAuthCookie(): string {
-  return getCookie(SecureStore.getItem(COOKIE_STORAGE_KEY) ?? "{}");
+  return getAuthClient().getCookie();
 }
 
 export function authFetch(
@@ -23,7 +20,9 @@ export function authFetch(
   const cookie = getAuthCookie();
   const headers = new Headers(init.headers as HeadersInit | undefined);
   if (cookie && !headers.has("Cookie")) headers.set("Cookie", cookie);
-  return expoFetch(input, { ...init, headers });
+  // Better Auth owns the cookie in SecureStore. Letting NSURLSession also add
+  // cookies from its shared jar can send duplicate (and stale) session tokens.
+  return expoFetch(input, { ...init, credentials: "omit", headers });
 }
 
 export type UploadCategory = "image" | "document" | "text" | "spreadsheet";
@@ -50,6 +49,7 @@ export async function uploadFile(file: {
   const res = await expoFetch(`${getApiBase()}/api/uploads`, {
     method: "POST",
     body: form,
+    credentials: "omit",
     headers: { Cookie: getAuthCookie() },
   });
 

--- a/apps/mobile/src/lib/auth/client.ts
+++ b/apps/mobile/src/lib/auth/client.ts
@@ -3,13 +3,10 @@ import { expoClient } from "@better-auth/expo/client";
 import * as SecureStore from "expo-secure-store";
 import { getServerUrl } from "@/lib/server-url";
 
-let cached: ReturnType<typeof createAuthClient> | null = null;
-
-export function getAuthClient() {
-  if (cached) return cached;
+function createClient() {
   const baseURL = getServerUrl();
   if (!baseURL) throw new Error("Server URL not set");
-  cached = createAuthClient({
+  return createAuthClient({
     baseURL,
     plugins: [
       expoClient({
@@ -19,6 +16,15 @@ export function getAuthClient() {
       }),
     ],
   });
+}
+
+// Infer from the configured factory so Expo plugin actions such as getCookie
+// remain part of the client type.
+type AuthClient = ReturnType<typeof createClient>;
+let cached: AuthClient | null = null;
+
+export function getAuthClient(): AuthClient {
+  if (!cached) cached = createClient();
   return cached;
 }
 


### PR DESCRIPTION
## Summary

- Read auth cookies through the Better Auth Expo client so chunked SecureStore values are reconstructed.
- Disable Expo’s native cookie jar for authenticated requests that already attach the Better Auth cookie.
- Apply the same handling to multipart uploads.

## Testing

- Ran the mobile TypeScript typecheck.
- Built and installed a Release build on a physical iPhone.
- Signed in to an OvertChat server and confirmed models load and chat requests work without the previous `401 Unauthorized` error.