### PR TITLE
Move agent session launch controls into the composer

### DIFF
--- a/apps/web/app/(app)/agents/new/loading.tsx
+++ b/apps/web/app/(app)/agents/new/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../[id]/loading";

--- a/apps/web/app/(app)/agents/new/page.tsx
+++ b/apps/web/app/(app)/agents/new/page.tsx
@@ -1,0 +1,37 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { isAgentProviderId } from "@overtchat/agent-bridge";
+import { NewAgentSessionView } from "@/components/agents/NewAgentSessionView";
+import { auth } from "@/lib/auth/server";
+import { getOwnedAgentWorkspace } from "@/lib/db/agentConnections";
+
+export default async function NewAgentSessionPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    workspaceId?: string | string[];
+    provider?: string | string[];
+  }>;
+}) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+  if (session.user.role !== "admin") redirect("/");
+
+  const query = await searchParams;
+  const workspaceId =
+    typeof query.workspaceId === "string" ? query.workspaceId : "";
+  const provider = typeof query.provider === "string" ? query.provider : "";
+  if (!workspaceId || !isAgentProviderId(provider)) redirect("/");
+
+  const owned = await getOwnedAgentWorkspace(workspaceId, session.user.id);
+  if (!owned) redirect("/");
+
+  return (
+    <NewAgentSessionView
+      provider={provider}
+      workspaceId={owned.workspace.id}
+      workspaceName={owned.workspace.name}
+      workspacePath={owned.workspace.path}
+    />
+  );
+}

--- a/apps/web/components/SidebarAgentWorkspaces.tsx
+++ b/apps/web/components/SidebarAgentWorkspaces.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import {
   ChevronDown,
@@ -36,6 +36,7 @@ import {
 import { useSidebar } from "@/components/sidebar-context";
 import { motionClasses } from "@/lib/motion";
 import { AGENT_PROVIDER_VISUALS } from "@/lib/agents/providerVisuals";
+import { newAgentSessionHref } from "@/lib/agents/sessionDraft";
 import { useAgentProviderSnapshot } from "@/lib/queries/agentConnections";
 import { useAgentWorkspaceGitStatus } from "@/lib/queries/agentWorkspaces";
 import { cn } from "@/lib/utils";
@@ -71,6 +72,8 @@ function WorkspaceNode({
   providerFilter: AgentProviderId | null;
 }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const { closeMobile } = useSidebar();
   const [createOpen, setCreateOpen] = useState(false);
   const hasActiveSession = group.sessions.some(
     ({ session }) => pathname === `/agents/${session.id}`,
@@ -118,6 +121,17 @@ function WorkspaceNode({
     };
   });
 
+  function startNewSession() {
+    const target = sessionTargets[0];
+    if (sessionTargets.length !== 1 || !target) {
+      setCreateOpen(true);
+      return;
+    }
+    setOpen(true);
+    closeMobile();
+    router.push(newAgentSessionHref(target.workspace.id, target.provider));
+  }
+
   return (
     <li>
       <div className="group flex min-w-0 rounded-md motion-colors hover:bg-sidebar-accent">
@@ -160,7 +174,7 @@ function WorkspaceNode({
         </button>
         <button
           type="button"
-          onClick={() => setCreateOpen(true)}
+          onClick={startNewSession}
           disabled={sessionTargets.length === 0}
           aria-label={`New session in ${group.name}`}
           title={
@@ -209,7 +223,7 @@ function WorkspaceNode({
             )}
         </ul>
       )}
-      {sessionTargets.length > 0 && (
+      {sessionTargets.length > 1 && (
         <NewAgentSessionDialog
           open={createOpen}
           onOpenChange={(next) => {

--- a/apps/web/components/agents/AgentComposerControls.tsx
+++ b/apps/web/components/agents/AgentComposerControls.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronRight,
   ListTodo,
+  Loader2,
   ShieldAlert,
   ShieldCheck,
   X,
@@ -25,6 +26,7 @@ import type {
 } from "@overtchat/agent-bridge";
 import { motionClasses } from "@/lib/motion";
 import { modelIconForModel } from "@/lib/providers/catalog";
+import { AGENT_MODEL_DEFAULTS_LOADING_MESSAGE } from "@/lib/agents/sessionDraft";
 import { cn } from "@/lib/utils";
 
 export interface AgentComposerControlsProps {
@@ -40,6 +42,7 @@ export interface AgentComposerControlsProps {
   modeId: string;
   modes: AgentMode[];
   disabled: boolean;
+  modelLoading?: boolean;
   onSelectModel: (model: AgentModel) => void;
   onSelectThinking: (level: string) => void;
   onSelectCollaborationMode: (mode: AgentCollaborationMode) => void;
@@ -56,6 +59,7 @@ const choiceItemClassName =
 
 export function AgentComposerControls(props: AgentComposerControlsProps) {
   const hasModelOrEffort =
+    props.modelLoading === true ||
     props.models.length > 0 ||
     (props.thinkingOptions.length > 1 && props.thinkingLevel !== null);
   const hasControls =
@@ -203,7 +207,7 @@ function ModeControl(props: AgentComposerControlsProps) {
               Enable Full access?
             </AlertDialog.Title>
             <AlertDialog.Description className="mt-2 text-sm text-muted-foreground">
-              Codex will be able to run commands and modify files without
+              {props.providerLabel} will be able to run commands and modify files without
               sandbox restrictions or approval prompts.
             </AlertDialog.Description>
             <div className="mt-5 flex justify-end gap-2">
@@ -250,6 +254,28 @@ function ModelEffortControl(props: AgentComposerControlsProps) {
     : `Model: ${modelLabel}`;
   const showEffort =
     props.thinkingOptions.length > 1 && props.thinkingLevel !== null;
+
+  if (props.modelLoading && props.models.length === 0) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="min-w-0 max-w-48 gap-1.5 px-2"
+        disabled
+        aria-label={AGENT_MODEL_DEFAULTS_LOADING_MESSAGE}
+        data-testid="agent-model-effort-trigger"
+      >
+        <Loader2
+          className={cn(
+            "size-4 text-muted-foreground",
+            motionClasses.spinner,
+          )}
+        />
+        <span className="truncate">Loading model…</span>
+      </Button>
+    );
+  }
 
   return (
     <Menu.Root

--- a/apps/web/components/agents/AgentSessionView.tsx
+++ b/apps/web/components/agents/AgentSessionView.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/lib/queries/agentSessions";
 import { commandForAgentSessionSubmit } from "@/lib/agents/sessionCommands";
 import { latestAgentTaskList } from "@/lib/agents/presentation";
+import { agentSessionDraftRestoreKey } from "@/lib/agents/sessionDraft";
 import {
   AGENT_CREATE_PREFERENCES_KEY,
   DEFAULT_AGENT_CREATE_PREFERENCES,
@@ -166,10 +167,6 @@ function currentGoal(snapshot: AgentRuntimeSnapshot): AgentGoal | null {
     createdAt: typeof goal.createdAt === "number" ? goal.createdAt : 0,
     updatedAt: typeof goal.updatedAt === "number" ? goal.updatedAt : 0,
   };
-}
-
-function forkDraftKey(sessionId: string): string {
-  return `overtchat:agent-fork-draft:${sessionId}`;
 }
 
 function workspaceFileSelection(value: unknown): AgentWorkspaceFileSelection | null {
@@ -447,7 +444,7 @@ export function AgentSessionView({
             return true;
           }
           window.sessionStorage.setItem(
-            forkDraftKey(result.sessionId),
+            agentSessionDraftRestoreKey(result.sessionId),
             draft,
           );
         }
@@ -799,7 +796,7 @@ export function AgentSessionView({
                 onSteerQueued={(id) =>
                   run({ type: "steer_queued_message", id })
                 }
-                restoreDraftKey={forkDraftKey(sessionId)}
+                restoreDraftKey={agentSessionDraftRestoreKey(sessionId)}
                 restoredDraft={restoredDraft}
               />
             </div>

--- a/apps/web/components/agents/NewAgentSessionDialog.tsx
+++ b/apps/web/components/agents/NewAgentSessionDialog.tsx
@@ -1,55 +1,23 @@
 "use client";
 
 import Image from "next/image";
-import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Dialog } from "@base-ui/react/dialog";
-import { Check, Loader2 } from "lucide-react";
 import type {
-  AgentModel,
   AgentProviderId,
-  AgentSessionLaunchConfig,
   AgentWorkspaceListItem,
 } from "@overtchat/agent-bridge";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { toast } from "@/components/ui/toast";
 import { useSidebar } from "@/components/sidebar-context";
-import { motionClasses } from "@/lib/motion";
 import { AGENT_PROVIDER_VISUALS } from "@/lib/agents/providerVisuals";
-import {
-  AGENT_CREATE_PREFERENCES_KEY,
-  DEFAULT_AGENT_CREATE_PREFERENCES,
-  mergeAgentProviderPreferences,
-  parseAgentCreatePreferences,
-} from "@/lib/agents/createPreferences";
-import {
-  useAgentWorkspaceCatalog,
-  useCreateAgentSession,
-} from "@/lib/queries/agentConnections";
-import { useLocalStorage } from "@/lib/useLocalStorage";
+import { newAgentSessionHref } from "@/lib/agents/sessionDraft";
+import { motionClasses } from "@/lib/motion";
 import { cn } from "@/lib/utils";
-import { useRouter } from "next/navigation";
 
-function defaultModel(models: AgentModel[]): AgentModel | null {
-  return models.find((model) => model.isDefault) ?? models[0] ?? null;
-}
-
-function defaultThinking(model: AgentModel | null): string {
-  if (!model) return "";
-  return (
-    model.defaultThinkingOptionId ??
-    model.thinkingOptions?.find((option) => option.isDefault)?.id ??
-    model.thinkingOptions?.[0]?.id ??
-    ""
-  );
-}
+export type NewAgentSessionTarget = {
+  workspace: AgentWorkspaceListItem;
+  provider: AgentProviderId;
+  providerLabel: string;
+};
 
 export function NewAgentSessionDialog({
   open,
@@ -59,178 +27,27 @@ export function NewAgentSessionDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  targets: Array<{
-    workspace: AgentWorkspaceListItem;
-    provider: AgentProviderId;
-    providerLabel: string;
-  }>;
+  targets: NewAgentSessionTarget[];
   machineLabel: string;
 }) {
   const router = useRouter();
   const { closeMobile } = useSidebar();
-  const [selectedProvider, setSelectedProvider] = useState<AgentProviderId | "">(
-    "",
-  );
-  const selectedTarget =
-    targets.length === 1
-      ? targets[0]
-      : targets.find((target) => target.provider === selectedProvider);
-  const workspace = selectedTarget?.workspace ?? targets[0]!.workspace;
-  const provider = selectedTarget?.provider;
-  const providerLabel = selectedTarget?.providerLabel;
-  const catalog = useAgentWorkspaceCatalog(
-    selectedTarget?.workspace.id ?? null,
-    selectedTarget?.provider ?? null,
-    open && selectedTarget !== undefined,
-  );
-  const createSession = useCreateAgentSession();
-  const [storedPreferences, setPreferences] = useLocalStorage<unknown>(
-    AGENT_CREATE_PREFERENCES_KEY,
-    DEFAULT_AGENT_CREATE_PREFERENCES,
-  );
-  const preferences = useMemo(
-    () => parseAgentCreatePreferences(storedPreferences),
-    [storedPreferences],
-  );
-  const [modelId, setModelId] = useState("");
-  const [thinkingOptionId, setThinkingOptionId] = useState("");
-  const [modeId, setModeId] = useState("");
-  const providerPreferences = provider
-    ? preferences.providerPreferences?.[provider]
-    : undefined;
-  const selectedModel = useMemo(
-    () => {
-      const models = catalog.data?.models ?? [];
-      return (
-        models.find((model) => model.id === modelId) ??
-        models.find((model) => model.id === providerPreferences?.model) ??
-        defaultModel(models)
-      );
-    },
-    [catalog.data?.models, modelId, providerPreferences?.model],
-  );
-  const effectiveModelId = selectedModel?.id ?? "";
-  const preferredThinking = selectedModel?.thinkingOptions?.find(
-    (option) =>
-      option.id === providerPreferences?.thinkingByModel?.[selectedModel.id],
-  )?.id;
-  const effectiveThinkingOptionId =
-    selectedModel?.thinkingOptions?.some(
-      (option) => option.id === thinkingOptionId,
-    )
-      ? thinkingOptionId
-      : (preferredThinking ?? defaultThinking(selectedModel));
-  const preferredMode = catalog.data?.modes.find(
-    (mode) => mode.id === providerPreferences?.mode,
-  )?.id;
-  const effectiveModeId =
-    (catalog.data?.modes.some((mode) => mode.id === modeId) ? modeId : "") ||
-    preferredMode ||
-    catalog.data?.defaultModeId ||
-    catalog.data?.modes[0]?.id ||
-    "";
+  const workspace = targets[0]!.workspace;
 
-  function updateProviderPreferences(
-    update: Parameters<typeof mergeAgentProviderPreferences>[0]["updates"],
-  ) {
-    if (!provider) return;
-    setPreferences(
-      mergeAgentProviderPreferences({ preferences, provider, updates: update }),
-    );
-  }
-
-  function selectModel(nextModelId: string | null) {
-    if (!nextModelId || !catalog.data) return;
-    const model = catalog.data.models.find((candidate) => candidate.id === nextModelId);
-    if (!model) return;
-    const remembered = providerPreferences?.thinkingByModel?.[model.id];
-    const thinking =
-      model.thinkingOptions?.some((option) => option.id === remembered)
-        ? remembered!
-        : defaultThinking(model);
-    setModelId(model.id);
-    setThinkingOptionId(thinking);
-    updateProviderPreferences({ model: model.id });
-  }
-
-  async function submit(event: React.FormEvent) {
-    event.preventDefault();
-    if (!selectedTarget || !provider || !effectiveModelId) return;
-    const launchConfig: AgentSessionLaunchConfig = {
-      model: effectiveModelId,
-      ...(effectiveThinkingOptionId
-        ? { thinkingOptionId: effectiveThinkingOptionId }
-        : {}),
-      ...(effectiveModeId ? { modeId: effectiveModeId } : {}),
-    };
-    setPreferences(
-      mergeAgentProviderPreferences({
-        preferences,
-        provider,
-        updates: {
-          model: effectiveModelId,
-          ...(effectiveModeId ? { mode: effectiveModeId } : {}),
-          ...(effectiveThinkingOptionId
-            ? {
-                thinkingByModel: {
-                  [effectiveModelId]: effectiveThinkingOptionId,
-                },
-              }
-            : {}),
-        },
-      }),
-    );
-    try {
-      const id = await createSession.mutateAsync({
-        workspaceId: selectedTarget.workspace.id,
-        provider,
-        launchConfig,
-      });
-      closeDialog();
-      closeMobile();
-      router.push(`/agents/${id}`);
-    } catch (cause) {
-      toast.error({
-        title: `Failed to start ${providerLabel ?? "agent"}`,
-        description:
-          cause instanceof Error
-            ? cause.message
-            : "A new session could not be started.",
-      });
-    }
-  }
-
-  const loading = catalog.isFetching && !catalog.data;
-  const error = catalog.error instanceof Error ? catalog.error.message : null;
-
-  function selectAgent(nextProvider: AgentProviderId) {
-    setSelectedProvider(nextProvider);
-    setModelId("");
-    setThinkingOptionId("");
-    setModeId("");
-  }
-
-  function closeDialog() {
-    setSelectedProvider("");
-    setModelId("");
-    setThinkingOptionId("");
-    setModeId("");
-    createSession.reset();
+  function selectAgent(target: NewAgentSessionTarget) {
     onOpenChange(false);
+    closeMobile();
+    router.push(newAgentSessionHref(target.workspace.id, target.provider));
   }
 
   return (
-    <Dialog.Root
-      open={open}
-      onOpenChange={(next) => {
-        if (createSession.isPending) return;
-        if (next) onOpenChange(true);
-        else closeDialog();
-      }}
-    >
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Backdrop
-          className={cn("fixed inset-0 z-40 bg-black/40", motionClasses.overlay)}
+          className={cn(
+            "fixed inset-0 z-40 bg-black/40",
+            motionClasses.overlay,
+          )}
         />
         <Dialog.Popup
           className={cn(
@@ -239,192 +56,47 @@ export function NewAgentSessionDialog({
           )}
         >
           <Dialog.Title className="text-lg font-semibold tracking-tight">
-            New session in {workspace.name}
+            Choose an agent
           </Dialog.Title>
           <Dialog.Description className="mt-1 text-sm text-muted-foreground">
-            <span className="font-mono">{workspace.path}</span>
+            New session in{" "}
+            <span className="font-medium text-foreground">
+              {workspace.name}
+            </span>
             <span aria-hidden="true"> · </span>
             {machineLabel}
           </Dialog.Description>
 
-          <form onSubmit={submit} className="mt-5 space-y-4">
-            <div className="space-y-2">
-              <Label>{targets.length > 1 ? "Choose an agent" : "Agent"}</Label>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {targets.map((target) => {
-                  const selected = target.provider === selectedTarget?.provider;
-                  const icon = AGENT_PROVIDER_VISUALS[target.provider];
-                  return (
-                    <button
-                      key={target.provider}
-                      type="button"
-                      aria-pressed={selected}
-                      aria-label={`Select ${target.providerLabel}`}
-                      onClick={() => selectAgent(target.provider)}
-                      className={cn(
-                        "flex min-h-16 items-center gap-3 rounded-lg border p-3 text-left outline-none motion-colors hover:bg-muted/30 focus-visible:ring-3 focus-visible:ring-ring/50",
-                        selected && "border-primary bg-primary/5 ring-1 ring-primary",
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "flex size-9 shrink-0 items-center justify-center rounded-md border bg-background",
-                          icon.darkSurface && "bg-zinc-950",
-                        )}
-                      >
-                        <Image
-                          src={icon.icon}
-                          alt=""
-                          className="size-5 object-contain"
-                        />
-                      </span>
-                      <span className="min-w-0 flex-1 text-sm font-medium">
-                        {target.providerLabel}
-                      </span>
-                      {selected && <Check className="size-4 shrink-0" />}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            {!selectedTarget ? (
-              <p className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
-                Choose an agent to configure this session.
-              </p>
-            ) : loading ? (
-              <div className="flex min-h-40 items-center justify-center rounded-lg border">
-                <Loader2
-                  className={cn(
-                    "size-5 text-muted-foreground",
-                    motionClasses.spinner,
-                  )}
-                />
-              </div>
-            ) : error ? (
-              <div className="space-y-4 rounded-lg border p-4">
-                <p className="text-sm text-destructive">{error}</p>
-                <Button
+          <div className="mt-5 grid gap-2 sm:grid-cols-2">
+            {targets.map((target) => {
+              const icon = AGENT_PROVIDER_VISUALS[target.provider];
+              return (
+                <button
+                  key={target.provider}
                   type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void catalog.refetch()}
+                  aria-label={`Start ${target.providerLabel} session`}
+                  onClick={() => selectAgent(target)}
+                  className="flex min-h-16 items-center gap-3 rounded-lg border p-3 text-left outline-none motion-colors hover:border-primary/50 hover:bg-muted/30 focus-visible:ring-3 focus-visible:ring-ring/50"
                 >
-                  Try again
-                </Button>
-              </div>
-            ) : (
-              <div className="space-y-4 border-t pt-4">
-              <div className="space-y-1.5">
-                <Label htmlFor={`agent-model-${workspace.id}`}>Model</Label>
-                <Select value={effectiveModelId} onValueChange={selectModel}>
-                  <SelectTrigger id={`agent-model-${workspace.id}`} className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {catalog.data?.models.map((model) => (
-                      <SelectItem key={model.id} value={model.id}>
-                        <span className="min-w-0">
-                          <span className="block truncate">{model.label}</span>
-                          {model.description && (
-                            <span className="block truncate text-xs text-muted-foreground">
-                              {model.description}
-                            </span>
-                          )}
-                        </span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {(selectedModel?.thinkingOptions?.length ?? 0) > 0 && (
-                <div className="space-y-1.5">
-                  <Label htmlFor={`agent-thinking-${workspace.id}`}>Reasoning</Label>
-                  <Select
-                    value={effectiveThinkingOptionId}
-                    onValueChange={(value) => {
-                      if (!value || !selectedModel) return;
-                      setThinkingOptionId(value);
-                      updateProviderPreferences({
-                        thinkingByModel: {
-                          ...providerPreferences?.thinkingByModel,
-                          [selectedModel.id]: value,
-                        },
-                      });
-                    }}
+                  <span
+                    className={cn(
+                      "flex size-9 shrink-0 items-center justify-center rounded-md border bg-background",
+                      icon.darkSurface && "bg-zinc-950",
+                    )}
                   >
-                    <SelectTrigger id={`agent-thinking-${workspace.id}`} className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {selectedModel?.thinkingOptions?.map((option) => (
-                        <SelectItem key={option.id} value={option.id}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
-
-              {(catalog.data?.modes.length ?? 0) > 0 && (
-                <div className="space-y-1.5">
-                  <Label htmlFor={`agent-mode-${workspace.id}`}>Permissions</Label>
-                  <Select
-                    value={effectiveModeId}
-                    onValueChange={(value) => {
-                      if (!value) return;
-                      setModeId(value);
-                      updateProviderPreferences({ mode: value });
-                    }}
-                  >
-                    <SelectTrigger id={`agent-mode-${workspace.id}`} className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {catalog.data?.modes.map((mode) => (
-                        <SelectItem key={mode.id} value={mode.id}>
-                          <span className="min-w-0">
-                            <span className="block truncate">{mode.label}</span>
-                            {mode.description && (
-                              <span className="block truncate text-xs text-muted-foreground">
-                                {mode.description}
-                              </span>
-                            )}
-                          </span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
-              </div>
-            )}
-
-            <div className="flex items-center justify-end gap-2 border-t pt-4">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                disabled={createSession.isPending}
-                onClick={closeDialog}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                size="sm"
-                disabled={
-                  !selectedTarget ||
-                  !effectiveModelId ||
-                  createSession.isPending
-                }
-              >
-                {createSession.isPending ? "Starting…" : "Start session"}
-              </Button>
-            </div>
-          </form>
+                    <Image
+                      src={icon.icon}
+                      alt=""
+                      className="size-5 object-contain"
+                    />
+                  </span>
+                  <span className="min-w-0 flex-1 text-sm font-medium">
+                    {target.providerLabel}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </Dialog.Popup>
       </Dialog.Portal>
     </Dialog.Root>

--- a/apps/web/components/agents/NewAgentSessionView.tsx
+++ b/apps/web/components/agents/NewAgentSessionView.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import type {
+  AgentPromptImage,
+  AgentProviderId,
+  AgentSessionLaunchConfig,
+} from "@overtchat/agent-bridge";
+import { agentProviderMetadata } from "@overtchat/agent-bridge";
+import { SidebarToggle } from "@/components/SidebarToggle";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+import {
+  AGENT_CREATE_PREFERENCES_KEY,
+  DEFAULT_AGENT_CREATE_PREFERENCES,
+  mergeAgentProviderPreferences,
+  parseAgentCreatePreferences,
+} from "@/lib/agents/createPreferences";
+import {
+  AGENT_MODEL_DEFAULTS_LOADING_MESSAGE,
+  agentSessionDraftRestoreKey,
+  resolveAgentSessionDraftSelection,
+} from "@/lib/agents/sessionDraft";
+import { AGENT_PROVIDER_VISUALS } from "@/lib/agents/providerVisuals";
+import {
+  useAgentWorkspaceCatalog,
+  useCreateAgentSession,
+} from "@/lib/queries/agentConnections";
+import { sendAgentSessionCommand } from "@/lib/queries/agentSessions";
+import { useLocalStorage } from "@/lib/useLocalStorage";
+import { cn } from "@/lib/utils";
+import { AgentComposer } from "./AgentComposer";
+
+export function NewAgentSessionView({
+  provider,
+  workspaceId,
+  workspaceName,
+  workspacePath,
+}: {
+  provider: AgentProviderId;
+  workspaceId: string;
+  workspaceName: string;
+  workspacePath: string;
+}) {
+  const router = useRouter();
+  const providerMetadata = agentProviderMetadata(provider);
+  const providerVisual = AGENT_PROVIDER_VISUALS[provider];
+  const catalog = useAgentWorkspaceCatalog(workspaceId, provider);
+  const createSession = useCreateAgentSession();
+  const [sendingFirstPrompt, setSendingFirstPrompt] = useState(false);
+  const [modelId, setModelId] = useState("");
+  const [thinkingOptionId, setThinkingOptionId] = useState("");
+  const [modeId, setModeId] = useState("");
+  const [storedPreferences, setStoredPreferences] = useLocalStorage<unknown>(
+    AGENT_CREATE_PREFERENCES_KEY,
+    DEFAULT_AGENT_CREATE_PREFERENCES,
+  );
+  const preferences = useMemo(
+    () => parseAgentCreatePreferences(storedPreferences),
+    [storedPreferences],
+  );
+  const providerPreferences = preferences.providerPreferences?.[provider];
+  const selection = useMemo(
+    () =>
+      resolveAgentSessionDraftSelection({
+        provider,
+        catalog: catalog.data,
+        preferences: providerPreferences,
+        modelId,
+        thinkingOptionId,
+        modeId,
+      }),
+    [
+      catalog.data,
+      modeId,
+      modelId,
+      provider,
+      providerPreferences,
+      thinkingOptionId,
+    ],
+  );
+  const selectedModel = selection.model;
+  const loadingDefaults = catalog.isFetching && !catalog.data;
+  const pending = createSession.isPending || sendingFirstPrompt;
+
+  useEffect(() => {
+    document.title = `New ${providerMetadata.label} session · ${workspaceName}`;
+  }, [providerMetadata.label, workspaceName]);
+
+  function updateProviderPreferences(
+    updates: Parameters<typeof mergeAgentProviderPreferences>[0]["updates"],
+  ) {
+    setStoredPreferences(
+      mergeAgentProviderPreferences({ preferences, provider, updates }),
+    );
+  }
+
+  async function submit(
+    message: string,
+    images: AgentPromptImage[],
+  ): Promise<boolean> {
+    if (loadingDefaults) {
+      toast.error({ title: AGENT_MODEL_DEFAULTS_LOADING_MESSAGE });
+      return false;
+    }
+    if (!catalog.data) {
+      toast.error({
+        title: "Model defaults could not be loaded",
+        description:
+          catalog.error instanceof Error
+            ? catalog.error.message
+            : `The ${providerMetadata.label} catalog is unavailable.`,
+      });
+      return false;
+    }
+    if (!selectedModel) {
+      toast.error({ title: "Select a model" });
+      return false;
+    }
+
+    const launchConfig: AgentSessionLaunchConfig = {
+      model: selectedModel.id,
+      ...(selection.thinkingOptionId
+        ? { thinkingOptionId: selection.thinkingOptionId }
+        : {}),
+      ...(selection.modeId ? { modeId: selection.modeId } : {}),
+    };
+    updateProviderPreferences({
+      model: selectedModel.id,
+      ...(selection.modeId ? { mode: selection.modeId } : {}),
+      ...(selection.thinkingOptionId
+        ? {
+            thinkingByModel: {
+              [selectedModel.id]: selection.thinkingOptionId,
+            },
+          }
+        : {}),
+    });
+
+    let sessionId: string;
+    try {
+      sessionId = await createSession.mutateAsync({
+        workspaceId,
+        provider,
+        launchConfig,
+      });
+    } catch (cause) {
+      toast.error({
+        title: `Failed to start ${providerMetadata.label}`,
+        description:
+          cause instanceof Error
+            ? cause.message
+            : "A new session could not be started.",
+      });
+      return false;
+    }
+
+    setSendingFirstPrompt(true);
+    try {
+      await sendAgentSessionCommand(sessionId, {
+        type: "prompt",
+        message,
+        ...(images.length > 0 ? { images } : {}),
+        clientMessageId: crypto.randomUUID(),
+      });
+    } catch (cause) {
+      window.sessionStorage.setItem(
+        agentSessionDraftRestoreKey(sessionId),
+        message,
+      );
+      toast.error({
+        title: `${providerMetadata.label} command failed`,
+        description:
+          cause instanceof Error
+            ? cause.message
+            : "The first message could not be sent.",
+      });
+    } finally {
+      router.replace(`/agents/${sessionId}`);
+    }
+    return true;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <header className="flex h-12 shrink-0 items-center gap-1 border-b px-3">
+        <SidebarToggle />
+        <div
+          aria-label={`${providerMetadata.label} agent`}
+          className="flex shrink-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-xs font-medium"
+        >
+          <span
+            className={cn(
+              "flex size-6 items-center justify-center rounded-md border bg-background",
+              providerVisual.darkSurface && "bg-zinc-950",
+            )}
+            aria-hidden="true"
+          >
+            <Image
+              src={providerVisual.icon}
+              alt=""
+              className="size-4 object-contain"
+            />
+          </span>
+          <span className="hidden sm:inline">{providerMetadata.label}</span>
+        </div>
+        <span className="hidden h-4 w-px bg-border sm:block" aria-hidden="true" />
+        <span
+          className="hidden max-w-40 truncate px-1 font-mono text-xs text-muted-foreground md:block lg:max-w-64 xl:max-w-96"
+          title={workspacePath}
+        >
+          {workspacePath}
+        </span>
+      </header>
+
+      <main className="flex min-h-0 flex-1 flex-col">
+        <div className="flex flex-1 items-center justify-center px-6 text-center">
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">
+              New {providerMetadata.label} session
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {workspaceName}
+            </p>
+          </div>
+        </div>
+
+        <div className="px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
+          <div className="mx-auto max-w-3xl">
+            {catalog.isError && !catalog.data && (
+              <div
+                role="alert"
+                className="mb-3 flex items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm"
+              >
+                <AlertTriangle className="size-4 shrink-0 text-destructive" />
+                <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                  {catalog.error instanceof Error
+                    ? catalog.error.message
+                    : "Model defaults could not be loaded."}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={catalog.isFetching}
+                  onClick={() => void catalog.refetch()}
+                >
+                  <RefreshCw />
+                  Retry
+                </Button>
+              </div>
+            )}
+            <AgentComposer
+              providerLabel={providerMetadata.label}
+              commands={[]}
+              queuedMessages={[]}
+              supportsSteer={false}
+              supportsImages={selectedModel?.input.includes("image") === true}
+              running={false}
+              pending={pending}
+              stopping={false}
+              disabled={false}
+              controls={{
+                providerLabel: providerMetadata.label,
+                models: catalog.data?.models ?? [],
+                currentModel: selectedModel
+                  ? { provider: selectedModel.provider, id: selectedModel.id }
+                  : null,
+                thinkingLevel: selection.thinkingOptionId || null,
+                thinkingOptions: selectedModel?.thinkingOptions ?? [],
+                collaborationMode: "default",
+                collaborationModes: [],
+                fastModeEnabled: false,
+                fastModeAvailable: false,
+                modeId: selection.modeId,
+                modes: selection.modes,
+                disabled: pending,
+                modelLoading: loadingDefaults,
+                onSelectModel: (model) => {
+                  setModelId(model.id);
+                  setThinkingOptionId("");
+                  updateProviderPreferences({ model: model.id });
+                },
+                onSelectThinking: (level) => {
+                  if (!selectedModel) return;
+                  setThinkingOptionId(level);
+                  updateProviderPreferences({
+                    model: selectedModel.id,
+                    thinkingByModel: { [selectedModel.id]: level },
+                  });
+                },
+                onSelectCollaborationMode: () => undefined,
+                onToggleFastMode: () => undefined,
+                onSelectMode: (selectedModeId) => {
+                  setModeId(selectedModeId);
+                  updateProviderPreferences({ mode: selectedModeId });
+                },
+              }}
+              onSubmit={submit}
+              onStop={() => undefined}
+              onEditQueued={async () => false}
+              onDeleteQueued={async () => false}
+              onSteerQueued={async () => false}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/e2e/connections.spec.ts
+++ b/apps/web/e2e/connections.spec.ts
@@ -272,6 +272,29 @@ async function enterWorkspacePath(
   await dialog.getByLabel("Directory path").fill(workspace);
 }
 
+async function openAgentDraft(
+  page: import("@playwright/test").Page,
+  providerLabel: string,
+  provider: string,
+): Promise<void> {
+  const isDraftUrl = (url: URL) =>
+    url.pathname === "/agents/new" &&
+    url.searchParams.get("provider") === provider;
+  const startButton = page
+    .getByRole("dialog", { name: "Choose an agent" })
+    .getByRole("button", { name: `Start ${providerLabel} session` });
+
+  const outcome = await Promise.race([
+    startButton.waitFor({ state: "visible" }).then(() => "choose" as const),
+    page.waitForURL(isDraftUrl).then(() => "navigated" as const),
+  ]);
+
+  if (outcome === "choose") {
+    await startButton.click();
+    await page.waitForURL(isDraftUrl);
+  }
+}
+
 test("explains agent access before setup", async ({ page }, testInfo) => {
   await page.goto("/signup");
   await page.locator("#name").fill("Connections E2E Admin");
@@ -437,7 +460,7 @@ test("shows the consolidated Add workspace flow after setup", async ({ page }, t
   ).toBe(true);
 });
 
-test("groups providers by directory, filters chats, refreshes globally, and reveals launch options progressively", async ({
+test("groups providers by directory, filters chats, refreshes globally, and opens inline launch controls", async ({
   page,
 }, testInfo) => {
   test.setTimeout(90_000);
@@ -452,6 +475,21 @@ test("groups providers by directory, filters chats, refreshes globally, and reve
 
   await startHostConnector(page, testInfo);
   const workspaceIds = seedMixedProviderWorkspace();
+  let releaseCatalog: () => void = () => undefined;
+  const catalogGate = new Promise<void>((resolve) => {
+    releaseCatalog = resolve;
+  });
+  let sessionCreateRequests = 0;
+  page.on("request", (request) => {
+    if (
+      request.method() === "POST" &&
+      /\/api\/agent-workspaces\/[^/]+\/sessions$/u.test(
+        new URL(request.url()).pathname,
+      )
+    ) {
+      sessionCreateRequests += 1;
+    }
+  });
   await page.route("**/api/agent-connections/discover", async (route) => {
     const target = route.request().postDataJSON();
     await route.fulfill({
@@ -505,6 +543,7 @@ test("groups providers by directory, filters chats, refreshes globally, and reve
   await page.route(
     /\/api\/agent-workspaces\/[^/]+\/catalog(?:\?.*)?$/u,
     async (route) => {
+      await catalogGate;
       const url = new URL(route.request().url());
       const id = url.pathname.split("/").at(-2);
       const provider =
@@ -623,20 +662,39 @@ test("groups providers by directory, filters chats, refreshes globally, and reve
   await page
     .getByRole("button", { name: `New session in ${workspaceName}` })
     .click();
-  const dialog = page.getByRole("dialog", {
-    name: `New session in ${workspaceName}`,
-  });
-  await expect(dialog.getByText("Choose an agent", { exact: true })).toBeVisible();
-  await expect(dialog.getByLabel("Model")).toHaveCount(0);
+  const dialog = page.getByRole("dialog", { name: "Choose an agent" });
+  await expect(dialog).toBeVisible();
   await expect(dialog.getByText(workspaceIds.codex, { exact: true })).toHaveCount(0);
-  await dialog.getByRole("button", { name: "Select Codex" }).click();
-  await expect(dialog.getByLabel("Model")).toBeVisible();
-  await expect(dialog.getByLabel("Reasoning")).toBeVisible();
-  await expect(dialog.getByLabel("Permissions")).toBeVisible();
-  await expect(dialog.getByRole("button", { name: "Start session" })).toBeEnabled();
+  await dialog
+    .getByRole("button", { name: "Start Codex session" })
+    .click();
+  await page.waitForURL(
+    (url) =>
+      url.pathname === "/agents/new" &&
+      url.searchParams.get("provider") === "codex",
+  );
+  await expect(page.getByRole("heading", { name: "New Codex session" })).toBeVisible();
+  const composer = page.getByTestId("agent-composer");
+  await expect(
+    composer.getByRole("button", {
+      name: "Model defaults are still loading",
+    }),
+  ).toBeVisible();
+  await composer.getByRole("combobox").fill("Do not launch yet");
+  await composer.getByRole("combobox").press("Enter");
+  await expect(
+    page
+      .getByLabel("Notifications")
+      .getByText("Model defaults are still loading", { exact: true }),
+  ).toBeVisible();
+  expect(sessionCreateRequests).toBe(0);
+
+  releaseCatalog();
+  await expect(composer.getByTestId("agent-model-effort-trigger")).toBeVisible();
+  await expect(composer.getByTestId("agent-access-mode-trigger")).toBeVisible();
 
   await page.screenshot({
-    path: testInfo.outputPath("workspace-progressive-launch.png"),
+    path: testInfo.outputPath("workspace-inline-launch.png"),
     fullPage: true,
   });
 });
@@ -817,15 +875,18 @@ test("connect local Pi, attach a workspace, and open a native session", async ({
         exact: true,
       })
       .click();
-    const sessionDialog = page.getByRole("dialog", {
-      name: `New session in ${workspaceName}`,
-    });
-    await sessionDialog.getByRole("button", { name: "Select Pi" }).click();
-    await expect(sessionDialog.getByLabel("Model")).toBeVisible({
+    await openAgentDraft(page, "Pi", "pi");
+    await expect(page.getByRole("heading", { name: "New Pi session" })).toBeVisible();
+    const draftComposer = page.getByTestId("agent-composer");
+    await expect(draftComposer.getByTestId("agent-model-effort-trigger")).toBeVisible({
       timeout: 30_000,
     });
-    await sessionDialog.getByRole("button", { name: "Start session" }).click();
-    await page.waitForURL("**/agents/**", { timeout: 150_000 });
+    await draftComposer.getByRole("combobox").fill("/name Initial Pi Session");
+    await draftComposer.getByRole("combobox").press("Enter");
+    await page.waitForURL(
+      (url) => url.pathname.startsWith("/agents/") && url.pathname !== "/agents/new",
+      { timeout: 150_000 },
+    );
     await expect(page.getByText("New Pi session")).toBeVisible({
       timeout: 150_000,
     });
@@ -987,24 +1048,23 @@ test("connect local Oh My Pi and use its native commands", async ({
       exact: true,
     })
     .click();
-  const sessionDialog = page.getByRole("dialog", {
-    name: `New session in ${workspaceName}`,
-  });
-  await sessionDialog
-    .getByRole("button", { name: "Select Oh My Pi" })
-    .click();
-  await expect(sessionDialog.getByLabel("Model")).toBeVisible({
+  await openAgentDraft(page, "Oh My Pi", "omp");
+  await expect(page.getByRole("heading", { name: "New Oh My Pi session" })).toBeVisible();
+  const draftComposer = page.getByTestId("agent-composer");
+  await expect(draftComposer.getByTestId("agent-model-effort-trigger")).toBeVisible({
     timeout: 30_000,
   });
-  await sessionDialog.getByRole("button", { name: "Start session" }).click();
-  await page.waitForURL("**/agents/**", { timeout: 150_000 });
+  await draftComposer.getByRole("combobox").fill("/model");
+  await draftComposer.getByRole("combobox").press("Enter");
+  await page.waitForURL(
+    (url) => url.pathname.startsWith("/agents/") && url.pathname !== "/agents/new",
+    { timeout: 150_000 },
+  );
   await expect(page.getByText("New Oh My Pi session")).toBeVisible({
     timeout: 150_000,
   });
 
   const composer = page.getByTestId("agent-composer").getByRole("combobox");
-  await composer.fill("/model");
-  await composer.press("Enter");
   await expect(page.getByText(/Current model:/)).toBeVisible({
     timeout: 30_000,
   });
@@ -1068,15 +1128,18 @@ test("connect local Codex and resume a native thread", async ({
       exact: true,
     })
     .click();
-  const sessionDialog = page.getByRole("dialog", {
-    name: `New session in ${workspaceName}`,
-  });
-  await sessionDialog.getByRole("button", { name: "Select Codex" }).click();
-  await expect(sessionDialog.getByLabel("Model")).toBeVisible({
+  await openAgentDraft(page, "Codex", "codex");
+  await expect(page.getByRole("heading", { name: "New Codex session" })).toBeVisible();
+  const draftComposer = page.getByTestId("agent-composer");
+  await expect(draftComposer.getByTestId("agent-model-effort-trigger")).toBeVisible({
     timeout: 30_000,
   });
-  await sessionDialog.getByRole("button", { name: "Start session" }).click();
-  await page.waitForURL("**/agents/**", { timeout: 150_000 });
+  await draftComposer.getByRole("combobox").fill("/name Codex E2E Session");
+  await draftComposer.getByRole("combobox").press("Enter");
+  await page.waitForURL(
+    (url) => url.pathname.startsWith("/agents/") && url.pathname !== "/agents/new",
+    { timeout: 150_000 },
+  );
   await expect(page.getByText("New Codex session")).toBeVisible({
     timeout: 150_000,
   });
@@ -1254,24 +1317,23 @@ test("connect to Oh My Pi through an existing SSH alias", async ({
       exact: true,
     })
     .click();
-  const sessionDialog = page.getByRole("dialog", {
-    name: `New session in ${remoteWorkspaceName}`,
-  });
-  await sessionDialog
-    .getByRole("button", { name: "Select Oh My Pi" })
-    .click();
-  await expect(sessionDialog.getByLabel("Model")).toBeVisible({
+  await openAgentDraft(page, "Oh My Pi", "omp");
+  await expect(page.getByRole("heading", { name: "New Oh My Pi session" })).toBeVisible();
+  const draftComposer = page.getByTestId("agent-composer");
+  await expect(draftComposer.getByTestId("agent-model-effort-trigger")).toBeVisible({
     timeout: 30_000,
   });
-  await sessionDialog.getByRole("button", { name: "Start session" }).click();
-  await page.waitForURL("**/agents/**", { timeout: 150_000 });
+  await draftComposer.getByRole("combobox").fill("/model");
+  await draftComposer.getByRole("combobox").press("Enter");
+  await page.waitForURL(
+    (url) => url.pathname.startsWith("/agents/") && url.pathname !== "/agents/new",
+    { timeout: 150_000 },
+  );
   await expect(page.getByText("New Oh My Pi session")).toBeVisible({
     timeout: 150_000,
   });
 
   const composer = page.getByTestId("agent-composer").getByRole("combobox");
-  await composer.fill("/model");
-  await composer.press("Enter");
   await expect(page.getByText(/Current model:/)).toBeVisible({
     timeout: 30_000,
   });

--- a/apps/web/lib/agents/sessionDraft.test.ts
+++ b/apps/web/lib/agents/sessionDraft.test.ts
@@ -1,0 +1,117 @@
+import type { AgentProviderCatalog } from "@overtchat/agent-bridge";
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_MODEL_DEFAULTS_LOADING_MESSAGE,
+  agentSessionDraftRestoreKey,
+  newAgentSessionHref,
+  resolveAgentSessionDraftSelection,
+} from "./sessionDraft";
+
+const catalog: AgentProviderCatalog = {
+  provider: "codex",
+  models: [
+    {
+      provider: "codex",
+      id: "first",
+      label: "First",
+      api: "openai-responses",
+      baseUrl: "",
+      reasoning: true,
+      input: ["text"],
+      contextWindow: null,
+      maxTokens: null,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      thinkingOptions: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", isDefault: true },
+      ],
+    },
+    {
+      provider: "codex",
+      id: "default",
+      label: "Default",
+      isDefault: true,
+      api: "openai-responses",
+      baseUrl: "",
+      reasoning: false,
+      input: ["text"],
+      contextWindow: null,
+      maxTokens: null,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+  ],
+  modes: [
+    { id: "auto", label: "Auto", description: "Ask when needed" },
+    { id: "full", label: "Full", description: "No prompts", dangerous: true },
+  ],
+  defaultModeId: "auto",
+};
+
+describe("agent session draft", () => {
+  it("uses the visible submission gate copy", () => {
+    expect(AGENT_MODEL_DEFAULTS_LOADING_MESSAGE).toBe(
+      "Model defaults are still loading",
+    );
+  });
+
+  it("builds an encoded draft URL and stable restore key", () => {
+    expect(newAgentSessionHref("workspace / one", "codex")).toBe(
+      "/agents/new?workspaceId=workspace+%2F+one&provider=codex",
+    );
+    expect(agentSessionDraftRestoreKey("session-1")).toBe(
+      "overtchat:agent-fork-draft:session-1",
+    );
+  });
+
+  it("restores valid provider preferences over catalog defaults", () => {
+    const selection = resolveAgentSessionDraftSelection({
+      provider: "codex",
+      catalog,
+      preferences: {
+        model: "first",
+        mode: "full",
+        thinkingByModel: { first: "low" },
+      },
+      modelId: "",
+      thinkingOptionId: "",
+      modeId: "",
+    });
+
+    expect(selection.model?.id).toBe("first");
+    expect(selection.thinkingOptionId).toBe("low");
+    expect(selection.modeId).toBe("full");
+  });
+
+  it("uses catalog defaults when preferences are stale", () => {
+    const selection = resolveAgentSessionDraftSelection({
+      provider: "codex",
+      catalog,
+      preferences: { model: "removed", mode: "removed" },
+      modelId: "",
+      thinkingOptionId: "",
+      modeId: "",
+    });
+
+    expect(selection.model?.id).toBe("default");
+    expect(selection.thinkingOptionId).toBe("");
+    expect(selection.modeId).toBe("auto");
+  });
+
+  it("exposes OMP permissions before its model catalog loads", () => {
+    const selection = resolveAgentSessionDraftSelection({
+      provider: "omp",
+      preferences: { mode: "write" },
+      modelId: "",
+      thinkingOptionId: "",
+      modeId: "",
+    });
+
+    expect(selection.model).toBeNull();
+    expect(selection.modes.map((mode) => mode.id)).toEqual([
+      "full",
+      "write",
+      "ask",
+    ]);
+    expect(selection.modeId).toBe("write");
+  });
+});

--- a/apps/web/lib/agents/sessionDraft.ts
+++ b/apps/web/lib/agents/sessionDraft.ts
@@ -1,0 +1,89 @@
+import {
+  agentProviderCreationDefaults,
+  type AgentMode,
+  type AgentModel,
+  type AgentProviderCatalog,
+  type AgentProviderId,
+} from "@overtchat/agent-bridge";
+import type { AgentProviderPreferences } from "./createPreferences";
+
+export type AgentSessionDraftSelection = {
+  model: AgentModel | null;
+  thinkingOptionId: string;
+  modeId: string;
+  modes: AgentMode[];
+};
+
+export const AGENT_MODEL_DEFAULTS_LOADING_MESSAGE =
+  "Model defaults are still loading";
+
+export function newAgentSessionHref(
+  workspaceId: string,
+  provider: AgentProviderId,
+): string {
+  const query = new URLSearchParams({ workspaceId, provider });
+  return `/agents/new?${query.toString()}`;
+}
+
+export function agentSessionDraftRestoreKey(sessionId: string): string {
+  return `overtchat:agent-fork-draft:${sessionId}`;
+}
+
+function defaultModel(models: AgentModel[]): AgentModel | null {
+  return models.find((model) => model.isDefault) ?? models[0] ?? null;
+}
+
+function defaultThinking(model: AgentModel | null): string {
+  if (!model) return "";
+  return (
+    model.defaultThinkingOptionId ??
+    model.thinkingOptions?.find((option) => option.isDefault)?.id ??
+    model.thinkingOptions?.[0]?.id ??
+    ""
+  );
+}
+
+export function resolveAgentSessionDraftSelection(input: {
+  provider: AgentProviderId;
+  catalog?: AgentProviderCatalog;
+  preferences?: AgentProviderPreferences;
+  modelId: string;
+  thinkingOptionId: string;
+  modeId: string;
+}): AgentSessionDraftSelection {
+  const models = input.catalog?.models ?? [];
+  const model =
+    models.find((candidate) => candidate.id === input.modelId) ??
+    models.find((candidate) => candidate.id === input.preferences?.model) ??
+    defaultModel(models);
+  const rememberedThinking = model?.thinkingOptions?.find(
+    (option) =>
+      option.id === input.preferences?.thinkingByModel?.[model.id],
+  )?.id;
+  const thinkingOptionId =
+    model?.thinkingOptions?.some(
+      (option) => option.id === input.thinkingOptionId,
+    )
+      ? input.thinkingOptionId
+      : (rememberedThinking ?? defaultThinking(model));
+  const creationDefaults = agentProviderCreationDefaults(input.provider);
+  const modes = [...(input.catalog?.modes ?? creationDefaults.modes)];
+  const preferredMode = modes.find(
+    (mode) => mode.id === input.preferences?.mode,
+  )?.id;
+  const catalogDefaultMode = modes.find(
+    (mode) => mode.id === input.catalog?.defaultModeId,
+  )?.id;
+  const staticDefaultMode = modes.find(
+    (mode) => mode.id === creationDefaults.defaultModeId,
+  )?.id;
+  const modeId =
+    modes.find((mode) => mode.id === input.modeId)?.id ??
+    preferredMode ??
+    catalogDefaultMode ??
+    staticDefaultMode ??
+    modes[0]?.id ??
+    "";
+
+  return { model, thinkingOptionId, modeId, modes };
+}

--- a/apps/web/lib/queries/agentSessions.ts
+++ b/apps/web/lib/queries/agentSessions.ts
@@ -49,6 +49,27 @@ async function responseError(response: Response): Promise<Error> {
   );
 }
 
+export type AgentSessionCommandResult = {
+  sessionId?: string;
+  draft?: string;
+  queuedMessages?: AgentQueuedMessage[];
+  usage?: AgentUsageSnapshot;
+  notice?: AgentProviderNotice;
+};
+
+export async function sendAgentSessionCommand(
+  id: string,
+  command: AgentSessionCommand,
+): Promise<AgentSessionCommandResult> {
+  const response = await fetch(`/api/agent-sessions/${id}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(command),
+  });
+  if (!response.ok) throw await responseError(response);
+  return (await response.json()) as AgentSessionCommandResult;
+}
+
 function isRetryableSessionOpenError(error: unknown): boolean {
   if (error instanceof AgentSessionHttpError) {
     return (
@@ -336,13 +357,7 @@ export function useAgentSessionCommand(id: string) {
   return useMutation({
     mutationFn: async (
       command: AgentSessionCommand,
-    ): Promise<{
-      sessionId?: string;
-      draft?: string;
-      queuedMessages?: AgentQueuedMessage[];
-      usage?: AgentUsageSnapshot;
-      notice?: AgentProviderNotice;
-    }> => {
+    ): Promise<AgentSessionCommandResult> => {
       const needsIdentity =
         (command.type === "prompt" ||
           command.type === "queue" ||
@@ -363,15 +378,18 @@ export function useAgentSessionCommand(id: string) {
       const wireCommand = generatedClientMessageId
         ? { ...command, clientMessageId: generatedClientMessageId }
         : command;
-      let response: Response;
       try {
-        response = await fetch(`/api/agent-sessions/${id}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(wireCommand),
-        });
+        const result = await sendAgentSessionCommand(id, wireCommand);
+        if (
+          fingerprint &&
+          retainedIdentity.current?.fingerprint === fingerprint &&
+          retainedIdentity.current.clientMessageId === generatedClientMessageId
+        ) {
+          retainedIdentity.current = null;
+        }
+        return result;
       } catch (cause) {
-        if (generatedClientMessageId) {
+        if (generatedClientMessageId && cause instanceof TypeError) {
           throw new Error(
             "The connection was lost while sending, so the command outcome is unknown. Inspect the session before retrying; an unchanged retry will reuse the same command identity.",
             { cause },
@@ -379,22 +397,6 @@ export function useAgentSessionCommand(id: string) {
         }
         throw cause;
       }
-      if (!response.ok) throw await responseError(response);
-      const result = (await response.json()) as {
-        sessionId?: string;
-        draft?: string;
-        queuedMessages?: AgentQueuedMessage[];
-        usage?: AgentUsageSnapshot;
-        notice?: AgentProviderNotice;
-      };
-      if (
-        fingerprint &&
-        retainedIdentity.current?.fingerprint === fingerprint &&
-        retainedIdentity.current.clientMessageId === generatedClientMessageId
-      ) {
-        retainedIdentity.current = null;
-      }
-      return result;
     },
     onSuccess: (data, command) => {
       if (data.queuedMessages) {

--- a/packages/agent-bridge/src/catalog.test.ts
+++ b/packages/agent-bridge/src/catalog.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { agentProviderCreationDefaults } from "./catalog";
+
+describe("agentProviderCreationDefaults", () => {
+  it("exposes OMP approval modes without runtime discovery", () => {
+    expect(agentProviderCreationDefaults("omp")).toEqual({
+      modes: [
+        expect.objectContaining({ id: "full", dangerous: true }),
+        expect.objectContaining({ id: "write" }),
+        expect.objectContaining({ id: "ask" }),
+      ],
+      defaultModeId: "full",
+    });
+  });
+
+  it("does not invent static modes for dynamically discovered providers", () => {
+    expect(agentProviderCreationDefaults("codex")).toEqual({
+      modes: [],
+      defaultModeId: null,
+    });
+  });
+});

--- a/packages/agent-bridge/src/catalog.ts
+++ b/packages/agent-bridge/src/catalog.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentMode,
   AgentProviderId,
   AgentRuntimeCapabilities,
 } from "./agents";
@@ -9,6 +10,41 @@ export type AgentProviderMetadata = {
   label: string;
   executable: string;
   capabilities: AgentRuntimeCapabilities;
+};
+
+export type AgentProviderCreationDefaults = {
+  modes: readonly AgentMode[];
+  defaultModeId: string | null;
+};
+
+const NO_CREATION_DEFAULTS: AgentProviderCreationDefaults = {
+  modes: [],
+  defaultModeId: null,
+};
+
+const OMP_CREATION_DEFAULTS: AgentProviderCreationDefaults = {
+  modes: [
+    {
+      id: "full",
+      label: "Full Access",
+      description:
+        "Launches OMP with yolo approval mode so tools run without prompts.",
+      dangerous: true,
+    },
+    {
+      id: "write",
+      label: "Write Approval",
+      description:
+        "Launches OMP with write approval mode — reads are free, writes require approval.",
+    },
+    {
+      id: "ask",
+      label: "Always Ask",
+      description:
+        "Launches OMP with always-ask approval mode for write and exec tools.",
+    },
+  ],
+  defaultModeId: "full",
 };
 
 export const AGENT_PROVIDERS: Record<
@@ -66,6 +102,16 @@ export function agentProviderMetadata(
   provider: AgentProviderId,
 ): AgentProviderMetadata {
   return AGENT_PROVIDERS[provider];
+}
+
+/**
+ * Launch settings that are part of a provider's stable CLI contract and can be
+ * rendered before runtime catalog discovery completes.
+ */
+export function agentProviderCreationDefaults(
+  provider: AgentProviderId,
+): AgentProviderCreationDefaults {
+  return provider === "omp" ? OMP_CREATION_DEFAULTS : NO_CREATION_DEFAULTS;
 }
 
 export function isAgentProviderId(value: string): value is AgentProviderId {

--- a/packages/agent-runtime/src/omp/config.ts
+++ b/packages/agent-runtime/src/omp/config.ts
@@ -1,22 +1,10 @@
-import type { AgentMode } from "@overtchat/agent-bridge";
+import {
+  agentProviderCreationDefaults,
+  type AgentMode,
+} from "@overtchat/agent-bridge";
 
 export const OMP_MODES: AgentMode[] = [
-  {
-    id: "full",
-    label: "Full Access",
-    description: "Launches OMP with yolo approval mode so tools run without prompts.",
-    dangerous: true,
-  },
-  {
-    id: "write",
-    label: "Write Approval",
-    description: "Launches OMP with write approval mode — reads are free, writes require approval.",
-  },
-  {
-    id: "ask",
-    label: "Always Ask",
-    description: "Launches OMP with always-ask approval mode for write and exec tools.",
-  },
+  ...agentProviderCreationDefaults("omp").modes,
 ];
 
 export function ompApprovalMode(modeId: string): string {

--- a/packages/agent-runtime/src/providers/omp.test.ts
+++ b/packages/agent-runtime/src/providers/omp.test.ts
@@ -47,6 +47,55 @@ describe("OMP provider adapter", () => {
     );
   });
 
+  it("uses OMP's resolved model and thinking defaults in its catalog", async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    mocks.startOmp.mockReturnValue({
+      getState: vi.fn().mockResolvedValue({
+        model: { provider: "omp", id: "vllm/configured" },
+        thinkingLevel: "high",
+      }),
+      getAvailableModels: vi.fn().mockResolvedValue([
+        {
+          provider: "omp",
+          id: "vllm/first",
+          label: "First",
+          thinkingOptions: [{ id: "low", label: "Low", isDefault: true }],
+        },
+        {
+          provider: "omp",
+          id: "vllm/configured",
+          label: "Configured",
+          defaultThinkingOptionId: "low",
+          thinkingOptions: [
+            { id: "low", label: "Low", isDefault: true },
+            { id: "high", label: "High" },
+          ],
+        },
+      ]),
+      stop,
+    });
+
+    const catalog = await ompProviderAdapter.fetchCatalog(
+      { transport: "local" },
+      { executable: "omp", cwd: "/workspace" },
+    );
+
+    expect(catalog.models[0]).not.toHaveProperty("isDefault");
+    expect(catalog.models[1]).toMatchObject({
+      id: "vllm/configured",
+      isDefault: true,
+      defaultThinkingOptionId: "high",
+      thinkingOptions: [
+        expect.objectContaining({ id: "low" }),
+        expect.objectContaining({ id: "high", isDefault: true }),
+      ],
+    });
+    expect(catalog.models[1]?.thinkingOptions?.[0]).not.toHaveProperty(
+      "isDefault",
+    );
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("waits for OMP's terminal agent end across async continuations", () => {
     const classifier = ompProviderAdapter.createEventClassifier();
 

--- a/packages/agent-runtime/src/providers/omp.ts
+++ b/packages/agent-runtime/src/providers/omp.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentModel,
   AgentProviderCatalog,
   AgentSlashCommand,
 } from "@overtchat/agent-bridge";
@@ -91,6 +92,47 @@ function sessionIdentity(state: Record<string, unknown>): AgentSessionIdentity {
   };
 }
 
+function applyStateDefaults(
+  models: AgentModel[],
+  state: Record<string, unknown>,
+): AgentModel[] {
+  const stateModel = state.model;
+  const defaultModelId =
+    stateModel && typeof stateModel === "object"
+      ? Reflect.get(stateModel, "id")
+      : undefined;
+  if (
+    typeof defaultModelId !== "string" ||
+    !models.some((model) => model.id === defaultModelId)
+  ) {
+    return models;
+  }
+
+  const stateThinkingLevel = state.thinkingLevel;
+  return models.map((model) => {
+    const updated = { ...model };
+    delete updated.isDefault;
+    if (model.id !== defaultModelId) return updated;
+
+    updated.isDefault = true;
+    if (
+      typeof stateThinkingLevel === "string" &&
+      model.thinkingOptions?.some(
+        (option) => option.id === stateThinkingLevel,
+      )
+    ) {
+      updated.defaultThinkingOptionId = stateThinkingLevel;
+      updated.thinkingOptions = model.thinkingOptions.map((option) => {
+        const next = { ...option };
+        delete next.isDefault;
+        if (option.id === stateThinkingLevel) next.isDefault = true;
+        return next;
+      });
+    }
+    return updated;
+  });
+}
+
 async function fetchCatalog(
   target: HostTarget,
   launch: Omit<AgentSessionLaunch, "resume">,
@@ -103,10 +145,11 @@ async function fetchCatalog(
     extraArgs: ["--no-extensions", "--no-skills", "--no-rules"],
   });
   try {
-    await client.getState();
+    const state = await client.getState();
+    const models = await client.getAvailableModels(120_000);
     return {
       provider: "omp",
-      models: await client.getAvailableModels(120_000),
+      models: applyStateDefaults(models, state),
       modes: OMP_MODES,
       defaultModeId: "full",
     };


### PR DESCRIPTION
## Summary

- open a new-agent draft composer immediately after provider selection, skipping the chooser when only one provider is available
- load each installed provider's catalog asynchronously in the composer, restore valid model/thinking preferences, and block early submission with the exact `Model defaults are still loading` message
- derive OMP's effective default model and thinking level from its live RPC state instead of model-list ordering
- expose OMP approval modes immediately from its stable launch contract and defer native session creation until the first message is submitted
- reuse the normal session command path for the first prompt and preserve its draft if sending fails

## Why

Catalog discovery no longer sits on the critical path to showing a usable chat surface. Models and defaults still come from the actual running provider; the UI does not guess them. OMP permissions remain independently selectable while discovery runs because they are static launch-time options.

## Validation

- `npm run typecheck -w packages/agent-bridge`
- `npm run typecheck -w packages/agent-runtime`
- `npm run typecheck -w apps/web`
- `npm test -w packages/agent-bridge --`
- `npm test -w packages/agent-runtime --`
- `npm test -w apps/web --`
- scoped ESLint for changed web files
- `npm run build -w apps/web`
- live OMP v18.0.9 catalog probe (one effective model/thinking default)
- `E2E_PORT=4742 npm run test:e2e -w apps/web -- --grep "opens inline launch controls"`