### PR TITLE
Show selected agent thinking level in composer

### DIFF
--- a/apps/web/components/agents/AgentComposerControls.tsx
+++ b/apps/web/components/agents/AgentComposerControls.tsx
@@ -247,7 +247,9 @@ function ModelEffortControl(props: AgentComposerControlsProps) {
   const modelLabel =
     selectedModel?.label ?? props.currentModel?.id ?? props.providerLabel;
   const effortLabel = props.thinkingLevel
-    ? thinkingLabel(props.thinkingLevel)
+    ? (props.thinkingOptions.find(
+        (option) => option.id === props.thinkingLevel,
+      )?.label ?? thinkingLabel(props.thinkingLevel))
     : null;
   const accessibleLabel = effortLabel
     ? `Model and effort: ${modelLabel}, ${effortLabel}`
@@ -289,7 +291,7 @@ function ModelEffortControl(props: AgentComposerControlsProps) {
           <Button
             variant="ghost"
             size="sm"
-            className="min-w-0 max-w-32 gap-1.5 px-2 @lg:max-w-48 @2xl:max-w-56"
+            className="min-w-0 shrink max-w-32 gap-1.5 px-2 @lg:max-w-48 @2xl:max-w-56"
             disabled={props.disabled}
             aria-label={accessibleLabel}
             data-testid="agent-model-effort-trigger"
@@ -298,10 +300,18 @@ function ModelEffortControl(props: AgentComposerControlsProps) {
       >
         <ModelBrandIcon
           iconId={iconForModel(selectedModel)}
-          className="size-4"
+          className="size-4 shrink-0"
         />
-        <span className="truncate">{modelLabel}</span>
-        <ChevronDown className="text-muted-foreground" />
+        <span className="min-w-0 truncate">{modelLabel}</span>
+        {showEffort && effortLabel && (
+          <span
+            className="shrink-0 text-muted-foreground"
+            data-testid="agent-effort-label"
+          >
+            · {effortLabel}
+          </span>
+        )}
+        <ChevronDown className="shrink-0 text-muted-foreground" />
       </Menu.Trigger>
       <Menu.Portal>
         <Menu.Positioner side="top" align="start" sideOffset={6}>

--- a/apps/web/e2e/agent-runtime.spec.ts
+++ b/apps/web/e2e/agent-runtime.spec.ts
@@ -1618,6 +1618,9 @@ test("shows durable turn activity without changing completed tool status", async
     name: "Model and effort: GPT-5.6, High",
   });
   await expect(modelEffortControl).toBeEnabled();
+  await expect(
+    modelEffortControl.getByTestId("agent-effort-label"),
+  ).toHaveText("· High");
   await modelEffortControl.click();
   await expect(
     page.getByRole("button", { name: "Scroll to bottom" }),
@@ -1702,6 +1705,12 @@ test("shows durable turn activity without changing completed tool status", async
       },
     });
   }, imageModel);
+  const lowModelEffortControl = agentComposer.getByRole("button", {
+    name: "Model and effort: GPT-5.6, Low",
+  });
+  await expect(
+    lowModelEffortControl.getByTestId("agent-effort-label"),
+  ).toHaveText("· Low");
   const planModeControl = agentComposer.getByRole("button", {
     name: "Plan mode",
   });
@@ -1718,11 +1727,7 @@ test("shows durable turn activity without changing completed tool status", async
   await expect(planModeControl).toHaveCount(0);
 
   await page.setViewportSize({ width: 1280, height: 720 });
-  await agentComposer
-    .getByRole("button", {
-      name: "Model and effort: GPT-5.6, Low",
-    })
-    .click();
+  await lowModelEffortControl.click();
   await page
     .getByRole("menu", { name: "Model and effort" })
     .getByRole("menuitem", { name: /Model.*GPT-5\.6/u })


### PR DESCRIPTION
## Summary

- show the selected thinking level beside the model in the collapsed Agent Connections composer control
- use each provider’s display label and keep the effort visible while the model name truncates on narrow layouts
- verify that the visible value follows runtime changes from High to Low

## Testing

- npm test -w @overtchat/web --
- npm run typecheck -w @overtchat/web --
- npm run lint -w @overtchat/web -- components/agents/AgentComposerControls.tsx e2e/agent-runtime.spec.ts
- E2E_PORT=4731 npm run test:e2e -w @overtchat/web -- e2e/agent-runtime.spec.ts --grep "shows durable turn activity without changing completed tool status"
- git diff --check