### PR TITLE
feat(site): refresh landing page story

### DIFF
--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -382,7 +382,8 @@ a:focus-visible,
 }
 
 .vignette-sidebar-action,
-.vignette-project {
+.vignette-project,
+.vignette-agent-workspace {
   display: flex;
   min-width: 0;
   align-items: center;
@@ -393,7 +394,8 @@ a:focus-visible,
 }
 
 .vignette-sidebar-action svg,
-.vignette-project svg {
+.vignette-project svg,
+.vignette-agent-workspace svg {
   width: 0.72rem;
   height: 0.72rem;
   flex-shrink: 0;
@@ -423,6 +425,25 @@ a:focus-visible,
   overflow: hidden;
   flex: 1;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vignette-agent-workspace span {
+  overflow: hidden;
+  flex: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vignette-agent-workspace small {
+  flex-shrink: 0;
+  border: 1px solid var(--sidebar-border);
+  border-radius: 999px;
+  padding: 0.12rem 0.28rem;
+  color: var(--muted-foreground);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 0.42rem;
+  line-height: 1;
   white-space: nowrap;
 }
 
@@ -779,6 +800,150 @@ a:focus-visible,
   border-block: 1px solid var(--border);
 }
 
+.access-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1.15fr);
+  align-items: center;
+  gap: clamp(0.8rem, 2.5vw, 1.75rem);
+  margin-bottom: 1.25rem;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1.4rem;
+  padding: clamp(1.25rem, 3.5vw, 2.5rem);
+  background:
+    radial-gradient(circle at 50% 0%, color-mix(in oklch, var(--accent) 75%, transparent), transparent 24rem),
+    var(--card);
+}
+
+.access-node {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: color-mix(in oklch, var(--background) 88%, transparent);
+}
+
+.access-node-primary {
+  border-color: color-mix(in oklch, var(--primary) 58%, var(--border));
+  background: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 12px 34px color-mix(in oklch, var(--primary) 18%, transparent);
+}
+
+.access-node-icon {
+  display: grid;
+  width: 2.4rem;
+  height: 2.4rem;
+  flex-shrink: 0;
+  border: 1px solid color-mix(in oklch, currentColor 18%, transparent);
+  border-radius: 0.75rem;
+  place-items: center;
+}
+
+.access-node-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.access-node div,
+.access-person div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.access-node strong,
+.access-person strong {
+  overflow: hidden;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.access-node small,
+.access-person small {
+  margin-top: 0.18rem;
+  color: var(--muted-foreground);
+  font-size: 0.68rem;
+  white-space: nowrap;
+}
+
+.access-node-primary small {
+  color: color-mix(in oklch, var(--primary-foreground) 72%, transparent);
+}
+
+.access-arrow {
+  display: grid;
+  color: var(--muted-foreground);
+  place-items: center;
+}
+
+.access-arrow svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.access-people {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.access-person {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 0.8rem;
+  padding: 0.62rem 0.75rem;
+  background: color-mix(in oklch, var(--background) 88%, transparent);
+}
+
+.access-person > span {
+  display: grid;
+  width: 1.7rem;
+  height: 1.7rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 0.63rem;
+  font-weight: 700;
+  place-items: center;
+}
+
+.access-safety {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.access-safety span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.access-safety svg {
+  width: 0.78rem;
+  height: 0.78rem;
+  color: var(--ring);
+}
+
 .step-card {
   padding: 2.25rem;
 }
@@ -807,6 +972,195 @@ a:focus-visible,
   color: var(--muted-foreground);
   font-size: 0.88rem;
   line-height: 1.7;
+}
+
+.voice-showcase {
+  display: grid;
+  grid-template-columns: minmax(0, 0.88fr) minmax(32rem, 1.12fr);
+  align-items: center;
+  gap: clamp(2.5rem, 7vw, 6rem);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: clamp(2rem, 5vw, 4.5rem);
+  background:
+    radial-gradient(circle at 100% 0%, color-mix(in oklch, var(--accent) 90%, transparent), transparent 28rem),
+    var(--card);
+}
+
+.voice-copy .section-lede {
+  margin: 1.5rem 0 0;
+}
+
+.voice-proof {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: end;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.voice-proof strong {
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: clamp(2.25rem, 5vw, 3.75rem);
+  font-weight: 650;
+  letter-spacing: -0.07em;
+  line-height: 0.85;
+}
+
+.voice-proof span {
+  max-width: 18rem;
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.voice-hardware-note {
+  margin: 1.35rem 0 0;
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+  line-height: 1.7;
+}
+
+.voice-console {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid oklch(1 0 0 / 12%);
+  border-radius: 1.35rem;
+  background: oklch(0.145 0.012 120);
+  color: oklch(0.95 0.008 120);
+  box-shadow: 0 24px 70px color-mix(in oklch, var(--foreground) 16%, transparent);
+}
+
+.voice-console-header,
+.voice-console-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  color: oklch(0.75 0.012 120);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 0.68rem;
+}
+
+.voice-console-header {
+  border-bottom: 1px solid oklch(1 0 0 / 9%);
+}
+
+.voice-console-header > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: oklch(0.93 0.01 120);
+}
+
+.voice-live-dot {
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 50%;
+  background: oklch(0.78 0.15 150);
+  box-shadow: 0 0 0 4px oklch(0.78 0.15 150 / 15%);
+}
+
+.voice-orb {
+  display: flex;
+  min-height: 13rem;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  margin: 1rem;
+  border: 1px solid oklch(1 0 0 / 9%);
+  border-radius: 1rem;
+  background:
+    radial-gradient(circle at 50% 50%, oklch(0.6 0.1 150 / 24%), transparent 12rem),
+    oklch(0.18 0.015 120);
+}
+
+.voice-orb > svg {
+  width: 2rem;
+  height: 2rem;
+  color: oklch(0.86 0.09 150);
+}
+
+.voice-wave {
+  display: flex;
+  height: 4.5rem;
+  align-items: center;
+  gap: 0.28rem;
+}
+
+.voice-wave span {
+  width: 0.22rem;
+  height: 30%;
+  border-radius: 999px;
+  background: oklch(0.86 0.09 150);
+}
+
+.voice-wave span:nth-child(3n + 1) { height: 52%; }
+.voice-wave span:nth-child(4n + 2) { height: 78%; }
+.voice-wave span:nth-child(5n) { height: 100%; }
+.voice-wave span:nth-child(7n) { height: 38%; }
+
+.voice-pipeline {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0 1rem 1rem;
+}
+
+.voice-pipeline > div {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  flex-direction: column;
+  border: 1px solid oklch(1 0 0 / 10%);
+  border-radius: 0.85rem;
+  padding: 0.8rem 0.5rem;
+  background: oklch(1 0 0 / 4%);
+  text-align: center;
+}
+
+.voice-pipeline > svg {
+  width: 0.8rem;
+  height: 0.8rem;
+  color: oklch(0.58 0.015 120);
+}
+
+.voice-pipeline div svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  margin-bottom: 0.45rem;
+  color: oklch(0.86 0.09 150);
+}
+
+.voice-pipeline strong {
+  overflow: hidden;
+  max-width: 100%;
+  font-size: 0.74rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-pipeline small {
+  margin-top: 0.2rem;
+  color: oklch(0.67 0.012 120);
+  font-size: 0.59rem;
+}
+
+.voice-console-footer {
+  justify-content: center;
+  border-top: 1px solid oklch(1 0 0 / 9%);
+  text-transform: uppercase;
+}
+
+.voice-console-footer span + span::before {
+  margin-right: 0.75rem;
+  color: oklch(0.48 0.012 120);
+  content: "·";
 }
 
 .feature-grid {
@@ -1611,6 +1965,7 @@ a:focus-visible,
   }
 
   .section-heading,
+  .voice-showcase,
   .architecture-grid,
   .quick-start-section,
   .release-cta {
@@ -1652,6 +2007,28 @@ a:focus-visible,
   .principle-list {
     grid-template-columns: 1fr;
   }
+
+  .access-card {
+    grid-template-columns: 1fr;
+  }
+
+  .access-arrow {
+    transform: rotate(90deg);
+  }
+
+  .access-people {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .access-person {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .access-safety {
+    grid-column: 1;
+    flex-wrap: wrap;
+  }
 }
 
 @media (max-width: 580px) {
@@ -1679,6 +2056,42 @@ a:focus-visible,
 
   .architecture-card {
     padding-inline: 1rem;
+  }
+
+  .voice-showcase {
+    margin-inline: calc(var(--page-gutter) * -0.4);
+    padding-inline: 1rem;
+  }
+
+  .voice-proof {
+    grid-template-columns: 1fr;
+  }
+
+  .voice-pipeline {
+    grid-template-columns: 1fr;
+  }
+
+  .voice-pipeline > svg {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+
+  .voice-console-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .voice-console-footer span + span::before {
+    display: none;
+  }
+
+  .access-people {
+    grid-template-columns: 1fr;
+  }
+
+  .access-person {
+    align-items: center;
+    flex-direction: row;
   }
 
   .architecture-node {

--- a/apps/site/app/manifest.ts
+++ b/apps/site/app/manifest.ts
@@ -7,7 +7,8 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "overtchat",
     short_name: "overtchat",
-    description: "A lightweight self-hosted chat client.",
+    description:
+      "A polished, privacy-first chat app for local and hosted models.",
     start_url: sitePath("/"),
     scope: sitePath("/"),
     display: "standalone",

--- a/apps/site/app/not-found.tsx
+++ b/apps/site/app/not-found.tsx
@@ -11,8 +11,8 @@ export default function NotFound() {
       <p className="eyebrow">404</p>
       <h1 className="page-title">Nothing here.</h1>
       <p className="page-lede">
-        This page either moved or never shipped. The project site and release
-        log are still right where they should be.
+        This page either moved or never shipped. Your way back to OvertChat is
+        still right where it should be.
       </p>
       <Link className="button button-primary" href="/">
         <ArrowLeft aria-hidden="true" />

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -2,22 +2,27 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
+  AudioLines,
   ArrowDown,
   ArrowRight,
+  Bot,
   Boxes,
   Braces,
   Check,
   Database,
-  EyeOff,
   Globe2,
   HardDrive,
+  KeyRound,
+  MemoryStick,
   MessageSquareText,
+  Mic2,
   Search,
+  Server,
   ShieldCheck,
   Smartphone,
+  Users,
   Volume2,
   WandSparkles,
-  WifiOff,
 } from "lucide-react";
 import Link from "next/link";
 import { CopyButton } from "@/components/CopyButton";
@@ -47,18 +52,18 @@ const steps: Array<{
 }> = [
   {
     number: "01",
-    title: "Start your server",
-    body: "Run one install command. The guided setup detects Docker and lets you choose local or API-backed search, speech, and coding-agent connections.",
+    title: "Bring any model",
+    body: "Connect vLLM, llama.cpp, SGLang, Ollama, LM Studio, a hosted provider, or any OpenAI-compatible endpoint once at the server.",
   },
   {
     number: "02",
-    title: "Connect your models",
-    body: "Create the first admin account, then add a hosted provider or an OpenAI-compatible local endpoint. OvertChat checks the connection before you begin.",
+    title: "Choose who gets in",
+    body: "Create accounts for people you trust. Public signup stays closed, and every person gets private history, projects, files, and memories.",
   },
   {
     number: "03",
-    title: "Chat from anywhere",
-    body: "Use the responsive web app or connect the native mobile client to the server you control. Your account, chat history, and files stay on that server.",
+    title: "Let them just chat",
+    body: "They sign in from the web or Android app. Nobody else needs an inference URL, a shared API key, or a lesson in your model stack.",
   },
 ];
 
@@ -69,8 +74,8 @@ const features: Array<{
 }> = [
   {
     icon: MessageSquareText,
-    title: "Fast, persistent chat",
-    body: "Streaming replies, resumable generations, editable messages, projects, and automatically titled history.",
+    title: "Leave. The reply won’t.",
+    body: "Generations keep running on the server when a tab closes or a phone backgrounds, then reconnect when you return.",
   },
   {
     icon: Search,
@@ -79,33 +84,33 @@ const features: Array<{
   },
   {
     icon: HardDrive,
-    title: "Rich attachments",
-    body: "Work with images, PDFs, Word and Excel documents, CSV files, and source code directly in a conversation.",
+    title: "Files, not just prompts",
+    body: "Work with images, PDFs, Word and Excel documents, CSV files, and source code directly in a chat.",
   },
   {
-    icon: Volume2,
-    title: "Voice, both ways",
-    body: "Bundled text-to-speech works out of the box. Optional local speech-to-text keeps dictation on your hardware.",
+    icon: MemoryStick,
+    title: "One server, personal to everyone",
+    body: "Private history, projects, saved memories, and preferences make a shared installation feel like each person’s own app.",
   },
   {
     icon: WandSparkles,
-    title: "Model flexibility",
-    body: "Native support for OpenAI, Anthropic, Google Gemini, and Amazon Bedrock, plus any OpenAI-compatible endpoint—hosted or on hardware you own.",
+    title: "Tools and reasoning included",
+    body: "Connect standard MCP servers, use built-in web search, and expose the reasoning controls supported by each local or hosted model.",
   },
   {
-    icon: ShieldCheck,
-    title: "Private by construction",
-    body: "No usage analytics, advertising SDK, or hosted account system. The server belongs to you.",
+    icon: Bot,
+    title: "A side door to coding agents",
+    body: "When useful, admins can run Codex, Claude Code, OpenCode, Pi, and Oh My Pi locally or over SSH without leaving the chat app.",
   },
 ];
 
 const principles = [
-  "One application process",
   "One portable SQLite file",
-  "A small Redis resume buffer",
-  "No RAG or embeddings stack",
-  "No plugin runtime",
   "No hosted control plane",
+  "No usage analytics",
+  "Optional local speech and search",
+  "Standard MCP support",
+  "One-command managed updates",
 ];
 
 function HomePageShell({ children }: { children: ReactNode }) {
@@ -130,16 +135,16 @@ export default function HomePage() {
           <p className="eyebrow">Open source · self-hosted</p>
           <h1 className="hero-headline">
             <span className="hero-headline-setup">
-              Your therapist has confidentiality.
+              Your AI chat.
             </span>
             <span className="hero-headline-punch">
-              Now your chat app does too.
+              Actually yours.
             </span>
           </h1>
           <p className="hero-lede">
-            OvertChat is a complete chat client for hosted and local models,
-            running on a server you own. Your account and chat history stay
-            there; model requests go only to the endpoints you choose.
+            OvertChat brings local and hosted models into one polished,
+            self-hosted app. You decide where requests go; accounts,
+            conversations, files, and memories stay on your server.
           </p>
           <div className="button-row">
             <a
@@ -155,15 +160,15 @@ export default function HomePage() {
             </a>
           </div>
           <div className="hero-facts" aria-label="Project highlights">
-            <span><WifiOff aria-hidden="true" /> Fully offline-capable</span>
-            <span><EyeOff aria-hidden="true" /> No usage analytics</span>
-            <span><Smartphone aria-hidden="true" /> Native mobile app</span>
+            <span><ShieldCheck aria-hidden="true" /> No OvertChat cloud</span>
+            <span><Users aria-hidden="true" /> Multi-user</span>
+            <span><AudioLines aria-hidden="true" /> Realtime local voice</span>
           </div>
         </div>
         <HeroVignette />
         <a
           className="hero-scroll-cue"
-          href={`#${HOME_SECTION_IDS.howItWorks}`}
+          href={`#${HOME_SECTION_IDS.sharing}`}
         >
           Continue
           <ArrowDown aria-hidden="true" />
@@ -177,30 +182,61 @@ export default function HomePage() {
           aria-label="Supported model endpoints"
           tabIndex={0}
         >
-          <span className="trust-strip-label">Connects to</span>
+          <span className="trust-strip-label">Bring your models</span>
           <span>Ollama</span>
           <span>vLLM</span>
           <span>llama.cpp</span>
+          <span>SGLang</span>
+          <span>LM Studio</span>
           <span>Hosted APIs</span>
-          <span>Any OpenAI-compatible endpoint</span>
         </div>
       </section>
 
       <section
         className="site-section site-container"
-        id={HOME_SECTION_IDS.howItWorks}
+        id={HOME_SECTION_IDS.sharing}
       >
         <div className="section-heading">
           <div>
-            <p className="eyebrow">How it works</p>
-            <h2 className="section-title">Your server is the product.</h2>
+            <p className="eyebrow">Built to be used</p>
+            <h2 className="section-title">Your models deserve an actual front door.</h2>
           </div>
           <p className="section-lede">
-            OvertChat keeps your account, chat history, and files on your
-            server. Model requests go directly to the local or hosted endpoints
-            you configure—never through an OvertChat-operated relay or control
-            plane.
+            An inference server is infrastructure. OvertChat is the part people
+            use: you configure the models once, then everyone you trust gets an
+            account and a private space of their own.
           </p>
+        </div>
+        <div
+          className="access-card"
+          role="img"
+          aria-label="A private model server connected through OvertChat to separate user accounts"
+        >
+          <div className="access-node">
+            <span className="access-node-icon"><Server /></span>
+            <div>
+              <strong>Your model server</strong>
+              <small>One private endpoint</small>
+            </div>
+          </div>
+          <span className="access-arrow"><ArrowRight /></span>
+          <div className="access-node access-node-primary">
+            <span className="access-node-icon"><Boxes /></span>
+            <div>
+              <strong>OvertChat</strong>
+              <small>Accounts, chat, voice, files</small>
+            </div>
+          </div>
+          <span className="access-arrow"><ArrowRight /></span>
+          <div className="access-people">
+            <div className="access-person"><span>Y</span><div><strong>You</strong><small>Admin</small></div></div>
+            <div className="access-person"><span>M</span><div><strong>Maya</strong><small>Private history</small></div></div>
+            <div className="access-person"><span>S</span><div><strong>Sam</strong><small>Private history</small></div></div>
+          </div>
+          <div className="access-safety">
+            <span><KeyRound /> Admin-created accounts</span>
+            <span><ShieldCheck /> Public signup closed</span>
+          </div>
         </div>
         <div className="steps-grid">
           {steps.map((step) => (
@@ -215,13 +251,73 @@ export default function HomePage() {
 
       <section
         className="site-section site-container"
+        id={HOME_SECTION_IDS.voice}
+      >
+        <div className="voice-showcase">
+          <div className="voice-copy">
+            <p className="eyebrow">Beyond the text box</p>
+            <h2 className="section-title">Local voice, at conversation speed.</h2>
+            <p className="section-lede">
+              Speak naturally. Cut in mid-answer. Change direction and keep
+              going. OvertChat wraps local Parakeet and Kokoro around the model
+              you choose, with web search and a saved transcript along for the
+              conversation.
+            </p>
+            <div className="voice-proof">
+              <strong>&lt;8 GB</strong>
+              <span>VRAM for the entire speech layer in our current NVIDIA testing. The rest belongs to the model.</span>
+            </div>
+            <p className="voice-hardware-note">
+              A 24 GB card can still have room for a capable quantized model.
+              Speech can also run on CPU or a second GPU when you want to go
+              bigger.
+            </p>
+          </div>
+          <div
+            className="voice-console"
+            role="img"
+            aria-label="Realtime voice moving from Parakeet speech recognition through the selected language model to Kokoro speech synthesis"
+          >
+            <div className="voice-console-header">
+              <span><span className="voice-live-dot" /> Listening</span>
+              <small>Realtime voice</small>
+            </div>
+            <div className="voice-orb">
+              <Mic2 />
+              <div className="voice-wave" aria-hidden="true">
+                {Array.from({ length: 15 }, (_, index) => <span key={index} />)}
+              </div>
+            </div>
+            <div className="voice-pipeline">
+              <div><AudioLines /><strong>Parakeet</strong><small>Speech to text</small></div>
+              <ArrowRight />
+              <div><Braces /><strong>Your model</strong><small>Local or hosted</small></div>
+              <ArrowRight />
+              <div><Volume2 /><strong>Kokoro</strong><small>Text to speech</small></div>
+            </div>
+            <div className="voice-console-footer">
+              <span>Interruptible</span>
+              <span>Search-aware</span>
+              <span>Transcript saved</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="site-section site-container"
         id={HOME_SECTION_IDS.features}
       >
-        <div className="section-heading compact-heading">
+        <div className="section-heading">
           <div>
-            <p className="eyebrow">What’s in the box</p>
-            <h2 className="section-title">The whole client, already wired up.</h2>
+            <p className="eyebrow">A focused Open WebUI alternative</p>
+            <h2 className="section-title">Everything around the model matters too.</h2>
           </div>
+          <p className="section-lede">
+            OvertChat stays focused on a fast, complete chat experience instead
+            of becoming another platform to maintain. The everyday details are
+            already handled.
+          </p>
         </div>
         <div className="feature-grid">
           {features.map(({ icon: Icon, title, body }) => (
@@ -240,12 +336,13 @@ export default function HomePage() {
       >
         <div className="site-container architecture-grid">
           <div className="architecture-copy">
-            <p className="eyebrow">Deliberately boring infrastructure</p>
-            <h2 className="section-title">Easy to understand. Easier to keep.</h2>
+            <p className="eyebrow">What “yours” means</p>
+            <h2 className="section-title">No mystery cloud in the middle.</h2>
             <p className="section-lede">
-              There is no distributed services diagram hiding behind the chat
-              box. Back up one database file, update one container image, and
-              keep operating on your terms.
+              Accounts, conversations, files, memories, and settings stay in
+              one portable SQLite database on your server. Model requests go
+              directly to the endpoints you configure. OvertChat operates no
+              account system, API relay, or hosted control plane.
             </p>
             <a
               className="text-link"
@@ -266,8 +363,8 @@ export default function HomePage() {
                 <span>OvertChat</span>
               </div>
               <div className="architecture-split">
-                <div className="architecture-node"><Database /><span>SQLite</span></div>
-                <div className="architecture-node"><Braces /><span>Your models</span></div>
+                <div className="architecture-node"><Database /><span>Your data</span></div>
+                <div className="architecture-node"><Braces /><span>Your endpoints</span></div>
               </div>
             </div>
             <ul className="principle-list">
@@ -286,11 +383,12 @@ export default function HomePage() {
         <div className="client-card client-card-web">
           <span className="client-icon"><Globe2 aria-hidden="true" /></span>
           <div className="client-card-body">
-            <p className="eyebrow">On the web</p>
-            <h2>Open it and get to work.</h2>
+            <p className="eyebrow">Wherever there’s a browser</p>
+            <h2>Open it. Pick up where you left off.</h2>
             <p>
-              A responsive interface for long conversations, projects, files,
-              web research, voice, and every model connected to your server.
+              Long conversations stay responsive, active replies survive a
+              disconnect, and every project, file, search, memory, and model is
+              waiting on the server.
             </p>
             <a href="https://github.com/yoloyash/overtchat#quick-start" className="text-link">
               Self-host the web app <ArrowRight aria-hidden="true" />
@@ -300,11 +398,12 @@ export default function HomePage() {
         <div className="client-card client-card-mobile">
           <span className="client-icon"><Smartphone aria-hidden="true" /></span>
           <div className="client-card-body">
-            <p className="eyebrow">On mobile</p>
-            <h2>Your server, in your pocket.</h2>
+            <p className="eyebrow">Away from the desk</p>
+            <h2>Same server. Smaller screen.</h2>
             <p>
-              The native client connects directly to your OvertChat instance.
-              Chats and attachments stay on that server—not in a hosted mobile backend.
+              The native Android app connects straight to OvertChat. Chats,
+              attachments, projects, search, and voice follow without moving
+              into a separate mobile backend.
             </p>
             <a
               href="https://play.google.com/store/apps/details?id=com.overtchat.mobile"
@@ -321,12 +420,12 @@ export default function HomePage() {
         id={HOME_SECTION_IDS.quickStart}
       >
         <div className="quick-start-copy">
-          <p className="eyebrow">Quick start</p>
-          <h2 className="section-title">From clone to chat in one stack.</h2>
+          <p className="eyebrow">Your turn</p>
+          <h2 className="section-title">One command between here and yours.</h2>
           <p className="section-lede">
-            Docker and an LLM endpoint are the only real prerequisites. The
-            first account becomes the administrator and the setup wizard handles
-            the rest.
+            The guided setup handles Docker, secrets, updates, and optional
+            search, speech, and Agent Connections. Bring a model endpoint; the
+            first account becomes the administrator.
           </p>
           <div className="button-row">
             <a
@@ -355,13 +454,13 @@ export default function HomePage() {
         id={HOME_SECTION_IDS.releases}
       >
         <div>
-          <p className="eyebrow">Built in public</p>
-          <h2 className="section-title">See what changed, without digging.</h2>
+          <p className="eyebrow">Still becoming yours</p>
+          <h2 className="section-title">Built in public. Shipped in the open.</h2>
         </div>
         <div className="release-cta-copy">
           <p className="section-lede">
-            Web and mobile releases live in one chronological log, generated
-            directly from the project’s GitHub Releases.
+            Follow every stable web and mobile release in one chronological log,
+            generated directly from the project’s GitHub Releases.
           </p>
           <Link className="button button-primary" href="/releases/">
             Browse releases

--- a/apps/site/app/privacy/page.tsx
+++ b/apps/site/app/privacy/page.tsx
@@ -19,12 +19,11 @@ export default function PrivacyPage() {
         <header className="legal-header">
           <p className="eyebrow">Legal</p>
           <h1 className="page-title">Privacy Policy</h1>
-          <p className="legal-updated">Last updated 22 August 2026</p>
+          <p className="legal-updated">Last updated 6 September 2026</p>
           <p className="page-lede">
-            OvertChat is an open-source chat client that connects to a server you
-            choose. The short version: we do not operate a hosted chat service,
-            and the server you point the app at is governed by whoever operates
-            it—which may be you.
+            OvertChat is open-source software that runs on a server you choose.
+            The short version: we do not operate a hosted chat service, and the
+            server you use is governed by whoever operates it—which may be you.
           </p>
         </header>
 
@@ -53,8 +52,9 @@ export default function PrivacyPage() {
                 locally on your device),
               </li>
               <li>
-                send your messages, attachments, and voice dictation audio to
-                your server so it can talk to a language model on your behalf,
+                send your messages, attachments, voice dictation, and realtime
+                voice audio to your server so it can use the speech and language
+                model providers configured by its administrator,
               </li>
               <li>
                 load chat history, projects, and settings you have created on
@@ -64,7 +64,10 @@ export default function PrivacyPage() {
             <p>
               How that server stores, retains, or shares that data is governed by
               whoever administers it—that is a separate policy from this one. If
-              you self-host, you are that administrator.
+              you self-host, you are that administrator. Local providers can keep
+              processing on infrastructure the administrator controls; hosted
+              providers receive the requests routed to them under their own
+              policies.
             </p>
           </section>
 
@@ -184,10 +187,12 @@ export default function PrivacyPage() {
             <h2>Permissions and why we ask for them</h2>
             <ul>
               <li>
-                <strong>Microphone</strong>—used only when you tap the dictation
-                button. The recording is sent to your configured server for
-                transcription when you stop recording and is deleted from the
-                app cache after transcription completes.
+                <strong>Microphone</strong>—used only after you start dictation or
+                a realtime voice conversation. Dictation is sent to your server
+                for transcription when you stop recording and is deleted from
+                the mobile app cache afterward. During browser realtime voice,
+                audio streams to your server while the session is active; its
+                transcript is saved there as a chat.
               </li>
               <li>
                 <strong>Camera</strong>—used only when you choose “Take Photo” to
@@ -208,8 +213,9 @@ export default function PrivacyPage() {
               Data selected through them leaves the device only when you choose
               an app action that uses it—for example, selecting an attachment
               uploads it to your server, and stopping dictation sends the
-              recording for transcription. Crash diagnostics are a separate
-              data flow to Sentry, described above.
+              recording for transcription. Realtime microphone streaming stops
+              when you mute or end the voice session. Crash diagnostics are a
+              separate data flow to Sentry, described above.
             </p>
           </section>
 

--- a/apps/site/app/releases/page.tsx
+++ b/apps/site/app/releases/page.tsx
@@ -7,7 +7,8 @@ import { fetchGithubReleases } from "@/lib/releases.server";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Releases",
-  description: "Web and mobile release notes for OvertChat.",
+  description:
+    "Every stable OvertChat web and mobile release, with notes and downloads in one chronological log.",
   path: "/releases/",
 });
 
@@ -20,13 +21,13 @@ export default async function ReleasesPage() {
     <main className="site-main" id="main-content" tabIndex={-1}>
       <section className="page-hero site-container release-page-hero">
         <div>
-          <p className="eyebrow">Changelog</p>
+          <p className="eyebrow">Built in public</p>
           <h1 className="page-title">What shipped.</h1>
         </div>
         <div>
           <p className="page-lede">
-            Every stable web and mobile release, in one place. This page is
-            generated directly from GitHub Releases whenever the project ships.
+            Follow OvertChat as it gets faster, more capable, and easier to run.
+            Every stable web and mobile release lands here directly from GitHub.
           </p>
           <a
             className="text-link"

--- a/apps/site/components/HeroVignette.tsx
+++ b/apps/site/components/HeroVignette.tsx
@@ -1,6 +1,7 @@
 import { MODEL_BRAND_ICONS } from "@overtchat/shared";
 import {
   ArrowUp,
+  Bot,
   ChevronDown,
   ChevronUp,
   FileText,
@@ -21,7 +22,7 @@ export function HeroVignette() {
     <div
       className="vignette"
       role="img"
-      aria-label="Illustration closely matching the OvertChat conversation interface"
+      aria-label="OvertChat conversation interface with personal projects and Codex and Claude Code agent workspaces"
     >
       <div className="vignette-glow" aria-hidden="true" />
       <div className="vignette-window" aria-hidden="true">
@@ -46,23 +47,35 @@ export function HeroVignette() {
           <div className="vignette-sidebar-label">Projects</div>
           <div className="vignette-project">
             <Folder />
-            <span>OvertChat launch</span>
+            <span>Household</span>
             <ChevronDown />
           </div>
           <div className="vignette-project-thread is-active">
-            Project architecture
+            Weeknight meals
+          </div>
+
+          <div className="vignette-sidebar-label">Agent workspaces</div>
+          <div className="vignette-agent-workspace">
+            <Bot />
+            <span>OvertChat</span>
+            <small>Codex</small>
+          </div>
+          <div className="vignette-agent-workspace">
+            <Bot />
+            <span>Notes</span>
+            <small>Claude Code</small>
           </div>
 
           <div className="vignette-sidebar-label">Today</div>
-          <div className="vignette-thread">Weekend reading</div>
-          <div className="vignette-thread">Model comparison</div>
+          <div className="vignette-thread">Homework helper</div>
+          <div className="vignette-thread">Weekend plans</div>
 
           <div className="vignette-sidebar-spacer" />
           <div className="vignette-profile">
             <span><User /></span>
             <div>
-              <strong>Yash</strong>
-              <small>yash@example.com</small>
+              <strong>Maya</strong>
+              <small>maya@home</small>
             </div>
             <ChevronUp />
           </div>
@@ -83,31 +96,31 @@ export function HeroVignette() {
                   ))}
                 </svg>
               </span>
-              <strong>Qwen 3.6 27B (Q6)</strong>
+              <strong>Qwen 3.8 27B</strong>
               <ChevronDown />
             </div>
           </header>
 
           <div className="vignette-messages">
             <div className="vignette-message vignette-message-user">
-              How do hosted and local models differ for privacy?
+              Plan a vegetarian dinner for six and make a shopping list.
             </div>
             <div className="vignette-tool">
               <Search />
-              <span>Searched 5 sources</span>
-              <span className="vignette-tool-time">1.4s</span>
+              <span>Searched 4 recipes</span>
+              <span className="vignette-tool-time">1.2s</span>
             </div>
             <div className="vignette-message vignette-message-assistant">
-              <p>Mostly in where requests go:</p>
+              <p>Here’s a low-stress menu everyone can share:</p>
               <ul>
-                <li>A hosted model receives prompts at its API</li>
-                <li>A local model can process them on your hardware</li>
-                <li>OvertChat stores chat history on your server</li>
+                <li>Roasted tomato and chickpea pasta</li>
+                <li>Arugula salad with lemon dressing</li>
+                <li>Garlic bread and berry crumble</li>
               </ul>
-              <p>You choose the endpoint for each conversation.</p>
+              <p>I grouped the shopping list by aisle below.</p>
               <div className="vignette-citations">
-                <span><Globe /> ollama.com</span>
-                <span><FileText /> openai.com</span>
+                <span><Globe /> 4 sources</span>
+                <span><FileText /> Shopping list</span>
               </div>
             </div>
           </div>

--- a/apps/site/components/SiteFooter.tsx
+++ b/apps/site/components/SiteFooter.tsx
@@ -6,7 +6,7 @@ export function SiteFooter() {
       <div className="site-container footer-inner">
         <div>
           <div className="footer-wordmark">overtchat</div>
-          <p>A complete, self-hosted chat client that runs on a server you own.</p>
+          <p>Your AI chat, running on your side of the internet.</p>
         </div>
         <nav className="footer-links" aria-label="Footer navigation">
           <Link href="/releases/">Releases</Link>
@@ -19,7 +19,7 @@ export function SiteFooter() {
       </div>
       <div className="site-container footer-meta">
         <span>MIT licensed.</span>
-        <span>No usage analytics. No hosted backend.</span>
+        <span>No usage analytics. No OvertChat cloud.</span>
       </div>
     </footer>
   );

--- a/apps/site/components/SiteHeader.tsx
+++ b/apps/site/components/SiteHeader.tsx
@@ -10,6 +10,7 @@ export function SiteHeader() {
           overtchat
         </Link>
         <nav className="site-nav" aria-label="Primary navigation">
+          <Link href="/#quick-start">Install</Link>
           <Link href="/releases/">Releases</Link>
           <a
             className="icon-button"

--- a/apps/site/lib/home-sections.ts
+++ b/apps/site/lib/home-sections.ts
@@ -1,6 +1,7 @@
 export const HOME_SECTION_IDS = {
   intro: "intro",
-  howItWorks: "how-it-works",
+  sharing: "sharing",
+  voice: "voice",
   features: "features",
   architecture: "architecture",
   clients: "clients",
@@ -10,10 +11,11 @@ export const HOME_SECTION_IDS = {
 
 export const HOME_SECTIONS = [
   { id: HOME_SECTION_IDS.intro, label: "Introduction" },
-  { id: HOME_SECTION_IDS.howItWorks, label: "How it works" },
-  { id: HOME_SECTION_IDS.features, label: "Features" },
-  { id: HOME_SECTION_IDS.architecture, label: "Architecture" },
-  { id: HOME_SECTION_IDS.clients, label: "Web + mobile" },
-  { id: HOME_SECTION_IDS.quickStart, label: "Quick start" },
+  { id: HOME_SECTION_IDS.sharing, label: "A front door" },
+  { id: HOME_SECTION_IDS.voice, label: "Talk" },
+  { id: HOME_SECTION_IDS.features, label: "Everyday chat" },
+  { id: HOME_SECTION_IDS.architecture, label: "What yours means" },
+  { id: HOME_SECTION_IDS.clients, label: "Anywhere" },
+  { id: HOME_SECTION_IDS.quickStart, label: "Make it yours" },
   { id: HOME_SECTION_IDS.releases, label: "Releases" },
 ] as const;

--- a/apps/site/lib/metadata.ts
+++ b/apps/site/lib/metadata.ts
@@ -3,9 +3,9 @@ import { absoluteSiteUrl } from "./site";
 
 export const SITE_NAME = "overtchat";
 export const DEFAULT_SITE_TITLE =
-  "overtchat — chat you actually own";
+  "overtchat — your AI chat, actually yours";
 export const DEFAULT_SITE_DESCRIPTION =
-  "A complete, self-hosted chat client for hosted and local language models. One Docker command brings up the whole stack, and your chat history is stored on your server.";
+  "A polished, privacy-first Open WebUI alternative for local and hosted models, with multi-user accounts, realtime local voice, files, search, memory, and mobile.";
 
 export function createPageMetadata({
   title,


### PR DESCRIPTION
## Summary

- reposition OvertChat around owned, multi-user AI chat and a polished front door for self-hosted models
- add the realtime local voice story and low-VRAM speech pipeline visualization
- surface coding-agent workspaces subtly in the hero and feature grid
- align site metadata, privacy copy, navigation, release copy, and supporting sections with the new narrative

## Validation

- npm run lint -w apps/site --
- npm run test -w apps/site --
- npm run typecheck -w apps/site --
- npm run build -w apps/site --
- git diff --check