### PR TITLE
chore(mobile): prepare 1.4.1 release

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "overtchat",
     "slug": "overtchat",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "orientation": "portrait",
     "scheme": "overtchat",
     "userInterfaceStyle": "automatic",
@@ -10,11 +10,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.overtchat.mobile",
-      "buildNumber": "12"
+      "buildNumber": "13"
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 12,
+      "versionCode": 13,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@overtchat/mobile",
   "main": "expo-router/entry",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "dev": "expo start --host=lan",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1081,7 +1081,7 @@
     },
     "apps/mobile": {
       "name": "@overtchat/mobile",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@ai-sdk/react": "^4.0.87",
         "@better-auth/expo": "1.6.23",


### PR DESCRIPTION
## Summary

- bump the Expo and mobile package versions from 1.4.0 to 1.4.1
- increment Android versionCode to 13 and mirror the iOS build number
- prepare the Android release containing the resumable-generation recovery changes from #248

## Validation

- npm run typecheck -w @overtchat/mobile --
- npm test -w @overtchat/mobile --
- verified app.json, package.json, and package-lock.json version consistency
- git diff --check

## Release

After merge, tag the merge commit as mobile-v1.4.1. The tagged workflow builds the signed AAB and APK on the self-hosted runner, smoke-tests the APK on a clean emulator, submits the verified AAB to Google Play production, and attaches the APK to the GitHub release.