### PR TITLE
feat(chat): discover local reasoning controls

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -965,6 +965,57 @@ describe("chat route setup boundary", () => {
     );
   });
 
+  it("forwards a discovered reasoning level to a local runtime", async () => {
+    mocks.parseChatRequest.mockResolvedValue({
+      ...parsedRequest,
+      reasoningLevel: "low",
+    });
+    mocks.getModelConfig.mockResolvedValue({
+      ...modelConfig,
+      providerId: "llamacpp",
+      apiFormat: "auto",
+    });
+    mocks.resolveModelCapabilities.mockReturnValue({
+      reasoningControls: {
+        toggle: true,
+        defaultLevel: "low",
+        efforts: ["low"],
+      },
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.createConfiguredLanguageModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "llamacpp",
+        reasoningLevel: "low",
+      }),
+    );
+  });
+
+  it("rejects reasoning overrides for non-local providers", async () => {
+    mocks.parseChatRequest.mockResolvedValue({
+      ...parsedRequest,
+      reasoningLevel: "low",
+    });
+    mocks.resolveModelCapabilities.mockReturnValue({
+      reasoningControls: {
+        toggle: true,
+        defaultLevel: "low",
+        efforts: ["low"],
+      },
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe(
+      "Reasoning level low is unavailable for this model",
+    );
+    expect(mocks.createConfiguredLanguageModel).not.toHaveBeenCalled();
+  });
+
   it("removes web tools when the capability is disabled", async () => {
     mocks.parseChatRequest.mockResolvedValue({
       ...parsedRequest,

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -994,7 +994,7 @@ describe("chat route setup boundary", () => {
     );
   });
 
-  it("rejects reasoning overrides for non-local providers", async () => {
+  it("rejects reasoning levels absent from discovered controls", async () => {
     mocks.parseChatRequest.mockResolvedValue({
       ...parsedRequest,
       reasoningLevel: "low",
@@ -1002,8 +1002,8 @@ describe("chat route setup boundary", () => {
     mocks.resolveModelCapabilities.mockReturnValue({
       reasoningControls: {
         toggle: true,
-        defaultLevel: "low",
-        efforts: ["low"],
+        defaultLevel: "medium",
+        efforts: ["medium"],
       },
     });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -223,12 +223,9 @@ async function handlePost(req: Request): Promise<Response> {
     modelConfig.providerId,
     modelConfig.model,
   );
-  const localReasoningProvider =
-    modelConfig.providerId === "llamacpp" || modelConfig.providerId === "vllm";
   if (
     reasoningLevel !== "default" &&
-    (!localReasoningProvider ||
-      !modelSupportsChatReasoningLevel(modelCapabilities, reasoningLevel))
+    !modelSupportsChatReasoningLevel(modelCapabilities, reasoningLevel)
   ) {
     throw new ChatRequestError(
       `Reasoning level ${reasoningLevel} is unavailable for this model`,

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -10,6 +10,7 @@ import {
   type TextStreamPart,
   type ToolSet,
 } from "ai";
+import { modelSupportsChatReasoningLevel } from "@overtchat/shared";
 import type { MessageStats } from "@/lib/chat/stats";
 import {
   INFERENCE_ACTIVITY_DATA_TYPE,
@@ -114,6 +115,7 @@ async function handlePost(req: Request): Promise<Response> {
     chatId,
     projectId,
     action,
+    reasoningLevel = "default",
     temporary,
     clientRequestId,
   } = parsedRequest;
@@ -221,6 +223,17 @@ async function handlePost(req: Request): Promise<Response> {
     modelConfig.providerId,
     modelConfig.model,
   );
+  const localReasoningProvider =
+    modelConfig.providerId === "llamacpp" || modelConfig.providerId === "vllm";
+  if (
+    reasoningLevel !== "default" &&
+    (!localReasoningProvider ||
+      !modelSupportsChatReasoningLevel(modelCapabilities, reasoningLevel))
+  ) {
+    throw new ChatRequestError(
+      `Reasoning level ${reasoningLevel} is unavailable for this model`,
+    );
+  }
   const supportsImageInput = modelCapabilities?.inputModalities
     ? modelCapabilities.inputModalities.includes("image")
     : modelCapabilities?.attachment !== false;
@@ -234,6 +247,7 @@ async function handlePost(req: Request): Promise<Response> {
       providerOptions: modelConfig.providerOptions,
       toolCallingEnabled: modelConfig.toolCallingEnabled,
       supportsImageInput,
+      reasoningLevel,
     });
   const chatTools = createWebTools({ userId, supportsImageInput });
   const inlined = await inlineUploads(messages, userId);

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -7,8 +7,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai";
 import {
   hasSuccessfulMemoryMutation,
+  modelSupportsChatReasoningLevel,
   modelSupportsToolCalling,
   type ChatKind,
+  type ChatReasoningLevel,
   type ChatRequestAction,
   type VoiceHistoryItem,
 } from "@overtchat/shared";
@@ -81,6 +83,7 @@ import {
 import type { VoiceTranscriptUpdate } from "@/lib/voice/client";
 
 const MESSAGE_STATS_STORAGE_KEY = "overtchat_stats_for_nerds";
+const REASONING_LEVELS_STORAGE_KEY = "overtchat_reasoning_levels";
 
 function shouldAutofocusComposer() {
   return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
@@ -124,6 +127,19 @@ export function ChatArea({
 
   const configured = (models?.length ?? 0) > 0 && Boolean(selectedId);
   const selectedModel = models?.find((model) => model.id === selectedId);
+  const reasoningControls = selectedModel?.capabilities?.reasoningControls;
+  const [reasoningLevels, setReasoningLevels] = useLocalStorage<
+    Record<string, ChatReasoningLevel>
+  >(REASONING_LEVELS_STORAGE_KEY, {});
+  const storedReasoningLevel = reasoningLevels[selectedId];
+  const reasoningLevel: ChatReasoningLevel =
+    storedReasoningLevel !== "default" &&
+    modelSupportsChatReasoningLevel(
+      selectedModel?.capabilities,
+      storedReasoningLevel,
+    )
+      ? storedReasoningLevel
+      : (reasoningControls?.defaultLevel ?? "default");
   const modelSupportsSearch = modelSupportsToolCalling(selectedModel);
   const [webSearchEnabled] = useLocalStorage<boolean>(
     WEB_SEARCH_ENABLED_STORAGE_KEY,
@@ -356,6 +372,7 @@ export function ChatArea({
     projectId: projectId ?? null,
     temporary,
     action,
+    reasoningLevel,
   });
 
   const streaming = status === "streaming" || status === "submitted";
@@ -653,6 +670,11 @@ export function ChatArea({
         models={models}
         selectedId={selectedId}
         onSelectModel={handleSelectModel}
+        reasoningControls={reasoningControls}
+        reasoningLevel={reasoningLevel}
+        onSelectReasoningLevel={(level) =>
+          setReasoningLevels({ ...reasoningLevels, [selectedId]: level })
+        }
         contextUsage={contextUsage}
         sessionUsage={sessionCostEnabled ? sessionUsage : undefined}
         showTempToggle={canToggleTemporary}

--- a/apps/web/components/chat/ChatHeader.tsx
+++ b/apps/web/components/chat/ChatHeader.tsx
@@ -1,18 +1,26 @@
 "use client";
 
 import { Ghost } from "lucide-react";
+import type {
+  ChatReasoningLevel,
+  ModelReasoningControls,
+} from "@overtchat/shared";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ModelPicker } from "@/components/ModelPicker";
 import { SidebarToggle } from "@/components/SidebarToggle";
 import type { PublicModelConfig } from "@/lib/model-config/schema";
 import type { UsageTotals } from "@/lib/usage/types";
+import { ReasoningPicker } from "./ReasoningPicker";
 import { UsageIndicator } from "./UsageIndicator";
 
 export function ChatHeader({
   models,
   selectedId,
   onSelectModel,
+  reasoningControls,
+  reasoningLevel,
+  onSelectReasoningLevel,
   contextUsage,
   sessionUsage,
   showTempToggle,
@@ -22,6 +30,9 @@ export function ChatHeader({
   models: PublicModelConfig[] | null;
   selectedId: string;
   onSelectModel: (id: string) => void;
+  reasoningControls?: ModelReasoningControls;
+  reasoningLevel: ChatReasoningLevel;
+  onSelectReasoningLevel: (level: ChatReasoningLevel) => void;
   contextUsage?: { usedTokens: number; contextWindow?: number };
   sessionUsage?: UsageTotals;
   showTempToggle: boolean;
@@ -35,6 +46,11 @@ export function ChatHeader({
         models={models}
         selectedId={selectedId}
         onSelect={onSelectModel}
+      />
+      <ReasoningPicker
+        controls={reasoningControls}
+        value={reasoningLevel}
+        onChange={onSelectReasoningLevel}
       />
       <div className="ml-auto flex items-center">
         <UsageIndicator

--- a/apps/web/components/chat/ReasoningPicker.tsx
+++ b/apps/web/components/chat/ReasoningPicker.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Menu } from "@base-ui/react/menu";
+import type {
+  ChatReasoningLevel,
+  ModelReasoningControls,
+  ModelReasoningLevel,
+} from "@overtchat/shared";
+import { Brain, Check, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export function ReasoningPicker({
+  controls,
+  value,
+  onChange,
+}: {
+  controls: ModelReasoningControls | undefined;
+  value: ChatReasoningLevel;
+  onChange: (level: ChatReasoningLevel) => void;
+}) {
+  if (!controls) return null;
+
+  const effectiveValue =
+    value === "default" ? controls.defaultLevel : value;
+  const rawOptions: ModelReasoningLevel[] = [];
+  if (controls.efforts?.length) {
+    if (controls.toggle) rawOptions.push("off");
+    if (controls.defaultLevel === "on") rawOptions.push("on");
+    rawOptions.push(...controls.efforts);
+  } else if (controls.toggle) {
+    rawOptions.push("on", "off");
+  }
+  const options = [...new Set(rawOptions)];
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="min-w-0 gap-1.5 px-2"
+            aria-label={`Thinking: ${effectiveValue}`}
+          />
+        }
+      >
+        <Brain className="size-4" />
+        <span className="hidden sm:inline">
+          {effectiveValue}
+          {effectiveValue === controls.defaultLevel ? " (default)" : ""}
+        </span>
+        <ChevronDown className="hidden text-muted-foreground sm:block" />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner side="bottom" align="start" sideOffset={6}>
+          <Menu.Popup
+            aria-label="Thinking level"
+            className={cn(
+              "z-50 w-48 rounded-lg border bg-popover p-1 text-sm text-popover-foreground shadow-md outline-none",
+              motionClasses.popup,
+            )}
+          >
+            {options.map((option) => (
+              <Menu.Item
+                key={option}
+                onClick={() => onChange(option)}
+                className={cn(
+                  "flex min-h-9 cursor-pointer items-center gap-2 rounded-md px-2.5 py-2 outline-none motion-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+                  option === effectiveValue &&
+                    "bg-accent text-accent-foreground",
+                )}
+              >
+                <span className="min-w-0 flex-1">
+                  {option}
+                  {option === controls.defaultLevel ? " (default)" : ""}
+                </span>
+                <span className="flex size-4 items-center justify-center">
+                  {option === effectiveValue ? (
+                    <Check className="size-3.5" />
+                  ) : null}
+                </span>
+              </Menu.Item>
+            ))}
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}

--- a/apps/web/lib/chat/request.test.ts
+++ b/apps/web/lib/chat/request.test.ts
@@ -38,7 +38,17 @@ describe("chat request parsing", () => {
       forceSearch: false,
       temporary: false,
       action: { type: "submit" },
+      reasoningLevel: "default",
     });
+  });
+
+  it("accepts supported reasoning levels and rejects unknown values", async () => {
+    await expect(
+      parseChatRequest(request({ ...validBody, reasoningLevel: "xhigh" })),
+    ).resolves.toMatchObject({ reasoningLevel: "xhigh" });
+    await expect(
+      parseChatRequest(request({ ...validBody, reasoningLevel: "ultra" })),
+    ).rejects.toBeInstanceOf(ChatRequestError);
   });
 
   it("preserves a submission receipt and creates one for legacy clients", async () => {
@@ -68,9 +78,19 @@ describe("chat request parsing", () => {
         forceSearch: true,
       }),
     );
+    const changedReasoning = await parseChatRequest(
+      request({
+        ...validBody,
+        clientRequestId: "request-one",
+        reasoningLevel: "low",
+      }),
+    );
 
     expect(chatRequestFingerprint(first)).toBe(chatRequestFingerprint(retry));
     expect(chatRequestFingerprint(changed)).not.toBe(
+      chatRequestFingerprint(first),
+    );
+    expect(chatRequestFingerprint(changedReasoning)).not.toBe(
       chatRequestFingerprint(first),
     );
   });

--- a/apps/web/lib/chat/request.ts
+++ b/apps/web/lib/chat/request.ts
@@ -1,5 +1,9 @@
 import { safeValidateUIMessages, type UIMessage } from "ai";
-import type { ChatRequestAction } from "@overtchat/shared";
+import {
+  REASONING_EFFORTS,
+  type ChatReasoningLevel,
+  type ChatRequestAction,
+} from "@overtchat/shared";
 import { createHash } from "node:crypto";
 import { z } from "zod";
 
@@ -35,6 +39,10 @@ const ChatRequestEnvelopeSchema = z.object({
   timeZone: z.string().trim().min(1).max(100).optional(),
   projectId: z.string().nullable().optional(),
   action: ChatRequestActionSchema.optional(),
+  reasoningLevel: z
+    .enum(["default", "off", "on", ...REASONING_EFFORTS])
+    .optional()
+    .default("default"),
   // Kept as a wire-compatibility input for already-open web clients and
   // released mobile clients. New clients send `action` explicitly.
   trigger: z
@@ -55,6 +63,7 @@ export interface ParsedChatRequest {
   timeZone?: string;
   projectId?: string | null;
   action: ChatRequestAction;
+  reasoningLevel: ChatReasoningLevel;
   temporary: boolean;
 }
 
@@ -77,6 +86,7 @@ export function chatRequestFingerprint({
   timeZone,
   projectId,
   action,
+  reasoningLevel,
   temporary,
 }: ParsedChatRequest): string {
   return createHash("sha256")
@@ -90,6 +100,7 @@ export function chatRequestFingerprint({
         timeZone: timeZone ?? null,
         projectId: projectId ?? null,
         action,
+        reasoningLevel,
         temporary,
       }),
     )
@@ -154,6 +165,7 @@ export async function parseChatRequest(
     timeZone: envelope.data.timeZone,
     projectId: envelope.data.projectId,
     action,
+    reasoningLevel: envelope.data.reasoningLevel,
     temporary: envelope.data.temporary,
   };
 }

--- a/apps/web/lib/model-config/client.test.ts
+++ b/apps/web/lib/model-config/client.test.ts
@@ -26,6 +26,11 @@ describe("model discovery client", () => {
                 toolCalling: true,
                 inputModalities: ["text", "image", "image", ""],
                 maxOutputTokens: 8192,
+                reasoningControls: {
+                  toggle: true,
+                  defaultLevel: "xhigh",
+                  efforts: ["low", "medium", "xhigh", "ultra"],
+                },
               },
             },
             {
@@ -54,6 +59,11 @@ describe("model discovery client", () => {
           toolCalling: true,
           inputModalities: ["text", "image"],
           maxOutputTokens: 8192,
+          reasoningControls: {
+            toggle: true,
+            defaultLevel: "xhigh",
+            efforts: ["low", "medium", "xhigh"],
+          },
         },
       },
       {

--- a/apps/web/lib/model-config/client.ts
+++ b/apps/web/lib/model-config/client.ts
@@ -1,6 +1,11 @@
 "use client";
 
-import type { ModelCapabilities } from "@overtchat/shared";
+import {
+  REASONING_EFFORTS,
+  type ModelCapabilities,
+  type ModelReasoningLevel,
+  type ReasoningEffort,
+} from "@overtchat/shared";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import type {
   CatalogModelPricing,
@@ -139,5 +144,38 @@ function readCapabilities(value: unknown): ModelCapabilities | undefined {
     const candidate = record[key];
     if (typeof candidate === "boolean") result[key] = candidate;
   }
+  const reasoningControls = readReasoningControls(record.reasoningControls);
+  if (reasoningControls) result.reasoningControls = reasoningControls;
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function readReasoningControls(
+  value: unknown,
+): ModelCapabilities["reasoningControls"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.toggle !== "boolean") return undefined;
+  const defaultLevel = readReasoningLevel(record.defaultLevel);
+  if (!defaultLevel) return undefined;
+  const efforts = Array.isArray(record.efforts)
+    ? record.efforts.filter((effort): effort is ReasoningEffort =>
+        REASONING_EFFORTS.includes(effort as ReasoningEffort),
+      )
+    : undefined;
+  return {
+    toggle: record.toggle,
+    defaultLevel,
+    ...(efforts && efforts.length > 0
+      ? { efforts: [...new Set(efforts)] }
+      : {}),
+  };
+}
+
+function readReasoningLevel(value: unknown): ModelReasoningLevel | undefined {
+  if (value === "off" || value === "on") return value;
+  return REASONING_EFFORTS.includes(value as ReasoningEffort)
+    ? (value as ReasoningEffort)
+    : undefined;
 }

--- a/apps/web/lib/model-config/schema.test.ts
+++ b/apps/web/lib/model-config/schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { modelSupportsToolCalling } from "@overtchat/shared";
+import {
+  modelSupportsChatReasoningLevel,
+  modelSupportsToolCalling,
+  type ModelCapabilities,
+} from "@overtchat/shared";
 
 import { ModelConfigSchema, ProviderConnectionSchema } from "./schema";
 
@@ -170,6 +174,11 @@ describe("provider configuration", () => {
         maxOutputTokens: 8192,
         inputModalities: ["text", "image"],
         toolCalling: false,
+        reasoningControls: {
+          toggle: true,
+          defaultLevel: "xhigh",
+          efforts: ["low", "medium", "xhigh"],
+        },
       },
     });
 
@@ -177,11 +186,28 @@ describe("provider configuration", () => {
       maxOutputTokens: 8192,
       inputModalities: ["text", "image"],
       toolCalling: false,
+      reasoningControls: {
+        toggle: true,
+        defaultLevel: "xhigh",
+        efforts: ["low", "medium", "xhigh"],
+      },
     });
     expect(
       ModelConfigSchema.safeParse({
         ...result,
         discoveredCapabilities: { maxOutputTokens: -1 },
+      }).success,
+    ).toBe(false);
+    expect(
+      ModelConfigSchema.safeParse({
+        ...result,
+        discoveredCapabilities: {
+          reasoningControls: {
+            toggle: true,
+            defaultLevel: "on",
+            efforts: ["ultra"],
+          },
+        },
       }).success,
     ).toBe(false);
   });
@@ -239,5 +265,20 @@ describe("provider configuration", () => {
     expect(modelSupportsToolCalling({ toolCallingEnabled: false })).toBe(false);
     expect(modelSupportsToolCalling({})).toBe(true);
     expect(modelSupportsToolCalling(null)).toBe(false);
+  });
+
+  it("accepts only reasoning levels discovered for a model", () => {
+    const capabilities: ModelCapabilities = {
+      reasoningControls: {
+        toggle: true,
+        defaultLevel: "xhigh",
+        efforts: ["low", "xhigh"],
+      },
+    };
+    expect(modelSupportsChatReasoningLevel(capabilities, "default")).toBe(true);
+    expect(modelSupportsChatReasoningLevel(capabilities, "on")).toBe(true);
+    expect(modelSupportsChatReasoningLevel(capabilities, "off")).toBe(true);
+    expect(modelSupportsChatReasoningLevel(capabilities, "xhigh")).toBe(true);
+    expect(modelSupportsChatReasoningLevel(capabilities, "medium")).toBe(false);
   });
 });

--- a/apps/web/lib/model-config/schema.ts
+++ b/apps/web/lib/model-config/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ModelCapabilities } from "@overtchat/shared";
+import { REASONING_EFFORTS, type ModelCapabilities } from "@overtchat/shared";
 import {
   API_FORMAT_IDS,
   PROVIDERS,
@@ -97,6 +97,13 @@ const ModelCapabilitiesSchema = z
     attachment: z.boolean().optional(),
     toolCalling: z.boolean().optional(),
     reasoning: z.boolean().optional(),
+    reasoningControls: z
+      .object({
+        toggle: z.boolean(),
+        defaultLevel: z.enum(["off", "on", ...REASONING_EFFORTS]),
+        efforts: z.array(z.enum(REASONING_EFFORTS)).optional(),
+      })
+      .optional(),
     structuredOutput: z.boolean().optional(),
     temperature: z.boolean().optional(),
   })

--- a/apps/web/lib/providers/server/adapters/llamacpp.ts
+++ b/apps/web/lib/providers/server/adapters/llamacpp.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { createOpenAICompatibleAdapter } from "@/lib/providers/server/adapters/openai-compatible";
+import { applyLocalReasoningLevel } from "@/lib/providers/server/adapters/local-reasoning";
 import { listLlamaCppModels } from "@/lib/providers/server/http";
 
 export const llamaCppAdapter = createOpenAICompatibleAdapter(
   "llamacpp",
   (connection) => listLlamaCppModels(connection.baseUrl, connection.apiKey),
-  (body) =>
-    body.stream === true
+  (body, config) => {
+    const withRuntimeExtensions = body.stream === true
       ? {
           ...body,
           // llama.cpp extensions that emit progress and timings in the same
@@ -14,5 +15,10 @@ export const llamaCppAdapter = createOpenAICompatibleAdapter(
           return_progress: true,
           timings_per_token: true,
         }
-      : body,
+      : body;
+    return applyLocalReasoningLevel(
+      withRuntimeExtensions,
+      config.reasoningLevel,
+    );
+  },
 );

--- a/apps/web/lib/providers/server/adapters/llamacpp.ts
+++ b/apps/web/lib/providers/server/adapters/llamacpp.ts
@@ -5,20 +5,24 @@ import { listLlamaCppModels } from "@/lib/providers/server/http";
 
 export const llamaCppAdapter = createOpenAICompatibleAdapter(
   "llamacpp",
-  (connection) => listLlamaCppModels(connection.baseUrl, connection.apiKey),
-  (body, config) => {
-    const withRuntimeExtensions = body.stream === true
-      ? {
-          ...body,
-          // llama.cpp extensions that emit progress and timings in the same
-          // SSE stream as the OpenAI-compatible response.
-          return_progress: true,
-          timings_per_token: true,
-        }
-      : body;
-    return applyLocalReasoningLevel(
-      withRuntimeExtensions,
-      config.reasoningLevel,
-    );
+  {
+    listModels: (connection) =>
+      listLlamaCppModels(connection.baseUrl, connection.apiKey),
+    transformRequestBody: (body, config) => {
+      const withRuntimeExtensions = body.stream === true
+        ? {
+            ...body,
+            // llama.cpp extensions that emit progress and timings in the same
+            // SSE stream as the OpenAI-compatible response.
+            return_progress: true,
+            timings_per_token: true,
+          }
+        : body;
+      return applyLocalReasoningLevel(
+        withRuntimeExtensions,
+        config.reasoningLevel,
+      );
+    },
+    acceptsReasoningLevel: true,
   },
 );

--- a/apps/web/lib/providers/server/adapters/local-reasoning.test.ts
+++ b/apps/web/lib/providers/server/adapters/local-reasoning.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { applyLocalReasoningLevel } from "./local-reasoning";
+
+describe("applyLocalReasoningLevel", () => {
+  it("leaves manual parameters untouched for the default selection", () => {
+    const body = {
+      reasoning_effort: "high",
+      chat_template_kwargs: { enable_thinking: false, custom: "value" },
+    };
+    expect(applyLocalReasoningLevel(body, "default")).toBe(body);
+  });
+
+  it("turns thinking off and overrides only conflicting native controls", () => {
+    expect(
+      applyLocalReasoningLevel(
+        {
+          temperature: 0.5,
+          reasoning_effort: "high",
+          chat_template_kwargs: { enable_thinking: true, custom: "value" },
+        },
+        "off",
+      ),
+    ).toEqual({
+      temperature: 0.5,
+      reasoning_effort: "none",
+      chat_template_kwargs: { enable_thinking: false, custom: "value" },
+    });
+  });
+
+  it("sends the selected effort through both local runtime controls", () => {
+    expect(applyLocalReasoningLevel({ stream: true }, "xhigh")).toEqual({
+      stream: true,
+      reasoning_effort: "xhigh",
+      chat_template_kwargs: { enable_thinking: true },
+    });
+  });
+
+  it("explicitly enables template thinking without inventing an effort", () => {
+    expect(
+      applyLocalReasoningLevel(
+        { reasoning_effort: "none", chat_template_kwargs: { custom: true } },
+        "on",
+      ),
+    ).toEqual({
+      reasoning_effort: undefined,
+      chat_template_kwargs: { custom: true, enable_thinking: true },
+    });
+  });
+});

--- a/apps/web/lib/providers/server/adapters/local-reasoning.ts
+++ b/apps/web/lib/providers/server/adapters/local-reasoning.ts
@@ -1,0 +1,26 @@
+import type { ChatReasoningLevel } from "@overtchat/shared";
+
+export function applyLocalReasoningLevel(
+  body: Record<string, unknown>,
+  level: ChatReasoningLevel | undefined,
+): Record<string, unknown> {
+  if (!level || level === "default") return body;
+
+  const existingTemplateKwargs = isRecord(body.chat_template_kwargs)
+    ? body.chat_template_kwargs
+    : {};
+  const enabled = level !== "off";
+  return {
+    ...body,
+    reasoning_effort:
+      level === "off" ? "none" : level === "on" ? undefined : level,
+    chat_template_kwargs: {
+      ...existingTemplateKwargs,
+      enable_thinking: enabled,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/web/lib/providers/server/adapters/openai-compatible.ts
+++ b/apps/web/lib/providers/server/adapters/openai-compatible.ts
@@ -14,6 +14,7 @@ type ListModels = (
 
 type TransformRequestBody = (
   body: Record<string, unknown>,
+  config: Parameters<ProviderAdapter["createLanguageModel"]>[0],
 ) => Record<string, unknown>;
 
 export function createOpenAICompatibleAdapter(
@@ -32,7 +33,12 @@ export function createOpenAICompatibleAdapter(
           apiKey: config.apiKey,
           model: config.model,
           supportsImageInput: config.supportsImageInput,
-          transformRequestBody,
+          ...(transformRequestBody
+            ? {
+                transformRequestBody: (body: Record<string, unknown>) =>
+                  transformRequestBody(body, config),
+              }
+            : {}),
         }),
         providerOptionsKey: id,
       };

--- a/apps/web/lib/providers/server/adapters/openai-compatible.ts
+++ b/apps/web/lib/providers/server/adapters/openai-compatible.ts
@@ -17,14 +17,24 @@ type TransformRequestBody = (
   config: Parameters<ProviderAdapter["createLanguageModel"]>[0],
 ) => Record<string, unknown>;
 
+interface OpenAICompatibleAdapterOptions {
+  listModels?: ListModels;
+  transformRequestBody?: TransformRequestBody;
+  acceptsReasoningLevel?: boolean;
+}
+
 export function createOpenAICompatibleAdapter(
   id: ProviderId,
-  listModels: ListModels = (connection) =>
-    listOpenAIModels(connection.baseUrl, connection.apiKey),
-  transformRequestBody?: TransformRequestBody,
+  options: OpenAICompatibleAdapterOptions = {},
 ): ProviderAdapter {
+  const listModels =
+    options.listModels ??
+    ((connection: ProviderConnection) =>
+      listOpenAIModels(connection.baseUrl, connection.apiKey));
+  const transformRequestBody = options.transformRequestBody;
   return {
     id,
+    acceptsReasoningLevel: options.acceptsReasoningLevel,
     createLanguageModel(config) {
       return {
         model: createOpenAICompatibleChatModel({

--- a/apps/web/lib/providers/server/adapters/vllm.ts
+++ b/apps/web/lib/providers/server/adapters/vllm.ts
@@ -1,4 +1,10 @@
 import "server-only";
 import { createOpenAICompatibleAdapter } from "@/lib/providers/server/adapters/openai-compatible";
+import { applyLocalReasoningLevel } from "@/lib/providers/server/adapters/local-reasoning";
+import { listVllmModels } from "@/lib/providers/server/http";
 
-export const vllmAdapter = createOpenAICompatibleAdapter("vllm");
+export const vllmAdapter = createOpenAICompatibleAdapter(
+  "vllm",
+  (connection) => listVllmModels(connection.baseUrl, connection.apiKey),
+  (body, config) => applyLocalReasoningLevel(body, config.reasoningLevel),
+);

--- a/apps/web/lib/providers/server/adapters/vllm.ts
+++ b/apps/web/lib/providers/server/adapters/vllm.ts
@@ -5,6 +5,11 @@ import { listVllmModels } from "@/lib/providers/server/http";
 
 export const vllmAdapter = createOpenAICompatibleAdapter(
   "vllm",
-  (connection) => listVllmModels(connection.baseUrl, connection.apiKey),
-  (body, config) => applyLocalReasoningLevel(body, config.reasoningLevel),
+  {
+    listModels: (connection) =>
+      listVllmModels(connection.baseUrl, connection.apiKey),
+    transformRequestBody: (body, config) =>
+      applyLocalReasoningLevel(body, config.reasoningLevel),
+    acceptsReasoningLevel: true,
+  },
 );

--- a/apps/web/lib/providers/server/http.test.ts
+++ b/apps/web/lib/providers/server/http.test.ts
@@ -366,6 +366,52 @@ describe("provider model discovery", () => {
     expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
+  it("drops an equivalent effort group when the runtime does not identify its projection", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return Response.json({ data: [{ id: "ambiguous-model" }] });
+      }
+      if (url.includes("/props?")) {
+        return Response.json({
+          chat_template_caps: { supports_reasoning_effort: true },
+        });
+      }
+      const body = JSON.parse(String(init?.body)) as {
+        reasoning_effort?: string;
+      };
+      const effort = body.reasoning_effort;
+      if (["overtchat-invalid-effort", "minimal", "max"].includes(effort ?? "")) {
+        return new Response("unsupported effort", { status: 400 });
+      }
+      const prompt =
+        effort === "none"
+          ? "thinking:off"
+          : effort === "high" || effort === "xhigh"
+            ? "thinking:deep"
+            : "thinking:low";
+      return Response.json({ prompt });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listLlamaCppModels("http://localhost:8080/v1", null),
+    ).resolves.toEqual([
+      {
+        id: "ambiguous-model",
+        capabilities: {
+          reasoning: true,
+          reasoningControls: {
+            toggle: true,
+            defaultLevel: "low",
+            efforts: ["low"],
+          },
+          temperature: true,
+        },
+      },
+    ]);
+  });
+
   it("discovers vLLM controls from deterministic render token IDs", async () => {
     const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
       const url = String(input);
@@ -374,7 +420,21 @@ describe("provider model discovery", () => {
       }
       const body = JSON.parse(String(init?.body)) as {
         reasoning_effort?: string;
+        tokens?: number[];
       };
+      if (url.endsWith("/detokenize")) {
+        const token = body.tokens?.at(-1);
+        return Response.json({
+          prompt:
+            token === 0
+              ? "thinking:off"
+              : token === 1
+                ? "thinking:low"
+                : token === 2
+                  ? "thinking:medium"
+                  : "thinking:xhigh",
+        });
+      }
       const effort = body.reasoning_effort;
       if (["overtchat-invalid-effort", "minimal", "max"].includes(effort ?? "")) {
         return new Response("unsupported effort", {
@@ -416,6 +476,12 @@ describe("provider model discovery", () => {
           Authorization: "Bearer nerdtastic",
           "Content-Type": "application/json",
         },
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/detokenize",
+      expect.objectContaining({
+        body: JSON.stringify({ model: "served-model", tokens: [100, 3] }),
       }),
     );
   });

--- a/apps/web/lib/providers/server/http.test.ts
+++ b/apps/web/lib/providers/server/http.test.ts
@@ -7,6 +7,7 @@ import {
   listGoogleModels,
   listLlamaCppModels,
   listOpenAIModels,
+  listVllmModels,
 } from "./http";
 
 afterEach(() => {
@@ -274,6 +275,147 @@ describe("provider model discovery", () => {
       "http://localhost:8080/props?model=proxied-model",
       expect.objectContaining({
         headers: { Authorization: "Bearer local-secret" },
+      }),
+    );
+  });
+
+  it("discovers Qwen 3.8 llama.cpp effort aliases from rendered prompts", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return Response.json({ data: [{ id: "qwen3.8-27b" }] });
+      }
+      if (url.includes("/props?")) {
+        return Response.json({
+          chat_template_caps: { supports_reasoning_effort: true },
+        });
+      }
+      const body = JSON.parse(String(init?.body)) as {
+        reasoning_effort?: string;
+      };
+      const effort = body.reasoning_effort;
+      if (["overtchat-invalid-effort", "minimal", "max"].includes(effort ?? "")) {
+        return new Response("unsupported effort", {
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+      }
+      const prompt =
+        effort === "none"
+          ? "thinking:off"
+          : effort === "low"
+            ? "thinking:low"
+            : effort === "medium"
+              ? "thinking:medium"
+              : "thinking:xhigh";
+      return Response.json({ prompt });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listLlamaCppModels("http://localhost:8080/v1", null),
+    ).resolves.toEqual([
+      {
+        id: "qwen3.8-27b",
+        capabilities: {
+          reasoning: true,
+          reasoningControls: {
+            toggle: true,
+            defaultLevel: "xhigh",
+            efforts: ["low", "medium", "xhigh"],
+          },
+          temperature: true,
+        },
+      },
+    ]);
+  });
+
+  it("discovers toggle-only Qwen 3.6 behavior when effort values are ignored", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return Response.json({ data: [{ id: "qwen3.6-35b-a3b" }] });
+      }
+      if (url.includes("/props?")) {
+        return Response.json({
+          chat_template_caps: { supports_reasoning_effort: false },
+        });
+      }
+      const body = JSON.parse(String(init?.body)) as {
+        reasoning_effort?: string;
+      };
+      return Response.json({
+        prompt:
+          body.reasoning_effort === "none" ? "thinking:off" : "thinking:on",
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listLlamaCppModels("http://localhost:8080/v1", null),
+    ).resolves.toEqual([
+      {
+        id: "qwen3.6-35b-a3b",
+        capabilities: {
+          reasoning: true,
+          reasoningControls: { toggle: true, defaultLevel: "on" },
+          temperature: true,
+        },
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("discovers vLLM controls from deterministic render token IDs", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return Response.json({ data: [{ id: "served-model" }] });
+      }
+      const body = JSON.parse(String(init?.body)) as {
+        reasoning_effort?: string;
+      };
+      const effort = body.reasoning_effort;
+      if (["overtchat-invalid-effort", "minimal", "max"].includes(effort ?? "")) {
+        return new Response("unsupported effort", {
+          status: 400,
+          statusText: "Bad Request",
+        });
+      }
+      const token =
+        effort === "none"
+          ? 0
+          : effort === "low"
+            ? 1
+            : effort === "medium"
+              ? 2
+              : 3;
+      return Response.json({ token_ids: [100, token] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listVllmModels("http://localhost:8000/v1", "nerdtastic"),
+    ).resolves.toEqual([
+      {
+        id: "served-model",
+        capabilities: {
+          reasoning: true,
+          reasoningControls: {
+            toggle: true,
+            defaultLevel: "xhigh",
+            efforts: ["low", "medium", "xhigh"],
+          },
+        },
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/v1/chat/completions/render",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer nerdtastic",
+          "Content-Type": "application/json",
+        },
       }),
     );
   });

--- a/apps/web/lib/providers/server/http.test.ts
+++ b/apps/web/lib/providers/server/http.test.ts
@@ -366,6 +366,92 @@ describe("provider model discovery", () => {
     expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
+  it("discovers GLM 5.3 effort levels without inventing a thinking toggle", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return Response.json({ data: [{ id: "glm-5.3-flash" }] });
+      }
+      if (url.includes("/props?")) {
+        return Response.json({
+          chat_template_caps: { supports_reasoning_effort: true },
+        });
+      }
+      const body = JSON.parse(String(init?.body)) as {
+        reasoning_effort?: string;
+      };
+      const effort = body.reasoning_effort;
+      const projected =
+        effort === "low" ? "Low" : effort === "high" ? "High" : "Max";
+      return Response.json({ prompt: `Reasoning Effort: ${projected}` });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listLlamaCppModels("http://localhost:8080/v1", null),
+    ).resolves.toEqual([
+      {
+        id: "glm-5.3-flash",
+        capabilities: {
+          reasoning: true,
+          reasoningControls: {
+            toggle: false,
+            defaultLevel: "max",
+            efforts: ["low", "high", "max"],
+          },
+          temperature: true,
+        },
+      },
+    ]);
+  });
+
+  it("keeps DeepSeek V4 toggles when its low effort matches unknown values", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return Response.json({ data: [{ id: "deepseek-v4-flash-0731" }] });
+      }
+      if (url.includes("/props?")) {
+        return Response.json({
+          chat_template_caps: { supports_reasoning_effort: true },
+        });
+      }
+      const body = JSON.parse(String(init?.body)) as {
+        reasoning_effort?: string;
+        chat_template_kwargs?: { enable_thinking?: boolean };
+      };
+      if (body.chat_template_kwargs?.enable_thinking === false) {
+        return Response.json({ prompt: "thinking:off" });
+      }
+      const effort = body.reasoning_effort;
+      const prompt =
+        effort === "high"
+          ? "Reasoning Effort: Absolute maximum"
+          : effort === "max"
+            ? "Reasoning Effort: Beyond maximum"
+            : "thinking:on";
+      return Response.json({ prompt });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listLlamaCppModels("http://localhost:8080/v1", null),
+    ).resolves.toEqual([
+      {
+        id: "deepseek-v4-flash-0731",
+        capabilities: {
+          reasoning: true,
+          reasoningControls: {
+            toggle: true,
+            defaultLevel: "on",
+            efforts: ["high", "max"],
+          },
+          temperature: true,
+        },
+      },
+    ]);
+  });
+
   it("drops an equivalent effort group when the runtime does not identify its projection", async () => {
     const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
       const url = String(input);

--- a/apps/web/lib/providers/server/http.ts
+++ b/apps/web/lib/providers/server/http.ts
@@ -481,19 +481,16 @@ async function discoverReasoningControls(
     render("off"),
     render("on"),
   ]);
-  if (
-    !defaultPrompt ||
-    !offPrompt ||
-    !onPrompt ||
-    onPrompt.key === offPrompt.key
-  ) {
-    return undefined;
-  }
+  if (!defaultPrompt) return undefined;
 
-  const defaultToggleLevel =
-    defaultPrompt.key === offPrompt.key
+  const toggle = Boolean(
+    offPrompt && onPrompt && onPrompt.key !== offPrompt.key,
+  );
+  const defaultToggleLevel = !toggle
+    ? undefined
+    : defaultPrompt.key === offPrompt?.key
       ? "off"
-      : defaultPrompt.key === onPrompt.key
+      : defaultPrompt.key === onPrompt?.key
         ? "on"
         : undefined;
 
@@ -513,25 +510,17 @@ async function discoverReasoningControls(
   >();
   for (let index = 0; index < REASONING_EFFORTS.length; index += 1) {
     const prompt = effortPrompts[index];
-    if (!prompt || prompt.key === invalidPrompt?.key) continue;
+    if (!prompt) continue;
     const effort = REASONING_EFFORTS[index];
     const group = groups.get(prompt.key) ?? { aliases: [], prompt };
     group.aliases.push(effort);
     groups.set(prompt.key, group);
   }
 
-  const hasDistinctEffort = [...groups.keys()].some(
-    (key) => key !== onPrompt.key,
-  );
-  if (!hasDistinctEffort) {
-    return defaultToggleLevel
-      ? { toggle: true, defaultLevel: defaultToggleLevel }
-      : undefined;
-  }
-
   const projectedGroups = await Promise.all(
     [...groups].map(async ([key, group]) => {
-      if (group.aliases.length === 1) {
+      const matchesInvalid = key === invalidPrompt?.key;
+      if (group.aliases.length === 1 && !matchesInvalid) {
         return [key, group.aliases[0]] as const;
       }
       const promptText =
@@ -550,9 +539,10 @@ async function discoverReasoningControls(
   if (!defaultLevel) return undefined;
   const selected = new Set(selectedByPrompt.values());
   const efforts = REASONING_EFFORTS.filter((effort) => selected.has(effort));
-  return efforts.length > 0
-    ? { toggle: true, defaultLevel, efforts }
-    : { toggle: true, defaultLevel };
+  if (efforts.length > 0) return { toggle, defaultLevel, efforts };
+  return defaultToggleLevel
+    ? { toggle: true, defaultLevel: defaultToggleLevel }
+    : undefined;
 }
 
 function projectedEffortAlias(

--- a/apps/web/lib/providers/server/http.ts
+++ b/apps/web/lib/providers/server/http.ts
@@ -60,6 +60,8 @@ interface LlamaCppProps {
 
 interface RenderProbeResult {
   key: string;
+  text?: string;
+  tokenIds?: number[];
 }
 
 export function normalizeBaseUrl(baseUrl: string): string {
@@ -91,8 +93,11 @@ export async function listVllmModels(
   const models = await listOpenAIModelsWithOptions(baseUrl, apiKey, false);
   return Promise.all(
     models.map(async (model) => {
-      const reasoningControls = await discoverReasoningControls((level) =>
-        renderVllmChatTemplate(baseUrl, apiKey, model.id, level),
+      const reasoningControls = await discoverReasoningControls(
+        (level) => renderVllmChatTemplate(baseUrl, apiKey, model.id, level),
+        true,
+        (prompt) =>
+          detokenizeVllmPrompt(baseUrl, apiKey, model.id, prompt.tokenIds),
       );
       return reasoningControls
         ? {
@@ -467,6 +472,9 @@ type ProbeLevel = "default" | "off" | "on" | ReasoningEffort | "invalid";
 async function discoverReasoningControls(
   render: (level: ProbeLevel) => Promise<RenderProbeResult | undefined>,
   probeEfforts = true,
+  resolvePromptText?: (
+    prompt: RenderProbeResult,
+  ) => Promise<string | undefined>,
 ): Promise<ModelReasoningControls | undefined> {
   const [defaultPrompt, offPrompt, onPrompt] = await Promise.all([
     render("default"),
@@ -499,13 +507,16 @@ async function discoverReasoningControls(
     render("invalid"),
     ...REASONING_EFFORTS.map((effort) => render(effort)),
   ]);
-  const groups = new Map<string, ReasoningEffort[]>();
+  const groups = new Map<
+    string,
+    { aliases: ReasoningEffort[]; prompt: RenderProbeResult }
+  >();
   for (let index = 0; index < REASONING_EFFORTS.length; index += 1) {
     const prompt = effortPrompts[index];
     if (!prompt || prompt.key === invalidPrompt?.key) continue;
     const effort = REASONING_EFFORTS[index];
-    const group = groups.get(prompt.key) ?? [];
-    group.push(effort);
+    const group = groups.get(prompt.key) ?? { aliases: [], prompt };
+    group.aliases.push(effort);
     groups.set(prompt.key, group);
   }
 
@@ -518,10 +529,20 @@ async function discoverReasoningControls(
       : undefined;
   }
 
+  const projectedGroups = await Promise.all(
+    [...groups].map(async ([key, group]) => {
+      if (group.aliases.length === 1) {
+        return [key, group.aliases[0]] as const;
+      }
+      const promptText =
+        group.prompt.text ?? (await resolvePromptText?.(group.prompt));
+      const projected = projectedEffortAlias(group.aliases, promptText);
+      return projected ? ([key, projected] as const) : undefined;
+    }),
+  );
   const selectedByPrompt = new Map(
-    [...groups].map(
-      ([key, aliases]) =>
-        [key, selectCanonicalEffortAlias(aliases)] as const,
+    projectedGroups.filter(
+      (group): group is readonly [string, ReasoningEffort] => group !== undefined,
     ),
   );
   const defaultLevel =
@@ -534,22 +555,15 @@ async function discoverReasoningControls(
     : { toggle: true, defaultLevel };
 }
 
-const EFFORT_ALIAS_PREFERENCE: readonly ReasoningEffort[] = [
-  "low",
-  "medium",
-  "xhigh",
-  "high",
-  "max",
-  "minimal",
-];
-
-function selectCanonicalEffortAlias(
+function projectedEffortAlias(
   aliases: ReasoningEffort[],
-): ReasoningEffort {
-  return (
-    EFFORT_ALIAS_PREFERENCE.find((effort) => aliases.includes(effort)) ??
-    aliases[0]
+  prompt: string | undefined,
+): ReasoningEffort | undefined {
+  if (!prompt) return undefined;
+  const matches = aliases.filter((alias) =>
+    new RegExp(`(^|[^a-z0-9_])${alias}([^a-z0-9_]|$)`, "iu").test(prompt),
   );
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 async function renderLlamaCppChatTemplate(
@@ -597,6 +611,27 @@ async function renderVllmChatTemplate(
   return renderedPromptKey(json);
 }
 
+async function detokenizeVllmPrompt(
+  baseUrl: string,
+  apiKey: string | null | undefined,
+  model: string,
+  tokenIds: number[] | undefined,
+): Promise<string | undefined> {
+  if (!tokenIds) return undefined;
+  const json = await tryFetchJson<Record<string, unknown>>(
+    appendPath(openAIServiceRoot(baseUrl), "detokenize"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({ model, tokens: tokenIds }),
+    },
+  );
+  return typeof json?.prompt === "string" ? json.prompt : undefined;
+}
+
 function reasoningProbeBody(model: string, level: ProbeLevel) {
   return {
     model,
@@ -623,9 +658,11 @@ function renderedPromptKey(
   json: Record<string, unknown> | undefined,
 ): RenderProbeResult | undefined {
   if (!json) return undefined;
-  if (typeof json.prompt === "string") return { key: `text:${json.prompt}` };
+  if (typeof json.prompt === "string") {
+    return { key: `text:${json.prompt}`, text: json.prompt };
+  }
   if (typeof json.prompt_text === "string") {
-    return { key: `text:${json.prompt_text}` };
+    return { key: `text:${json.prompt_text}`, text: json.prompt_text };
   }
   const tokenIds = Array.isArray(json.token_ids)
     ? json.token_ids
@@ -638,7 +675,7 @@ function renderedPromptKey(
       (token) => typeof token === "number" && Number.isInteger(token),
     )
   ) {
-    return { key: `tokens:${JSON.stringify(tokenIds)}` };
+    return { key: `tokens:${JSON.stringify(tokenIds)}`, tokenIds };
   }
   return undefined;
 }

--- a/apps/web/lib/providers/server/http.ts
+++ b/apps/web/lib/providers/server/http.ts
@@ -1,5 +1,10 @@
 import "server-only";
-import type { ModelCapabilities } from "@overtchat/shared";
+import {
+  REASONING_EFFORTS,
+  type ModelCapabilities,
+  type ModelReasoningControls,
+  type ReasoningEffort,
+} from "@overtchat/shared";
 import type { DiscoveredModel } from "@/lib/providers/server/types";
 
 const MODEL_LIST_TIMEOUT_MS = 10_000;
@@ -53,6 +58,10 @@ interface LlamaCppProps {
   modalities?: unknown;
 }
 
+interface RenderProbeResult {
+  key: string;
+}
+
 export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
@@ -73,6 +82,29 @@ export async function listLlamaCppModels(
   apiKey: string | null | undefined,
 ): Promise<DiscoveredModel[]> {
   return listOpenAIModelsWithOptions(baseUrl, apiKey, true);
+}
+
+export async function listVllmModels(
+  baseUrl: string,
+  apiKey: string | null | undefined,
+): Promise<DiscoveredModel[]> {
+  const models = await listOpenAIModelsWithOptions(baseUrl, apiKey, false);
+  return Promise.all(
+    models.map(async (model) => {
+      const reasoningControls = await discoverReasoningControls((level) =>
+        renderVllmChatTemplate(baseUrl, apiKey, model.id, level),
+      );
+      return reasoningControls
+        ? {
+            ...model,
+            capabilities: mergeCapabilities(model.capabilities, {
+              reasoning: true,
+              reasoningControls,
+            }),
+          }
+        : model;
+    }),
+  );
 }
 
 async function listOpenAIModelsWithOptions(
@@ -115,6 +147,14 @@ async function listOpenAIModelsWithOptions(
       if (!llamaModelIds.has(model.id)) return model;
       const props = await readLlamaCppProps(baseUrl, apiKey, model.id);
       if (!props) return model;
+      const reasoningControls = probeAllLlamaCppProps
+        ? await discoverLlamaCppReasoningControls(
+            baseUrl,
+            apiKey,
+            model.id,
+            props,
+          )
+        : undefined;
       return {
         ...model,
         contextWindow:
@@ -122,7 +162,7 @@ async function listOpenAIModelsWithOptions(
           model.contextWindow,
         capabilities: mergeCapabilities(
           model.capabilities,
-          llamaCppCapabilities(props),
+          llamaCppCapabilities(props, reasoningControls),
         ),
       };
     }),
@@ -379,6 +419,7 @@ function openAIServiceRoot(baseUrl: string): string {
 
 function llamaCppCapabilities(
   props: LlamaCppProps,
+  reasoningControls?: ModelReasoningControls,
 ): ModelCapabilities | undefined {
   const template = isRecord(props.chat_template_caps)
     ? props.chat_template_caps
@@ -394,9 +435,225 @@ function llamaCppCapabilities(
     outputModalities: vision === undefined ? undefined : ["text"],
     attachment: vision,
     toolCalling: readSupportedBoolean(template?.supports_tools),
-    reasoning: readSupportedBoolean(template?.supports_preserve_reasoning),
+    reasoning:
+      reasoningControls !== undefined
+        ? true
+        : readSupportedBoolean(template?.supports_preserve_reasoning),
+    reasoningControls,
     temperature: true,
   });
+}
+
+async function discoverLlamaCppReasoningControls(
+  baseUrl: string,
+  apiKey: string | null | undefined,
+  model: string,
+  props: LlamaCppProps,
+): Promise<ModelReasoningControls | undefined> {
+  const templateCaps = isRecord(props.chat_template_caps)
+    ? props.chat_template_caps
+    : undefined;
+  const supportsEffort =
+    readSupportedBoolean(templateCaps?.supports_reasoning_effort) === true;
+  return discoverReasoningControls(
+    (level) =>
+      renderLlamaCppChatTemplate(baseUrl, apiKey, model, level),
+    supportsEffort,
+  );
+}
+
+type ProbeLevel = "default" | "off" | "on" | ReasoningEffort | "invalid";
+
+async function discoverReasoningControls(
+  render: (level: ProbeLevel) => Promise<RenderProbeResult | undefined>,
+  probeEfforts = true,
+): Promise<ModelReasoningControls | undefined> {
+  const [defaultPrompt, offPrompt, onPrompt] = await Promise.all([
+    render("default"),
+    render("off"),
+    render("on"),
+  ]);
+  if (
+    !defaultPrompt ||
+    !offPrompt ||
+    !onPrompt ||
+    onPrompt.key === offPrompt.key
+  ) {
+    return undefined;
+  }
+
+  const defaultToggleLevel =
+    defaultPrompt.key === offPrompt.key
+      ? "off"
+      : defaultPrompt.key === onPrompt.key
+        ? "on"
+        : undefined;
+
+  if (!probeEfforts) {
+    return defaultToggleLevel
+      ? { toggle: true, defaultLevel: defaultToggleLevel }
+      : undefined;
+  }
+
+  const [invalidPrompt, ...effortPrompts] = await Promise.all([
+    render("invalid"),
+    ...REASONING_EFFORTS.map((effort) => render(effort)),
+  ]);
+  const groups = new Map<string, ReasoningEffort[]>();
+  for (let index = 0; index < REASONING_EFFORTS.length; index += 1) {
+    const prompt = effortPrompts[index];
+    if (!prompt || prompt.key === invalidPrompt?.key) continue;
+    const effort = REASONING_EFFORTS[index];
+    const group = groups.get(prompt.key) ?? [];
+    group.push(effort);
+    groups.set(prompt.key, group);
+  }
+
+  const hasDistinctEffort = [...groups.keys()].some(
+    (key) => key !== onPrompt.key,
+  );
+  if (!hasDistinctEffort) {
+    return defaultToggleLevel
+      ? { toggle: true, defaultLevel: defaultToggleLevel }
+      : undefined;
+  }
+
+  const selectedByPrompt = new Map(
+    [...groups].map(
+      ([key, aliases]) =>
+        [key, selectCanonicalEffortAlias(aliases)] as const,
+    ),
+  );
+  const defaultLevel =
+    selectedByPrompt.get(defaultPrompt.key) ?? defaultToggleLevel;
+  if (!defaultLevel) return undefined;
+  const selected = new Set(selectedByPrompt.values());
+  const efforts = REASONING_EFFORTS.filter((effort) => selected.has(effort));
+  return efforts.length > 0
+    ? { toggle: true, defaultLevel, efforts }
+    : { toggle: true, defaultLevel };
+}
+
+const EFFORT_ALIAS_PREFERENCE: readonly ReasoningEffort[] = [
+  "low",
+  "medium",
+  "xhigh",
+  "high",
+  "max",
+  "minimal",
+];
+
+function selectCanonicalEffortAlias(
+  aliases: ReasoningEffort[],
+): ReasoningEffort {
+  return (
+    EFFORT_ALIAS_PREFERENCE.find((effort) => aliases.includes(effort)) ??
+    aliases[0]
+  );
+}
+
+async function renderLlamaCppChatTemplate(
+  baseUrl: string,
+  apiKey: string | null | undefined,
+  model: string,
+  level: ProbeLevel,
+): Promise<RenderProbeResult | undefined> {
+  const body = reasoningProbeBody(model, level);
+  const json = await tryFetchJson<Record<string, unknown>>(
+    appendPath(openAIServiceRoot(baseUrl), "apply-template"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  return renderedPromptKey(json);
+}
+
+async function renderVllmChatTemplate(
+  baseUrl: string,
+  apiKey: string | null | undefined,
+  model: string,
+  level: ProbeLevel,
+): Promise<RenderProbeResult | undefined> {
+  const json = await tryFetchJson<Record<string, unknown>>(
+    appendPath(baseUrl, "chat/completions/render"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({
+        ...reasoningProbeBody(model, level),
+        return_prompt_text: true,
+        max_tokens: 1,
+      }),
+    },
+  );
+  return renderedPromptKey(json);
+}
+
+function reasoningProbeBody(model: string, level: ProbeLevel) {
+  return {
+    model,
+    messages: [{ role: "user", content: "hi" }],
+    ...(level === "default"
+      ? {}
+      : level === "on"
+        ? { chat_template_kwargs: { enable_thinking: true } }
+        : {
+            reasoning_effort:
+              level === "off"
+                ? "none"
+                : level === "invalid"
+                  ? "overtchat-invalid-effort"
+                  : level,
+            chat_template_kwargs: {
+              enable_thinking: level !== "off",
+            },
+          }),
+  };
+}
+
+function renderedPromptKey(
+  json: Record<string, unknown> | undefined,
+): RenderProbeResult | undefined {
+  if (!json) return undefined;
+  if (typeof json.prompt === "string") return { key: `text:${json.prompt}` };
+  if (typeof json.prompt_text === "string") {
+    return { key: `text:${json.prompt_text}` };
+  }
+  const tokenIds = Array.isArray(json.token_ids)
+    ? json.token_ids
+    : Array.isArray(json.prompt_token_ids)
+      ? json.prompt_token_ids
+      : undefined;
+  if (
+    tokenIds &&
+    tokenIds.every(
+      (token) => typeof token === "number" && Number.isInteger(token),
+    )
+  ) {
+    return { key: `tokens:${JSON.stringify(tokenIds)}` };
+  }
+  return undefined;
+}
+
+async function tryFetchJson<T>(
+  url: string,
+  init: Omit<RequestInit, "signal">,
+): Promise<T | undefined> {
+  try {
+    return await fetchJson<T>(url, init);
+  } catch {
+    // Render endpoints are runtime extensions and older servers may omit them.
+    // Discovery fails closed so an unverified control is never shown.
+    return undefined;
+  }
 }
 
 function mergeCapabilities(

--- a/apps/web/lib/providers/server/registry.test.ts
+++ b/apps/web/lib/providers/server/registry.test.ts
@@ -240,6 +240,16 @@ describe("provider registry", () => {
     ).toThrow("manages its API format automatically");
   });
 
+  it("rejects reasoning levels in adapters that do not consume them", () => {
+    expect(() =>
+      createConfiguredLanguageModel({
+        ...baseConfig,
+        providerId: "openai",
+        reasoningLevel: "low",
+      }),
+    ).toThrow("does not support per-chat reasoning levels");
+  });
+
   it.each(["vllm", "llamacpp", "sglang"] as const)(
     "uses the shared OpenAI-compatible transport for %s without requiring a key",
     (providerId) => {

--- a/apps/web/lib/providers/server/registry.test.ts
+++ b/apps/web/lib/providers/server/registry.test.ts
@@ -261,6 +261,52 @@ describe("provider registry", () => {
     },
   );
 
+  it.each(["vllm", "llamacpp"] as const)(
+    "serializes a per-chat effort for %s while preserving other params",
+    async (providerId) => {
+      let requestBody: Record<string, unknown> | undefined;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          requestBody = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return Response.json(
+            { error: { message: "intentional test response" } },
+            { status: 400 },
+          );
+        }),
+      );
+      const configured = createConfiguredLanguageModel({
+        ...baseConfig,
+        providerId,
+        reasoningLevel: "xhigh",
+        providerOptions: {
+          min_p: 0.1,
+          chat_template_kwargs: { custom: "value" },
+        },
+      });
+
+      await expect(
+        generateText({
+          model: configured.model,
+          prompt: "Hello",
+          providerOptions: configured.providerOptions,
+        }),
+      ).rejects.toThrow("intentional test response");
+
+      expect(requestBody).toMatchObject({
+        min_p: 0.1,
+        reasoning_effort: "xhigh",
+        chat_template_kwargs: {
+          custom: "value",
+          enable_thinking: true,
+        },
+      });
+    },
+  );
+
   it("requests and preserves live activity fields from llama.cpp", async () => {
     let requestBody: Record<string, unknown> | undefined;
     const progressChunk = {

--- a/apps/web/lib/providers/server/registry.ts
+++ b/apps/web/lib/providers/server/registry.ts
@@ -50,6 +50,15 @@ export function createConfiguredLanguageModel(
 ): ConfiguredLanguageModel {
   validateProviderModelConfig(config);
   const adapter = getProviderAdapter(config.providerId);
+  if (
+    config.reasoningLevel &&
+    config.reasoningLevel !== "default" &&
+    !adapter.acceptsReasoningLevel
+  ) {
+    throw new ProviderConfigurationError(
+      `${getProvider(config.providerId).label} does not support per-chat reasoning levels.`,
+    );
+  }
   let resolved: ReturnType<ProviderAdapter["createLanguageModel"]>;
   try {
     resolved = adapter.createLanguageModel(config);

--- a/apps/web/lib/providers/server/types.ts
+++ b/apps/web/lib/providers/server/types.ts
@@ -1,6 +1,6 @@
 import type { LanguageModelV4 } from "@ai-sdk/provider";
 import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
-import type { ModelCapabilities } from "@overtchat/shared";
+import type { ChatReasoningLevel, ModelCapabilities } from "@overtchat/shared";
 import type { ApiFormat, ProviderId } from "@/lib/providers/catalog";
 
 export interface ProviderConnection {
@@ -16,6 +16,8 @@ export interface ProviderModelConfig extends ProviderConnection {
   /** App capability policy; provider adapters do not infer this from model IDs. */
   toolCallingEnabled?: boolean;
   supportsImageInput?: boolean;
+  /** Per-chat local-runtime override. `default` leaves the request untouched. */
+  reasoningLevel?: ChatReasoningLevel;
 }
 
 export interface ResolvedLanguageModel {

--- a/apps/web/lib/providers/server/types.ts
+++ b/apps/web/lib/providers/server/types.ts
@@ -16,7 +16,7 @@ export interface ProviderModelConfig extends ProviderConnection {
   /** App capability policy; provider adapters do not infer this from model IDs. */
   toolCallingEnabled?: boolean;
   supportsImageInput?: boolean;
-  /** Per-chat local-runtime override. `default` leaves the request untouched. */
+  /** Per-chat override. Provider adapters decide whether and how to consume it. */
   reasoningLevel?: ChatReasoningLevel;
 }
 
@@ -43,6 +43,8 @@ export type PromptCacheStrategy =
 
 export interface ProviderAdapter {
   readonly id: ProviderId;
+  /** The adapter consumes `reasoningLevel` instead of silently ignoring it. */
+  readonly acceptsReasoningLevel?: boolean;
   validateConnection?(connection: ProviderConnection): void;
   validateModelConfig?(config: ProviderModelConfig): void;
   createLanguageModel(config: ProviderModelConfig): ResolvedLanguageModel;

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import type { ModelCapabilities, ModelReasoningLevel } from "./models";
 
 export const CHAT_KINDS = ["text", "voice"] as const;
 export type ChatKind = (typeof CHAT_KINDS)[number];
@@ -9,6 +10,21 @@ export type ChatRequestAction =
   | { type: "regenerate"; targetAssistantMessageId: string }
   | { type: "retry"; userMessageId: string };
 
+export type ChatReasoningLevel =
+  | "default"
+  | ModelReasoningLevel;
+
+export function modelSupportsChatReasoningLevel(
+  capabilities: ModelCapabilities | null | undefined,
+  level: ChatReasoningLevel | undefined,
+): level is ChatReasoningLevel {
+  if (level === "default") return true;
+  const controls = capabilities?.reasoningControls;
+  if (!controls || !level) return false;
+  if (level === "off" || level === "on") return controls.toggle;
+  return controls.efforts?.includes(level) === true;
+}
+
 export interface ChatRequestBody {
   messages: UIMessage[];
   modelConfigId: string;
@@ -16,6 +32,7 @@ export interface ChatRequestBody {
   /** Stable for one user intent and reused only when its HTTP start is retried. */
   clientRequestId: string;
   action: ChatRequestAction;
+  reasoningLevel?: ChatReasoningLevel;
   webSearchEnabled?: boolean;
   forceSearch?: boolean;
   timeZone?: string;

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -31,6 +31,27 @@ export const MODEL_BRAND_ICON_IDS = [
 
 export type ModelBrandIconId = (typeof MODEL_BRAND_ICON_IDS)[number];
 
+export const REASONING_EFFORTS = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+export type ModelReasoningLevel = "off" | "on" | ReasoningEffort;
+
+export interface ModelReasoningControls {
+  /** The runtime can render a distinct non-reasoning prompt. */
+  toggle: boolean;
+  /** Explicit level whose rendered prompt matches an omitted override. */
+  defaultLevel: ModelReasoningLevel;
+  /** Distinct effort behaviors accepted by the loaded chat template. */
+  efforts?: ReasoningEffort[];
+}
+
 /**
  * Capabilities reported by a provider/runtime or supplied by the exact
  * vendored model catalog. Missing fields are unknown, not false.
@@ -43,6 +64,7 @@ export interface ModelCapabilities {
   attachment?: boolean;
   toolCalling?: boolean;
   reasoning?: boolean;
+  reasoningControls?: ModelReasoningControls;
   structuredOutput?: boolean;
   temperature?: boolean;
 }


### PR DESCRIPTION
## Summary

- discover native reasoning controls for models served by llama.cpp and vLLM
- support toggle-only, effort-only, and combined reasoning controls
- add an in-chat thinking picker that shows runtime literals unchanged and marks the detected default
- serialize selected levels through reasoning_effort and chat_template_kwargs without requiring duplicate model configurations
- validate levels against discovered model capabilities while provider adapters declare whether they consume the override

## Detection

Discovery compares rendered prompts rather than generated model output:

- llama.cpp uses /props and /apply-template
- vLLM uses /v1/chat/completions/render and compares prompt text or token IDs
- omitted, on, off, supported effort candidates, and an invalid sentinel distinguish effective levels from accepted-but-ignored values
- effort discovery does not require the template to expose an on/off toggle
- equivalent aliases are collapsed only when the rendered prompt unambiguously identifies the projected literal
- a candidate matching the invalid fallback is retained only when the rendered prompt identifies that projection, covering templates such as GLM 5.3 where unknown values project to max
- token-only vLLM renders are detokenized without inference when alias projection must be identified
- ambiguous alias groups fail closed instead of using an app-defined preference

## Scope

This PR intentionally supports only llama.cpp and vLLM. Cloud providers and SGLang remain unchanged and can be handled separately without changing the provider-neutral chat route.

## Validation coverage

- llama.cpp with Qwen3.8-27B: off, low, medium, xhigh; xhigh detected as default
- llama.cpp with Qwen3.6-35B-A3B: on/off only; graded values are ignored and therefore not exposed
- vLLM with Qwen3.8-Flash-Next: off, low, medium, xhigh; minimal, high, and max are rejected
- vLLM token-only render output successfully round-trips through /detokenize and identifies xhigh
- Unsloth GLM-5.3-Flash GGUF template: low, high, max; no invented toggle; max detected as default
- Unsloth DeepSeek-V4-Flash-0731 and Vision-Exp GGUF templates: off, on, high, max; ambiguous low aliases fail closed

## Validation

- npm test -w apps/web -- (123 files, 775 tests)
- npm run typecheck -w apps/web --
- npm run lint -w apps/web --
- npm run build -w apps/web --

## Rollout note

Existing local model configurations must be rediscovered and saved once so the new reasoning controls are persisted.
