### PR TITLE
fix(agents): preserve OMP transcript order

### DIFF
--- a/apps/web/components/agents/AgentMessageList.tsx
+++ b/apps/web/components/agents/AgentMessageList.tsx
@@ -287,6 +287,9 @@ function AgentTranscriptRow({
   if (item.type === "assistant_error") {
     return <AgentErrorNotice error={item.error} />;
   }
+  if (item.type === "notification") {
+    return <AgentNotificationNotice notification={item.notification} />;
+  }
   if (item.type === "turn_footer") {
     return (
       <AgentTurnFooter
@@ -315,6 +318,36 @@ function AgentTranscriptRow({
       active={active}
       sequencePosition={activitySequencePosition ?? "single"}
     />
+  );
+}
+
+function AgentNotificationNotice({
+  notification,
+}: {
+  notification: Extract<
+    AgentTranscriptItem,
+    { type: "notification" }
+  >["notification"];
+}) {
+  const warning = notification.level === "warning";
+  const error = notification.level === "error";
+  const Icon = warning || error ? AlertTriangle : Info;
+  return (
+    <div
+      className="flex items-start gap-2 py-1 text-sm text-muted-foreground"
+      role={error ? "alert" : "status"}
+    >
+      <Icon
+        className={cn(
+          "mt-0.5 size-4 shrink-0",
+          warning && "text-amber-500",
+          error && "text-destructive",
+        )}
+      />
+      <span className="min-w-0 flex-1 text-foreground/90">
+        {notification.message}
+      </span>
+    </div>
   );
 }
 

--- a/apps/web/lib/agents/presentation.test.ts
+++ b/apps/web/lib/agents/presentation.test.ts
@@ -7,6 +7,7 @@ import {
   formatAgentToolDetail,
   latestAgentTaskList,
   presentAgentError,
+  presentOmpSystemNotice,
   projectAgentTranscript,
   type AgentToolActivity,
 } from "./presentation";
@@ -62,6 +63,52 @@ function projectedTools(messages: unknown[]) {
 }
 
 describe("projectAgentTranscript", () => {
+  it("renders OMP background results as concise notifications", () => {
+    const notice = [
+      "<system-notice>",
+      "Background job bg_4 has completed. Resume your work using the result below.",
+      "verbose command output",
+      "</system-notice>",
+    ].join("\n");
+
+    expect(
+      projectAgentTranscript([
+        {
+          role: "custom",
+          customType: "async-result",
+          content: notice,
+          display: true,
+          timestamp: 4,
+        },
+      ]),
+    ).toEqual([
+      {
+        type: "notification",
+        key: "notification:4",
+        notification: {
+          level: "info",
+          message: "Background job bg_4 completed",
+        },
+      },
+    ]);
+  });
+
+  it("uses OMP task-result status for restored background notices", () => {
+    const notice = [
+      "<system-notice>",
+      "Background job DocsSmokeTwo has failed.",
+      '<task-result id=“DocsSmokeTwo” agent=“explore” status=“failed”>',
+      "<output>boom</output>",
+      "</task-result>",
+      "</system-notice>",
+    ].join("\n");
+
+    expect(presentOmpSystemNotice(notice)).toEqual({
+      level: "error",
+      message: "Background job DocsSmokeTwo failed",
+    });
+  });
+
   it("keeps reasoning distinct while grouping consecutive tool activity", () => {
     const projected = projectAgentTranscript([
       { role: "user", content: "Remove the old image", timestamp: 1 },

--- a/apps/web/lib/agents/presentation.ts
+++ b/apps/web/lib/agents/presentation.ts
@@ -60,6 +60,11 @@ export type AgentErrorPresentation = {
   details: string | null;
 };
 
+export type AgentNotificationPresentation = {
+  level: "info" | "warning" | "error";
+  message: string;
+};
+
 export type AgentTaskStatus = "pending" | "in_progress" | "completed";
 
 export type AgentTask = {
@@ -91,6 +96,11 @@ export type AgentTranscriptItem =
       type: "assistant_error";
       key: string;
       error: AgentErrorPresentation;
+    }
+  | {
+      type: "notification";
+      key: string;
+      notification: AgentNotificationPresentation;
     }
   | {
       type: "activity";
@@ -298,6 +308,89 @@ function textOfContent(content: unknown): string {
         : [];
     })
     .join("\n");
+}
+
+const OMP_SYSTEM_NOTICE_OPEN_TAG = "<system-notice>";
+const OMP_SYSTEM_NOTICE_CLOSE_TAG = "</system-notice>";
+const OMP_TASK_RESULT_TAG_PATTERN = /<task-result\b([^>]*)>/iu;
+const OMP_TASK_RESULT_ATTRIBUTE_PATTERN =
+  /([\w-]+)=["'“‘]([^"'“”‘’]*)["'”’]/gu;
+const OMP_BACKGROUND_JOB_PATTERN =
+  /^Background job\s+(.+?)\s+has\s+(completed|failed|errored|canceled|cancelled|stopped)\b/iu;
+
+function ompNotificationLevel(
+  status: string | null,
+): AgentNotificationPresentation["level"] {
+  const normalized = status?.toLowerCase() ?? null;
+  if (normalized === "failed" || normalized === "error" || normalized === "errored") {
+    return "error";
+  }
+  if (
+    normalized === "canceled" ||
+    normalized === "cancelled" ||
+    normalized === "stopped"
+  ) {
+    return "warning";
+  }
+  return "info";
+}
+
+function normalizedOmpJobStatus(status: string | null): string {
+  const normalized = status?.toLowerCase() ?? "completed";
+  if (normalized === "error" || normalized === "errored") return "failed";
+  if (normalized === "cancelled") return "canceled";
+  return normalized;
+}
+
+function ompNoticeFirstLine(text: string): string | null {
+  const openIndex = text.indexOf(OMP_SYSTEM_NOTICE_OPEN_TAG);
+  const closeIndex = text.indexOf(OMP_SYSTEM_NOTICE_CLOSE_TAG);
+  const body = text.slice(
+    openIndex + OMP_SYSTEM_NOTICE_OPEN_TAG.length,
+    closeIndex === -1 ? undefined : closeIndex,
+  );
+  return (
+    body
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .find((line) => line && !line.startsWith("<")) ?? null
+  );
+}
+
+export function presentOmpSystemNotice(
+  text: string,
+): AgentNotificationPresentation | null {
+  if (!text.trimStart().startsWith(OMP_SYSTEM_NOTICE_OPEN_TAG)) return null;
+
+  const taskResult = text.match(OMP_TASK_RESULT_TAG_PATTERN);
+  if (taskResult) {
+    const attributes = new Map<string, string>();
+    for (const match of (taskResult[1] ?? "").matchAll(
+      OMP_TASK_RESULT_ATTRIBUTE_PATTERN,
+    )) {
+      const name = match[1];
+      const value = match[2];
+      if (name && value !== undefined) attributes.set(name, value.trim());
+    }
+    const id = attributes.get("id") || null;
+    const status = attributes.get("status") || null;
+    if (id) {
+      return {
+        level: ompNotificationLevel(status),
+        message: `Background job ${id} ${normalizedOmpJobStatus(status)}`,
+      };
+    }
+  }
+
+  const firstLine = ompNoticeFirstLine(text);
+  const backgroundJob = firstLine?.match(OMP_BACKGROUND_JOB_PATTERN);
+  if (backgroundJob?.[1] && backgroundJob[2]) {
+    return {
+      level: ompNotificationLevel(backgroundJob[2]),
+      message: `Background job ${backgroundJob[1]} ${normalizedOmpJobStatus(backgroundJob[2])}`,
+    };
+  }
+  return firstLine ? { level: "info", message: firstLine } : null;
 }
 
 const MAX_ERROR_SUMMARY_LENGTH = 240;
@@ -726,6 +819,17 @@ export function projectAgentTranscript(
     }
 
     if (role === "custom" && record.display === false) return;
+    if (role === "custom") {
+      const notification = presentOmpSystemNotice(textOfContent(record.content));
+      if (notification) {
+        items.push({
+          type: "notification",
+          key: `notification:${identity}`,
+          notification,
+        });
+        return;
+      }
+    }
 
     items.push({
       type: "message",

--- a/packages/agent-runtime/src/providers/omp.test.ts
+++ b/packages/agent-runtime/src/providers/omp.test.ts
@@ -46,4 +46,32 @@ describe("OMP provider adapter", () => {
       expect.objectContaining({ modeId: "full" }),
     );
   });
+
+  it("waits for OMP's terminal agent end across async continuations", () => {
+    const classifier = ompProviderAdapter.createEventClassifier();
+
+    expect(classifier.classify({ type: "agent_start" })).toMatchObject({
+      started: true,
+      terminal: false,
+    });
+    classifier.classify({
+      type: "message_end",
+      message: { role: "assistant", content: "First pass" },
+    });
+
+    expect(
+      classifier.classify({
+        type: "agent_end",
+        isTerminal: false,
+        messages: [{ role: "assistant", content: "First pass" }],
+      }),
+    ).toMatchObject({ terminal: false });
+    expect(
+      classifier.classify({
+        type: "agent_end",
+        isTerminal: true,
+        messages: [{ role: "assistant", content: "Final pass" }],
+      }),
+    ).toMatchObject({ terminal: true });
+  });
 });

--- a/packages/agent-runtime/src/providers/omp.ts
+++ b/packages/agent-runtime/src/providers/omp.ts
@@ -61,6 +61,7 @@ class OmpEventClassifier implements AgentRuntimeEventClassifier {
     }
     const terminal =
       (event.type === "agent_end" &&
+        event.isTerminal !== false &&
         (this.sawAssistant ||
           (Array.isArray(event.messages) &&
             event.messages.some((message) => messageRole(message) === "assistant")))) ||
@@ -116,6 +117,10 @@ async function fetchCatalog(
 
 export const ompProviderAdapter: AgentProviderAdapter = {
   provider: "omp",
+  // OMP's live events preserve display chronology across async-result
+  // continuations. Replacing them at settle time with its mutable model-context
+  // snapshot can move already-rendered tool and custom-message rows.
+  refreshMessagesAfterTerminal: false,
   startSession(target, launch) {
     return startOmp(target, {
       executable: launch.executable,

--- a/packages/agent-runtime/src/providers/types.ts
+++ b/packages/agent-runtime/src/providers/types.ts
@@ -122,6 +122,13 @@ export interface AgentRuntimeEventClassifier {
 
 export interface AgentProviderAdapter {
   readonly provider: AgentProviderId;
+  /**
+   * Whether a normal provider-terminal transition should replace the live
+   * transcript with a freshly fetched history snapshot. Providers whose live
+   * event stream is the canonical display order should disable this and leave
+   * full history hydration to session startup and explicit refreshes.
+   */
+  readonly refreshMessagesAfterTerminal?: boolean;
   startSession(
     target: HostTarget,
     launch: AgentSessionLaunch,

--- a/packages/agent-runtime/src/runtime/registry.test.ts
+++ b/packages/agent-runtime/src/runtime/registry.test.ts
@@ -41,6 +41,7 @@ const stats = {
 vi.mock("@overtchat/agent-runtime/providers/registry", () => ({
   agentProviderAdapter: (provider: AgentProviderId) => ({
     provider,
+    refreshMessagesAfterTerminal: provider !== "omp",
     capabilities: { steer: true },
     probeConnection: vi.fn(),
     probeTarget: vi.fn(),
@@ -617,6 +618,83 @@ describe("agent runtime", () => {
       ]);
     });
     expect(mocks.prompt).not.toHaveBeenCalled();
+    await registry.stopAll();
+  });
+
+  it("preserves OMP live transcript order when the provider settles", async () => {
+    mocks.getMessages
+      .mockResolvedValueOnce({ messages: [] })
+      .mockResolvedValueOnce({
+        messages: [
+          { id: "final", role: "assistant", content: [{ type: "text", text: "Done" }] },
+          {
+            id: "tools",
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call-1", name: "bash", arguments: {} }],
+          },
+        ],
+      });
+    const registry = new AgentRuntimeRegistry({ resolveImages: async () => [] });
+    const runtime = await registry.getOrStart({
+      connectionId: "connection",
+      workspaceId: "workspace",
+      provider: "omp",
+      target: { transport: "local" },
+      executable: "omp",
+      cwd: "/workspace",
+      sessionId: "session",
+      providerSessionId: "provider-session",
+      providerSessionPath: "/sessions/provider-session.jsonl",
+      launchConfig: {},
+    });
+
+    mocks.eventSubscriber?.({
+      type: "message_end",
+      message: {
+        id: "tools",
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call-1", name: "bash", arguments: {} },
+        ],
+      },
+    });
+    mocks.eventSubscriber?.({
+      type: "tool_execution_end",
+      toolCallId: "call-1",
+      toolName: "bash",
+      result: { content: [{ type: "text", text: "output" }] },
+    });
+    mocks.eventSubscriber?.({
+      type: "message_end",
+      message: {
+        role: "custom",
+        customType: "async-result",
+        content: "<system-notice>Background job bg_4 completed</system-notice>",
+        timestamp: 2,
+      },
+    });
+    mocks.eventSubscriber?.({
+      type: "message_end",
+      message: {
+        id: "final",
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    });
+    mocks.eventSubscriber?.({
+      type: "agent_end",
+      messages: [{ role: "assistant", content: "Done" }],
+    });
+
+    await vi.waitFor(() => expect(runtime.snapshot().status).toBe("idle"));
+    expect(mocks.getMessages).toHaveBeenCalledOnce();
+    expect(
+      runtime.snapshot().messages.map((message) =>
+        message && typeof message === "object"
+          ? Reflect.get(message, "role")
+          : null,
+      ),
+    ).toEqual(["assistant", "toolResult", "custom", "assistant"]);
     await registry.stopAll();
   });
 

--- a/packages/agent-runtime/src/runtime/registry.ts
+++ b/packages/agent-runtime/src/runtime/registry.ts
@@ -900,28 +900,34 @@ export class AgentSessionRuntime {
     await this.client.discardForkedSession?.(session);
   }
 
-  async refresh(): Promise<void> {
+  async refresh(options: { messages?: boolean } = {}): Promise<void> {
     if (this.refreshPromise) return this.refreshPromise;
     this.refreshPromise = (async () => {
       const [state, messageData, stats, commands] =
         await Promise.all([
           this.client.getState(),
-          this.client.getMessages(),
+          options.messages === false
+            ? Promise.resolve(null)
+            : this.client.getMessages(),
           this.client.getSessionStats().catch(() => emptyStats()),
           this.client.getCommands().catch(() => this.commands),
         ]);
       this.state = state;
-      this.messages = reconcileSubmittedUserMessages(
-        this.messages,
-        messageData.messages,
-      );
+      if (messageData) {
+        this.messages = reconcileSubmittedUserMessages(
+          this.messages,
+          messageData.messages,
+        );
+      }
       this.stats = stats;
       this.commands = this.adapter.mergeCommands(commands);
       this.status = state.isStreaming === true ? "running" : "idle";
-      const reconciledQueue = reconcileRestoredQueuedMessages(
-        this.queuedMessages,
-        messageData.messages,
-      );
+      const reconciledQueue = messageData
+        ? reconcileRestoredQueuedMessages(
+            this.queuedMessages,
+            messageData.messages,
+          )
+        : { messages: this.queuedMessages, changed: false };
       if (reconciledQueue.changed) {
         this.queuedMessages = reconciledQueue.messages;
         await this.publishQueueUpdate();
@@ -1310,7 +1316,9 @@ export class AgentSessionRuntime {
       isCompacting: false,
     };
     try {
-      await this.refresh();
+      await this.refresh({
+        messages: this.adapter.refreshMessagesAfterTerminal !== false,
+      });
     } catch (error) {
       this.error = errorMessage(error);
       this.publish({


### PR DESCRIPTION
## Summary

- Preserve OMP live transcript chronology when a turn settles instead of replacing it with a reordered history snapshot.
- Respect nonterminal agent_end events so background-agent continuations do not settle the parent turn early.
- Render OMP background-job notices as concise, status-aware notifications.

## Testing

- npm test -w packages/agent-runtime --
- npm run typecheck -w packages/agent-runtime --
- npm test -w apps/connector --
- npm run typecheck -w apps/connector --
- npm run build -w apps/connector --
- npm test -w apps/web --
- npm run lint -w apps/web --
- npm run typecheck -w apps/web --
- npm run build -w apps/web --
