### PR TITLE
feat(chat): add cloud reasoning controls

### DIFF
--- a/apps/web/lib/providers/server/adapters/anthropic.ts
+++ b/apps/web/lib/providers/server/adapters/anthropic.ts
@@ -1,10 +1,12 @@
 import "server-only";
 import { listAnthropicModels } from "@/lib/providers/server/http";
+import { applyAnthropicReasoningLevel } from "@/lib/providers/server/adapters/cloud-reasoning";
 import { createAnthropicMessagesModel } from "@/lib/providers/server/transports";
 import type { ProviderAdapter } from "@/lib/providers/server/types";
 
 export const anthropicAdapter: ProviderAdapter = {
   id: "anthropic",
+  acceptsReasoningLevel: true,
   createLanguageModel(config) {
     return {
       model: createAnthropicMessagesModel({
@@ -15,6 +17,8 @@ export const anthropicAdapter: ProviderAdapter = {
         authentication: "api-key",
       }),
       providerOptionsKey: "anthropic",
+      transformProviderOptions: (options) =>
+        applyAnthropicReasoningLevel(options, config.reasoningLevel),
       promptCacheKind: "anthropic",
     };
   },

--- a/apps/web/lib/providers/server/adapters/cloud-reasoning.test.ts
+++ b/apps/web/lib/providers/server/adapters/cloud-reasoning.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyAnthropicReasoningLevel,
+  applyDeepSeekReasoningBody,
+  applyDeepSeekReasoningOptions,
+  applyGoogleReasoningLevel,
+  applyOpenAIReasoningLevel,
+} from "./cloud-reasoning";
+
+describe("cloud reasoning controls", () => {
+  it("leaves saved parameters untouched for the default selection", () => {
+    const options = { reasoningEffort: "high", custom: true };
+    expect(applyOpenAIReasoningLevel(options, "default")).toBe(options);
+  });
+
+  it("overrides only OpenAI's configured effort", () => {
+    expect(
+      applyOpenAIReasoningLevel(
+        { reasoningEffort: "high", reasoningSummary: "auto" },
+        "off",
+      ),
+    ).toEqual({ reasoningEffort: "none", reasoningSummary: "auto" });
+  });
+
+  it("uses Anthropic adaptive thinking and preserves display controls", () => {
+    expect(
+      applyAnthropicReasoningLevel(
+        {
+          effort: "low",
+          cacheControl: { type: "ephemeral" },
+          thinking: { type: "enabled", budgetTokens: 4096, display: "summarized" },
+        },
+        "max",
+      ),
+    ).toEqual({
+      effort: "max",
+      cacheControl: { type: "ephemeral" },
+      thinking: { type: "adaptive", display: "summarized" },
+    });
+    expect(
+      applyAnthropicReasoningLevel(
+        { effort: "high", thinking: { type: "adaptive", display: "summarized" } },
+        "off",
+      ),
+    ).toEqual({ thinking: { type: "disabled" } });
+  });
+
+  it("uses Google's native level while preserving unrelated thinking options", () => {
+    expect(
+      applyGoogleReasoningLevel(
+        {
+          safetySettings: [],
+          thinkingConfig: {
+            thinkingBudget: 4096,
+            thinkingLevel: "low",
+            includeThoughts: false,
+          },
+        },
+        "high",
+      ),
+    ).toEqual({
+      safetySettings: [],
+      thinkingConfig: { thinkingLevel: "high", includeThoughts: false },
+    });
+  });
+
+  it("separates DeepSeek's effort and toggle controls", () => {
+    expect(
+      applyDeepSeekReasoningOptions(
+        { reasoningEffort: "high", custom: true },
+        "off",
+      ),
+    ).toEqual({ custom: true });
+    expect(
+      applyDeepSeekReasoningBody(
+        {
+          reasoning_effort: "high",
+          thinking: { type: "enabled", custom: true },
+        },
+        "off",
+      ),
+    ).toEqual({ thinking: { type: "disabled", custom: true } });
+    expect(
+      applyDeepSeekReasoningBody({ reasoning_effort: "max" }, "max"),
+    ).toEqual({
+      reasoning_effort: "max",
+      thinking: { type: "enabled" },
+    });
+  });
+});

--- a/apps/web/lib/providers/server/adapters/cloud-reasoning.ts
+++ b/apps/web/lib/providers/server/adapters/cloud-reasoning.ts
@@ -1,0 +1,106 @@
+import type { ChatReasoningLevel } from "@overtchat/shared";
+
+export function applyOpenAIReasoningLevel(
+  options: Record<string, unknown>,
+  level: ChatReasoningLevel | undefined,
+): Record<string, unknown> {
+  if (!level || level === "default") return options;
+  const { reasoningEffort: _configuredEffort, ...rest } = options;
+  void _configuredEffort;
+  return level === "on"
+    ? rest
+    : {
+        ...rest,
+        reasoningEffort: level === "off" ? "none" : level,
+      };
+}
+
+export function applyAnthropicReasoningLevel(
+  options: Record<string, unknown>,
+  level: ChatReasoningLevel | undefined,
+): Record<string, unknown> {
+  if (!level || level === "default") return options;
+  const {
+    effort: _configuredEffort,
+    thinking: configuredThinking,
+    ...rest
+  } = options;
+  void _configuredEffort;
+  if (level === "off") {
+    return { ...rest, thinking: { type: "disabled" } };
+  }
+
+  const thinking = isRecord(configuredThinking)
+    ? configuredThinking
+    : {};
+  const { budgetTokens: _configuredBudget, ...thinkingOptions } = thinking;
+  void _configuredBudget;
+  return {
+    ...rest,
+    thinking: { ...thinkingOptions, type: "adaptive" },
+    ...(level === "on" ? {} : { effort: level }),
+  };
+}
+
+export function applyGoogleReasoningLevel(
+  options: Record<string, unknown>,
+  level: ChatReasoningLevel | undefined,
+): Record<string, unknown> {
+  if (!level || level === "default") return options;
+  const configuredThinking = isRecord(options.thinkingConfig)
+    ? options.thinkingConfig
+    : {};
+  const {
+    thinkingBudget: _configuredBudget,
+    thinkingLevel: _configuredLevel,
+    ...thinkingOptions
+  } = configuredThinking;
+  void _configuredBudget;
+  void _configuredLevel;
+  return {
+    ...options,
+    thinkingConfig: {
+      ...thinkingOptions,
+      ...(level === "off"
+        ? { thinkingBudget: 0 }
+        : level === "on"
+          ? {}
+          : { thinkingLevel: level }),
+    },
+  };
+}
+
+export function applyDeepSeekReasoningOptions(
+  options: Record<string, unknown>,
+  level: ChatReasoningLevel | undefined,
+): Record<string, unknown> {
+  if (!level || level === "default") return options;
+  const { reasoningEffort: _configuredEffort, ...rest } = options;
+  void _configuredEffort;
+  return level === "off" || level === "on"
+    ? rest
+    : { ...rest, reasoningEffort: level };
+}
+
+export function applyDeepSeekReasoningBody(
+  body: Record<string, unknown>,
+  level: ChatReasoningLevel | undefined,
+): Record<string, unknown> {
+  if (!level || level === "default") return body;
+  const existingThinking = isRecord(body.thinking) ? body.thinking : {};
+  const withThinking: Record<string, unknown> = {
+    ...body,
+    thinking: {
+      ...existingThinking,
+      type: level === "off" ? "disabled" : "enabled",
+    },
+  };
+  if (level !== "off" && level !== "on") return withThinking;
+  const { reasoning_effort: _configuredEffort, ...rest } = withThinking;
+  void _configuredEffort;
+  return rest;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/apps/web/lib/providers/server/adapters/deepseek.test.ts
+++ b/apps/web/lib/providers/server/adapters/deepseek.test.ts
@@ -38,6 +38,27 @@ describe("DeepSeek adapter", () => {
     expect(prepareDeepSeekRequest(nonThinking)).toBe(nonThinking);
   });
 
+  it("applies explicit effort and toggle selections", () => {
+    expect(
+      prepareDeepSeekRequest(
+        {
+          reasoning_effort: "max",
+          thinking: { type: "disabled", custom: true },
+        },
+        "max",
+      ),
+    ).toEqual({
+      reasoning_effort: "max",
+      thinking: { type: "enabled", custom: true },
+    });
+    expect(
+      prepareDeepSeekRequest(
+        { reasoning_effort: "max", thinking: { type: "enabled" } },
+        "off",
+      ),
+    ).toEqual({ thinking: { type: "disabled" } });
+  });
+
   it("discovers models through the authenticated OpenAI-compatible endpoint", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json({

--- a/apps/web/lib/providers/server/adapters/deepseek.ts
+++ b/apps/web/lib/providers/server/adapters/deepseek.ts
@@ -1,10 +1,16 @@
 import "server-only";
+import {
+  applyDeepSeekReasoningBody,
+  applyDeepSeekReasoningOptions,
+} from "@/lib/providers/server/adapters/cloud-reasoning";
 import { listOpenAIModels } from "@/lib/providers/server/http";
 import { createOpenAICompatibleChatModel } from "@/lib/providers/server/transports";
 import type { ProviderAdapter } from "@/lib/providers/server/types";
+import type { ChatReasoningLevel } from "@overtchat/shared";
 
 export const deepSeekAdapter: ProviderAdapter = {
   id: "deepseek",
+  acceptsReasoningLevel: true,
   createLanguageModel(config) {
     return {
       model: createOpenAICompatibleChatModel({
@@ -13,9 +19,12 @@ export const deepSeekAdapter: ProviderAdapter = {
         apiKey: config.apiKey,
         model: config.model,
         supportsImageInput: config.supportsImageInput,
-        transformRequestBody: prepareDeepSeekRequest,
+        transformRequestBody: (body) =>
+          prepareDeepSeekRequest(body, config.reasoningLevel),
       }),
       providerOptionsKey: "deepseek",
+      transformProviderOptions: (options) =>
+        applyDeepSeekReasoningOptions(options, config.reasoningLevel),
     };
   },
   listModels(connection) {
@@ -26,18 +35,20 @@ export const deepSeekAdapter: ProviderAdapter = {
 /** DeepSeek defaults to thinking mode, which rejects forced tool choice. */
 export function prepareDeepSeekRequest(
   body: Record<string, unknown>,
+  reasoningLevel?: ChatReasoningLevel,
 ): Record<string, unknown> {
-  if (body.tool_choice !== "required") return body;
-  const thinking = body.thinking;
+  const withReasoning = applyDeepSeekReasoningBody(body, reasoningLevel);
+  if (withReasoning.tool_choice !== "required") return withReasoning;
+  const thinking = withReasoning.thinking;
   if (
     thinking &&
     typeof thinking === "object" &&
     !Array.isArray(thinking) &&
     (thinking as Record<string, unknown>).type === "disabled"
   ) {
-    return body;
+    return withReasoning;
   }
-  const { tool_choice: _unsupported, ...compatible } = body;
+  const { tool_choice: _unsupported, ...compatible } = withReasoning;
   void _unsupported;
   return compatible;
 }

--- a/apps/web/lib/providers/server/adapters/google.ts
+++ b/apps/web/lib/providers/server/adapters/google.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { listGoogleModels } from "@/lib/providers/server/http";
+import { applyGoogleReasoningLevel } from "@/lib/providers/server/adapters/cloud-reasoning";
 import { createGoogleGenerativeModel } from "@/lib/providers/server/transports";
 import type { ProviderAdapter } from "@/lib/providers/server/types";
 
@@ -9,6 +10,7 @@ const GOOGLE_THINKING_DEFAULTS = {
 
 export const googleAdapter: ProviderAdapter = {
   id: "google",
+  acceptsReasoningLevel: true,
   createLanguageModel(config) {
     return {
       model: createGoogleGenerativeModel({
@@ -19,6 +21,8 @@ export const googleAdapter: ProviderAdapter = {
       }),
       providerOptionsKey: "google",
       defaultProviderOptions: GOOGLE_THINKING_DEFAULTS,
+      transformProviderOptions: (options) =>
+        applyGoogleReasoningLevel(options, config.reasoningLevel),
     };
   },
   listModels(connection) {

--- a/apps/web/lib/providers/server/adapters/openai.ts
+++ b/apps/web/lib/providers/server/adapters/openai.ts
@@ -1,10 +1,12 @@
 import "server-only";
 import { listOpenAIModels } from "@/lib/providers/server/http";
+import { applyOpenAIReasoningLevel } from "@/lib/providers/server/adapters/cloud-reasoning";
 import { createOpenAIResponsesModel } from "@/lib/providers/server/transports";
 import type { ProviderAdapter } from "@/lib/providers/server/types";
 
 export const openAIAdapter: ProviderAdapter = {
   id: "openai",
+  acceptsReasoningLevel: true,
   createLanguageModel(config) {
     return {
       model: createOpenAIResponsesModel({
@@ -14,6 +16,8 @@ export const openAIAdapter: ProviderAdapter = {
         model: config.model,
       }),
       providerOptionsKey: "openai",
+      transformProviderOptions: (options) =>
+        applyOpenAIReasoningLevel(options, config.reasoningLevel),
       promptCacheKind: "openai",
     };
   },

--- a/apps/web/lib/providers/server/model-catalog-artifacts.ts
+++ b/apps/web/lib/providers/server/model-catalog-artifacts.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-export const MODEL_CATALOG_SCHEMA_VERSION = 1;
+export const MODEL_CATALOG_SCHEMA_VERSION = 2;
 export const MODEL_CATALOG_SOURCE_URL = "https://models.dev/api.json";
 
 export interface ModelCatalogManifest {

--- a/apps/web/lib/providers/server/model-catalog-reasoning.test.ts
+++ b/apps/web/lib/providers/server/model-catalog-reasoning.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { catalogReasoningControlsFor } from "./model-catalog-reasoning";
+
+describe("catalog reasoning controls", () => {
+  it("copies OpenAI effort values and treats none as an off control", () => {
+    expect(
+      catalogReasoningControlsFor("openai", [
+        {
+          type: "effort",
+          values: ["none", "low", "medium", "high", "xhigh"],
+        },
+      ]),
+    ).toEqual({
+      toggle: true,
+      defaultLevel: "medium",
+      efforts: ["low", "medium", "high", "xhigh"],
+    });
+  });
+
+  it("uses provider defaults without remapping effort names", () => {
+    expect(
+      catalogReasoningControlsFor("anthropic", [
+        {
+          type: "effort",
+          values: ["low", "medium", "high", "xhigh", "max"],
+        },
+      ]),
+    ).toEqual({
+      toggle: false,
+      defaultLevel: "high",
+      efforts: ["low", "medium", "high", "xhigh", "max"],
+    });
+    expect(
+      catalogReasoningControlsFor("google", [
+        { type: "effort", values: ["minimal", "low", "medium", "high"] },
+      ]),
+    ).toEqual({
+      toggle: false,
+      defaultLevel: "high",
+      efforts: ["minimal", "low", "medium", "high"],
+    });
+    expect(
+      catalogReasoningControlsFor("deepseek", [
+        { type: "toggle" },
+        { type: "effort", values: ["low", "high", "max"] },
+      ]),
+    ).toEqual({
+      toggle: true,
+      defaultLevel: "max",
+      efforts: ["low", "high", "max"],
+    });
+  });
+
+  it("uses a fixed model's only effort as its concrete default", () => {
+    expect(
+      catalogReasoningControlsFor("openai", [
+        { type: "effort", values: ["high"] },
+      ]),
+    ).toEqual({
+      toggle: false,
+      defaultLevel: "high",
+      efforts: ["high"],
+    });
+  });
+
+  it("fails closed for budget, toggle-only, unknown, and ambiguous metadata", () => {
+    expect(
+      catalogReasoningControlsFor("anthropic", [
+        { type: "effort", values: ["low", "medium", "high"] },
+        { type: "budget_tokens", min: 1024 },
+      ]),
+    ).toBeUndefined();
+    expect(
+      catalogReasoningControlsFor("google", [{ type: "toggle" }]),
+    ).toBeUndefined();
+    expect(
+      catalogReasoningControlsFor("bedrock", [
+        { type: "effort", values: ["low", "medium", "high"] },
+      ]),
+    ).toBeUndefined();
+    expect(
+      catalogReasoningControlsFor("openai", [
+        { type: "effort", values: ["low", "high", "default", null] },
+      ]),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/lib/providers/server/model-catalog-reasoning.ts
+++ b/apps/web/lib/providers/server/model-catalog-reasoning.ts
@@ -1,0 +1,69 @@
+import {
+  REASONING_EFFORTS,
+  type ModelReasoningControls,
+  type ReasoningEffort,
+} from "@overtchat/shared";
+
+const DEFAULT_REASONING_LEVELS = {
+  openai: "medium",
+  anthropic: "high",
+  google: "high",
+  deepseek: "max",
+} as const satisfies Record<string, ReasoningEffort>;
+
+type CloudReasoningProviderId = keyof typeof DEFAULT_REASONING_LEVELS;
+
+/**
+ * Converts provider-specific models.dev reasoning metadata into controls that
+ * OvertChat can send without remapping. Token-budget models stay hidden until
+ * the product has a native budget control.
+ */
+export function catalogReasoningControlsFor(
+  providerId: string,
+  reasoningOptions: unknown,
+): ModelReasoningControls | undefined {
+  if (!isCloudReasoningProvider(providerId)) return undefined;
+  if (!Array.isArray(reasoningOptions)) return undefined;
+
+  const options = reasoningOptions.filter(isRecord);
+  if (options.some((option) => option.type === "budget_tokens")) {
+    return undefined;
+  }
+
+  const effortValues = options.flatMap((option) =>
+    option.type === "effort" && Array.isArray(option.values)
+      ? option.values
+      : [],
+  );
+  const supported = new Set(effortValues);
+  const efforts = REASONING_EFFORTS.filter((effort) =>
+    supported.has(effort),
+  );
+  if (efforts.length === 0) return undefined;
+
+  const preferredDefault = DEFAULT_REASONING_LEVELS[providerId];
+  const defaultLevel = efforts.includes(preferredDefault)
+    ? preferredDefault
+    : efforts.length === 1
+      ? efforts[0]
+      : undefined;
+  if (!defaultLevel) return undefined;
+
+  return {
+    toggle:
+      supported.has("none") ||
+      options.some((option) => option.type === "toggle"),
+    defaultLevel,
+    efforts,
+  };
+}
+
+function isCloudReasoningProvider(
+  providerId: string,
+): providerId is CloudReasoningProviderId {
+  return providerId in DEFAULT_REASONING_LEVELS;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/apps/web/lib/providers/server/model-catalog.json
+++ b/apps/web/lib/providers/server/model-catalog.json
@@ -264,7 +264,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gpt-5-mini": {
       "context": 400000,
@@ -286,7 +296,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gpt-5-nano": {
       "context": 400000,
@@ -308,7 +328,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gpt-5-pro": {
       "context": 400000,
@@ -329,7 +359,14 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "high"
+        ]
+      }
     },
     "gpt-5.1": {
       "context": 400000,
@@ -351,7 +388,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gpt-5.2": {
       "context": 400000,
@@ -373,7 +419,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.2-chat-latest": {
       "context": 128000,
@@ -394,7 +450,14 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "medium"
+        ]
+      }
     },
     "gpt-5.2-pro": {
       "context": 400000,
@@ -415,7 +478,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": false,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.3-chat-latest": {
       "context": 128000,
@@ -459,7 +531,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.3-codex-spark": {
       "context": 128000,
@@ -482,7 +564,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.4": {
       "context": 1050000,
@@ -521,7 +613,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.4-mini": {
       "context": 400000,
@@ -543,7 +645,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.4-nano": {
       "context": 400000,
@@ -565,7 +677,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.4-pro": {
       "context": 1050000,
@@ -600,7 +722,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": false,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.5": {
       "context": 1050000,
@@ -639,7 +770,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.5-pro": {
       "context": 1050000,
@@ -675,7 +816,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "gpt-5.6": {
       "context": 1050000,
@@ -717,7 +867,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "gpt-5.6-luna": {
       "context": 1050000,
@@ -759,7 +920,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "gpt-5.6-sol": {
       "context": 1050000,
@@ -801,7 +973,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "gpt-5.6-terra": {
       "context": 1050000,
@@ -843,7 +1026,71 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    },
+    "gpt-6-astra": {
+      "context": 1050000,
+      "input": 922000,
+      "output": 128000,
+      "cost": {
+        "cache_read": 1,
+        "cache_write": 12.5,
+        "context_over_200k": {
+          "cache_read": 2,
+          "cache_write": 25,
+          "input": 20,
+          "output": 75
+        },
+        "input": 10,
+        "output": 50,
+        "tiers": [
+          {
+            "cache_read": 2,
+            "cache_write": 25,
+            "input": 20,
+            "output": 75,
+            "tier": {
+              "size": 272000,
+              "type": "context"
+            }
+          }
+        ]
+      },
+      "input_modalities": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output_modalities": [
+        "text"
+      ],
+      "attachment": true,
+      "tool_call": true,
+      "reasoning": true,
+      "structured_output": true,
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "gpt-image-1": {
       "input_modalities": [
@@ -928,7 +1175,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": false,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     },
     "o1": {
       "context": 200000,
@@ -950,7 +1208,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "o1-pro": {
       "context": 200000,
@@ -970,7 +1237,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "o3": {
       "context": 200000,
@@ -992,7 +1268,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "o3-mini": {
       "context": 200000,
@@ -1012,7 +1297,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "o3-pro": {
       "context": 200000,
@@ -1032,7 +1326,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "o4-mini": {
       "context": 200000,
@@ -1053,7 +1356,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "medium",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "text-embedding-3-large": {
       "context": 8191,
@@ -1132,7 +1444,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "claude-fable-5-1": {
       "context": 1000000,
@@ -1155,7 +1478,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "claude-haiku-4-5": {
       "context": 200000,
@@ -1293,7 +1627,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "claude-opus-4-8": {
       "context": 1000000,
@@ -1316,7 +1661,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "claude-opus-5": {
       "context": 1000000,
@@ -1339,7 +1695,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     },
     "claude-sonnet-4-5": {
       "context": 1000000,
@@ -1431,7 +1798,18 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": false
+      "temperature": false,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
     }
   },
   "google": {
@@ -1718,7 +2096,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3-pro-image": {
       "context": 131072,
@@ -1738,7 +2126,15 @@
       "attachment": true,
       "tool_call": false,
       "reasoning": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "high"
+        ]
+      }
     },
     "gemini-3-pro-image-preview": {
       "context": 131072,
@@ -1780,7 +2176,15 @@
       "attachment": true,
       "tool_call": false,
       "reasoning": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "high"
+        ]
+      }
     },
     "gemini-3.1-flash-image-preview": {
       "context": 65536,
@@ -1801,7 +2205,15 @@
       "attachment": true,
       "tool_call": false,
       "reasoning": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "high"
+        ]
+      }
     },
     "gemini-3.1-flash-lite": {
       "context": 1048576,
@@ -1826,7 +2238,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.1-flash-lite-image": {
       "context": 65536,
@@ -1847,7 +2269,15 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": false,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "high"
+        ]
+      }
     },
     "gemini-3.1-flash-lite-preview": {
       "context": 1048576,
@@ -1872,7 +2302,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.1-flash-live-preview": {
       "context": 131072,
@@ -1897,7 +2337,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": false,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.1-flash-tts-preview": {
       "context": 8192,
@@ -1955,7 +2405,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.1-pro-preview-customtools": {
       "context": 1048576,
@@ -1995,7 +2454,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.5-flash": {
       "context": 1048576,
@@ -2020,7 +2488,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.5-flash-lite": {
       "context": 1048576,
@@ -2044,7 +2522,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.5-live-translate-preview": {
       "context": 16384,
@@ -2090,7 +2578,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.7-flash": {
       "context": 1048576,
@@ -2115,7 +2613,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-3.8-flash": {
       "context": 1048576,
@@ -2140,7 +2647,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-embedding-001": {
       "context": 2048,
@@ -2206,7 +2722,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-flash-lite-latest": {
       "context": 1048576,
@@ -2230,7 +2755,17 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": false,
+        "defaultLevel": "high",
+        "efforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     },
     "gemini-omni-flash-preview": {
       "context": 131072,
@@ -2393,7 +2928,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "max",
+        "efforts": [
+          "low",
+          "high",
+          "max"
+        ]
+      }
     },
     "deepseek-v4-flash-vision-exp": {
       "context": 1000000,
@@ -2415,7 +2959,16 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "max",
+        "efforts": [
+          "low",
+          "high",
+          "max"
+        ]
+      }
     },
     "deepseek-v4-pro": {
       "context": 1000000,
@@ -2436,7 +2989,15 @@
       "tool_call": true,
       "reasoning": true,
       "structured_output": true,
-      "temperature": true
+      "temperature": true,
+      "reasoning_controls": {
+        "toggle": true,
+        "defaultLevel": "max",
+        "efforts": [
+          "high",
+          "max"
+        ]
+      }
     }
   },
   "bedrock": {

--- a/apps/web/lib/providers/server/model-catalog.manifest.json
+++ b/apps/web/lib/providers/server/model-catalog.manifest.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": 1,
-  "generatedAt": "2026-09-02T16:33:13.849Z",
+  "schemaVersion": 2,
+  "generatedAt": "2026-09-05T10:01:03.081Z",
   "sourceUrl": "https://models.dev/api.json",
-  "sourceSha256": "897563b77f1f4401288db80306da7e7346585013220ece3c51869f6ab81bf577",
-  "catalogSha256": "3abf261491592b7aa8888fe71767ca79b46f4a21a4739027a45b28f88381038d",
-  "modelCount": 226
+  "sourceSha256": "6a5569d05e3218fa337cf01ff8bbf5af556bc1afc1f410b3ee569f438c31f9d0",
+  "catalogSha256": "3ea5ac93301ad63e1faf10962ad5e57ce8c2f5d19b7fade9edf73633e6f7200f",
+  "modelCount": 227
 }

--- a/apps/web/lib/providers/server/model-catalog.test.ts
+++ b/apps/web/lib/providers/server/model-catalog.test.ts
@@ -69,6 +69,46 @@ describe("vendored model catalog", () => {
     });
   });
 
+  it("exposes exact cloud reasoning controls without Bedrock fallback", () => {
+    expect(catalogCapabilitiesFor("openai", "gpt-5.4")).toMatchObject({
+      reasoningControls: {
+        toggle: true,
+        defaultLevel: "medium",
+        efforts: ["low", "medium", "high", "xhigh"],
+      },
+    });
+    expect(
+      catalogCapabilitiesFor("anthropic", "claude-opus-4-7"),
+    ).toMatchObject({
+      reasoningControls: {
+        toggle: false,
+        defaultLevel: "high",
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+      },
+    });
+    expect(
+      catalogCapabilitiesFor("google", "gemini-3.1-pro-preview"),
+    ).toMatchObject({
+      reasoningControls: {
+        toggle: false,
+        defaultLevel: "high",
+        efforts: ["low", "medium", "high"],
+      },
+    });
+    expect(
+      catalogCapabilitiesFor("deepseek", "deepseek-v4-flash"),
+    ).toMatchObject({
+      reasoningControls: {
+        toggle: true,
+        defaultLevel: "max",
+        efforts: ["low", "high", "max"],
+      },
+    });
+    expect(
+      catalogCapabilitiesFor("bedrock", "openai.gpt-5.4"),
+    ).not.toHaveProperty("reasoningControls");
+  });
+
   it("normalizes base pricing and identifies context tiers", () => {
     expect(catalogPricingFor("openai", "gpt-4")).toEqual({
       input: 30,

--- a/apps/web/lib/providers/server/model-catalog.ts
+++ b/apps/web/lib/providers/server/model-catalog.ts
@@ -1,5 +1,8 @@
 import "server-only";
-import type { ModelCapabilities } from "@overtchat/shared";
+import type {
+  ModelCapabilities,
+  ModelReasoningControls,
+} from "@overtchat/shared";
 import type { CatalogModelPricing } from "@/lib/model-config/schema";
 import type { ProviderId } from "@/lib/providers/catalog";
 import catalogJson from "@/lib/providers/server/model-catalog.json";
@@ -14,6 +17,7 @@ export interface ModelCatalogEntry {
   attachment?: boolean;
   tool_call?: boolean;
   reasoning?: boolean;
+  reasoning_controls?: ModelReasoningControls;
   structured_output?: boolean;
   temperature?: boolean;
 }
@@ -82,6 +86,7 @@ export function catalogCapabilitiesFor(
     attachment: entry.attachment,
     toolCalling: entry.tool_call,
     reasoning: entry.reasoning,
+    reasoningControls: entry.reasoning_controls,
     structuredOutput: entry.structured_output,
     temperature: entry.temperature,
   });

--- a/apps/web/lib/providers/server/registry.test.ts
+++ b/apps/web/lib/providers/server/registry.test.ts
@@ -244,11 +244,103 @@ describe("provider registry", () => {
     expect(() =>
       createConfiguredLanguageModel({
         ...baseConfig,
-        providerId: "openai",
+        providerId: "custom",
+        apiFormat: "openai-chat",
         reasoningLevel: "low",
       }),
     ).toThrow("does not support per-chat reasoning levels");
   });
+
+  it.each([
+    {
+      providerId: "openai" as const,
+      model: "gpt-5.4",
+      reasoningLevel: "xhigh" as const,
+      providerOptions: { reasoningEffort: "low", reasoningSummary: "auto" },
+      expectedBody: { reasoning: { effort: "xhigh", summary: "auto" } },
+    },
+    {
+      providerId: "anthropic" as const,
+      model: "claude-opus-4-7",
+      reasoningLevel: "max" as const,
+      providerOptions: {
+        effort: "low",
+        thinking: { type: "enabled", budgetTokens: 4096 },
+      },
+      expectedBody: {
+        thinking: { type: "adaptive" },
+        output_config: { effort: "max" },
+      },
+    },
+    {
+      providerId: "google" as const,
+      model: "gemini-3.1-pro-preview",
+      reasoningLevel: "high" as const,
+      providerOptions: {
+        thinkingConfig: { thinkingBudget: 4096, includeThoughts: false },
+      },
+      expectedBody: {
+        generationConfig: {
+          thinkingConfig: {
+            thinkingLevel: "high",
+            includeThoughts: false,
+          },
+        },
+      },
+    },
+    {
+      providerId: "deepseek" as const,
+      model: "deepseek-v4-flash",
+      reasoningLevel: "max" as const,
+      providerOptions: { reasoningEffort: "low", custom: true },
+      expectedBody: {
+        reasoning_effort: "max",
+        thinking: { type: "enabled" },
+        custom: true,
+      },
+    },
+  ])(
+    "serializes an explicit $providerId selection over saved reasoning params",
+    async ({
+      providerId,
+      model,
+      reasoningLevel,
+      providerOptions,
+      expectedBody,
+    }) => {
+      let requestBody: Record<string, unknown> | undefined;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          requestBody = JSON.parse(String(init?.body)) as Record<
+            string,
+            unknown
+          >;
+          return Response.json(
+            { error: { message: "intentional test response" } },
+            { status: 400 },
+          );
+        }),
+      );
+      const configured = createConfiguredLanguageModel({
+        ...baseConfig,
+        providerId,
+        model,
+        reasoningLevel,
+        providerOptions,
+      });
+
+      await expect(
+        generateText({
+          model: configured.model,
+          prompt: "Hello",
+          providerOptions: configured.providerOptions,
+        }),
+      ).rejects.toThrow();
+
+      expect(requestBody).toMatchObject(expectedBody);
+    },
+  );
 
   it.each(["vllm", "llamacpp", "sglang"] as const)(
     "uses the shared OpenAI-compatible transport for %s without requiring a key",

--- a/apps/web/lib/providers/server/registry.ts
+++ b/apps/web/lib/providers/server/registry.ts
@@ -70,10 +70,13 @@ export function createConfiguredLanguageModel(
       { cause: error },
     );
   }
-  const options = {
+  const configuredOptions = {
     ...(resolved.defaultProviderOptions ?? {}),
     ...(config.providerOptions ?? {}),
   };
+  const options = resolved.transformProviderOptions
+    ? resolved.transformProviderOptions(configuredOptions)
+    : configuredOptions;
 
   return {
     model: wrapLanguageModel({

--- a/apps/web/lib/providers/server/types.ts
+++ b/apps/web/lib/providers/server/types.ts
@@ -24,6 +24,10 @@ export interface ResolvedLanguageModel {
   model: LanguageModelV4;
   providerOptionsKey: string;
   defaultProviderOptions?: Record<string, unknown>;
+  /** Applies explicit per-chat controls after saved provider options merge. */
+  transformProviderOptions?: (
+    options: Record<string, unknown>,
+  ) => Record<string, unknown>;
   promptCacheKind?: "anthropic" | "openai";
 }
 

--- a/apps/web/scripts/generate-model-catalog.ts
+++ b/apps/web/scripts/generate-model-catalog.ts
@@ -14,11 +14,13 @@ import {
   writeFileSync,
 } from "node:fs";
 import { resolve } from "node:path";
+import type { ModelReasoningControls } from "@overtchat/shared";
 import {
   createModelCatalogManifest,
   MODEL_CATALOG_SOURCE_URL,
   validateModelCatalogArtifacts,
 } from "../lib/providers/server/model-catalog-artifacts";
+import { catalogReasoningControlsFor } from "../lib/providers/server/model-catalog-reasoning";
 
 const PROVIDERS = [
   ["openai", "openai"],
@@ -46,6 +48,7 @@ interface CatalogEntry {
   attachment?: boolean;
   tool_call?: boolean;
   reasoning?: boolean;
+  reasoning_controls?: ModelReasoningControls;
   structured_output?: boolean;
   temperature?: boolean;
 }
@@ -134,6 +137,14 @@ async function main() {
       copyBoolean(sourceModel, entry, "reasoning");
       copyBoolean(sourceModel, entry, "structured_output");
       copyBoolean(sourceModel, entry, "temperature");
+
+      if (sourceModel.reasoning === true) {
+        const reasoningControls = catalogReasoningControlsFor(
+          providerId,
+          sourceModel.reasoning_options,
+        );
+        if (reasoningControls) entry.reasoning_controls = reasoningControls;
+      }
 
       if (models[id]) {
         throw new Error(`Duplicate models.dev model ID "${providerId}/${id}"`);


### PR DESCRIPTION
## Summary

- derive native reasoning controls for built-in OpenAI, Anthropic, Google, and DeepSeek models from their provider-specific `models.dev` metadata
- send the selected level using each provider's native request shape, with explicit chat choices overriding conflicting saved advanced parameters
- fail closed for token-budget models, ambiguous metadata, custom providers, and Bedrock instead of inventing mappings

## Behavior

- effort names are preserved exactly; `none` or an explicit toggle becomes Off
- defaults are concrete supported levels: OpenAI medium, Anthropic high, Google high, and DeepSeek max
- saved provider options remain untouched when no explicit chat override is applied
- the refreshed upstream catalog adds `openai/gpt-6-astra` alongside the new reasoning metadata

## Validation

- `npm run catalog:check`
- `npm run typecheck -w apps/web --`
- `npm run lint -w apps/web --`
- `npm run test -w apps/web --` (790 tests)
- `npm run build -w apps/web --`
