### PR TITLE
release: app 0.21.0 and connector 0.11.0

### DIFF
--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -133,7 +133,7 @@ describe.sequential("connector client compatibility", () => {
 
     const headers = new Headers(requests[0]!.init?.headers);
     expect(headers.get("x-overtchat-connector-version")).toBeNull();
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.10.0");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.11.0");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -16,6 +16,7 @@
 /install/connector/0.8.1 https://github.com/yoloyash/overtchat/releases/download/connector-v0.8.1/install-connector.sh 302
 /install/connector/0.9.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.9.0/install-connector.sh 302
 /install/connector/0.10.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.10.0/install-connector.sh 302
+/install/connector/0.11.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.11.0/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.10.0 302
+/install-connector.sh /install/connector/0.11.0 302

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,9 +1,9 @@
 {
   "format": 1,
   "cliVersion": "0.1.13",
-  "appVersion": "0.20.0",
+  "appVersion": "0.21.0",
   "voiceVersion": "0.1.1",
-  "connectorVersion": "0.10.0",
+  "connectorVersion": "0.11.0",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",
   "searxngImage": "docker.io/searxng/searxng@sha256:11a9b34cdc0b1ec2b991470a2762ecb5a1a531898289fb51dcd015260450729e",

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -83,7 +83,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.10.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.11.0 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -157,9 +157,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.10.0",
+            version: "0.11.0",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.10.0 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.11.0 | sh -s -- --upgrade",
           },
         },
       ],
@@ -172,14 +172,14 @@ describe("Host Connectors route", () => {
         id: "current",
         name: "Current",
         managed: false,
-        version: "0.10.0",
+        version: "0.11.0",
         lastSeenAt: null,
       },
       {
         id: "newer",
         name: "Newer",
         managed: false,
-        version: "0.11.0",
+        version: "0.12.0",
         lastSeenAt: null,
       },
     ]);

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.20.0}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.21.0}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,7 +552,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -22,7 +22,7 @@ import {
 /** Increment only for a breaking web-to-connector wire contract change. */
 export const HOST_CONNECTOR_PROTOCOL_VERSION = 3;
 /** Published connector artifact version; independent of wire compatibility. */
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.10.0";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.11.0";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/packages/agent-runtime/src/claude/client.ts
+++ b/packages/agent-runtime/src/claude/client.ts
@@ -217,7 +217,7 @@ function safeEnvironment(): Record<string, string | undefined> {
   // environment as command prefixes would both override remote credentials
   // and expose local secrets in process arguments.
   return {
-    CLAUDE_AGENT_SDK_CLIENT_APP: "overtchat/0.10.0",
+    CLAUDE_AGENT_SDK_CLIENT_APP: "overtchat/0.11.0",
     TERM: "dumb",
     NO_COLOR: "1",
   };

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.10.0"
+connector_version="0.11.0"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
## Summary

Prepare a coordinated app and Host Connector release from the current combined `main`.

- app: `0.20.0` → `0.21.0`
- Host Connector: `0.10.0` → `0.11.0`

## Included changes

- #241 — Browserslist security update
- #242 — model catalog refresh
- #248 — server-owned, resumable chat generations
- #249 — lower-latency local and SSH agent launch

## Release notes

- Generation state is now persisted in SQLite and resumable stream deltas remain buffered in Redis.
- Duplicate generation starts are idempotent, preventing a reconnect from invoking the model twice.
- Saved coding-agent workspaces can open the launch dialog immediately.
- Remote provider discovery is approximately 41% faster on the measured SSH target.
- Repeated model catalog loading is removed from session creation.

## Migration and compatibility

- Adds the forward-only, additive `chat_generations` table through migration `0015_flat_whiplash.sql`.
- Released clients remain compatible because the new client request ID is optional at the server boundary.
- Host Connector protocol version remains unchanged.
- Managed updates snapshot SQLite before applying migrations.
- Mobile recovery changes are present on `main`, but a mobile tag and Play production submission are intentionally separate from this release.

## Validation

- release version, manifest, installer, and redirect consistency checks
- focused connector version and web connector-route tests
- project site tests
- repository development/release script tests
- full lint, typecheck, test, production image, and connector artifact validation before tagging
