### PR TITLE
feat(mobile): enable full-width drawer swipe

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/_layout.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/_layout.tsx
@@ -1,14 +1,16 @@
 import { Drawer } from "expo-router/drawer";
+import { useWindowDimensions } from "react-native";
 import { AppDrawer } from "@/components/drawer/AppDrawer";
 import { useTheme } from "@/lib/theme";
 
 export default function DrawerLayout() {
   const { colors } = useTheme();
+  const { width } = useWindowDimensions();
   return (
     <Drawer
       screenOptions={{
         drawerType: "front",
-        swipeEdgeWidth: 40,
+        swipeEdgeWidth: width,
         drawerStyle: { backgroundColor: colors.card, width: 300 },
         overlayColor: "rgba(0,0,0,0.4)",
         headerStyle: { backgroundColor: colors.background },


### PR DESCRIPTION
## Summary

- let the chat drawer swipe begin anywhere across the viewport instead of requiring a narrow edge gesture
- derive the activation width from live window dimensions so it stays correct through rotation and tablet resizing
- keep the existing drawer button and presentation unchanged

This makes the gesture feel deliberate and polished instead of forcing users to find a small activation strip.

## Validation

- `npm run typecheck -w @overtchat/mobile --`
- verified on an Android device: swiping right across the chat surface opens the drawer as intended