### PR TITLE
fix(chat): recover server-owned generations after disconnects

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -9,6 +9,7 @@ import {
 import type { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { useQueryClient } from "@tanstack/react-query";
 import * as DocumentPicker from "expo-document-picker";
+import * as Crypto from "expo-crypto";
 import * as ImagePicker from "expo-image-picker";
 import { useHeaderHeight } from "expo-router/react-navigation";
 import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai";
@@ -45,6 +46,7 @@ import { authFetch, getApiBase } from "@/lib/api";
 import { getAuthClient } from "@/lib/auth/client";
 import { useAttachments, type PickedFile } from "@/lib/chat/useAttachments";
 import { useChatSession } from "@/lib/chat/session";
+import { useChatGenerationRecovery } from "@/lib/chat/useChatGenerationRecovery";
 import { useChatMessages } from "@/lib/queries/chatMessages";
 import { useModelConfigs } from "@/lib/queries/modelConfigs";
 import type { ChatListItem } from "@/lib/queries/chats";
@@ -181,6 +183,7 @@ function ChatSurface({
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [searchRequested, setSearchRequested] = useState(false);
+  const [chatPersisted, setChatPersisted] = useState(!isNew);
   const webSearchEnabled = useWebSearchEnabled();
   const pickerRef = useRef<BottomSheetModal>(null);
   const addSheetRef = useRef<BottomSheetModal>(null);
@@ -220,12 +223,14 @@ function ChatSurface({
     status,
     stop,
     error,
+    resumeStream,
+    clearError,
   } = useChat({
     id: chatId,
     // Rendering every provider delta makes the React Native tree contend with
     // scrolling and touch handling. The AI SDK coalesces subscriber updates.
     throttle: 60,
-    resume: !isNew,
+    resume: false,
     transport,
     messages: initialMessages,
     onFinish: ({ message, isAbort }) => {
@@ -233,9 +238,27 @@ function ChatSurface({
         void qc.invalidateQueries({ queryKey: queryKeys.personalization() });
       }
       if (isAbort) return;
+      setChatPersisted(true);
       void qc.invalidateQueries({ queryKey: queryKeys.chats() });
       void qc.invalidateQueries({ queryKey: queryKeys.chatMessages(chatId) });
     },
+  });
+
+  const handleGenerationSettled = useCallback(() => {
+    setChatPersisted(true);
+    void qc.invalidateQueries({ queryKey: queryKeys.chats() });
+    void qc.invalidateQueries({ queryKey: queryKeys.chatMessages(chatId) });
+  }, [chatId, qc]);
+  const reconcileGeneration = useChatGenerationRecovery({
+    baseURL,
+    chatId,
+    enabled: chatPersisted,
+    recoverOnMount: !isNew,
+    stopLocalStream: stop,
+    resumeStream,
+    clearError,
+    setMessages,
+    onSettled: handleGenerationSettled,
   });
 
   const handleStop = useCallback(() => {
@@ -403,6 +426,7 @@ function ChatSurface({
       searchEnabled: requested,
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       chatId,
+      clientRequestId: Crypto.randomUUID(),
       projectId,
       temporary: false,
       action,
@@ -417,10 +441,14 @@ function ChatSurface({
   const lastErrorRef = useRef<Error | undefined>(undefined);
   useEffect(() => {
     if (error && error !== lastErrorRef.current) {
-      toastError("Chat error", error);
+      if (/abort|connection|fetch|network|socket/i.test(error.message)) {
+        void reconcileGeneration();
+      } else {
+        toastError("Chat error", error);
+      }
     }
     lastErrorRef.current = error;
-  }, [error]);
+  }, [error, reconcileGeneration]);
 
   const userRefreshingMessages = useRef(false);
   const wasFetchingMessages = useRef(false);
@@ -450,6 +478,7 @@ function ChatSurface({
     const wasNew = isNewRef.current;
     if (wasNew) {
       isNewRef.current = false;
+      setChatPersisted(true);
       qc.setQueryData<ChatListItem[]>(queryKeys.chats(), (prev) => {
         const next: ChatListItem = {
           id: chatId,

--- a/apps/mobile/src/lib/chat/useChatGenerationRecovery.ts
+++ b/apps/mobile/src/lib/chat/useChatGenerationRecovery.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef } from "react";
+import { AppState } from "react-native";
+import * as Network from "expo-network";
+import type { ChatGenerationState } from "@overtchat/shared";
+import type { UIMessage } from "ai";
+import { authFetch } from "@/lib/api";
+
+const POLL_DELAY_MS = 1_500;
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function applyTerminalMessage(
+  current: UIMessage[],
+  responseMessage: UIMessage | undefined,
+) {
+  if (!responseMessage) return current;
+  const index = current.findIndex(({ id }) => id === responseMessage.id);
+  if (index === -1) return [...current, responseMessage];
+  const next = [...current];
+  next[index] = responseMessage;
+  return next;
+}
+
+/** React Native counterpart to the web foreground recovery protocol. */
+export function useChatGenerationRecovery({
+  baseURL,
+  chatId,
+  enabled,
+  recoverOnMount,
+  stopLocalStream,
+  resumeStream,
+  clearError,
+  setMessages,
+  onSettled,
+}: {
+  baseURL: string;
+  chatId: string;
+  enabled: boolean;
+  recoverOnMount: boolean;
+  stopLocalStream: () => void;
+  resumeStream: () => Promise<void>;
+  clearError: () => void;
+  setMessages: (
+    messages: UIMessage[] | ((current: UIMessage[]) => UIMessage[]),
+  ) => void;
+  onSettled: () => void;
+}) {
+  const epochRef = useRef(0);
+  const recoveryRef = useRef<Promise<void> | null>(null);
+
+  const reconcile = useCallback(async () => {
+    if (!enabled) return;
+    if (recoveryRef.current) return recoveryRef.current;
+
+    const epoch = epochRef.current;
+    const recovery = (async () => {
+      while (epochRef.current === epoch) {
+        const response = await authFetch(
+          `${baseURL}/api/chat/${encodeURIComponent(chatId)}/stream/status`,
+        );
+        if (!response.ok) {
+          throw new Error(`Could not inspect generation (${response.status})`);
+        }
+        const generation = (await response.json()) as ChatGenerationState;
+
+        if (!generation.active) {
+          setMessages((current) =>
+            applyTerminalMessage(current, generation.responseMessage),
+          );
+          clearError();
+          onSettled();
+          return;
+        }
+
+        // Abort only the device's stale fetch. The explicit cancel endpoint is
+        // the sole operation allowed to stop the server-owned generation.
+        stopLocalStream();
+        clearError();
+        await resumeStream();
+
+        if (epochRef.current !== epoch || AppState.currentState !== "active") {
+          return;
+        }
+        await delay(POLL_DELAY_MS);
+      }
+    })();
+
+    recoveryRef.current = recovery;
+    try {
+      await recovery;
+    } finally {
+      if (recoveryRef.current === recovery) recoveryRef.current = null;
+    }
+  }, [
+    baseURL,
+    chatId,
+    clearError,
+    enabled,
+    onSettled,
+    resumeStream,
+    setMessages,
+    stopLocalStream,
+  ]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const recover = () => void reconcile().catch(() => undefined);
+    const appStateSubscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") recover();
+    });
+    const networkSubscription = Network.addNetworkStateListener((state) => {
+      if (state.isConnected && state.isInternetReachable !== false) recover();
+    });
+    if (recoverOnMount) recover();
+
+    return () => {
+      epochRef.current += 1;
+      appStateSubscription.remove();
+      networkSubscription.remove();
+    };
+  }, [enabled, reconcile, recoverOnMount]);
+
+  return reconcile;
+}

--- a/apps/web/app/api/chat/[id]/stream/cancel/route.ts
+++ b/apps/web/app/api/chat/[id]/stream/cancel/route.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/lib/auth/server";
 import { preflight, withCors } from "@/lib/cors";
 import { getActiveStreamId, getChat } from "@/lib/db/chats";
-import { clearActiveStreamId } from "@/lib/db/chatTurns";
+import { completeChatStream } from "@/lib/db/chatTurns";
 import * as cancelRegistry from "@/lib/streams/cancel-registry";
 
 export function OPTIONS(req: Request) {
@@ -22,7 +22,7 @@ export async function POST(
 
   const streamId = await getActiveStreamId(id);
   if (streamId && !cancelRegistry.cancel(streamId)) {
-    await clearActiveStreamId(id, streamId);
+    completeChatStream({ chatId: id, streamId, status: "aborted" });
   }
 
   return withCors(req, new Response(null, { status: 204 }));

--- a/apps/web/app/api/chat/[id]/stream/route.ts
+++ b/apps/web/app/api/chat/[id]/stream/route.ts
@@ -1,10 +1,9 @@
-import { UI_MESSAGE_STREAM_HEADERS } from "ai";
 import { auth } from "@/lib/auth/server";
-import { corsHeaders, preflight, withCors } from "@/lib/cors";
+import { preflight, withCors } from "@/lib/cors";
 import { getActiveStreamId, getChat } from "@/lib/db/chats";
-import { clearActiveStreamId } from "@/lib/db/chatTurns";
+import { failChatStream } from "@/lib/db/chatTurns";
 import * as cancelRegistry from "@/lib/streams/cancel-registry";
-import { getStreamContext } from "@/lib/streams/context";
+import { resumeChatStreamResponse } from "@/lib/streams/http";
 
 export const maxDuration = 300;
 
@@ -27,36 +26,29 @@ export async function GET(
   const streamId = await getActiveStreamId(id);
   if (!streamId) return withCors(req, new Response(null, { status: 204 }));
 
-  const streamContext = getStreamContext();
-  if (!streamContext) {
-    if (!cancelRegistry.has(streamId)) {
-      await clearActiveStreamId(id, streamId);
-    }
-    return withCors(req, new Response(null, { status: 204 }));
-  }
-
-  let replay: Awaited<ReturnType<typeof streamContext.resumeExistingStream>>;
+  let response: Response | null;
   try {
-    replay = await streamContext.resumeExistingStream(streamId);
-  } catch (err) {
-    console.warn("[resumable-stream] failed to resume stream", err);
+    response = await resumeChatStreamResponse(req, streamId);
+  } catch (error) {
+    console.warn("[resumable-stream] failed to resume stream", error);
     if (!cancelRegistry.has(streamId)) {
-      await clearActiveStreamId(id, streamId);
+      failChatStream({
+        chatId: id,
+        streamId,
+        error: "Generation stream could not be resumed.",
+      });
     }
     return withCors(req, new Response(null, { status: 204 }));
   }
-  if (!replay) {
+  if (!response) {
     if (!cancelRegistry.has(streamId)) {
-      await clearActiveStreamId(id, streamId);
+      failChatStream({
+        chatId: id,
+        streamId,
+        error: "Generation stream was no longer available.",
+      });
     }
     return withCors(req, new Response(null, { status: 204 }));
   }
-
-  const headers = corsHeaders(req);
-  for (const [k, v] of Object.entries(UI_MESSAGE_STREAM_HEADERS)) {
-    headers.set(k, v);
-  }
-  headers.set("Content-Encoding", "none");
-
-  return new Response(replay, { headers });
+  return response;
 }

--- a/apps/web/app/api/chat/[id]/stream/status/route.test.ts
+++ b/apps/web/app/api/chat/[id]/stream/status/route.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getChat: vi.fn(),
+  getChatMessage: vi.fn(),
+  getChatGeneration: vi.fn(),
+  getLatestChatGeneration: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/chats", () => ({ getChat: mocks.getChat }));
+vi.mock("@/lib/db/chatTurns", () => ({
+  getChatMessage: mocks.getChatMessage,
+  getChatGeneration: mocks.getChatGeneration,
+  getLatestChatGeneration: mocks.getLatestChatGeneration,
+}));
+
+import { GET } from "./route";
+
+const request = () =>
+  new Request("http://server.test/api/chat/chat/stream/status", {
+    headers: { Origin: "exp://mobile" },
+  });
+const context = { params: Promise.resolve({ id: "chat" }) };
+
+describe("chat generation status", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getSession.mockResolvedValue({ user: { id: "user" } });
+    mocks.getChat.mockResolvedValue({
+      id: "chat",
+      userId: "user",
+      activeStreamId: null,
+    });
+    mocks.getLatestChatGeneration.mockResolvedValue(null);
+    mocks.getChatGeneration.mockResolvedValue(null);
+    mocks.getChatMessage.mockResolvedValue(null);
+  });
+
+  it("returns an authoritative running generation", async () => {
+    mocks.getChat.mockResolvedValue({
+      id: "chat",
+      userId: "user",
+      activeStreamId: "stream",
+    });
+    mocks.getChatGeneration.mockResolvedValue({
+      id: "stream",
+      status: "running",
+      startedAt: new Date(1_000),
+      completedAt: null,
+      responseMessageId: null,
+    });
+
+    const response = await GET(request(), context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      active: true,
+      streamId: "stream",
+      status: "running",
+      startedAt: 1_000,
+      completedAt: null,
+    });
+  });
+
+  it("returns the persisted terminal assistant for reconciliation", async () => {
+    const responseMessage = {
+      id: "assistant",
+      role: "assistant",
+      parts: [{ type: "text", text: "Finished while backgrounded" }],
+    };
+    mocks.getLatestChatGeneration.mockResolvedValue({
+      id: "stream",
+      status: "complete",
+      startedAt: new Date(1_000),
+      completedAt: new Date(2_000),
+      responseMessageId: "assistant",
+    });
+    mocks.getChatMessage.mockResolvedValue(responseMessage);
+
+    const response = await GET(request(), context);
+
+    await expect(response.json()).resolves.toEqual({
+      active: false,
+      streamId: "stream",
+      status: "complete",
+      startedAt: 1_000,
+      completedAt: 2_000,
+      responseMessage,
+    });
+  });
+
+  it("does not reveal another user's chat", async () => {
+    mocks.getChat.mockResolvedValue(null);
+
+    const response = await GET(request(), context);
+
+    expect(response.status).toBe(404);
+    expect(mocks.getLatestChatGeneration).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/chat/[id]/stream/status/route.ts
+++ b/apps/web/app/api/chat/[id]/stream/status/route.ts
@@ -1,0 +1,49 @@
+import type { ChatGenerationState } from "@overtchat/shared";
+import { auth } from "@/lib/auth/server";
+import { preflight, withCors } from "@/lib/cors";
+import { getChat } from "@/lib/db/chats";
+import {
+  getChatMessage,
+  getChatGeneration,
+  getLatestChatGeneration,
+} from "@/lib/db/chatTurns";
+
+export function OPTIONS(req: Request) {
+  return preflight(req);
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) {
+    return withCors(req, new Response("Unauthorized", { status: 401 }));
+  }
+
+  const { id } = await params;
+  const chat = await getChat(id, session.user.id);
+  if (!chat) {
+    return withCors(req, new Response("Not found", { status: 404 }));
+  }
+
+  const active = chat.activeStreamId !== null;
+  const generation = chat.activeStreamId
+    ? await getChatGeneration(chat.activeStreamId, session.user.id)
+    : await getLatestChatGeneration(id, session.user.id);
+  const responseMessage = generation?.responseMessageId
+    ? await getChatMessage(id, generation.responseMessageId)
+    : null;
+  const body: ChatGenerationState = {
+    active,
+    streamId: chat.activeStreamId ?? generation?.id ?? null,
+    status: active ? "running" : (generation?.status ?? "idle"),
+    startedAt: generation?.startedAt.getTime() ?? null,
+    completedAt: generation?.completedAt?.getTime() ?? null,
+    ...(responseMessage ? { responseMessage } : {}),
+  };
+
+  const response = Response.json(body);
+  response.headers.set("Cache-Control", "no-store");
+  return withCors(req, response);
+}

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -11,11 +11,15 @@ const mocks = vi.hoisted(() => {
   return {
     getSession: vi.fn(),
     parseChatRequest: vi.fn(),
+    chatRequestFingerprint: vi.fn(),
     getChat: vi.fn(),
     getMessages: vi.fn(),
     clearActiveStreamId: vi.fn(),
     commitChatTurn: vi.fn(),
     completeChatStream: vi.fn(),
+    failChatStream: vi.fn(),
+    getChatGeneration: vi.fn(),
+    getChatGenerationByRequestId: vi.fn(),
     inlineUploads: vi.fn(),
     getModelConfig: vi.fn(),
     getServerCapability: vi.fn(),
@@ -36,6 +40,7 @@ const mocks = vi.hoisted(() => {
     cancelUnregister: vi.fn(),
     cancelHas: vi.fn(),
     getStreamContext: vi.fn(),
+    resumeChatStreamResponse: vi.fn(),
     currentDateSystemPrompt: vi.fn(),
     consumeStream: vi.fn(),
     convertToModelMessages: vi.fn(),
@@ -112,6 +117,7 @@ vi.mock("@/lib/chat/request", () => {
     }
   }
   return {
+    chatRequestFingerprint: mocks.chatRequestFingerprint,
     ChatRequestError,
     parseChatRequest: mocks.parseChatRequest,
   };
@@ -124,6 +130,9 @@ vi.mock("@/lib/db/chatTurns", () => ({
   clearActiveStreamId: mocks.clearActiveStreamId,
   commitChatTurn: mocks.commitChatTurn,
   completeChatStream: mocks.completeChatStream,
+  failChatStream: mocks.failChatStream,
+  getChatGeneration: mocks.getChatGeneration,
+  getChatGenerationByRequestId: mocks.getChatGenerationByRequestId,
 }));
 vi.mock("@/lib/db/uploads", () => ({ inlineUploads: mocks.inlineUploads }));
 vi.mock("@/lib/db/modelConfigs", () => ({
@@ -166,6 +175,9 @@ vi.mock("@/lib/streams/cancel-registry", () => ({
 vi.mock("@/lib/streams/context", () => ({
   getStreamContext: mocks.getStreamContext,
 }));
+vi.mock("@/lib/streams/http", () => ({
+  resumeChatStreamResponse: mocks.resumeChatStreamResponse,
+}));
 
 import { ProviderConfigurationError } from "@/lib/providers/server/errors";
 import { POST } from "./route";
@@ -183,6 +195,7 @@ const parsedRequest = {
   messages,
   modelConfigId: "model-config",
   chatId: "chat",
+  clientRequestId: "client-request",
   webSearchEnabled: true,
   forceSearch: false,
   timeZone: "America/Los_Angeles",
@@ -245,6 +258,7 @@ describe("chat route setup boundary", () => {
 
     mocks.getSession.mockResolvedValue({ user: { id: "user" } });
     mocks.parseChatRequest.mockResolvedValue({ ...parsedRequest });
+    mocks.chatRequestFingerprint.mockReturnValue("request-fingerprint");
     mocks.getModelConfig.mockResolvedValue({ ...modelConfig });
     mocks.getServerCapability.mockReturnValue({ provider: "bundled" });
     mocks.listEffectiveMcpServers.mockResolvedValue([]);
@@ -254,6 +268,8 @@ describe("chat route setup boundary", () => {
       release: mocks.releaseMcpBinding,
     });
     mocks.getChat.mockResolvedValue(null);
+    mocks.getChatGenerationByRequestId.mockResolvedValue(null);
+    mocks.getChatGeneration.mockResolvedValue(null);
     mocks.getMessages.mockResolvedValue([]);
     mocks.getProject.mockResolvedValue(null);
     mocks.getActivePersonalization.mockResolvedValue(null);
@@ -277,6 +293,8 @@ describe("chat route setup boundary", () => {
     mocks.cancelHas.mockReturnValue(false);
     mocks.commitChatTurn.mockReturnValue("committed");
     mocks.completeChatStream.mockReturnValue(true);
+    mocks.failChatStream.mockReturnValue(true);
+    mocks.resumeChatStreamResponse.mockResolvedValue(null);
     mocks.clearActiveStreamId.mockResolvedValue(undefined);
     mocks.ensureChatTitle.mockResolvedValue(null);
     mocks.getStreamContext.mockReturnValue(null);
@@ -613,10 +631,11 @@ describe("chat route setup boundary", () => {
 
     expect(response.status).toBe(500);
     expect(mocks.cancelUnregister).toHaveBeenCalledWith(claim.streamId);
-    expect(mocks.clearActiveStreamId).toHaveBeenCalledWith(
-      "chat",
-      claim.streamId,
-    );
+    expect(mocks.failChatStream).toHaveBeenCalledWith({
+      chatId: "chat",
+      streamId: claim.streamId,
+      error: "stream setup failed",
+    });
     consoleSpy.mockRestore();
   });
 
@@ -643,6 +662,7 @@ describe("chat route setup boundary", () => {
         id: "assistant-message",
         parts: [{ type: "text", text: "Partial" }],
       },
+      status: "aborted",
     });
     expect(mocks.cancelUnregister).toHaveBeenCalledWith(claim.streamId);
   });
@@ -688,6 +708,8 @@ describe("chat route setup boundary", () => {
       chatId: "chat",
       streamId: claim.streamId,
       assistantMessage: undefined,
+      status: "error",
+      error: "provider failed",
     });
     consoleSpy.mockRestore();
   });
@@ -719,6 +741,7 @@ describe("chat route setup boundary", () => {
         id: "assistant-message",
         parts: [{ type: "text", text: "Recovered answer" }],
       },
+      status: "complete",
     });
   });
 
@@ -781,6 +804,84 @@ describe("chat route setup boundary", () => {
     expect(response.status).toBe(409);
     expect(mocks.createConfiguredLanguageModel).not.toHaveBeenCalled();
     expect(mocks.commitChatTurn).not.toHaveBeenCalled();
+  });
+
+  it("blocks a second request when another server owns the durable run", async () => {
+    mocks.getChat.mockResolvedValue(existingChat("existing-stream"));
+    mocks.getChatGeneration.mockResolvedValue({
+      id: "existing-stream",
+      chatId: "chat",
+      userId: "user",
+      clientRequestId: "other-client-request",
+      requestFingerprint: "other-request-fingerprint",
+      status: "running",
+      error: null,
+      responseMessageId: null,
+      startedAt: new Date(),
+      completedAt: null,
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    expect(mocks.cancelHas).toHaveBeenCalledWith("existing-stream");
+    expect(mocks.createConfiguredLanguageModel).not.toHaveBeenCalled();
+    expect(mocks.commitChatTurn).not.toHaveBeenCalled();
+  });
+
+  it("reattaches an exact duplicate start without invoking the model", async () => {
+    mocks.getChatGenerationByRequestId.mockResolvedValue({
+      id: "existing-stream",
+      chatId: "chat",
+      userId: "user",
+      clientRequestId: "client-request",
+      requestFingerprint: "request-fingerprint",
+      status: "running",
+      error: null,
+      responseMessageId: null,
+      startedAt: new Date(),
+      completedAt: null,
+    });
+    mocks.resumeChatStreamResponse.mockResolvedValue(
+      new Response("resumed", { status: 200 }),
+    );
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-OvertChat-Generation")).toBe("resumed");
+    expect(mocks.resumeChatStreamResponse).toHaveBeenCalledWith(
+      expect.any(Request),
+      "existing-stream",
+    );
+    expect(mocks.getModelConfig).not.toHaveBeenCalled();
+    expect(mocks.agentStream).not.toHaveBeenCalled();
+    expect(mocks.commitChatTurn).not.toHaveBeenCalled();
+  });
+
+  it("never restarts a completed duplicate submission", async () => {
+    mocks.getChatGenerationByRequestId.mockResolvedValue({
+      id: "completed-stream",
+      chatId: "chat",
+      userId: "user",
+      clientRequestId: "client-request",
+      requestFingerprint: "request-fingerprint",
+      status: "complete",
+      error: null,
+      responseMessageId: "assistant-message",
+      startedAt: new Date(),
+      completedAt: new Date(),
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    await expect(response.text()).resolves.toBe(
+      "Generation request was already completed",
+    );
+    expect(mocks.resumeChatStreamResponse).not.toHaveBeenCalled();
+    expect(mocks.getModelConfig).not.toHaveBeenCalled();
+    expect(mocks.agentStream).not.toHaveBeenCalled();
   });
 
   it("does not continue a voice chat through the text generation route", async () => {
@@ -1330,6 +1431,7 @@ describe("chat route setup boundary", () => {
         id: "assistant-message",
         parts: [{ type: "text", text: "Hello" }],
       },
+      status: "complete",
       usage: {
         occurredAt: expect.any(Date),
         providerId: "custom",
@@ -1551,6 +1653,7 @@ describe("chat route setup boundary", () => {
           stats: { contextTokens: 110, contextWindow: 128_000 },
         },
       },
+      status: "complete",
     });
   });
 });

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -31,7 +31,11 @@ import {
 } from "@/lib/tools";
 import { corsHeaders, preflight, withCors } from "@/lib/cors";
 import { auth } from "@/lib/auth/server";
-import { ChatRequestError, parseChatRequest } from "@/lib/chat/request";
+import {
+  chatRequestFingerprint,
+  ChatRequestError,
+  parseChatRequest,
+} from "@/lib/chat/request";
 import {
   ChatHistoryConflictError,
   reconstructPersistedMessages,
@@ -42,6 +46,10 @@ import {
   clearActiveStreamId,
   commitChatTurn,
   completeChatStream,
+  failChatStream,
+  getChatGeneration,
+  getChatGenerationByRequestId,
+  type ChatGenerationRow,
   type CompletedGenerationUsage,
 } from "@/lib/db/chatTurns";
 import { inlineUploads } from "@/lib/db/uploads";
@@ -74,6 +82,7 @@ import { createConfiguredLanguageModel } from "@/lib/providers/server/registry";
 import { readLlamaCppInferenceActivity } from "@/lib/providers/server/llamacpp-activity";
 import * as cancelRegistry from "@/lib/streams/cancel-registry";
 import { getStreamContext } from "@/lib/streams/context";
+import { resumeChatStreamResponse } from "@/lib/streams/http";
 
 export const maxDuration = 300;
 
@@ -95,6 +104,7 @@ async function handlePost(req: Request): Promise<Response> {
     return withCors(req, new Response("Unauthorized", { status: 401 }));
   }
   const userId = session.user.id;
+  const parsedRequest = await parseChatRequest(req);
   const {
     messages: requestMessages,
     modelConfigId,
@@ -105,7 +115,24 @@ async function handlePost(req: Request): Promise<Response> {
     projectId,
     action,
     temporary,
-  } = await parseChatRequest(req);
+    clientRequestId,
+  } = parsedRequest;
+  const requestFingerprint = chatRequestFingerprint(parsedRequest);
+
+  if (!temporary) {
+    const existingGeneration = await getChatGenerationByRequestId(
+      userId,
+      clientRequestId,
+    );
+    if (existingGeneration) {
+      return duplicateGenerationResponse({
+        req,
+        generation: existingGeneration,
+        chatId,
+        requestFingerprint,
+      });
+    }
+  }
 
   const modelConfig = await getModelConfig(modelConfigId);
   if (!modelConfig || !modelConfig.enabled) {
@@ -126,7 +153,14 @@ async function handlePost(req: Request): Promise<Response> {
   }
   let staleStreamId: string | null = null;
   if (existingChat?.activeStreamId) {
-    if (cancelRegistry.has(existingChat.activeStreamId)) {
+    const activeGeneration = await getChatGeneration(
+      existingChat.activeStreamId,
+      userId,
+    );
+    if (
+      cancelRegistry.has(existingChat.activeStreamId) ||
+      activeGeneration?.status === "running"
+    ) {
       return withCors(
         req,
         new Response("Stream already in progress for this chat", {
@@ -279,6 +313,8 @@ async function handlePost(req: Request): Promise<Response> {
         userId,
         projectId: resolvedProjectId,
         streamId,
+        clientRequestId,
+        requestFingerprint,
         staleStreamId,
         truncateFromMessageId,
         userMessage: persistUserMessage
@@ -288,6 +324,29 @@ async function handlePost(req: Request): Promise<Response> {
 
       if (commitResult === "committed") {
         streamClaimed = true;
+      } else if (commitResult === "duplicate") {
+        cancelRegistry.unregister(streamId);
+        await mcpBinding?.release();
+        const generation = await getChatGenerationByRequestId(
+          userId,
+          clientRequestId,
+        );
+        if (!generation) {
+          throw new Error("Idempotent generation claim disappeared");
+        }
+        return duplicateGenerationResponse({
+          req,
+          generation,
+          chatId,
+          requestFingerprint,
+        });
+      } else if (commitResult === "idempotency-conflict") {
+        cancelRegistry.unregister(streamId);
+        await mcpBinding?.release();
+        return withCors(
+          req,
+          new Response("Client request ID was already used", { status: 409 }),
+        );
       } else if (commitResult === "stream-active") {
         cancelRegistry.unregister(streamId);
         await mcpBinding?.release();
@@ -526,7 +585,7 @@ async function handlePost(req: Request): Promise<Response> {
 
         return { stats };
       },
-      onEnd: async ({ responseMessage }) => {
+      onEnd: async ({ responseMessage, isAborted }) => {
         if (temporary) return;
         // Stop is an intentional user abort, so retain whatever the model
         // produced. Provider stream errors still discard broken fragments.
@@ -535,12 +594,16 @@ async function handlePost(req: Request): Promise<Response> {
             ? {
                 id: responseMessage.id,
                 parts: responseMessage.parts,
-                metadata:
-                  responseMessage.metadata &&
-                  typeof responseMessage.metadata === "object" &&
-                  !Array.isArray(responseMessage.metadata)
-                    ? (responseMessage.metadata as Record<string, unknown>)
-                    : undefined,
+                ...(responseMessage.metadata &&
+                typeof responseMessage.metadata === "object" &&
+                !Array.isArray(responseMessage.metadata)
+                  ? {
+                      metadata: responseMessage.metadata as Record<
+                        string,
+                        unknown
+                      >,
+                    }
+                  : {}),
               }
             : undefined;
 
@@ -549,6 +612,15 @@ async function handlePost(req: Request): Promise<Response> {
             chatId,
             streamId,
             assistantMessage,
+            status: streamError ? "error" : isAborted ? "aborted" : "complete",
+            ...(streamError
+              ? {
+                  error:
+                    streamError instanceof Error
+                      ? streamError.message
+                      : "Provider stream failed.",
+                }
+              : {}),
             ...(assistantMessage && completedGenerationUsage
               ? { usage: completedGenerationUsage }
               : {}),
@@ -615,13 +687,59 @@ async function handlePost(req: Request): Promise<Response> {
     if (controller) cancelRegistry.unregister(streamId);
     if (streamClaimed) {
       try {
-        await clearActiveStreamId(chatId, streamId);
+        failChatStream({
+          chatId,
+          streamId,
+          error: error instanceof Error ? error.message : "Generation setup failed.",
+        });
       } catch (cleanupError) {
         console.error("[clear-active-stream]", cleanupError);
       }
     }
     throw error;
   }
+}
+
+async function duplicateGenerationResponse({
+  req,
+  generation,
+  chatId,
+  requestFingerprint,
+}: {
+  req: Request;
+  generation: ChatGenerationRow;
+  chatId: string;
+  requestFingerprint: string;
+}): Promise<Response> {
+  if (
+    generation.chatId !== chatId ||
+    generation.requestFingerprint !== requestFingerprint
+  ) {
+    return withCors(
+      req,
+      new Response("Client request ID was already used", { status: 409 }),
+    );
+  }
+  if (generation.status !== "running") {
+    return withCors(
+      req,
+      new Response("Generation request was already completed", { status: 409 }),
+    );
+  }
+
+  try {
+    const response = await resumeChatStreamResponse(req, generation.id);
+    if (response) {
+      response.headers.set("X-OvertChat-Generation", "resumed");
+      return response;
+    }
+  } catch (error) {
+    console.warn("[generation-idempotency] failed to attach duplicate", error);
+  }
+  return withCors(
+    req,
+    new Response("Generation is already in progress", { status: 409 }),
+  );
 }
 
 function observeChatStream(

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -42,6 +42,7 @@ import {
   type StoredMessageStats,
 } from "@/lib/chat/stats";
 import { messagesForChatRequest } from "@/lib/chat/history";
+import { useChatGenerationRecovery } from "@/lib/chat/useChatGenerationRecovery";
 import { stripCitationMarkers } from "@/lib/citations";
 import { voiceHistoryToUiMessages } from "@/lib/voice/history";
 import {
@@ -82,13 +83,6 @@ const MESSAGE_STATS_STORAGE_KEY = "overtchat_stats_for_nerds";
 
 function shouldAutofocusComposer() {
   return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
-}
-
-function lastUserMessageId(messages: UIMessage[]): string | undefined {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index].role === "user") return messages[index].id;
-  }
-  return undefined;
 }
 
 interface Props {
@@ -240,9 +234,11 @@ export function ChatArea({
     status,
     stop,
     error,
+    resumeStream,
+    clearError,
   } = useChat({
     id: temporary ? undefined : chatId,
-    resume: !temporary && !isNew,
+    resume: false,
     transport,
     messages: initialMessages,
     throttle: 32,
@@ -277,6 +273,25 @@ export function ChatArea({
         qc.invalidateQueries({ queryKey: activityKeys.all() }),
       ]);
     },
+  });
+  const handleGenerationSettled = useCallback(() => {
+    setInferenceActivity(null);
+    setChatPersisted(true);
+    void Promise.all([
+      qc.invalidateQueries({ queryKey: chatKeys.list() }),
+      qc.invalidateQueries({ queryKey: chatKeys.usage(chatId) }),
+      qc.invalidateQueries({ queryKey: activityKeys.all() }),
+    ]);
+  }, [chatId, qc]);
+  const reconcileGeneration = useChatGenerationRecovery({
+    chatId,
+    enabled: !temporary && chatPersisted,
+    recoverOnMount: !isNew,
+    stopLocalStream: stop,
+    resumeStream,
+    clearError,
+    setMessages,
+    onSettled: handleGenerationSettled,
   });
   const [olderMessageCursor, setOlderMessageCursor] = useState(
     initialMessageCursor ?? null,
@@ -327,6 +342,7 @@ export function ChatArea({
     forceSearch: searchAvailable && forceSearch,
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     chatId,
+    clientRequestId: crypto.randomUUID(),
     projectId: projectId ?? null,
     temporary,
     action,
@@ -379,6 +395,7 @@ export function ChatArea({
   const markNewChatPersisted = useCallback(() => {
     if (!isNewRef.current) return false;
     isNewRef.current = false;
+    setChatPersisted(true);
     setComposerDraftScope(chatComposerDraftScope(chatId));
     window.history.replaceState(null, "", `/chat/${chatId}`);
     return true;
@@ -437,14 +454,10 @@ export function ChatArea({
     });
   }
 
-  function handleRetry() {
+  function handleReconnect() {
     if (streaming || !configured) return;
-    const userMessageId = lastUserMessageId(messages);
-    if (!userMessageId) return;
     setInferenceActivity(null);
-    regenerate({
-      body: requestBody({ type: "retry", userMessageId }),
-    });
+    void reconcileGeneration();
   }
 
   function handleEdit(messageId: string, text: string, files: FileUIPart[]) {
@@ -692,7 +705,7 @@ export function ChatArea({
             onLoadOlderMessages={handleLoadOlderMessages}
             onRegenerate={handleRegenerate}
             onEdit={handleEdit}
-            onRetry={handleRetry}
+            onReconnect={handleReconnect}
           />
 
           <div className="px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -37,7 +37,7 @@ export function MessageList({
   onLoadOlderMessages,
   onRegenerate,
   onEdit,
-  onRetry,
+  onReconnect,
 }: {
   messages: UIMessage[];
   streaming: boolean;
@@ -53,7 +53,7 @@ export function MessageList({
   onLoadOlderMessages: () => void;
   onRegenerate: (id: string) => void;
   onEdit: (id: string, text: string, files: FileUIPart[]) => void;
-  onRetry: () => void;
+  onReconnect: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const initialScrollCompleteRef = useRef(false);
@@ -185,7 +185,9 @@ export function MessageList({
                 </>
               );
             } else if (error && item.index === errorOffset) {
-              content = <ChatErrorBubble error={error} onRetry={onRetry} />;
+              content = (
+                <ChatErrorBubble error={error} onReconnect={onReconnect} />
+              );
             }
 
             return (
@@ -319,10 +321,10 @@ function PendingDots() {
 
 function ChatErrorBubble({
   error,
-  onRetry,
+  onReconnect,
 }: {
   error: Error;
-  onRetry: () => void;
+  onReconnect: () => void;
 }) {
   return (
     <div
@@ -336,10 +338,10 @@ function ChatErrorBubble({
       <Button
         variant="outline"
         size="sm"
-        onClick={onRetry}
+        onClick={onReconnect}
         className="shrink-0"
       >
-        <RotateCcw /> Retry
+        <RotateCcw /> Reconnect
       </Button>
     </div>
   );

--- a/apps/web/drizzle/0015_flat_whiplash.sql
+++ b/apps/web/drizzle/0015_flat_whiplash.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `chat_generations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`chat_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`client_request_id` text NOT NULL,
+	`request_fingerprint` text NOT NULL,
+	`status` text DEFAULT 'running' NOT NULL,
+	`error` text,
+	`response_message_id` text,
+	`started_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`completed_at` integer,
+	FOREIGN KEY (`chat_id`) REFERENCES `chats`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `chat_generations_userId_clientRequestId_idx` ON `chat_generations` (`user_id`,`client_request_id`);--> statement-breakpoint
+CREATE INDEX `chat_generations_chatId_startedAt_idx` ON `chat_generations` (`chat_id`,`started_at`);

--- a/apps/web/drizzle/meta/0015_snapshot.json
+++ b/apps/web/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2280 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e3b068dc-3fa2-4077-8f01-191272f1b0ba",
+  "prevId": "79c01a3c-b20b-49f0-b5be-4a72aa7766f9",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connections": {
+      "name": "agent_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shell_mode": {
+          "name": "shell_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "detected_version": {
+          "name": "detected_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_connections_hostId_provider_idx": {
+          "name": "agent_connections_hostId_provider_idx",
+          "columns": [
+            "host_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connections_host_id_agent_hosts_id_fk": {
+          "name": "agent_connections_host_id_agent_hosts_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "agent_hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_hosts": {
+      "name": "agent_hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_alias": {
+          "name": "ssh_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_hosts_userId_updatedAt_idx": {
+          "name": "agent_hosts_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "agent_hosts_connectorId_idx": {
+          "name": "agent_hosts_connectorId_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_hosts_user_id_user_id_fk": {
+          "name": "agent_hosts_user_id_user_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_hosts_connector_id_host_connectors_id_fk": {
+          "name": "agent_hosts_connector_id_host_connectors_id_fk",
+          "tableFrom": "agent_hosts",
+          "tableTo": "host_connectors",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_sessions": {
+      "name": "agent_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_session_path": {
+          "name": "provider_session_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking_option_id": {
+          "name": "thinking_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode_id": {
+          "name": "mode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_modified_at": {
+          "name": "provider_modified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_sessions_workspaceId_providerSessionPath_idx": {
+          "name": "agent_sessions_workspaceId_providerSessionPath_idx",
+          "columns": [
+            "workspace_id",
+            "provider_session_path"
+          ],
+          "isUnique": true
+        },
+        "agent_sessions_workspaceId_providerModifiedAt_idx": {
+          "name": "agent_sessions_workspaceId_providerModifiedAt_idx",
+          "columns": [
+            "workspace_id",
+            "provider_modified_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_workspace_id_agent_workspaces_id_fk": {
+          "name": "agent_sessions_workspace_id_agent_workspaces_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_workspaces": {
+      "name": "agent_workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "agent_workspaces_connectionId_path_idx": {
+          "name": "agent_workspaces_connectionId_path_idx",
+          "columns": [
+            "connection_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_connection_id_agent_connections_id_fk": {
+          "name": "agent_workspaces_connection_id_agent_connections_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "agent_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_generations": {
+      "name": "chat_generations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_message_id": {
+          "name": "response_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_generations_userId_clientRequestId_idx": {
+          "name": "chat_generations_userId_clientRequestId_idx",
+          "columns": [
+            "user_id",
+            "client_request_id"
+          ],
+          "isUnique": true
+        },
+        "chat_generations_chatId_startedAt_idx": {
+          "name": "chat_generations_chatId_startedAt_idx",
+          "columns": [
+            "chat_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_generations_chat_id_chats_id_fk": {
+          "name": "chat_generations_chat_id_chats_id_fk",
+          "tableFrom": "chat_generations",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_generations_user_id_user_id_fk": {
+          "name": "chat_generations_user_id_user_id_fk",
+          "tableFrom": "chat_generations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "chats_userId_updatedAt_idx": {
+          "name": "chats_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "chats_userId_projectId_updatedAt_idx": {
+          "name": "chats_userId_projectId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_user_id_fk": {
+          "name": "chats_user_id_user_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_usage": {
+      "name": "generation_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uncached_input_tokens": {
+          "name": "uncached_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_cost_nano_usd": {
+          "name": "input_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_cost_nano_usd": {
+          "name": "output_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_cost_nano_usd": {
+          "name": "cache_read_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_nano_usd": {
+          "name": "cache_write_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_nano_usd": {
+          "name": "total_cost_nano_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generation_usage_userId_occurredAt_idx": {
+          "name": "generation_usage_userId_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_userId_providerId_model_occurredAt_idx": {
+          "name": "generation_usage_userId_providerId_model_occurredAt_idx",
+          "columns": [
+            "user_id",
+            "provider_id",
+            "model",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_context_occurredAt_idx": {
+          "name": "generation_usage_context_occurredAt_idx",
+          "columns": [
+            "context",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_chatId_idx": {
+          "name": "generation_usage_chatId_idx",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        },
+        "generation_usage_messageId_idx": {
+          "name": "generation_usage_messageId_idx",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "generation_usage_user_id_user_id_fk": {
+          "name": "generation_usage_user_id_user_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_usage_chat_id_chats_id_fk": {
+          "name": "generation_usage_chat_id_chats_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "generation_usage_message_id_messages_id_fk": {
+          "name": "generation_usage_message_id_messages_id_fk",
+          "tableFrom": "generation_usage",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connector_pairings": {
+      "name": "host_connector_pairings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connector_pairings_userId_idx": {
+          "name": "host_connector_pairings_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connector_pairings_user_id_user_id_fk": {
+          "name": "host_connector_pairings_user_id_user_id_fk",
+          "tableFrom": "host_connector_pairings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_connectors": {
+      "name": "host_connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "host_connectors_userId_idx": {
+          "name": "host_connectors_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "host_connectors_user_id_user_id_fk": {
+          "name": "host_connectors_user_id_user_id_fk",
+          "tableFrom": "host_connectors",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'everyone'"
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "memories_userId_key_idx": {
+          "name": "memories_userId_key_idx",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "memories_user_id_user_id_fk": {
+          "name": "memories_user_id_user_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "messages_chatId_createdAt_idx": {
+          "name": "messages_chatId_createdAt_idx",
+          "columns": [
+            "chat_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_configs": {
+      "name": "model_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "api_format": {
+          "name": "api_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai-chat'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_context_window": {
+          "name": "discovered_context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_capabilities": {
+          "name": "discovered_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_options": {
+          "name": "provider_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calling_enabled": {
+          "name": "tool_calling_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "task_model": {
+          "name": "task_model",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "model_configs_taskModel_idx": {
+          "name": "model_configs_taskModel_idx",
+          "columns": [
+            "task_model"
+          ],
+          "isUnique": true,
+          "where": "\"model_configs\".\"task_model\" = true"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "projects_userId_updatedAt_idx": {
+          "name": "projects_userId_updatedAt_idx",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_user_id_fk": {
+          "name": "projects_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "server_capabilities": {
+      "name": "server_capabilities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bundled_installed": {
+          "name": "bundled_installed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploads": {
+      "name": "uploads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "uploads_user_id_user_id_fk": {
+          "name": "uploads_user_id_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_mcp_server_preferences": {
+      "name": "user_mcp_server_preferences",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_mcp_server_preferences_serverId_idx": {
+          "name": "user_mcp_server_preferences_serverId_idx",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_mcp_server_preferences_user_id_user_id_fk": {
+          "name": "user_mcp_server_preferences_user_id_user_id_fk",
+          "tableFrom": "user_mcp_server_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mcp_server_preferences_server_id_mcp_servers_id_fk": {
+          "name": "user_mcp_server_preferences_server_id_mcp_servers_id_fk",
+          "tableFrom": "user_mcp_server_preferences",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_mcp_server_preferences_user_id_server_id_pk": {
+          "columns": [
+            "user_id",
+            "server_id"
+          ],
+          "name": "user_mcp_server_preferences_user_id_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_personalization": {
+      "name": "user_personalization",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_personalization_user_id_user_id_fk": {
+          "name": "user_personalization_user_id_user_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788128256206,
       "tag": "0014_lush_karnak",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1788400628562,
+      "tag": "0015_flat_whiplash",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/e2e/stream-resumption.spec.ts
+++ b/apps/web/e2e/stream-resumption.spec.ts
@@ -20,11 +20,13 @@ let modelServer: Server;
 let modelBaseUrl: string;
 let firstChunk = deferred();
 let continueStream = deferred();
+let streamingRequests = 0;
 
 test.beforeEach(() => {
   resetE2eDatabase();
   firstChunk = deferred();
   continueStream = deferred();
+  streamingRequests = 0;
 });
 
 test.beforeAll(async () => {
@@ -60,6 +62,8 @@ test.beforeAll(async () => {
       );
       return;
     }
+
+    streamingRequests += 1;
 
     response.writeHead(200, {
       "Content-Type": "text/event-stream",
@@ -171,4 +175,51 @@ test("reload resumes an active chat stream through Redis", async ({ page }) => {
     page.getByText("Before reload. After reload.", { exact: false }),
   ).toBeVisible({ timeout: 15_000 });
   await page.getByLabel("Send message").waitFor({ state: "visible" });
+});
+
+test("network restoration reconciles the same generation without restarting it", async ({
+  page,
+  context,
+}) => {
+  test.skip(!process.env.REDIS_URL, "REDIS_URL is required for resumption.");
+
+  await page.goto("/signup");
+  await page.locator("#name").fill("Foreground Tester");
+  await page.locator("#email").fill("foreground@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/", { timeout: 15_000 });
+  seedModel();
+  await page.reload();
+
+  await page.getByPlaceholder("Message…").fill("Finish while I am offline.");
+  await page.getByLabel("Send message").click();
+  await firstChunk.promise;
+  await expect(page.getByText("Before reload.", { exact: false })).toBeVisible();
+
+  await context.setOffline(true);
+  continueStream.resolve();
+  await expect
+    .poll(() => {
+      const database = openE2eDatabase();
+      try {
+        return (
+          database
+            .prepare(
+              "SELECT status FROM chat_generations ORDER BY started_at DESC LIMIT 1",
+            )
+            .get() as { status?: string } | undefined
+        )?.status;
+      } finally {
+        database.close();
+      }
+    })
+    .toBe("complete");
+
+  await context.setOffline(false);
+  await expect(
+    page.getByText("Before reload. After reload.", { exact: false }),
+  ).toBeVisible({ timeout: 15_000 });
+  expect(streamingRequests).toBe(1);
+  await expect(page.getByRole("button", { name: "Reconnect" })).toHaveCount(0);
 });

--- a/apps/web/lib/chat/request.test.ts
+++ b/apps/web/lib/chat/request.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { ChatRequestError, parseChatRequest } from "./request";
+import {
+  chatRequestFingerprint,
+  ChatRequestError,
+  parseChatRequest,
+} from "./request";
 
 function request(body: unknown): Request {
   return new Request("http://example.test/api/chat", {
@@ -35,6 +39,40 @@ describe("chat request parsing", () => {
       temporary: false,
       action: { type: "submit" },
     });
+  });
+
+  it("preserves a submission receipt and creates one for legacy clients", async () => {
+    await expect(
+      parseChatRequest(
+        request({ ...validBody, clientRequestId: "request-one" }),
+      ),
+    ).resolves.toMatchObject({ clientRequestId: "request-one" });
+
+    const legacy = await parseChatRequest(request(validBody));
+    expect(legacy.clientRequestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+  });
+
+  it("fingerprints the intent independently of its retry receipt", async () => {
+    const first = await parseChatRequest(
+      request({ ...validBody, clientRequestId: "request-one" }),
+    );
+    const retry = await parseChatRequest(
+      request({ ...validBody, clientRequestId: "request-two" }),
+    );
+    const changed = await parseChatRequest(
+      request({
+        ...validBody,
+        clientRequestId: "request-one",
+        forceSearch: true,
+      }),
+    );
+
+    expect(chatRequestFingerprint(first)).toBe(chatRequestFingerprint(retry));
+    expect(chatRequestFingerprint(changed)).not.toBe(
+      chatRequestFingerprint(first),
+    );
   });
 
   it("rejects malformed JSON", async () => {

--- a/apps/web/lib/chat/request.ts
+++ b/apps/web/lib/chat/request.ts
@@ -1,5 +1,6 @@
 import { safeValidateUIMessages, type UIMessage } from "ai";
 import type { ChatRequestAction } from "@overtchat/shared";
+import { createHash } from "node:crypto";
 import { z } from "zod";
 
 const ChatRequestActionSchema = z.discriminatedUnion("type", [
@@ -22,6 +23,10 @@ const ChatRequestEnvelopeSchema = z.object({
   messages: z.unknown(),
   modelConfigId: z.string().trim().min(1, "Missing modelConfigId"),
   chatId: z.string().trim().min(1, "Missing chatId"),
+  // Optional for wire compatibility with released clients. Current clients
+  // mint one UUID per user intent so a repeated POST can attach to the same
+  // generation instead of starting a second model call.
+  clientRequestId: z.string().trim().min(1).max(200).optional(),
   webSearchEnabled: z.boolean().optional().default(true),
   forceSearch: z.boolean().optional(),
   // Accepted during the mobile rollout. `true` maps cleanly to the new
@@ -44,6 +49,7 @@ export interface ParsedChatRequest {
   messages: UIMessage[];
   modelConfigId: string;
   chatId: string;
+  clientRequestId: string;
   webSearchEnabled: boolean;
   forceSearch: boolean;
   timeZone?: string;
@@ -60,6 +66,34 @@ export class ChatRequestError extends Error {
     this.name = "ChatRequestError";
     this.status = status;
   }
+}
+
+export function chatRequestFingerprint({
+  messages,
+  modelConfigId,
+  chatId,
+  webSearchEnabled,
+  forceSearch,
+  timeZone,
+  projectId,
+  action,
+  temporary,
+}: ParsedChatRequest): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        messages,
+        modelConfigId,
+        chatId,
+        webSearchEnabled,
+        forceSearch,
+        timeZone: timeZone ?? null,
+        projectId: projectId ?? null,
+        action,
+        temporary,
+      }),
+    )
+    .digest("hex");
 }
 
 export async function parseChatRequest(
@@ -114,6 +148,7 @@ export async function parseChatRequest(
     messages: validated.data,
     modelConfigId: envelope.data.modelConfigId,
     chatId: envelope.data.chatId,
+    clientRequestId: envelope.data.clientRequestId ?? crypto.randomUUID(),
     webSearchEnabled: envelope.data.webSearchEnabled,
     forceSearch: envelope.data.webSearchEnabled && forceSearch,
     timeZone: envelope.data.timeZone,

--- a/apps/web/lib/chat/useChatGenerationRecovery.test.tsx
+++ b/apps/web/lib/chat/useChatGenerationRecovery.test.tsx
@@ -1,0 +1,152 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import type { UIMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatGenerationRecovery } from "./useChatGenerationRecovery";
+
+function Probe({
+  stopLocalStream,
+  resumeStream,
+  clearError,
+  setMessages,
+  onSettled,
+}: {
+  stopLocalStream: () => void;
+  resumeStream: () => Promise<void>;
+  clearError: () => void;
+  setMessages: (
+    messages: UIMessage[] | ((current: UIMessage[]) => UIMessage[]),
+  ) => void;
+  onSettled: () => void;
+}) {
+  useChatGenerationRecovery({
+    chatId: "chat",
+    enabled: true,
+    recoverOnMount: false,
+    stopLocalStream,
+    resumeStream,
+    clearError,
+    setMessages,
+    onSettled,
+  });
+  return null;
+}
+
+describe("web chat generation recovery", () => {
+  let root: Root;
+  let container: HTMLElement;
+  const originalGlobals = new Map<
+    PropertyKey,
+    PropertyDescriptor | undefined
+  >();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { window } = parseHTML(
+      '<!doctype html><html><body><div id="root"></div></body></html>',
+    );
+    Object.defineProperty(window.document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    for (const [key, value] of Object.entries({
+      window,
+      document: window.document,
+      navigator: window.navigator,
+      HTMLElement: window.HTMLElement,
+      Event: window.Event,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    })) {
+      originalGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        writable: true,
+        value,
+      });
+    }
+    container = window.document.getElementById("root") as HTMLElement;
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    for (const [key, descriptor] of originalGlobals) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+    originalGlobals.clear();
+  });
+
+  it("reattaches the same run on foreground and applies its terminal message", async () => {
+    const responseMessage = {
+      id: "assistant",
+      role: "assistant" as const,
+      parts: [{ type: "text" as const, text: "Completed" }],
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({
+          active: true,
+          streamId: "stream",
+          status: "running",
+          startedAt: 1,
+          completedAt: null,
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          active: false,
+          streamId: "stream",
+          status: "complete",
+          startedAt: 1,
+          completedAt: 2,
+          responseMessage,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const stopLocalStream = vi.fn();
+    const resumeStream = vi.fn().mockResolvedValue(undefined);
+    const clearError = vi.fn();
+    let messages: UIMessage[] = [];
+    const setMessages = vi.fn(
+      (update: UIMessage[] | ((current: UIMessage[]) => UIMessage[])) => {
+        messages = typeof update === "function" ? update(messages) : update;
+      },
+    );
+    const onSettled = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <Probe
+          stopLocalStream={stopLocalStream}
+          resumeStream={resumeStream}
+          clearError={clearError}
+          setMessages={setMessages}
+          onSettled={onSettled}
+        />,
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(stopLocalStream).toHaveBeenCalledOnce();
+    expect(resumeStream).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(messages).toEqual([responseMessage]);
+    expect(clearError).toHaveBeenCalledTimes(2);
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/chat/useChatGenerationRecovery.ts
+++ b/apps/web/lib/chat/useChatGenerationRecovery.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import type { ChatGenerationState } from "@overtchat/shared";
+import type { UIMessage } from "ai";
+
+const POLL_DELAY_MS = 1_500;
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => window.setTimeout(resolve, ms));
+}
+
+function applyTerminalMessage(
+  current: UIMessage[],
+  responseMessage: UIMessage | undefined,
+) {
+  if (!responseMessage) return current;
+  const index = current.findIndex(({ id }) => id === responseMessage.id);
+  if (index === -1) return [...current, responseMessage];
+  const next = [...current];
+  next[index] = responseMessage;
+  return next;
+}
+
+/**
+ * Reconciles the mounted transport with the server-owned generation. Mobile
+ * browsers can leave a dead fetch looking open, so server status—not the local
+ * reader—is authoritative after mount, foreground, and network restoration.
+ */
+export function useChatGenerationRecovery({
+  chatId,
+  enabled,
+  recoverOnMount,
+  stopLocalStream,
+  resumeStream,
+  clearError,
+  setMessages,
+  onSettled,
+}: {
+  chatId: string;
+  enabled: boolean;
+  recoverOnMount: boolean;
+  stopLocalStream: () => void;
+  resumeStream: () => Promise<void>;
+  clearError: () => void;
+  setMessages: (
+    messages: UIMessage[] | ((current: UIMessage[]) => UIMessage[]),
+  ) => void;
+  onSettled: () => void;
+}) {
+  const epochRef = useRef(0);
+  const recoveryRef = useRef<Promise<void> | null>(null);
+
+  const reconcile = useCallback(async () => {
+    if (!enabled) return;
+    if (recoveryRef.current) return recoveryRef.current;
+
+    const epoch = epochRef.current;
+    const recovery = (async () => {
+      while (epochRef.current === epoch) {
+        const response = await fetch(
+          `/api/chat/${encodeURIComponent(chatId)}/stream/status`,
+          { cache: "no-store" },
+        );
+        if (!response.ok) {
+          throw new Error(`Could not inspect generation (${response.status})`);
+        }
+        const generation = (await response.json()) as ChatGenerationState;
+
+        if (!generation.active) {
+          setMessages((current) =>
+            applyTerminalMessage(current, generation.responseMessage),
+          );
+          clearError();
+          onSettled();
+          return;
+        }
+
+        // This only aborts the stale client reader. Saved generations use a
+        // distinct server AbortController and stop only via the cancel route.
+        stopLocalStream();
+        clearError();
+        await resumeStream();
+
+        if (
+          epochRef.current !== epoch ||
+          document.visibilityState === "hidden"
+        ) {
+          return;
+        }
+        await delay(POLL_DELAY_MS);
+      }
+    })();
+
+    recoveryRef.current = recovery;
+    try {
+      await recovery;
+    } finally {
+      if (recoveryRef.current === recovery) recoveryRef.current = null;
+    }
+  }, [
+    chatId,
+    clearError,
+    enabled,
+    onSettled,
+    resumeStream,
+    setMessages,
+    stopLocalStream,
+  ]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const recover = () => void reconcile().catch(() => undefined);
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") recover();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("online", recover);
+    if (recoverOnMount) recover();
+
+    return () => {
+      epochRef.current += 1;
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("online", recover);
+    };
+  }, [enabled, reconcile, recoverOnMount]);
+
+  return reconcile;
+}

--- a/apps/web/lib/db/chatTurns.test.ts
+++ b/apps/web/lib/db/chatTurns.test.ts
@@ -37,6 +37,22 @@ raw.exec(`
     updated_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
     FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
   );
+  CREATE TABLE chat_generations (
+    id TEXT PRIMARY KEY NOT NULL,
+    chat_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    client_request_id TEXT NOT NULL,
+    request_fingerprint TEXT NOT NULL,
+    status TEXT DEFAULT 'running' NOT NULL,
+    error TEXT,
+    response_message_id TEXT,
+    started_at INTEGER NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+    completed_at INTEGER,
+    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+  );
+  CREATE UNIQUE INDEX chat_generations_userId_clientRequestId_idx
+    ON chat_generations (user_id, client_request_id);
   CREATE TABLE messages (
     id TEXT PRIMARY KEY NOT NULL,
     chat_id TEXT NOT NULL,
@@ -94,6 +110,7 @@ beforeAll(async () => {
 beforeEach(() => {
   raw.exec(`
     DELETE FROM generation_usage;
+    DELETE FROM chat_generations;
     DELETE FROM messages;
     DELETE FROM messages_fts;
     DELETE FROM chats;
@@ -146,6 +163,78 @@ function messageIds(): string[] {
 }
 
 describe("transactional chat turns", () => {
+  it("returns the original generation for an exact duplicate submission", () => {
+    expect(
+      chatTurns.commitChatTurn({
+        chatId: "chat",
+        userId: "user",
+        projectId: null,
+        streamId: "stream-one",
+        clientRequestId: "request-one",
+        requestFingerprint: "fingerprint-one",
+        staleStreamId: null,
+        userMessage: {
+          id: "user-message",
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      }),
+    ).toBe("committed");
+
+    expect(
+      chatTurns.commitChatTurn({
+        chatId: "chat",
+        userId: "user",
+        projectId: null,
+        streamId: "stream-two",
+        clientRequestId: "request-one",
+        requestFingerprint: "fingerprint-one",
+        staleStreamId: null,
+        userMessage: {
+          id: "user-message-two",
+          parts: [{ type: "text", text: "Duplicate" }],
+        },
+      }),
+    ).toBe("duplicate");
+
+    expect(messageIds()).toEqual(["user-message"]);
+    expect(
+      raw
+        .prepare("SELECT id FROM chat_generations ORDER BY started_at")
+        .all(),
+    ).toEqual([{ id: "stream-one" }]);
+    expect(
+      raw
+        .prepare("SELECT active_stream_id AS id FROM chats WHERE id = 'chat'")
+        .get(),
+    ).toEqual({ id: "stream-one" });
+  });
+
+  it("rejects reuse of a receipt for a different intent", () => {
+    expect(
+      chatTurns.commitChatTurn({
+        chatId: "chat",
+        userId: "user",
+        projectId: null,
+        streamId: "stream-one",
+        clientRequestId: "request-one",
+        requestFingerprint: "fingerprint-one",
+        staleStreamId: null,
+      }),
+    ).toBe("committed");
+
+    expect(
+      chatTurns.commitChatTurn({
+        chatId: "chat",
+        userId: "user",
+        projectId: null,
+        streamId: "stream-two",
+        clientRequestId: "request-one",
+        requestFingerprint: "different-intent",
+        staleStreamId: null,
+      }),
+    ).toBe("idempotency-conflict");
+  });
+
   it("rolls back branch deletion when replacement insertion fails", () => {
     seedChat();
 
@@ -155,6 +244,8 @@ describe("transactional chat turns", () => {
         userId: "user",
         projectId: null,
         streamId: "stream",
+        clientRequestId: "request-stream",
+        requestFingerprint: "fingerprint-stream",
         staleStreamId: null,
         truncateFromMessageId: "edit",
         userMessage: {
@@ -181,6 +272,8 @@ describe("transactional chat turns", () => {
         userId: "user",
         projectId: null,
         streamId: "stream",
+        clientRequestId: "request-stream",
+        requestFingerprint: "fingerprint-stream",
         staleStreamId: null,
         truncateFromMessageId: "edit",
         userMessage: {
@@ -208,6 +301,8 @@ describe("transactional chat turns", () => {
         userId: "user",
         projectId: null,
         streamId: "stream-one",
+        clientRequestId: "request-stream-one",
+        requestFingerprint: "fingerprint-stream-one",
         staleStreamId: null,
         userMessage: {
           id: "user-message",
@@ -222,6 +317,8 @@ describe("transactional chat turns", () => {
         userId: "user",
         projectId: null,
         streamId: "stream-two",
+        clientRequestId: "request-stream-two",
+        requestFingerprint: "fingerprint-stream-two",
         staleStreamId: null,
         userMessage: {
           id: "second-user-message",
@@ -270,6 +367,19 @@ describe("transactional chat turns", () => {
         .get(),
     ).toEqual({ id: null });
     expect(messageIds()).toEqual(["user-message", "assistant-message"]);
+    expect(
+      raw
+        .prepare(
+          `SELECT status, response_message_id AS responseMessageId,
+                  completed_at AS completedAt
+           FROM chat_generations WHERE id = 'stream-one'`,
+        )
+        .get(),
+    ).toEqual({
+      status: "complete",
+      responseMessageId: "assistant-message",
+      completedAt: expect.any(Number),
+    });
     expect(
       raw.prepare("SELECT message_id FROM messages_fts ORDER BY rowid").all(),
     ).toEqual([
@@ -346,6 +456,8 @@ describe("transactional chat turns", () => {
         userId: "user",
         projectId: null,
         streamId: "stream",
+        clientRequestId: "request-stream",
+        requestFingerprint: "fingerprint-stream",
         staleStreamId: null,
         userMessage: {
           id: "user-message",
@@ -431,6 +543,8 @@ describe("transactional chat turns", () => {
         userId: "user",
         projectId: null,
         streamId: "new-stream",
+        clientRequestId: "request-new-stream",
+        requestFingerprint: "fingerprint-new-stream",
         staleStreamId: null,
         truncateFromMessageId: "edit",
         userMessage: {

--- a/apps/web/lib/db/chatTurns.ts
+++ b/apps/web/lib/db/chatTurns.ts
@@ -1,9 +1,10 @@
 import "server-only";
 import { and, eq, sql } from "drizzle-orm";
 import type { UIMessage, UIMessagePart, UIDataTypes, UITools } from "ai";
+import type { ChatGenerationStatus } from "@overtchat/shared";
 import { db } from "@/lib/db/client";
 import { tryRecordGenerationUsage } from "@/lib/db/generationUsage";
-import { chats, messages } from "@/lib/db/schema";
+import { chatGenerations, chats, messages } from "@/lib/db/schema";
 import type { ProviderId } from "@/lib/providers/catalog";
 import type { EstimatedGenerationCost } from "@/lib/providers/server/model-cost";
 import { extractSearchText } from "@/lib/search/extract";
@@ -25,9 +26,65 @@ export type CompletedGenerationUsage = {
 
 export type CommitChatTurnResult =
   | "committed"
+  | "duplicate"
+  | "idempotency-conflict"
   | "not-found"
   | "stream-active"
   | "history-conflict";
+
+export type ChatGenerationRow = typeof chatGenerations.$inferSelect;
+
+export async function getChatGeneration(
+  streamId: string,
+  userId: string,
+): Promise<ChatGenerationRow | null> {
+  const [row] = await db
+    .select()
+    .from(chatGenerations)
+    .where(
+      and(
+        eq(chatGenerations.id, streamId),
+        eq(chatGenerations.userId, userId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export async function getChatGenerationByRequestId(
+  userId: string,
+  clientRequestId: string,
+): Promise<ChatGenerationRow | null> {
+  const [row] = await db
+    .select()
+    .from(chatGenerations)
+    .where(
+      and(
+        eq(chatGenerations.userId, userId),
+        eq(chatGenerations.clientRequestId, clientRequestId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export async function getLatestChatGeneration(
+  chatId: string,
+  userId: string,
+): Promise<ChatGenerationRow | null> {
+  const [row] = await db
+    .select()
+    .from(chatGenerations)
+    .where(
+      and(
+        eq(chatGenerations.chatId, chatId),
+        eq(chatGenerations.userId, userId),
+      ),
+    )
+    .orderBy(sql`${chatGenerations.startedAt} DESC`)
+    .limit(1);
+  return row ?? null;
+}
 
 export async function getChatMessage(
   chatId: string,
@@ -57,6 +114,8 @@ export function commitChatTurn({
   userId,
   projectId,
   streamId,
+  clientRequestId,
+  requestFingerprint,
   staleStreamId,
   truncateFromMessageId,
   userMessage,
@@ -65,11 +124,34 @@ export function commitChatTurn({
   userId: string;
   projectId: string | null;
   streamId: string;
+  clientRequestId: string;
+  requestFingerprint: string;
   staleStreamId: string | null;
   truncateFromMessageId?: string;
   userMessage?: { id: string; parts: AnyPart[] };
 }): CommitChatTurnResult {
   return db.transaction((tx) => {
+    const duplicate = tx
+      .select({
+        chatId: chatGenerations.chatId,
+        requestFingerprint: chatGenerations.requestFingerprint,
+      })
+      .from(chatGenerations)
+      .where(
+        and(
+          eq(chatGenerations.userId, userId),
+          eq(chatGenerations.clientRequestId, clientRequestId),
+        ),
+      )
+      .limit(1)
+      .get();
+    if (duplicate) {
+      return duplicate.chatId === chatId &&
+        duplicate.requestFingerprint === requestFingerprint
+        ? "duplicate"
+        : "idempotency-conflict";
+    }
+
     const existing = tx
       .select()
       .from(chats)
@@ -99,6 +181,33 @@ export function commitChatTurn({
         .values({ id: chatId, userId, projectId, title: null })
         .run();
     }
+
+    if (staleStreamId) {
+      tx.update(chatGenerations)
+        .set({
+          status: "error",
+          error: "Generation stream was no longer available.",
+          completedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(chatGenerations.id, staleStreamId),
+            eq(chatGenerations.status, "running"),
+          ),
+        )
+        .run();
+    }
+
+    tx.insert(chatGenerations)
+      .values({
+        id: streamId,
+        chatId,
+        userId,
+        clientRequestId,
+        requestFingerprint,
+        status: "running",
+      })
+      .run();
 
     if (truncateFromRowId !== null) {
       tx.run(sql`
@@ -139,6 +248,8 @@ export function completeChatStream({
   streamId,
   assistantMessage,
   usage,
+  status = assistantMessage ? "complete" : "error",
+  error,
 }: {
   chatId: string;
   streamId: string;
@@ -148,6 +259,8 @@ export function completeChatStream({
     metadata?: Record<string, unknown>;
   };
   usage?: CompletedGenerationUsage;
+  status?: Exclude<ChatGenerationStatus, "running">;
+  error?: string;
 }): boolean {
   const completed = db.transaction((tx) => {
     const chat = tx
@@ -187,6 +300,20 @@ export function completeChatStream({
       })
       .where(and(eq(chats.id, chatId), eq(chats.activeStreamId, streamId)))
       .run();
+    tx.update(chatGenerations)
+      .set({
+        status,
+        error: error ?? null,
+        responseMessageId: assistantMessage?.id ?? null,
+        completedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(chatGenerations.id, streamId),
+          eq(chatGenerations.status, "running"),
+        ),
+      )
+      .run();
     return { userId: chat.userId };
   });
 
@@ -204,6 +331,23 @@ export function completeChatStream({
   }
 
   return true;
+}
+
+export function failChatStream({
+  chatId,
+  streamId,
+  error,
+}: {
+  chatId: string;
+  streamId: string;
+  error: string;
+}): boolean {
+  return completeChatStream({
+    chatId,
+    streamId,
+    status: "error",
+    error,
+  });
 }
 
 export async function clearActiveStreamId(

--- a/apps/web/lib/db/schema.ts
+++ b/apps/web/lib/db/schema.ts
@@ -9,7 +9,9 @@ import {
 } from "drizzle-orm/sqlite-core";
 import type { UIMessagePart, UIDataTypes, UITools } from "ai";
 import {
+  CHAT_GENERATION_STATUSES,
   CHAT_KINDS,
+  type ChatGenerationStatus,
   type ChatKind,
   type ModelCapabilities,
 } from "@overtchat/shared";
@@ -381,6 +383,46 @@ export const chats = sqliteTable(
   ],
 );
 
+/**
+ * Durable identity and lifecycle for a model generation. Stream chunks remain
+ * ephemeral (Redis when configured); SQLite is the authority for whether a
+ * user intent is already running or has reached a terminal state.
+ */
+export const chatGenerations = sqliteTable(
+  "chat_generations",
+  {
+    id: text("id").primaryKey(),
+    chatId: text("chat_id")
+      .notNull()
+      .references(() => chats.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    clientRequestId: text("client_request_id").notNull(),
+    requestFingerprint: text("request_fingerprint").notNull(),
+    status: text("status", { enum: CHAT_GENERATION_STATUSES })
+      .$type<ChatGenerationStatus>()
+      .default("running")
+      .notNull(),
+    error: text("error"),
+    responseMessageId: text("response_message_id"),
+    startedAt: integer("started_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    completedAt: integer("completed_at", { mode: "timestamp_ms" }),
+  },
+  (table) => [
+    uniqueIndex("chat_generations_userId_clientRequestId_idx").on(
+      table.userId,
+      table.clientRequestId,
+    ),
+    index("chat_generations_chatId_startedAt_idx").on(
+      table.chatId,
+      table.startedAt,
+    ),
+  ],
+);
+
 export const messages = sqliteTable(
   "messages",
   {
@@ -513,8 +555,23 @@ export const chatsRelations = relations(chats, ({ one, many }) => ({
     references: [projects.id],
   }),
   messages: many(messages),
+  generations: many(chatGenerations),
   generationUsage: many(generationUsage),
 }));
+
+export const chatGenerationsRelations = relations(
+  chatGenerations,
+  ({ one }) => ({
+    chat: one(chats, {
+      fields: [chatGenerations.chatId],
+      references: [chats.id],
+    }),
+    user: one(user, {
+      fields: [chatGenerations.userId],
+      references: [user.id],
+    }),
+  }),
+);
 
 export const projectsRelations = relations(projects, ({ one, many }) => ({
   user: one(user, {

--- a/apps/web/lib/streams/http.ts
+++ b/apps/web/lib/streams/http.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import { UI_MESSAGE_STREAM_HEADERS } from "ai";
+import { corsHeaders } from "@/lib/cors";
+import { getStreamContext } from "@/lib/streams/context";
+
+/** Attach an HTTP consumer to an existing generation without starting work. */
+export async function resumeChatStreamResponse(
+  req: Request,
+  streamId: string,
+): Promise<Response | null> {
+  const streamContext = getStreamContext();
+  if (!streamContext) return null;
+
+  const stream = await streamContext.resumeExistingStream(streamId);
+  if (!stream) return null;
+
+  const headers = corsHeaders(req);
+  for (const [key, value] of Object.entries(UI_MESSAGE_STREAM_HEADERS)) {
+    headers.set(key, value);
+  }
+  headers.set("Content-Encoding", "none");
+  headers.set("X-OvertChat-Stream-Id", streamId);
+  return new Response(stream, { headers });
+}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -124,6 +124,13 @@ connector with Ctrl-C; stop the retained development Redis container with
 `npm run dev:down`. Disposable connector state lives under `.overtchat-dev/`
 and never uses the installed production connector.
 
+Chat generations are owned by the server rather than by one browser or mobile
+connection. SQLite records each generation's identity and terminal status;
+Redis buffers in-flight stream events so a client can detach and resume after
+backgrounding or a network change. Without Redis, generation and final-message
+persistence still continue, and clients reconcile the completed response from
+SQLite, but missed live deltas cannot be replayed.
+
 Safe defaults are tracked in `apps/web/.env.development`; machine-specific
 values belong in `apps/web/.env.local`. The root `.env` is source-development
 configuration, and `apps/web/.env` must remain a symlink to `../../.env`. For

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -13,10 +13,31 @@ export interface ChatRequestBody {
   messages: UIMessage[];
   modelConfigId: string;
   chatId: string;
+  /** Stable for one user intent and reused only when its HTTP start is retried. */
+  clientRequestId: string;
   action: ChatRequestAction;
   webSearchEnabled?: boolean;
   forceSearch?: boolean;
   timeZone?: string;
   projectId?: string | null;
   temporary?: boolean;
+}
+
+export const CHAT_GENERATION_STATUSES = [
+  "running",
+  "complete",
+  "error",
+  "aborted",
+] as const;
+
+export type ChatGenerationStatus =
+  (typeof CHAT_GENERATION_STATUSES)[number];
+
+export interface ChatGenerationState {
+  active: boolean;
+  streamId: string | null;
+  status: ChatGenerationStatus | "idle";
+  startedAt: number | null;
+  completedAt: number | null;
+  responseMessage?: UIMessage;
 }


### PR DESCRIPTION
## Summary

- persist a server-owned generation receipt and lifecycle for every saved chat turn
- make generation starts idempotent with a client request ID and request fingerprint
- reconcile web and Expo clients on mount, foreground, and network restoration by resuming the existing stream or loading its persisted terminal response
- replace the failed-stream `Retry` action with `Reconnect`, so recovery can never invoke the model a second time
- retain Redis for replayable live deltas while using SQLite as the authority for running and terminal generation state

## Why this is a proper fix

The HTTP reader is now treated as a detachable view of server-owned work. A dropped mobile connection does not own or cancel inference, and the client no longer guesses whether it should regenerate. It asks the server for the generation state, attaches to that generation when possible, and otherwise reconciles the already-persisted response. Repeated start requests carry a stable receipt and cannot create a second provider call.

If the full server process dies, OvertChat does not silently restart a potentially billable generation. The orphaned run is terminalized during reconciliation and remains an explicit failure. A separate durable worker queue would be needed for process-crash continuation and is intentionally outside this single-node fix.

## Validation

- `npm run typecheck -w packages/shared -- --pretty false`
- `npm run typecheck -w apps/mobile -- --pretty false`
- `npm run typecheck -w apps/web -- --pretty false`
- `npm run lint -w apps/mobile --`
- `npm run lint -w apps/web --`
- `npm run test -w apps/web -- --run` (118 files, 745 tests)
- `npm run build -w apps/web --`
- isolated Playwright stream-resumption suite with Redis, including a network-loss/restoration assertion that verifies exactly one upstream model request

Closes #245
