### PR TITLE
perf(agents): reduce remote launch latency

### DIFF
--- a/apps/connector/src/client.ts
+++ b/apps/connector/src/client.ts
@@ -21,6 +21,10 @@ import { ConnectorInstanceLock } from "./lock.js";
 import { ConnectorStateJournal } from "./state.js";
 import { ConnectorTimelineStore } from "./timeline.js";
 import { CONNECTOR_VERSION } from "./version.js";
+import {
+  ConnectorCommandScheduler,
+  isConnectorCommandBarrier,
+} from "./command-scheduler.js";
 
 const RECONNECT_BASE_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;
@@ -65,6 +69,7 @@ function waitForRetry(milliseconds: number, signal: AbortSignal): Promise<void> 
 
 export class ConnectorClient {
   private readonly daemon: ConnectorDaemon;
+  private readonly commandScheduler: ConnectorCommandScheduler;
   private readonly stopAbort = new AbortController();
   private commandStreamAbort: AbortController | undefined;
   private eventRequestAbort: AbortController | undefined;
@@ -100,6 +105,9 @@ export class ConnectorClient {
       journal,
       timelines,
       (error) => this.fail(error),
+    );
+    this.commandScheduler = new ConnectorCommandScheduler((command) =>
+      this.daemon.handle(command),
     );
   }
 
@@ -166,6 +174,10 @@ export class ConnectorClient {
       this.eventRequestAbort?.abort();
       let failure: unknown;
       for (const close of [
+        async () => {
+          this.commandScheduler.close();
+          await this.commandScheduler.drain();
+        },
         () => this.daemon.stop(),
         // Requests already accepted by the daemon may finish while stop is
         // draining them. Their responses are durable protocol events, so
@@ -234,7 +246,15 @@ export class ConnectorClient {
             if (!isHostConnectorCommand(command)) {
               throw new Error("OvertChat sent an invalid connector command.");
             }
-            await this.daemon.handle(command);
+            if (command.type === "sync") {
+              await this.commandScheduler.drain();
+              await this.daemon.handle(command);
+            } else if (isConnectorCommandBarrier(command)) {
+              await this.commandScheduler.drain();
+              await this.daemon.handle(command);
+            } else {
+              this.commandScheduler.enqueue(command);
+            }
           }
           newline = buffered.indexOf("\n");
         }

--- a/apps/connector/src/command-scheduler.test.ts
+++ b/apps/connector/src/command-scheduler.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HostConnectorCommand } from "@overtchat/agent-bridge";
+import {
+  ConnectorCommandScheduler,
+  isConnectorCommandBarrier,
+} from "./command-scheduler";
+
+function request(
+  id: string,
+  type: "git_status" | "get_catalog" | "create_session",
+): Extract<HostConnectorCommand, { type: "request" }> {
+  const requests = {
+    git_status: {
+      type: "git_status" as const,
+      target: { transport: "local" as const, shellMode: "login" as const },
+      path: "/workspace",
+    },
+    get_catalog: {
+      type: "get_catalog" as const,
+      workspace: {
+        connectionId: "connection",
+        workspaceId: "workspace",
+        provider: "codex" as const,
+        target: { transport: "local" as const, shellMode: "login" as const },
+        executable: "codex",
+        cwd: "/workspace",
+      },
+    },
+    create_session: {
+      type: "create_session" as const,
+      sessionId: id,
+      workspace: {
+        connectionId: "connection",
+        workspaceId: "workspace",
+        provider: "codex" as const,
+        target: { transport: "local" as const, shellMode: "login" as const },
+        executable: "codex",
+        cwd: "/workspace",
+      },
+      launchConfig: {},
+    },
+  };
+  return { type: "request", requestId: id, request: requests[type] };
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("ConnectorCommandScheduler", () => {
+  it("bounds concurrency and promotes interactive work over queued probes", async () => {
+    const first = deferred();
+    const order: string[] = [];
+    const handle = vi.fn(async (command: HostConnectorCommand) => {
+      if (command.type !== "request") return;
+      order.push(command.requestId);
+      if (command.requestId === "git-1") await first.promise;
+    });
+    const scheduler = new ConnectorCommandScheduler(handle, 1);
+
+    scheduler.enqueue(request("git-1", "git_status"));
+    scheduler.enqueue(request("git-2", "git_status"));
+    scheduler.enqueue(request("catalog", "get_catalog"));
+    scheduler.enqueue(request("launch", "create_session"));
+    first.resolve();
+    await scheduler.drain();
+
+    expect(order).toEqual(["git-1", "launch", "catalog", "git-2"]);
+  });
+
+  it("runs independent work concurrently up to the configured limit", async () => {
+    const releases = [deferred(), deferred()];
+    let active = 0;
+    let maximum = 0;
+    const scheduler = new ConnectorCommandScheduler(async () => {
+      const release = releases[active];
+      active += 1;
+      maximum = Math.max(maximum, active);
+      await release?.promise;
+      active -= 1;
+    }, 2);
+
+    scheduler.enqueue(request("git-1", "git_status"));
+    scheduler.enqueue(request("git-2", "git_status"));
+    await vi.waitFor(() => expect(maximum).toBe(2));
+    releases[0]!.resolve();
+    releases[1]!.resolve();
+    await scheduler.drain();
+
+    expect(maximum).toBe(2);
+  });
+
+  it("identifies synchronization and destructive commands as barriers", () => {
+    expect(
+      isConnectorCommandBarrier({
+        type: "sync",
+        connectionEpoch: "epoch",
+        activeSessionIds: [],
+      }),
+    ).toBe(true);
+    expect(
+      isConnectorCommandBarrier({
+        type: "request",
+        requestId: "stop",
+        request: { type: "stop_all" },
+      }),
+    ).toBe(true);
+    expect(isConnectorCommandBarrier(request("launch", "create_session"))).toBe(
+      false,
+    );
+  });
+
+  it("drops pending work when closed and drains running work", async () => {
+    const running = deferred();
+    const order: string[] = [];
+    const scheduler = new ConnectorCommandScheduler(async (command) => {
+      if (command.type !== "request") return;
+      order.push(command.requestId);
+      await running.promise;
+    }, 1);
+
+    scheduler.enqueue(request("running", "git_status"));
+    scheduler.enqueue(request("pending", "git_status"));
+    scheduler.close();
+    running.resolve();
+    await scheduler.drain();
+
+    expect(order).toEqual(["running"]);
+  });
+});

--- a/apps/connector/src/command-scheduler.ts
+++ b/apps/connector/src/command-scheduler.ts
@@ -1,0 +1,120 @@
+import type { HostConnectorCommand } from "@overtchat/agent-bridge";
+
+const DEFAULT_CONCURRENCY = 4;
+
+type ScheduledCommand = {
+  command: Extract<HostConnectorCommand, { type: "request" }>;
+  queuedAt: number;
+  sequence: number;
+};
+
+function priority(command: ScheduledCommand["command"]): number {
+  switch (command.request.type) {
+    case "create_session":
+    case "open_session":
+    case "session_command":
+    case "subscribe_session":
+    case "unsubscribe_session":
+      return 0;
+    case "get_catalog":
+    case "list_workspace_directory":
+    case "read_workspace_file":
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+export function isConnectorCommandBarrier(
+  command: HostConnectorCommand,
+): boolean {
+  return (
+    command.type === "sync" ||
+    (command.type === "request" &&
+      [
+        "stop_session",
+        "stop_workspace",
+        "stop_connection",
+        "stop_all",
+      ].includes(command.request.type))
+  );
+}
+
+export class ConnectorCommandScheduler {
+  private readonly pending: ScheduledCommand[] = [];
+  private running = 0;
+  private sequence = 0;
+  private closed = false;
+  private readonly drainWaiters = new Set<() => void>();
+
+  constructor(
+    private readonly handle: (command: HostConnectorCommand) => Promise<void>,
+    private readonly concurrency = DEFAULT_CONCURRENCY,
+    private readonly now: () => number = Date.now,
+  ) {
+    if (!Number.isInteger(concurrency) || concurrency < 1) {
+      throw new Error(
+        "Connector command concurrency must be a positive integer.",
+      );
+    }
+  }
+
+  enqueue(command: Extract<HostConnectorCommand, { type: "request" }>): void {
+    if (this.closed) return;
+    this.pending.push({
+      command,
+      queuedAt: this.now(),
+      sequence: this.sequence++,
+    });
+    this.pending.sort(
+      (left, right) =>
+        priority(left.command) - priority(right.command) ||
+        left.sequence - right.sequence,
+    );
+    this.pump();
+  }
+
+  async drain(): Promise<void> {
+    if (this.running === 0 && this.pending.length === 0) return;
+    await new Promise<void>((resolve) => this.drainWaiters.add(resolve));
+  }
+
+  close(): void {
+    this.closed = true;
+    this.pending.length = 0;
+    this.finishDrainIfIdle();
+  }
+
+  private pump(): void {
+    while (
+      !this.closed &&
+      this.running < this.concurrency &&
+      this.pending.length > 0
+    ) {
+      const scheduled = this.pending.shift()!;
+      const queueMs = this.now() - scheduled.queuedAt;
+      if (queueMs >= 100) {
+        console.info(
+          `[connector:timing] request_queue type=${scheduled.command.request.type} queue_ms=${queueMs}`,
+        );
+      }
+      this.running += 1;
+      void this.handle(scheduled.command).then(
+        () => this.finished(),
+        () => this.finished(),
+      );
+    }
+  }
+
+  private finishDrainIfIdle(): void {
+    if (this.running !== 0 || this.pending.length !== 0) return;
+    for (const resolve of this.drainWaiters) resolve();
+    this.drainWaiters.clear();
+  }
+
+  private finished(): void {
+    this.running -= 1;
+    this.pump();
+    this.finishDrainIfIdle();
+  }
+}

--- a/apps/connector/src/daemon.test.ts
+++ b/apps/connector/src/daemon.test.ts
@@ -993,6 +993,48 @@ describe("connector daemon command identity", () => {
     );
   });
 
+  it("invalidates the shared provider catalog after a failed launch", async () => {
+    const { journal, timelines } = await openJournal();
+    mocks.create.mockRejectedValueOnce(new Error("launch failed"));
+    const emitted: HostConnectorEventPayload[] = [];
+    const daemon = new ConnectorDaemon(
+      (event) => emitted.push(event),
+      async () => [],
+      journal,
+      timelines,
+    );
+    const catalogs = Reflect.get(daemon, "providerCatalogs") as {
+      invalidate: (descriptor: unknown) => void;
+    };
+    const invalidate = vi.spyOn(catalogs, "invalidate");
+
+    await daemon.handle({
+      type: "request",
+      requestId: "create",
+      request: {
+        type: "create_session",
+        sessionId: "session",
+        workspace,
+        launchConfig: {},
+      },
+    });
+
+    expect(invalidate).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "workspace" }),
+    );
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "response",
+        requestId: "create",
+        success: false,
+        error: "launch failed",
+      }),
+    );
+    await daemon.stop();
+    await timelines.close();
+    await journal.close();
+  });
+
   it("discards a subscription that resolves after bounded shutdown", async () => {
     const { journal, timelines } = await openJournal();
     const subscribed = deferred<

--- a/apps/connector/src/daemon.ts
+++ b/apps/connector/src/daemon.ts
@@ -16,6 +16,7 @@ import {
 } from "@overtchat/agent-bridge";
 import {
   AgentRuntimeRegistry,
+  AgentProviderCatalogManager,
   AgentProviderSnapshotManager,
   agentProviderAdapter,
   configureProcessSpawner,
@@ -126,6 +127,7 @@ function sessionDescriptor(descriptor: AgentDaemonSessionDescriptor) {
 export class ConnectorDaemon {
   private readonly processHost = new ConnectorProcessHost();
   private readonly providerSnapshots = new AgentProviderSnapshotManager();
+  private readonly providerCatalogs = new AgentProviderCatalogManager();
   private readonly registry: AgentRuntimeRegistry;
   private readonly subscriptions = new Map<string, SessionSubscription>();
   private readonly captures = new Map<string, TimelineCapture>();
@@ -182,6 +184,8 @@ export class ConnectorDaemon {
           );
         });
       },
+      resolveCatalog: (descriptor) =>
+        this.providerCatalogs.getCatalog(descriptor),
     });
   }
 
@@ -203,6 +207,7 @@ export class ConnectorDaemon {
       );
       return;
     }
+    const startedAt = Date.now();
     try {
       const data = await this.handleRequest(command.request);
       this.emit({
@@ -218,6 +223,13 @@ export class ConnectorDaemon {
         success: false,
         error: errorMessage(error),
       });
+    } finally {
+      const elapsedMs = Date.now() - startedAt;
+      if (elapsedMs >= 250) {
+        console.info(
+          `[connector:timing] request type=${command.request.type} elapsed_ms=${elapsedMs}`,
+        );
+      }
     }
   }
 
@@ -355,14 +367,7 @@ export class ConnectorDaemon {
       }
       case "get_catalog": {
         const workspace = workspaceDescriptor(request.workspace);
-        return agentProviderAdapter(workspace.provider).fetchCatalog(
-          workspace.target,
-          {
-            executable: workspace.executable,
-            cwd: workspace.cwd,
-            detectedVersion: workspace.detectedVersion,
-          },
-        );
+        return this.providerCatalogs.getCatalog(workspace);
       }
       case "list_directories":
         return listAgentDirectories(hostTarget(request.target), request.path);
@@ -386,12 +391,19 @@ export class ConnectorDaemon {
           request.path,
         );
       case "create_session": {
+        const workspace = workspaceDescriptor(request.workspace);
         const created = await this.serializeSession(request.sessionId, async () => {
-          const result = await this.registry.create(
-            request.sessionId,
-            workspaceDescriptor(request.workspace),
-            request.launchConfig,
-          );
+          let result;
+          try {
+            result = await this.registry.create(
+              request.sessionId,
+              workspace,
+              request.launchConfig,
+            );
+          } catch (error) {
+            this.providerCatalogs.invalidate(workspace);
+            throw error;
+          }
           await this.assertRuntimeAccepted(request.sessionId);
           await this.journal.recordSession({
             ...request.workspace,

--- a/apps/web/components/SidebarAgentWorkspaces.tsx
+++ b/apps/web/components/SidebarAgentWorkspaces.tsx
@@ -86,6 +86,7 @@ function WorkspaceNode({
     agentConnectionTarget(representativeTarget.connection),
   );
   const gitStatus = useAgentWorkspaceGitStatus(representativeWorkspace.id, {
+    enabled: open || hasActiveSession,
     active: hasActiveSession,
     running: hasRunningSession,
   }).data;
@@ -160,14 +161,12 @@ function WorkspaceNode({
         <button
           type="button"
           onClick={() => setCreateOpen(true)}
-          disabled={providerSnapshot.isPending || sessionTargets.length === 0}
+          disabled={sessionTargets.length === 0}
           aria-label={`New session in ${group.name}`}
           title={
             sessionTargets.length > 0
               ? `New session in ${group.name}`
-              : providerSnapshot.isPending
-                ? "Detecting agents on this machine"
-                : "No agents are currently available on this machine"
+              : "No agents are currently available on this machine"
           }
           className={cn(
             "flex min-h-11 w-9 shrink-0 items-center justify-center rounded-r-md text-muted-foreground motion-colors hover:text-foreground focus-visible:text-foreground max-md:w-11",

--- a/apps/web/lib/queries/agentWorkspaces.test.tsx
+++ b/apps/web/lib/queries/agentWorkspaces.test.tsx
@@ -1,0 +1,109 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { parseHTML } from "linkedom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAgentWorkspaceGitStatus } from "./agentWorkspaces";
+
+function Probe({ enabled }: { enabled: boolean }) {
+  const query = useAgentWorkspaceGitStatus("workspace", { enabled });
+  return <div>{query.data?.branch ?? "idle"}</div>;
+}
+
+describe("agent workspace queries", () => {
+  let container: HTMLElement;
+  let root: Root;
+  let queryClient: QueryClient;
+  const originalGlobals = new Map<
+    PropertyKey,
+    PropertyDescriptor | undefined
+  >();
+
+  beforeEach(() => {
+    const { window } = parseHTML(
+      '<!doctype html><html><body><div id="root"></div></body></html>',
+    );
+    for (const [key, value] of Object.entries({
+      window,
+      document: window.document,
+      navigator: window.navigator,
+      HTMLElement: window.HTMLElement,
+      Event: window.Event,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    })) {
+      originalGlobals.set(
+        key,
+        Object.getOwnPropertyDescriptor(globalThis, key),
+      );
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        writable: true,
+        value,
+      });
+    }
+    container = window.document.getElementById("root") as HTMLElement;
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        Response.json({
+          status: {
+            isGit: true,
+            repositoryRoot: "/workspace",
+            branch: "main",
+            upstream: null,
+            ahead: null,
+            behind: null,
+            dirty: false,
+            changedFiles: 0,
+            additions: 0,
+            deletions: 0,
+            lineStatsComplete: true,
+          },
+        }),
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    queryClient.clear();
+    vi.restoreAllMocks();
+    for (const [key, descriptor] of originalGlobals) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+    originalGlobals.clear();
+  });
+
+  it("defers Git work until the workspace is visible", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Probe enabled={false} />
+        </QueryClientProvider>,
+      );
+    });
+    expect(fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Probe enabled />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    await act(async () => {
+      await vi.waitFor(() => expect(container.textContent).toBe("main"));
+    });
+  });
+});

--- a/apps/web/lib/queries/agentWorkspaces.ts
+++ b/apps/web/lib/queries/agentWorkspaces.ts
@@ -29,17 +29,24 @@ async function fetchAgentWorkspaceGitStatus(
 export function useAgentWorkspaceGitStatus(
   id: string,
   {
+    enabled = true,
     active = false,
     running = false,
-  }: { active?: boolean; running?: boolean } = {},
+  }: { enabled?: boolean; active?: boolean; running?: boolean } = {},
 ) {
   return useQuery({
     queryKey: agentWorkspaceKeys.gitStatus(id),
     queryFn: () => fetchAgentWorkspaceGitStatus(id),
-    enabled: Boolean(id),
+    enabled: Boolean(id) && enabled,
     retry: false,
     staleTime: 4_000,
-    refetchInterval: running ? 2_000 : active ? 5_000 : false,
+    refetchInterval: enabled
+      ? running
+        ? 2_000
+        : active
+          ? 5_000
+          : false
+      : false,
   });
 }
 

--- a/packages/agent-runtime/src/codex/probe.ts
+++ b/packages/agent-runtime/src/codex/probe.ts
@@ -1,6 +1,7 @@
 import type { ConnectorShellMode } from "@overtchat/agent-bridge";
 import type {
   AgentConnectionDraft,
+  AgentModel,
   AgentReadyConnectionProbe,
 } from "@overtchat/agent-bridge";
 import {
@@ -64,7 +65,20 @@ export async function probeCodexTarget(
     throw new Error(`Codex could not be started. ${failures.join(" ")}`);
   }
 
-  const server = await startCodexAppServer(resolved.target, executable);
+  const models = await fetchCodexModels(resolved.target, executable);
+  return {
+    status: "ready",
+    version: resolved.version,
+    models,
+    shellMode: resolved.shellMode,
+  };
+}
+
+export async function fetchCodexModels(
+  target: HostTarget,
+  executable: string,
+): Promise<AgentModel[]> {
+  const server = await startCodexAppServer(target, executable);
   try {
     await server.ready();
     const [accountResponse, modelResponse] = await Promise.all([
@@ -87,12 +101,7 @@ export async function probeCodexTarget(
         "Codex is installed, but it did not report any usable models.",
       );
     }
-    return {
-      status: "ready",
-      version: resolved.version,
-      models,
-      shellMode: resolved.shellMode,
-    };
+    return models;
   } finally {
     await server.stop();
   }

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -7,6 +7,7 @@ export {
 export * from "./runtime/filesystem";
 export * from "./runtime/git";
 export * from "./runtime/process";
+export * from "./runtime/provider-catalogs";
 export * from "./runtime/provider-snapshots";
 export * from "./runtime/registry";
 export {

--- a/packages/agent-runtime/src/providers/codex.test.ts
+++ b/packages/agent-runtime/src/providers/codex.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  fetchCodexModels: vi.fn(),
+}));
+
+vi.mock("@overtchat/agent-runtime/codex/probe", () => ({
+  fetchCodexModels: mocks.fetchCodexModels,
+  probeCodexConnection: vi.fn(),
+  probeCodexTarget: vi.fn(),
+}));
 
 import { codexProviderAdapter } from "./codex";
 
 describe("codexProviderAdapter", () => {
+  it("loads a catalog without repeating the executable version probe", async () => {
+    mocks.fetchCodexModels.mockResolvedValueOnce([]);
+
+    await expect(
+      codexProviderAdapter.fetchCatalog(
+        { transport: "ssh", alias: "host", shellMode: "login" },
+        {
+          executable: "/usr/local/bin/codex",
+          cwd: "/workspace",
+          detectedVersion: "0.147.0",
+        },
+      ),
+    ).resolves.toMatchObject({ provider: "codex", models: [] });
+
+    expect(mocks.fetchCodexModels).toHaveBeenCalledWith(
+      expect.objectContaining({ shellMode: "login" }),
+      "/usr/local/bin/codex",
+    );
+  });
+
   it("marks compaction as working before its turn notification arrives", () => {
     const classifier = codexProviderAdapter.createEventClassifier();
     expect(classifier.classify({ type: "compaction_start" })).toEqual({

--- a/packages/agent-runtime/src/providers/codex.ts
+++ b/packages/agent-runtime/src/providers/codex.ts
@@ -16,6 +16,7 @@ import { startCodexRuntime } from "@overtchat/agent-runtime/codex/client";
 import {
   probeCodexConnection,
   probeCodexTarget,
+  fetchCodexModels,
 } from "@overtchat/agent-runtime/codex/probe";
 import { CODEX_MODES } from "@overtchat/agent-runtime/codex/client";
 import { listCodexWorkspaceSessions } from "@overtchat/agent-runtime/codex/sessions";
@@ -170,7 +171,7 @@ export const codexProviderAdapter: AgentProviderAdapter = {
   listWorkspaceSessions: listCodexWorkspaceSessions,
   fetchCatalog: async (target, launch) => ({
     provider: "codex",
-    models: (await probeCodexTarget(target, launch.executable)).models,
+    models: await fetchCodexModels(target, launch.executable),
     modes: CODEX_MODES,
     defaultModeId: "auto",
   }),

--- a/packages/agent-runtime/src/runtime/discovery.test.ts
+++ b/packages/agent-runtime/src/runtime/discovery.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ executeOnHost: vi.fn() }));
+
+vi.mock("@overtchat/agent-runtime/runtime/process", () => ({
+  executeOnHost: mocks.executeOnHost,
+}));
+
+import {
+  AGENT_INSTALLATION_DISCOVERY_SCRIPT,
+  discoverAgentInstallations,
+} from "./discovery";
+
+describe("agent installation discovery", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("discovers and versions all providers in one host execution", async () => {
+    mocks.executeOnHost.mockResolvedValue({
+      stdout: [
+        "codex",
+        "/usr/local/bin/codex",
+        "codex-cli 1.2.3",
+        "claude",
+        "/usr/local/bin/claude",
+        "2.3.4 (Claude Code)",
+        "pi",
+        "/usr/local/bin/pi",
+        "pi 3.4.5",
+        "omp",
+        "/usr/local/bin/omp",
+        "omp 4.5.6",
+        "opencode",
+        "/usr/local/bin/opencode",
+        "opencode 5.6.7",
+        "",
+      ].join("\0"),
+      stderr: "",
+    });
+
+    await expect(
+      discoverAgentInstallations({ transport: "ssh", alias: "devbox" }),
+    ).resolves.toHaveLength(5);
+    expect(mocks.executeOnHost).toHaveBeenCalledOnce();
+    expect(mocks.executeOnHost).toHaveBeenCalledWith(
+      { transport: "ssh", alias: "devbox", shellMode: "interactive" },
+      expect.objectContaining({
+        command: "/bin/sh",
+        args: expect.arrayContaining([
+          "-c",
+          AGENT_INSTALLATION_DISCOVERY_SCRIPT,
+          "overtchat-agent-discovery",
+        ]),
+      }),
+    );
+  });
+
+  it("falls back to the alternate shell mode and ignores invalid versions", async () => {
+    mocks.executeOnHost
+      .mockResolvedValueOnce({
+        stdout: "codex\0/usr/local/bin/codex\0not-a-version\0",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        stdout: "codex\0/usr/local/bin/codex\0codex 1.2.3\0",
+        stderr: "",
+      });
+
+    await expect(
+      discoverAgentInstallations({ transport: "local" }),
+    ).resolves.toEqual([
+      {
+        provider: "codex",
+        executable: "/usr/local/bin/codex",
+        version: "1.2.3",
+        shellMode: "login",
+      },
+    ]);
+    expect(mocks.executeOnHost).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent-runtime/src/runtime/discovery.ts
+++ b/packages/agent-runtime/src/runtime/discovery.ts
@@ -16,12 +16,61 @@ const AGENT_SHELL_MODES = [
   "login",
 ] as const satisfies readonly ConnectorShellMode[];
 
-const EXECUTABLE_DISCOVERY = String.raw`
+export const AGENT_INSTALLATION_DISCOVERY_SCRIPT = String.raw`
+set -u
+directory=$(mktemp -d "${"$"}{TMPDIR:-/tmp}/overtchat-agent-discovery.XXXXXX") || exit 1
+cleanup() { rm -rf -- "$directory"; }
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+i=0
 for candidate do
   resolved=$(command -v "$candidate" 2>/dev/null) || continue
   case "$resolved" in
-    /*) printf '%s\0%s\0' "$candidate" "$resolved" ;;
+    /*)
+      printf '%s\0%s\0' "$candidate" "$resolved" > "$directory/meta.$i"
+      "$resolved" --version > "$directory/version.$i" 2>&1 &
+      printf '%s' "$!" > "$directory/pid.$i"
+      i=$((i + 1))
+      ;;
   esac
+done
+
+ticks=0
+while [ "$ticks" -lt 100 ]; do
+  running=0
+  for pid_file in "$directory"/pid.*; do
+    [ -f "$pid_file" ] || continue
+    pid=$(cat "$pid_file")
+    if kill -0 "$pid" 2>/dev/null; then
+      running=1
+      break
+    fi
+  done
+  [ "$running" -eq 0 ] && break
+  sleep 0.1
+  ticks=$((ticks + 1))
+done
+
+for pid_file in "$directory"/pid.*; do
+  [ -f "$pid_file" ] || continue
+  index=${"$"}{pid_file##*.}
+  pid=$(cat "$pid_file")
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    sleep 0.1
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+  if wait "$pid"; then
+    {
+      cat "$directory/meta.$index"
+      cat "$directory/version.$index"
+      printf '\0'
+    } > "$directory/result.$index"
+  fi
+done
+for file in "$directory"/result.*; do
+  [ -f "$file" ] || continue
+  cat "$file"
 done
 `.trim();
 
@@ -74,48 +123,40 @@ async function discoverAgentInstallationsInMode(
     command: "/bin/sh",
     args: [
       "-c",
-      EXECUTABLE_DISCOVERY,
+      AGENT_INSTALLATION_DISCOVERY_SCRIPT,
       "overtchat-agent-discovery",
       ...providers.map(({ executable }) => executable),
     ],
   });
   const fields = result.stdout.split("\0");
   if (fields.at(-1) === "") fields.pop();
-  const resolved = new Map<string, string>();
-  for (let index = 0; index + 1 < fields.length; index += 2) {
+  const installations = new Map<AgentProviderId, DetectedAgentInstallation>();
+  for (let index = 0; index + 2 < fields.length; index += 3) {
     const command = fields[index];
     const executable = fields[index + 1];
+    const versionOutput = fields[index + 2];
+    const provider = providers.find(
+      (candidate) => candidate.executable === command,
+    );
+    const version = parseAgentVersion(versionOutput ?? "");
     if (
-      command &&
+      provider &&
       executable?.startsWith("/") &&
-      executable.length <= 500
+      executable.length <= 500 &&
+      version
     ) {
-      resolved.set(command, executable);
+      installations.set(provider.id, {
+        provider: provider.id,
+        executable,
+        version,
+        shellMode,
+      });
     }
   }
-
-  const installations = await Promise.all(
-    providers.map(async ({ id, executable: command }) => {
-      const executable = resolved.get(command);
-      if (!executable) return null;
-      try {
-        const versionResult = await executeOnHost(resolvedTarget, {
-          command: executable,
-          args: ["--version"],
-        });
-        const version = parseAgentVersion(versionResult.stdout);
-        return version
-          ? { provider: id, executable, version, shellMode }
-          : null;
-      } catch {
-        return null;
-      }
-    }),
-  );
-  return installations.filter(
-    (installation): installation is DetectedAgentInstallation =>
-      installation !== null,
-  );
+  return providers.flatMap(({ id }) => {
+    const installation = installations.get(id);
+    return installation ? [installation] : [];
+  });
 }
 
 export async function discoverAgentInstallations(

--- a/packages/agent-runtime/src/runtime/provider-catalogs.test.ts
+++ b/packages/agent-runtime/src/runtime/provider-catalogs.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ fetchCatalog: vi.fn() }));
+
+vi.mock("@overtchat/agent-runtime/providers/registry", () => ({
+  agentProviderAdapter: () => ({ fetchCatalog: mocks.fetchCatalog }),
+}));
+
+import { AgentProviderCatalogManager } from "./provider-catalogs";
+
+const descriptor = {
+  connectionId: "connection",
+  workspaceId: "workspace",
+  provider: "codex" as const,
+  target: {
+    transport: "ssh" as const,
+    alias: "macbook",
+    shellMode: "login" as const,
+  },
+  executable: "/usr/local/bin/codex",
+  detectedVersion: "1.2.3",
+  cwd: "/workspace",
+};
+
+const catalog = {
+  provider: "codex" as const,
+  models: [
+    {
+      provider: "codex" as const,
+      id: "model",
+      label: "Model",
+      api: "codex-app-server",
+      baseUrl: "",
+      reasoning: true,
+      input: ["text" as const],
+      contextWindow: null,
+      maxTokens: null,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+  ],
+  modes: [],
+  defaultModeId: null,
+};
+
+describe("AgentProviderCatalogManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchCatalog.mockResolvedValue(catalog);
+  });
+
+  it("reuses a catalog and deduplicates concurrent cold loads", async () => {
+    let now = 100;
+    const manager = new AgentProviderCatalogManager(1_000, () => now);
+
+    const [left, right] = await Promise.all([
+      manager.getCatalog(descriptor),
+      manager.getCatalog(descriptor),
+    ]);
+    now = 500;
+    const cached = await manager.getCatalog(descriptor);
+
+    expect(left).toBe(catalog);
+    expect(right).toBe(catalog);
+    expect(cached).toBe(catalog);
+    expect(mocks.fetchCatalog).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes expired and invalidated catalogs", async () => {
+    let now = 100;
+    const manager = new AgentProviderCatalogManager(1_000, () => now);
+
+    await manager.getCatalog(descriptor);
+    now = 1_101;
+    await manager.getCatalog(descriptor);
+    manager.invalidate(descriptor);
+    await manager.getCatalog(descriptor);
+
+    expect(mocks.fetchCatalog).toHaveBeenCalledTimes(3);
+  });
+
+  it("separates catalogs by workspace and executable version", async () => {
+    const manager = new AgentProviderCatalogManager();
+
+    await manager.getCatalog(descriptor);
+    await manager.getCatalog({ ...descriptor, cwd: "/other" });
+    await manager.getCatalog({ ...descriptor, detectedVersion: "2.0.0" });
+
+    expect(mocks.fetchCatalog).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not cache failed loads", async () => {
+    const manager = new AgentProviderCatalogManager();
+    mocks.fetchCatalog
+      .mockRejectedValueOnce(new Error("catalog unavailable"))
+      .mockResolvedValueOnce(catalog);
+
+    await expect(manager.getCatalog(descriptor)).rejects.toThrow(
+      "catalog unavailable",
+    );
+    await expect(manager.getCatalog(descriptor)).resolves.toBe(catalog);
+
+    expect(mocks.fetchCatalog).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent-runtime/src/runtime/provider-catalogs.ts
+++ b/packages/agent-runtime/src/runtime/provider-catalogs.ts
@@ -1,0 +1,100 @@
+import type { AgentProviderCatalog } from "@overtchat/agent-bridge";
+import { agentProviderAdapter } from "@overtchat/agent-runtime/providers/registry";
+import type { AgentWorkspaceDescriptor } from "@overtchat/agent-runtime/runtime/registry";
+
+const DEFAULT_CATALOG_TTL_MS = 5 * 60_000;
+const MAX_CACHED_CATALOGS = 128;
+
+type CachedCatalog = {
+  catalog: AgentProviderCatalog;
+  expiresAt: number;
+  usedAt: number;
+};
+
+function catalogKey(descriptor: AgentWorkspaceDescriptor): string {
+  return JSON.stringify([
+    descriptor.provider,
+    descriptor.target.transport,
+    descriptor.target.transport === "ssh" ? descriptor.target.alias : "",
+    descriptor.target.shellMode ?? "interactive",
+    descriptor.executable,
+    descriptor.detectedVersion ?? "",
+    descriptor.cwd,
+  ]);
+}
+
+export class AgentProviderCatalogManager {
+  private readonly catalogs = new Map<string, CachedCatalog>();
+  private readonly loads = new Map<string, Promise<AgentProviderCatalog>>();
+
+  constructor(
+    private readonly ttlMs = DEFAULT_CATALOG_TTL_MS,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  getCatalog(
+    descriptor: AgentWorkspaceDescriptor,
+    options: { refresh?: boolean } = {},
+  ): Promise<AgentProviderCatalog> {
+    const key = catalogKey(descriptor);
+    const active = this.loads.get(key);
+    if (active) return active;
+    const current = this.catalogs.get(key);
+    const now = this.now();
+    if (current && !options.refresh && current.expiresAt > now) {
+      current.usedAt = now;
+      return Promise.resolve(current.catalog);
+    }
+    if (current) this.catalogs.delete(key);
+
+    const load = this.load(descriptor, key).finally(() => {
+      if (this.loads.get(key) === load) this.loads.delete(key);
+    });
+    this.loads.set(key, load);
+    return load;
+  }
+
+  invalidate(descriptor: AgentWorkspaceDescriptor): void {
+    this.catalogs.delete(catalogKey(descriptor));
+  }
+
+  private async load(
+    descriptor: AgentWorkspaceDescriptor,
+    key: string,
+  ): Promise<AgentProviderCatalog> {
+    const startedAt = this.now();
+    const adapter = agentProviderAdapter(descriptor.provider);
+    const catalog = await adapter.fetchCatalog(descriptor.target, {
+      executable: descriptor.executable,
+      cwd: descriptor.cwd,
+      detectedVersion: descriptor.detectedVersion,
+    });
+    const loadedAt = this.now();
+    this.catalogs.set(key, {
+      catalog,
+      expiresAt: loadedAt + this.ttlMs,
+      usedAt: loadedAt,
+    });
+    this.prune();
+    const elapsedMs = loadedAt - startedAt;
+    if (elapsedMs >= 250) {
+      console.info(
+        `[connector:timing] catalog_load provider=${descriptor.provider} transport=${descriptor.target.transport} elapsed_ms=${elapsedMs}`,
+      );
+    }
+    return catalog;
+  }
+
+  private prune(): void {
+    if (this.catalogs.size <= MAX_CACHED_CATALOGS) return;
+    const oldest = [...this.catalogs.entries()].sort(
+      ([, left], [, right]) => left.usedAt - right.usedAt,
+    );
+    for (const [key] of oldest.slice(
+      0,
+      this.catalogs.size - MAX_CACHED_CATALOGS,
+    )) {
+      this.catalogs.delete(key);
+    }
+  }
+}

--- a/packages/agent-runtime/src/runtime/registry.test.ts
+++ b/packages/agent-runtime/src/runtime/registry.test.ts
@@ -1676,6 +1676,47 @@ describe("agent runtime", () => {
     await registry.stopAll();
   });
 
+  it("uses a connector-supplied catalog without probing the provider again", async () => {
+    const resolveCatalog = vi.fn().mockResolvedValue({
+      provider: "codex",
+      models: [
+        {
+          provider: "codex",
+          id: "cached-model",
+          label: "Cached model",
+          isDefault: true,
+          api: "codex-app-server",
+          baseUrl: "",
+          reasoning: true,
+          input: ["text"],
+          contextWindow: null,
+          maxTokens: null,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        },
+      ],
+      modes: [],
+      defaultModeId: null,
+    });
+    const registry = new AgentRuntimeRegistry({
+      resolveImages: async () => [],
+      resolveCatalog,
+    });
+
+    const created = await registry.create("session", {
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "codex",
+      target: { transport: "local" },
+      executable: "codex",
+      cwd: "/workspace",
+    });
+
+    expect(resolveCatalog).toHaveBeenCalledOnce();
+    expect(mocks.fetchCatalog).not.toHaveBeenCalled();
+    expect(created.launchConfig.model).toBe("cached-model");
+    await registry.stopAll();
+  });
+
   it("persists live model, thinking, and mode selections into resume metadata", async () => {
     const updateSessionMetadata = vi.fn();
     const registry = new AgentRuntimeRegistry({

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -1,5 +1,6 @@
 import type {
   AgentModel,
+  AgentProviderCatalog,
   AgentPromptImage,
   AgentProviderSessionMetadata,
   AgentProviderId,
@@ -99,6 +100,9 @@ export type AgentRuntimeRegistryOptions = {
     sessionId: string,
     runtime: AgentSessionRuntime,
   ) => void | Promise<void>;
+  resolveCatalog?: (
+    descriptor: AgentWorkspaceDescriptor,
+  ) => Promise<AgentProviderCatalog>;
 };
 
 function emptyStats(): AgentSessionStats {
@@ -1913,11 +1917,13 @@ export class AgentRuntimeRegistry {
     descriptor: AgentWorkspaceDescriptor,
     requested: AgentSessionLaunchConfig,
   ): Promise<AgentSessionLaunchConfig> {
-    const catalog = await adapter.fetchCatalog(descriptor.target, {
-      executable: descriptor.executable,
-      cwd: descriptor.cwd,
-      detectedVersion: descriptor.detectedVersion,
-    });
+    const catalog = this.options.resolveCatalog
+      ? await this.options.resolveCatalog(descriptor)
+      : await adapter.fetchCatalog(descriptor.target, {
+          executable: descriptor.executable,
+          cwd: descriptor.cwd,
+          detectedVersion: descriptor.detectedVersion,
+        });
     const model = requested.model
       ? catalog.models.find((candidate) => candidate.id === requested.model)
       : catalog.models.find((candidate) => candidate.isDefault) ??


### PR DESCRIPTION
## Summary

- make saved agent targets immediately available in the launch dialog while provider discovery refreshes in the background
- collapse remote provider discovery and version checks into one SSH shell and run version probes concurrently
- cache and single-flight provider catalogs, then reuse the selected catalog during session creation
- prioritize launch/session commands over background Git and discovery work with bounded connector concurrency
- defer Git status requests for collapsed workspaces and add slow-request timing logs

## Benchmarks

Measured against the same macOS SSH target from the development server.

| Path | Before | After | Change |
| --- | ---: | ---: | ---: |
| Discover and version all 5 providers | 2.72–2.73s | 1.58–1.66s | ~41% faster |
| Codex catalog load, steady state | 1.85–1.88s | 0.927–0.930s | ~50% faster |
| Repeated catalog load between picker and create | 1.83–1.89s | ~0ms cache hit | ~1.85s removed |
| Saved-workspace launch-button discovery gate | 2.72–2.73s | 0s | removed |

The measured cold Codex create baseline was 4.63s. Removing its repeated ~1.85s catalog stage should reduce the post-selection launch path to roughly 2.8s; provider process startup remains the dominant floor.

## Implementation

- add a 5-minute, 128-entry provider catalog cache with per-key single-flight loading
- invalidate cached catalogs after failed provider startup
- skip the redundant Codex version probe when loading a catalog from an already-discovered target
- probe all provider versions inside one remote shell, with a 10-second per-discovery deadline and failure isolation
- dispatch connector requests with concurrency 4 and stable priority ordering
- preserve synchronization and destructive stop commands as barriers
- only fetch Git status for visible or active workspaces
- emit connector timing logs for slow catalog loads, queued requests, and request execution

## Compatibility

- no database migrations
- no connector protocol or capability changes
- no persistent remote daemon
- no SSH configuration or multiplexing changes

## Test plan

- `npm run lint`
- `npm run typecheck`
- `npm test -w packages/agent-runtime`
- `npm test -w apps/connector`
- `npm test -w apps/web`
- `npm run build -w apps/connector`
- `npm run build -w apps/web`
- live SSH discovery and Codex catalog benchmarks
