### PR TITLE
feat(web): show active generations in the chat sidebar

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -2,7 +2,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { auth } from "@/lib/auth/server";
-import { listChats } from "@/lib/db/chats";
+import { listActiveChatIds, listChats } from "@/lib/db/chats";
 import { listProjects } from "@/lib/db/projects";
 import { listAgentConnections } from "@/lib/db/agentConnections";
 import { withConnectorSessionDirectory } from "@/lib/agents/connector/directory";
@@ -41,6 +41,10 @@ export default async function AppLayout({
           updatedAt: c.updatedAt.getTime(),
         }));
       },
+    }),
+    qc.prefetchQuery({
+      queryKey: chatKeys.active(),
+      queryFn: () => listActiveChatIds(session.user.id),
     }),
     qc.prefetchQuery({
       queryKey: projectKeys.list(),

--- a/apps/web/app/api/chats/active/route.test.ts
+++ b/apps/web/app/api/chats/active/route.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  listActiveChatIds: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/server", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+vi.mock("@/lib/db/chats", () => ({
+  listActiveChatIds: mocks.listActiveChatIds,
+}));
+
+import { GET } from "./route";
+
+const request = () =>
+  new Request("http://server.test/api/chats/active", {
+    headers: { Origin: "exp://mobile" },
+  });
+
+describe("active chats", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getSession.mockResolvedValue({ user: { id: "user" } });
+    mocks.listActiveChatIds.mockResolvedValue(["chat-a", "chat-b"]);
+  });
+
+  it("returns the authenticated user's active chat IDs", async () => {
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.listActiveChatIds).toHaveBeenCalledWith("user");
+    await expect(response.json()).resolves.toEqual({
+      activeChatIds: ["chat-a", "chat-b"],
+    });
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mocks.getSession.mockResolvedValue(null);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(401);
+    expect(mocks.listActiveChatIds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/chats/active/route.ts
+++ b/apps/web/app/api/chats/active/route.ts
@@ -1,0 +1,22 @@
+import { auth } from "@/lib/auth/server";
+import { preflight, withCors } from "@/lib/cors";
+import { listActiveChatIds } from "@/lib/db/chats";
+import type { ActiveChatIdsResponse } from "@/lib/queries/chats";
+
+export function OPTIONS(req: Request) {
+  return preflight(req);
+}
+
+export async function GET(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) {
+    return withCors(req, new Response("Unauthorized", { status: 401 }));
+  }
+
+  const body: ActiveChatIdsResponse = {
+    activeChatIds: await listActiveChatIds(session.user.id),
+  };
+  const response = Response.json(body);
+  response.headers.set("Cache-Control", "no-store");
+  return withCors(req, response);
+}

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -199,15 +199,27 @@ export function SidebarItem({
           href={`/chat/${chat.id}`}
           onClick={closeMobile}
           className={cn(
-            "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
+            "min-w-0 flex-1 truncate rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
             active && "bg-sidebar-accent",
           )}
         >
+          {chat.title ? (
+            <RevealedTitle
+              key={chat.title}
+              title={chat.title}
+              reveal={revealNextTitle}
+              onComplete={markTitleRevealComplete}
+            />
+          ) : (
+            "Untitled"
+          )}
+        </Link>
+        <div className="relative mr-0.5 size-5.5 shrink-0 max-md:size-7.5">
           {generating && (
             <span
               role="status"
               aria-label={`Generating response for ${chat.title?.trim() || "Untitled"}`}
-              className="shrink-0 text-muted-foreground"
+              className="pointer-events-none absolute inset-0 flex items-center justify-center text-muted-foreground motion-opacity group-hover:opacity-0 group-focus-within:opacity-0"
             >
               <LoaderCircle
                 aria-hidden="true"
@@ -215,21 +227,7 @@ export function SidebarItem({
               />
             </span>
           )}
-          <span className="min-w-0 truncate">
-            {chat.title ? (
-              <RevealedTitle
-                key={chat.title}
-                title={chat.title}
-                reveal={revealNextTitle}
-                onComplete={markTitleRevealComplete}
-              />
-            ) : (
-              "Untitled"
-            )}
-          </span>
-        </Link>
-        <div className="relative mr-0.5 size-5.5 shrink-0 max-md:size-7.5">
-          {chat.kind === "voice" && (
+          {chat.kind === "voice" && !generating && (
             <AudioWaveform
               aria-label="Voice chat"
               className="pointer-events-none absolute inset-0 m-auto size-3.5 text-muted-foreground group-hover:hidden group-focus-within:hidden max-md:hidden"
@@ -240,7 +238,9 @@ export function SidebarItem({
               aria-label="Chat actions"
               className={cn(
                 "absolute inset-0 flex items-center justify-center rounded hover:bg-sidebar-accent",
-                motionClasses.hoverReveal,
+                generating
+                  ? "opacity-0 motion-opacity group-hover:opacity-100 group-focus-within:opacity-100 data-[popup-open]:opacity-100"
+                  : motionClasses.hoverReveal,
               )}
             >
               <MoreHorizontal className="size-3.5 text-muted-foreground" />

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -10,6 +10,7 @@ import {
   AudioWaveform,
   FolderInput,
   MoreHorizontal,
+  LoaderCircle,
   Pencil,
   Trash2,
 } from "lucide-react";
@@ -46,9 +47,11 @@ export interface ProjectOption {
 export function SidebarChatList({
   chats,
   projects,
+  activeChatIds,
 }: {
   chats: DatedChat[];
   projects: ProjectOption[];
+  activeChatIds: ReadonlySet<string>;
 }) {
   if (chats.length === 0) {
     return (
@@ -72,7 +75,12 @@ export function SidebarChatList({
           </div>
           <ul className="flex flex-col gap-0.5">
             {g.items.map((c) => (
-              <SidebarItem key={c.id} chat={c} projects={projects} />
+              <SidebarItem
+                key={c.id}
+                chat={c}
+                projects={projects}
+                generating={activeChatIds.has(c.id)}
+              />
             ))}
           </ul>
         </div>
@@ -85,10 +93,12 @@ export function SidebarItem({
   chat,
   projects,
   currentProjectId = null,
+  generating = false,
 }: {
   chat: Chat;
   projects: ProjectOption[];
   currentProjectId?: string | null;
+  generating?: boolean;
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -189,20 +199,34 @@ export function SidebarItem({
           href={`/chat/${chat.id}`}
           onClick={closeMobile}
           className={cn(
-            "min-w-0 flex-1 truncate rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
+            "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
             active && "bg-sidebar-accent",
           )}
         >
-          {chat.title ? (
-            <RevealedTitle
-              key={chat.title}
-              title={chat.title}
-              reveal={revealNextTitle}
-              onComplete={markTitleRevealComplete}
-            />
-          ) : (
-            "Untitled"
+          {generating && (
+            <span
+              role="status"
+              aria-label={`Generating response for ${chat.title?.trim() || "Untitled"}`}
+              className="shrink-0 text-muted-foreground"
+            >
+              <LoaderCircle
+                aria-hidden="true"
+                className={cn("size-3.5", motionClasses.spinner)}
+              />
+            </span>
           )}
+          <span className="min-w-0 truncate">
+            {chat.title ? (
+              <RevealedTitle
+                key={chat.title}
+                title={chat.title}
+                reveal={revealNextTitle}
+                onComplete={markTitleRevealComplete}
+              />
+            ) : (
+              "Untitled"
+            )}
+          </span>
         </Link>
         <div className="relative mr-0.5 size-5.5 shrink-0 max-md:size-7.5">
           {chat.kind === "voice" && (

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/SidebarProjects";
 import { SidebarAgentWorkspaces } from "@/components/SidebarAgentWorkspaces";
 import { useSidebar } from "@/components/sidebar-context";
-import { useChats } from "@/lib/queries/chats";
+import { useActiveChatIds, useChats } from "@/lib/queries/chats";
 import { useProjects } from "@/lib/queries/projects";
 import {
   useAgentConnectionSessionDirectory,
@@ -42,7 +42,9 @@ export function SidebarClient({ isAdmin }: { isAdmin: boolean }) {
   const pathname = usePathname();
 
   const { data: chats = [] } = useChats();
+  const { data: activeChatIds = [] } = useActiveChatIds();
   const { data: projects = [] } = useProjects();
+  const activeChats = useMemo(() => new Set(activeChatIds), [activeChatIds]);
 
   const projectOptions = useMemo(
     () => projects.map((p) => ({ id: p.id, name: p.name })),
@@ -138,7 +140,10 @@ export function SidebarClient({ isAdmin }: { isAdmin: boolean }) {
         </nav>
 
         <SectionLabel>Projects</SectionLabel>
-        <SidebarProjects projects={projectsWithChats} />
+        <SidebarProjects
+          projects={projectsWithChats}
+          activeChatIds={activeChats}
+        />
         <button
           type="button"
           onClick={() => setCreatingProject(true)}
@@ -150,7 +155,11 @@ export function SidebarClient({ isAdmin }: { isAdmin: boolean }) {
 
         {isAdmin && <AdminAgentWorkspaces />}
 
-        <SidebarChatList chats={unprojected} projects={projectOptions} />
+        <SidebarChatList
+          chats={unprojected}
+          projects={projectOptions}
+          activeChatIds={activeChats}
+        />
       </div>
 
       <CreateProjectDialog

--- a/apps/web/components/SidebarProjects.tsx
+++ b/apps/web/components/SidebarProjects.tsx
@@ -26,8 +26,10 @@ interface ProjectWithChats extends ProjectOption {
 
 export function SidebarProjects({
   projects,
+  activeChatIds,
 }: {
   projects: ProjectWithChats[];
+  activeChatIds: ReadonlySet<string>;
 }) {
   const projectOptions: ProjectOption[] = projects.map((p) => ({
     id: p.id,
@@ -43,6 +45,7 @@ export function SidebarProjects({
           key={p.id}
           project={p}
           projectOptions={projectOptions}
+          activeChatIds={activeChatIds}
         />
       ))}
     </ul>
@@ -52,9 +55,11 @@ export function SidebarProjects({
 function ProjectNode({
   project,
   projectOptions,
+  activeChatIds,
 }: {
   project: ProjectWithChats;
   projectOptions: ProjectOption[];
+  activeChatIds: ReadonlySet<string>;
 }) {
   const pathname = usePathname();
   const { closeMobile } = useSidebar();
@@ -115,6 +120,7 @@ function ProjectNode({
                 chat={c}
                 projects={projectOptions}
                 currentProjectId={project.id}
+                generating={activeChatIds.has(c.id)}
               />
             ))
           )}

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -23,6 +23,7 @@ import {
 import { usePublicCapabilities } from "@/lib/queries/capabilities";
 import {
   useChats,
+  setActiveChatInCache,
   useChatUsage,
   useLoadOlderChatMessages,
   type ChatListItem,
@@ -250,7 +251,12 @@ export function ChatArea({
         setInferenceActivity(part.data);
       }
     },
-    onError: () => setInferenceActivity(null),
+    onError: () => {
+      setInferenceActivity(null);
+      if (!temporaryRef.current) {
+        void qc.invalidateQueries({ queryKey: chatKeys.active() });
+      }
+    },
     onFinish: ({ message, isError }) => {
       setInferenceActivity(null);
       const stats = readMessageStats(message);
@@ -262,6 +268,7 @@ export function ChatArea({
         });
       }
       if (temporaryRef.current) return;
+      setActiveChatInCache(qc, chatId, false);
       if (hasSuccessfulMemoryMutation(message)) {
         void qc.invalidateQueries({ queryKey: personalizationKeys.all() });
       }
@@ -269,6 +276,7 @@ export function ChatArea({
       setChatPersisted(true);
       void Promise.all([
         qc.invalidateQueries({ queryKey: chatKeys.list() }),
+        qc.invalidateQueries({ queryKey: chatKeys.active() }),
         qc.invalidateQueries({ queryKey: chatKeys.usage(chatId) }),
         qc.invalidateQueries({ queryKey: activityKeys.all() }),
       ]);
@@ -277,8 +285,10 @@ export function ChatArea({
   const handleGenerationSettled = useCallback(() => {
     setInferenceActivity(null);
     setChatPersisted(true);
+    setActiveChatInCache(qc, chatId, false);
     void Promise.all([
       qc.invalidateQueries({ queryKey: chatKeys.list() }),
+      qc.invalidateQueries({ queryKey: chatKeys.active() }),
       qc.invalidateQueries({ queryKey: chatKeys.usage(chatId) }),
       qc.invalidateQueries({ queryKey: activityKeys.all() }),
     ]);
@@ -401,6 +411,12 @@ export function ChatArea({
     return true;
   }, [chatId]);
 
+  const markGenerationStarted = useCallback(() => {
+    if (!temporaryRef.current) {
+      setActiveChatInCache(qc, chatId, true);
+    }
+  }, [chatId, qc]);
+
   function handleSubmit(text: string, attachments: FileUIPart[]) {
     if (voiceActive) {
       voiceSessionRef.current?.sendMessage(text);
@@ -423,6 +439,7 @@ export function ChatArea({
         return [next, ...prev];
       });
     }
+    markGenerationStarted();
     sendMessage(
       { text, files: attachments },
       { body: requestBody({ type: "submit" }, searchRequested) },
@@ -445,6 +462,7 @@ export function ChatArea({
   function handleRegenerate(messageId: string) {
     if (streaming || !configured) return;
     setInferenceActivity(null);
+    markGenerationStarted();
     regenerate({
       messageId,
       body: requestBody({
@@ -463,6 +481,7 @@ export function ChatArea({
   function handleEdit(messageId: string, text: string, files: FileUIPart[]) {
     if (streaming || !configured) return;
     setInferenceActivity(null);
+    markGenerationStarted();
     sendMessage(
       { text, files, messageId },
       {

--- a/apps/web/e2e/stream-resumption.spec.ts
+++ b/apps/web/e2e/stream-resumption.spec.ts
@@ -164,6 +164,17 @@ test("sidebar tracks generation after leaving the active chat", async ({
     });
     await expect(generating).toBeVisible();
 
+    const generatingRow = generating.locator("xpath=ancestor::li[1]");
+    const chatActions = generatingRow.getByRole("button", {
+      name: "Chat actions",
+    });
+    await expect(chatActions).toHaveCSS("opacity", "0");
+    await generatingRow.hover();
+    await expect(generating).toHaveCSS("opacity", "0");
+    await expect(chatActions).toHaveCSS("opacity", "1");
+    await page.getByRole("link", { name: /New chat/u }).hover();
+    await expect(generating).toHaveCSS("opacity", "1");
+
     await page.getByRole("link", { name: /New chat/u }).click();
     await expect(page).toHaveURL(/\/$/u);
     await expect(generating).toBeVisible();

--- a/apps/web/e2e/stream-resumption.spec.ts
+++ b/apps/web/e2e/stream-resumption.spec.ts
@@ -140,6 +140,41 @@ function seedModel() {
   }
 }
 
+test("sidebar tracks generation after leaving the active chat", async ({
+  page,
+}) => {
+  await page.goto("/signup");
+  await page.locator("#name").fill("Sidebar Generation Tester");
+  await page.locator("#email").fill("sidebar-generation@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/", { timeout: 15_000 });
+  seedModel();
+  await page.reload();
+
+  try {
+    await page
+      .getByPlaceholder("Message…")
+      .fill("Keep generating in the background.");
+    await page.getByLabel("Send message").click();
+    await firstChunk.promise;
+
+    const generating = page.getByRole("status", {
+      name: /Generating response for/u,
+    });
+    await expect(generating).toBeVisible();
+
+    await page.getByRole("link", { name: /New chat/u }).click();
+    await expect(page).toHaveURL(/\/$/u);
+    await expect(generating).toBeVisible();
+
+    continueStream.resolve();
+    await expect(generating).toHaveCount(0, { timeout: 10_000 });
+  } finally {
+    continueStream.resolve();
+  }
+});
+
 test("reload resumes an active chat stream through Redis", async ({ page }) => {
   test.skip(!process.env.REDIS_URL, "REDIS_URL is required for resumption.");
 

--- a/apps/web/lib/db/chatTurns.test.ts
+++ b/apps/web/lib/db/chatTurns.test.ts
@@ -163,6 +163,37 @@ function messageIds(): string[] {
 }
 
 describe("transactional chat turns", () => {
+  it("lists only generations that still own a running chat stream", async () => {
+    seedChat();
+    expect(
+      chatTurns.commitChatTurn({
+        chatId: "chat",
+        userId: "user",
+        projectId: null,
+        streamId: "stream-one",
+        clientRequestId: "request-one",
+        requestFingerprint: "fingerprint-one",
+        staleStreamId: null,
+        userMessage: {
+          id: "user-message",
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      }),
+    ).toBe("committed");
+
+    await expect(chatDb.listActiveChatIds("user")).resolves.toEqual(["chat"]);
+
+    expect(
+      chatTurns.completeChatStream({
+        chatId: "chat",
+        streamId: "stream-one",
+        status: "error",
+        error: "Generation failed",
+      }),
+    ).toBe(true);
+    await expect(chatDb.listActiveChatIds("user")).resolves.toEqual([]);
+  });
+
   it("returns the original generation for an exact duplicate submission", () => {
     expect(
       chatTurns.commitChatTurn({

--- a/apps/web/lib/db/chats.ts
+++ b/apps/web/lib/db/chats.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { UIMessage } from "ai";
 import { db } from "@/lib/db/client";
-import { chats, messages } from "@/lib/db/schema";
+import { chatGenerations, chats, messages } from "@/lib/db/schema";
 import {
   CHAT_MESSAGE_PAGE_SIZE,
   type ChatMessagePage,
@@ -87,6 +87,21 @@ export async function listChats(
     .where(eq(chats.userId, userId))
     .orderBy(desc(chats.updatedAt))
     .limit(limit);
+}
+
+export async function listActiveChatIds(userId: string): Promise<string[]> {
+  const rows = await db
+    .select({ id: chats.id })
+    .from(chats)
+    .innerJoin(chatGenerations, eq(chats.activeStreamId, chatGenerations.id))
+    .where(
+      and(
+        eq(chats.userId, userId),
+        eq(chatGenerations.userId, userId),
+        eq(chatGenerations.status, "running"),
+      ),
+    );
+  return rows.map(({ id }) => id);
 }
 
 export async function listChatsByProject(

--- a/apps/web/lib/queries/chats.test.ts
+++ b/apps/web/lib/queries/chats.test.ts
@@ -1,0 +1,31 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_CHATS_POLL_MS,
+  activeChatsRefetchInterval,
+  setActiveChatInCache,
+} from "./chats";
+import { chatKeys } from "./keys";
+
+describe("active chat query state", () => {
+  it("polls only while at least one chat is active", () => {
+    expect(activeChatsRefetchInterval(undefined)).toBe(false);
+    expect(activeChatsRefetchInterval([])).toBe(false);
+    expect(activeChatsRefetchInterval(["chat"])).toBe(ACTIVE_CHATS_POLL_MS);
+  });
+
+  it("optimistically adds, deduplicates, and removes chat IDs", () => {
+    const queryClient = new QueryClient();
+
+    setActiveChatInCache(queryClient, "chat-a", true);
+    setActiveChatInCache(queryClient, "chat-a", true);
+    setActiveChatInCache(queryClient, "chat-b", true);
+    expect(queryClient.getQueryData(chatKeys.active())).toEqual([
+      "chat-a",
+      "chat-b",
+    ]);
+
+    setActiveChatInCache(queryClient, "chat-a", false);
+    expect(queryClient.getQueryData(chatKeys.active())).toEqual(["chat-b"]);
+  });
+});

--- a/apps/web/lib/queries/chats.ts
+++ b/apps/web/lib/queries/chats.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type QueryClient,
   useMutation,
   useQuery,
   useQueryClient,
@@ -19,6 +20,12 @@ export type ChatListItem = {
   updatedAt: number;
 };
 
+export type ActiveChatIdsResponse = {
+  activeChatIds: string[];
+};
+
+export const ACTIVE_CHATS_POLL_MS = 2_000;
+
 async function fetchChats(): Promise<ChatListItem[]> {
   const r = await fetch("/api/chats");
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -30,6 +37,45 @@ export function useChats() {
   return useQuery({
     queryKey: chatKeys.list(),
     queryFn: fetchChats,
+  });
+}
+
+async function fetchActiveChatIds(): Promise<string[]> {
+  const response = await fetch("/api/chats/active", { cache: "no-store" });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const body = (await response.json()) as ActiveChatIdsResponse;
+  return body.activeChatIds;
+}
+
+export function activeChatsRefetchInterval(
+  activeChatIds: string[] | undefined,
+): number | false {
+  return activeChatIds && activeChatIds.length > 0
+    ? ACTIVE_CHATS_POLL_MS
+    : false;
+}
+
+export function useActiveChatIds() {
+  return useQuery({
+    queryKey: chatKeys.active(),
+    queryFn: fetchActiveChatIds,
+    staleTime: 1_000,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
+    refetchInterval: (query) => activeChatsRefetchInterval(query.state.data),
+    retry: false,
+  });
+}
+
+export function setActiveChatInCache(
+  queryClient: QueryClient,
+  chatId: string,
+  active: boolean,
+) {
+  queryClient.setQueryData<string[]>(chatKeys.active(), (current = []) => {
+    const containsChat = current.includes(chatId);
+    if (active) return containsChat ? current : [...current, chatId];
+    return containsChat ? current.filter((id) => id !== chatId) : current;
   });
 }
 

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -1,6 +1,7 @@
 export const chatKeys = {
   all: () => ["chats"] as const,
   list: () => [...chatKeys.all(), "list"] as const,
+  active: () => [...chatKeys.all(), "active"] as const,
   detail: (id: string) => [...chatKeys.all(), "detail", id] as const,
   usage: (id: string) => [...chatKeys.detail(id), "usage"] as const,
 };


### PR DESCRIPTION
## Summary

- expose authenticated, user-scoped active chat IDs from the existing durable generation state
- hydrate and track active generations through React Query, including optimistic start/settle updates and polling while work is active
- show an accessible, reduced-motion-safe spinner in the fixed trailing action slot for recent and project chat rows
- reveal the three-dot chat menu in that same slot on hover or keyboard focus without shifting the title
- verify that the indicator remains visible after navigating away and clears when generation finishes

## Context

Normal persisted chats did not expose generation activity in the sidebar. Coding-agent sessions already had a runtime indicator.

This follows the same general model as LibreChat active-job polling. Open WebUI distributes equivalent state through socket events; a focused active-state query fits OvertChat without introducing a new global realtime channel.

## Database

No migration is required. This reuses `chats.active_stream_id` and `chat_generations.status`.

## Testing

- `npm run test -w @overtchat/web --` — 121 files, 751 tests passed
- `npm run typecheck -w @overtchat/web --`
- scoped ESLint for all touched files
- isolated Playwright sidebar-generation scenario passed, including the spinner-to-actions hover transition