### PR TITLE
feat(mobile): add reasoning level controls

### DIFF
--- a/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
+++ b/apps/mobile/src/app/(authed)/(drawer)/chat.tsx
@@ -2,8 +2,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { useChat } from "@ai-sdk/react";
 import {
   hasSuccessfulMemoryMutation,
+  modelSupportsChatReasoningLevel,
   modelSupportsToolCalling,
   type ChatKind,
+  type ChatReasoningLevel,
   type ChatRequestAction,
 } from "@overtchat/shared";
 import type { BottomSheetModal } from "@gorhom/bottom-sheet";
@@ -40,8 +42,12 @@ import { AddToChatSheet } from "@/components/chat/AddToChatSheet";
 import { Composer } from "@/components/chat/Composer";
 import { MessageList } from "@/components/chat/MessageList";
 import { MiniSpeechPlayer } from "@/components/chat/MiniSpeechPlayer";
-import { ModelPickerSheet } from "@/components/chat/ModelPickerSheet";
-import { ModelBrandIcon } from "@/components/ModelBrandIcon";
+import {
+  ModelPickerSheet,
+  reasoningLabel,
+  reasoningOptionsForControls,
+  type ModelPickerSheetRef,
+} from "@/components/chat/ModelPickerSheet";
 import { authFetch, getApiBase } from "@/lib/api";
 import { getAuthClient } from "@/lib/auth/client";
 import { useAttachments, type PickedFile } from "@/lib/chat/useAttachments";
@@ -51,6 +57,10 @@ import { useChatMessages } from "@/lib/queries/chatMessages";
 import { useModelConfigs } from "@/lib/queries/modelConfigs";
 import type { ChatListItem } from "@/lib/queries/chats";
 import { queryKeys } from "@/lib/queries/keys";
+import {
+  setReasoningLevel,
+  useReasoningLevels,
+} from "@/lib/reasoningPreferences";
 import { useWebSearchEnabled } from "@/lib/toolPreferences";
 import { useSpeech } from "@/lib/useSpeech";
 import { useTheme } from "@/lib/theme";
@@ -185,7 +195,8 @@ function ChatSurface({
   const [searchRequested, setSearchRequested] = useState(false);
   const [chatPersisted, setChatPersisted] = useState(!isNew);
   const webSearchEnabled = useWebSearchEnabled();
-  const pickerRef = useRef<BottomSheetModal>(null);
+  const reasoningLevels = useReasoningLevels();
+  const pickerRef = useRef<ModelPickerSheetRef>(null);
   const addSheetRef = useRef<BottomSheetModal>(null);
 
   useEffect(() => {
@@ -271,6 +282,22 @@ function ChatSurface({
   const streaming = status === "streaming" || status === "submitted";
   const configured = Boolean(selectedId);
   const selectedModel = models?.find((m) => m.id === selectedId) ?? null;
+  const reasoningControls = selectedModel?.capabilities?.reasoningControls;
+  const storedReasoningLevel = selectedId
+    ? reasoningLevels[selectedId]
+    : undefined;
+  const reasoningLevel: ChatReasoningLevel =
+    storedReasoningLevel !== "default" &&
+    modelSupportsChatReasoningLevel(
+      selectedModel?.capabilities,
+      storedReasoningLevel,
+    )
+      ? storedReasoningLevel
+      : (reasoningControls?.defaultLevel ?? "default");
+  const thinkingLevelLabel =
+    reasoningOptionsForControls(reasoningControls).length > 1
+      ? reasoningLabel(reasoningLevel)
+      : undefined;
   const searchAvailable =
     webSearchEnabled && modelSupportsToolCalling(selectedModel);
   const searchUnavailableReason = !webSearchEnabled
@@ -356,42 +383,7 @@ function ChatSurface({
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerTitle: () => (
-        <Pressable
-          onPress={() => pickerRef.current?.present()}
-          style={styles.headerTitle}
-        >
-          {modelsPending ? (
-            <ActivityIndicator color={colors.mutedForeground} size="small" />
-          ) : (
-            <>
-              <ModelBrandIcon
-                iconId={
-                  selectedModel?.modelIconId ?? selectedModel?.providerIconId
-                }
-                color={colors.mutedForeground}
-                size={16}
-                style={styles.headerTitleIcon}
-              />
-              <Text
-                numberOfLines={1}
-                style={[
-                  styles.headerTitleText,
-                  { color: colors.foreground, fontFamily: fonts.sansSemiBold },
-                ]}
-              >
-                {selectedModel?.label ?? "Select model"}
-              </Text>
-              <Ionicons
-                name="chevron-down"
-                size={16}
-                color={colors.mutedForeground}
-                style={styles.headerTitleCaret}
-              />
-            </>
-          )}
-        </Pressable>
-      ),
+      headerTitle: "",
       headerRight: () => (
         <Pressable
           accessibilityRole="button"
@@ -403,17 +395,7 @@ function ChatSurface({
         </Pressable>
       ),
     });
-  }, [
-    navigation,
-    modelsPending,
-    selectedModel?.id,
-    selectedModel?.label,
-    selectedModel?.modelIconId,
-    selectedModel?.providerIconId,
-    colors,
-    fonts,
-    onNewChat,
-  ]);
+  }, [navigation, colors, onNewChat]);
 
   function requestBody(action: ChatRequestAction, forceSearch = false) {
     const requested = searchAvailable && forceSearch;
@@ -430,6 +412,7 @@ function ChatSurface({
       projectId,
       temporary: false,
       action,
+      ...(reasoningControls ? { reasoningLevel } : {}),
     };
   }
 
@@ -635,12 +618,21 @@ function ChatSurface({
             streaming={streaming}
             searchAvailable={searchAvailable}
             searchRequested={searchAvailable && searchRequested}
+            modelLabel={selectedModel?.label}
+            modelIconId={
+              selectedModel?.modelIconId ?? selectedModel?.providerIconId
+            }
+            thinkingLevelLabel={thinkingLevelLabel}
             attachments={attachments}
             attachmentMeta={attachmentMeta}
             uploading={uploading}
             uploadError={uploadError}
             isAdmin={isAdmin}
             onClearSearch={() => setSearchRequested(false)}
+            onOpenModelPicker={() => {
+              Keyboard.dismiss();
+              pickerRef.current?.present();
+            }}
             onOpenAddSheet={() => {
               Keyboard.dismiss();
               addSheetRef.current?.present();
@@ -662,9 +654,14 @@ function ChatSurface({
         selectedId={selectedId}
         loading={modelsPending}
         error={modelsError}
+        reasoningControls={reasoningControls}
+        reasoningLevel={reasoningLevel}
         onSelect={(modelId) => {
           setSearchRequested(false);
           setSelectedId(modelId);
+        }}
+        onSelectReasoningLevel={(level) => {
+          if (selectedId) setReasoningLevel(selectedId, level);
         }}
       />
 
@@ -682,10 +679,6 @@ function ChatSurface({
 
 const styles = StyleSheet.create({
   root: { flex: 1 },
-  headerTitle: { flexDirection: "row", alignItems: "center", maxWidth: 240 },
-  headerTitleIcon: { marginRight: 7 },
-  headerTitleText: { flexShrink: 1, fontSize: 16, maxWidth: 190 },
-  headerTitleCaret: { marginLeft: 4 },
   headerRight: { paddingHorizontal: 12 },
   gate: {
     flex: 1,

--- a/apps/mobile/src/components/chat/AttachmentChip.tsx
+++ b/apps/mobile/src/components/chat/AttachmentChip.tsx
@@ -115,7 +115,9 @@ export function AttachmentChip({
             accessibilityLabel={label}
           />
         </Pressable>
-        {onRemove && <RemoveButton onPress={onRemove} label={label} />}
+        {onRemove && (
+          <RemoveButton onPress={onRemove} label={label} compact />
+        )}
         <ImageView
           images={[source]}
           imageIndex={0}
@@ -166,7 +168,7 @@ export function AttachmentChip({
       borderColor: colors.border,
       backgroundColor: colors.muted,
       borderRadius: radii.md,
-      paddingRight: onRemove ? 30 : 14,
+      paddingRight: onRemove ? 48 : 14,
     },
   ];
   const docContent = (
@@ -227,27 +229,35 @@ export function AttachmentChip({
 function RemoveButton({
   onPress,
   label,
+  compact = false,
 }: {
   onPress: () => void;
   label: string;
+  compact?: boolean;
 }) {
   const { colors } = useTheme();
   return (
     <Pressable
       onPress={onPress}
-      hitSlop={8}
       accessibilityRole="button"
       accessibilityLabel={`Remove ${label}`}
       style={({ pressed }) => [
-        styles.removeBtn,
-        {
-          backgroundColor: colors.background,
-          borderColor: colors.border,
-          opacity: pressed ? 0.7 : 1,
-        },
+        styles.removeButtonTarget,
+        compact && styles.removeButtonTargetCompact,
+        { opacity: pressed ? 0.7 : 1 },
       ]}
     >
-      <Ionicons name="close" size={12} color={colors.foreground} />
+      <View
+        style={[
+          styles.removeButtonSurface,
+          {
+            backgroundColor: colors.background,
+            borderColor: colors.border,
+          },
+        ]}
+      >
+        <Ionicons name="close" size={12} color={colors.foreground} />
+      </View>
     </Pressable>
   );
 }
@@ -282,7 +292,18 @@ const styles = StyleSheet.create({
   docMeta: { flex: 1, minWidth: 0 },
   docLabel: { fontSize: 13 },
   docSub: { fontSize: 11, marginTop: 2 },
-  removeBtn: {
+  removeButtonTarget: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    width: 48,
+    height: 48,
+  },
+  removeButtonTargetCompact: {
+    width: 32,
+    height: 32,
+  },
+  removeButtonSurface: {
     position: "absolute",
     top: 4,
     right: 4,

--- a/apps/mobile/src/components/chat/Composer.tsx
+++ b/apps/mobile/src/components/chat/Composer.tsx
@@ -1,9 +1,11 @@
 import { Ionicons } from "@expo/vector-icons";
+import type { ModelBrandIconId } from "@overtchat/shared";
 import type { FileUIPart } from "ai";
 import * as Haptics from "expo-haptics";
 import { TextInputWrapper } from "expo-paste-input";
 import { useEffect, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import type { AttachmentMeta } from "@/lib/chat/attachments";
 import { dictationErrorMessage } from "@/lib/chat/message";
 import { useTheme } from "@/lib/theme";
@@ -16,12 +18,16 @@ export function Composer({
   streaming,
   searchAvailable,
   searchRequested,
+  modelLabel,
+  modelIconId,
+  thinkingLevelLabel,
   attachments,
   attachmentMeta,
   uploading,
   uploadError,
   isAdmin,
   onClearSearch,
+  onOpenModelPicker,
   onOpenAddSheet,
   onRemoveAttachment,
   onDismissUploadError,
@@ -33,12 +39,16 @@ export function Composer({
   streaming: boolean;
   searchAvailable: boolean;
   searchRequested: boolean;
+  modelLabel?: string;
+  modelIconId?: ModelBrandIconId;
+  thinkingLevelLabel?: string;
   attachments: FileUIPart[];
   attachmentMeta: Record<string, AttachmentMeta>;
   uploading: boolean;
   uploadError: string | null;
   isAdmin: boolean;
   onClearSearch: () => void;
+  onOpenModelPicker: () => void;
   onOpenAddSheet: () => void;
   onRemoveAttachment: (index: number) => void;
   onDismissUploadError: () => void;
@@ -90,12 +100,16 @@ export function Composer({
     onClearSearch();
   }
 
+  function openModelPicker() {
+    Haptics.selectionAsync().catch(() => {});
+    onOpenModelPicker();
+  }
+
   const canSend =
     (input.trim().length > 0 || attachments.length > 0) &&
     !streaming &&
     !uploading &&
     configured;
-  const showPillsRow = searchRequested;
   const showAttachmentsRow = attachments.length > 0 || uploading;
 
   return (
@@ -179,42 +193,27 @@ export function Composer({
           </View>
         )}
 
-        {showPillsRow && (
-          <View style={styles.pillsRow}>
-            {searchRequested && (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Remove Search from this message"
-                onPress={clearSearch}
-                style={({ pressed }) => [
-                  styles.pill,
-                  {
-                    backgroundColor: colors.accent,
-                    borderRadius: radii.pill,
-                    opacity: pressed ? 0.8 : 1,
-                  },
-                ]}
-              >
-                <Ionicons
-                  name="globe-outline"
-                  size={14}
-                  color={colors.foreground}
-                />
-                <Text
-                  style={[
-                    styles.pillLabel,
-                    { color: colors.foreground, fontFamily: fonts.sansMedium },
-                  ]}
-                >
-                  Search
-                </Text>
-                <Ionicons name="close" size={14} color={colors.foreground} />
-              </Pressable>
-            )}
-          </View>
-        )}
+        <TextInputWrapper
+          style={styles.inputWrapper}
+          onPaste={(payload) => {
+            if (payload.type === "images") onPasteImages(payload.uris);
+          }}
+        >
+          <TextInput
+            value={input}
+            onChangeText={setInput}
+            editable={configured && dictation.status !== "transcribing"}
+            multiline
+            placeholder={configured ? "Message…" : "No models configured"}
+            placeholderTextColor={colors.mutedForeground}
+            style={[
+              styles.input,
+              { color: colors.foreground, fontFamily: fonts.sansRegular },
+            ]}
+          />
+        </TextInputWrapper>
 
-        <View style={styles.inputRow}>
+        <View style={styles.controlsRow}>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={
@@ -224,37 +223,114 @@ export function Composer({
             }
             onPress={openAdd}
             style={({ pressed }) => [
-              styles.iconButton,
-              {
-                backgroundColor: "transparent",
-                borderColor: colors.border,
-                borderRadius: radii.pill,
-                opacity: pressed ? 0.7 : 1,
-              },
+              styles.iconHitTarget,
+              { opacity: pressed ? 0.7 : 1 },
             ]}
           >
-            <Ionicons name="add" size={20} color={colors.mutedForeground} />
+            <View
+              style={[
+                styles.secondaryButtonSurface,
+                {
+                  borderColor: colors.border,
+                  borderRadius: radii.pill,
+                },
+              ]}
+            >
+              <Ionicons name="add" size={19} color={colors.mutedForeground} />
+            </View>
           </Pressable>
 
-          <TextInputWrapper
-            style={styles.inputWrapper}
-            onPaste={(payload) => {
-              if (payload.type === "images") onPasteImages(payload.uris);
-            }}
-          >
-            <TextInput
-              value={input}
-              onChangeText={setInput}
-              editable={configured && dictation.status !== "transcribing"}
-              multiline
-              placeholder={configured ? "Message…" : "No models configured"}
-              placeholderTextColor={colors.mutedForeground}
-              style={[
-                styles.input,
-                { color: colors.foreground, fontFamily: fonts.sansRegular },
+          {searchRequested ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Turn off Search for this message"
+              accessibilityState={{ selected: true }}
+              onPress={clearSearch}
+              style={({ pressed }) => [
+                styles.iconHitTarget,
+                { opacity: pressed ? 0.7 : 1 },
               ]}
-            />
-          </TextInputWrapper>
+            >
+              <View
+                style={[
+                  styles.secondaryButtonSurface,
+                  {
+                    backgroundColor: colors.accent,
+                    borderColor: "transparent",
+                    borderRadius: radii.pill,
+                  },
+                ]}
+              >
+                <Ionicons
+                  name="globe-outline"
+                  size={18}
+                  color={colors.foreground}
+                />
+              </View>
+            </Pressable>
+          ) : null}
+
+          {modelLabel ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                thinkingLevelLabel
+                  ? `Model and thinking: ${modelLabel}, ${thinkingLevelLabel}`
+                  : `Model: ${modelLabel}`
+              }
+              onPress={openModelPicker}
+              style={({ pressed }) => [
+                styles.modelHitTarget,
+                { opacity: pressed ? 0.8 : 1 },
+              ]}
+            >
+              <View
+                style={[
+                  styles.modelButtonSurface,
+                  {
+                    backgroundColor: colors.muted,
+                    borderRadius: radii.pill,
+                  },
+                ]}
+              >
+                <ModelBrandIcon
+                  iconId={modelIconId}
+                  color={colors.mutedForeground}
+                  size={15}
+                  style={styles.modelButtonIcon}
+                />
+                <Text
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                  style={[
+                    styles.modelButtonLabel,
+                    {
+                      color: colors.foreground,
+                      fontFamily: fonts.sansMedium,
+                    },
+                  ]}
+                >
+                  {modelLabel}
+                </Text>
+                {thinkingLevelLabel ? (
+                  <Text
+                    numberOfLines={1}
+                    style={[
+                      styles.modelButtonThinking,
+                      {
+                        color: colors.mutedForeground,
+                        fontFamily: fonts.sansMedium,
+                      },
+                    ]}
+                  >
+                    {thinkingLevelLabel}
+                  </Text>
+                ) : null}
+              </View>
+            </Pressable>
+          ) : null}
+
+          <View style={styles.controlsSpacer} />
 
           {!streaming && !canSend ? (
             <Pressable
@@ -269,17 +345,8 @@ export function Composer({
               disabled={dictation.status === "transcribing"}
               onPress={toggleMic}
               style={({ pressed }) => [
-                styles.iconButton,
+                styles.iconHitTarget,
                 {
-                  backgroundColor:
-                    dictation.status === "recording"
-                      ? colors.destructive
-                      : "transparent",
-                  borderColor:
-                    dictation.status === "recording"
-                      ? "transparent"
-                      : colors.border,
-                  borderRadius: radii.pill,
                   opacity:
                     dictation.status === "transcribing"
                       ? 0.6
@@ -289,15 +356,32 @@ export function Composer({
                 },
               ]}
             >
-              <Ionicons
-                name={dictation.status === "recording" ? "stop" : "mic"}
-                size={dictation.status === "recording" ? 16 : 20}
-                color={
-                  dictation.status === "recording"
-                    ? colors.background
-                    : colors.mutedForeground
-                }
-              />
+              <View
+                style={[
+                  styles.secondaryButtonSurface,
+                  {
+                    backgroundColor:
+                      dictation.status === "recording"
+                        ? colors.destructive
+                        : "transparent",
+                    borderColor:
+                      dictation.status === "recording"
+                        ? "transparent"
+                        : colors.border,
+                    borderRadius: radii.pill,
+                  },
+                ]}
+              >
+                <Ionicons
+                  name={dictation.status === "recording" ? "stop" : "mic"}
+                  size={dictation.status === "recording" ? 15 : 19}
+                  color={
+                    dictation.status === "recording"
+                      ? colors.background
+                      : colors.mutedForeground
+                  }
+                />
+              </View>
             </Pressable>
           ) : null}
 
@@ -307,16 +391,25 @@ export function Composer({
               accessibilityLabel="Stop generating"
               onPress={onStop}
               style={({ pressed }) => [
-                styles.iconButton,
-                {
-                  backgroundColor: colors.secondary,
-                  borderRadius: radii.pill,
-                  borderColor: "transparent",
-                  opacity: pressed ? 0.85 : 1,
-                },
+                styles.iconHitTarget,
+                { opacity: pressed ? 0.85 : 1 },
               ]}
             >
-              <Ionicons name="stop" size={16} color={colors.secondaryForeground} />
+              <View
+                style={[
+                  styles.primaryButtonSurface,
+                  {
+                    backgroundColor: colors.secondary,
+                    borderRadius: radii.pill,
+                  },
+                ]}
+              >
+                <Ionicons
+                  name="stop"
+                  size={15}
+                  color={colors.secondaryForeground}
+                />
+              </View>
             </Pressable>
           ) : (
             <Pressable
@@ -325,16 +418,27 @@ export function Composer({
               disabled={!canSend}
               onPress={submit}
               style={({ pressed }) => [
-                styles.iconButton,
+                styles.iconHitTarget,
                 {
-                  backgroundColor: colors.primary,
-                  borderRadius: radii.pill,
-                  borderColor: "transparent",
                   opacity: !canSend ? 0.4 : pressed ? 0.85 : 1,
                 },
               ]}
             >
-              <Ionicons name="arrow-up" size={20} color={colors.primaryForeground} />
+              <View
+                style={[
+                  styles.primaryButtonSurface,
+                  {
+                    backgroundColor: colors.primary,
+                    borderRadius: radii.pill,
+                  },
+                ]}
+              >
+                <Ionicons
+                  name="arrow-up"
+                  size={19}
+                  color={colors.primaryForeground}
+                />
+              </View>
             </Pressable>
           )}
         </View>
@@ -346,6 +450,8 @@ export function Composer({
 const styles = StyleSheet.create({
   wrapper: { gap: 6 },
   errorBanner: {
+    minHeight: 48,
+    justifyContent: "center",
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderWidth: StyleSheet.hairlineWidth,
@@ -374,34 +480,49 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
   },
   uploadingText: { fontSize: 12 },
-  pillsRow: {
+  controlsRow: {
     flexDirection: "row",
-    flexWrap: "wrap",
+    alignItems: "center",
     gap: 6,
-    paddingHorizontal: 6,
-    paddingTop: 4,
   },
-  pill: {
+  inputWrapper: { alignSelf: "stretch" },
+  modelHitTarget: {
+    height: 48,
+    maxWidth: 210,
+    minWidth: 0,
+    flexShrink: 1,
+    justifyContent: "center",
+  },
+  modelButtonSurface: {
+    height: 36,
+    minWidth: 0,
     flexDirection: "row",
     alignItems: "center",
     gap: 5,
-    paddingLeft: 9,
-    paddingRight: 7,
-    paddingVertical: 5,
+    paddingHorizontal: 10,
   },
-  pillLabel: { fontSize: 14 },
-  inputRow: {
-    flexDirection: "row",
-    alignItems: "flex-end",
-    gap: 6,
+  modelButtonIcon: { flexShrink: 0 },
+  modelButtonLabel: { flexShrink: 1, minWidth: 0, fontSize: 13 },
+  modelButtonThinking: { flexShrink: 0, fontSize: 13 },
+  controlsSpacer: { flex: 1 },
+  iconHitTarget: {
+    width: 48,
+    height: 48,
+    alignItems: "center",
+    justifyContent: "center",
   },
-  inputWrapper: { flex: 1 },
-  iconButton: {
-    width: 42,
-    height: 42,
+  secondaryButtonSurface: {
+    width: 38,
+    height: 38,
     alignItems: "center",
     justifyContent: "center",
     borderWidth: StyleSheet.hairlineWidth,
+  },
+  primaryButtonSurface: {
+    width: 40,
+    height: 40,
+    alignItems: "center",
+    justifyContent: "center",
   },
   input: {
     minHeight: 42,

--- a/apps/mobile/src/components/chat/ModelPickerSheet.tsx
+++ b/apps/mobile/src/components/chat/ModelPickerSheet.tsx
@@ -6,8 +6,20 @@ import {
   BottomSheetScrollView,
   BottomSheetTextInput,
 } from "@gorhom/bottom-sheet";
-import type { PublicModelConfig } from "@overtchat/shared";
-import { forwardRef, useCallback, useMemo, useState } from "react";
+import type {
+  ChatReasoningLevel,
+  ModelReasoningControls,
+  ModelReasoningLevel,
+  PublicModelConfig,
+} from "@overtchat/shared";
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -20,7 +32,12 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ModelBrandIcon } from "@/components/ModelBrandIcon";
 import { useTheme } from "@/lib/theme";
 
-export type ModelPickerSheetRef = BottomSheetModal;
+type ModelPickerPanel = "models" | "thinking";
+
+export interface ModelPickerSheetRef {
+  present: (panel?: ModelPickerPanel) => void;
+  dismiss: () => void;
+}
 
 const SEARCH_THRESHOLD = 7;
 
@@ -31,19 +48,58 @@ export const ModelPickerSheet = forwardRef<
     selectedId: string | null;
     loading?: boolean;
     error?: Error | null;
+    reasoningControls?: ModelReasoningControls;
+    reasoningLevel: ChatReasoningLevel;
     onSelect: (id: string) => void;
+    onSelectReasoningLevel: (level: ChatReasoningLevel) => void;
   }
 >(function ModelPickerSheet(
-  { models, selectedId, loading = false, error = null, onSelect },
+  {
+    models,
+    selectedId,
+    loading = false,
+    error = null,
+    reasoningControls,
+    reasoningLevel,
+    onSelect,
+    onSelectReasoningLevel,
+  },
   ref,
 ) {
   const { colors, radii, fonts } = useTheme();
   const insets = useSafeAreaInsets();
   const { height } = useWindowDimensions();
+  const modalRef = useRef<BottomSheetModal>(null);
   const [search, setSearch] = useState("");
+  const [panel, setPanel] = useState<ModelPickerPanel>("models");
   const sheetMaxHeight = Math.min(640, Math.round(height * 0.86));
-  const showSearch = !loading && !error && models.length > SEARCH_THRESHOLD;
+  const showSearch =
+    panel === "models" &&
+    !loading &&
+    !error &&
+    models.length > SEARCH_THRESHOLD;
   const searchTerm = search.trim();
+  const selectedModel = models.find((model) => model.id === selectedId);
+  const reasoningOptions = useMemo(
+    () => reasoningOptionsForControls(reasoningControls),
+    [reasoningControls],
+  );
+  const effectiveReasoningLevel =
+    reasoningLevel === "default"
+      ? reasoningControls?.defaultLevel
+      : reasoningLevel;
+  const showThinking = reasoningOptions.length > 1;
+
+  useImperativeHandle(ref, () => ({
+    present(nextPanel = "models") {
+      setSearch("");
+      setPanel(nextPanel);
+      modalRef.current?.present();
+    },
+    dismiss() {
+      modalRef.current?.dismiss();
+    },
+  }));
 
   const filteredModels = useMemo(() => {
     if (!searchTerm) return models;
@@ -67,11 +123,14 @@ export const ModelPickerSheet = forwardRef<
 
   return (
     <BottomSheetModal
-      ref={ref}
+      ref={modalRef}
       enableDynamicSizing
       maxDynamicContentSize={sheetMaxHeight}
       backdropComponent={renderBackdrop}
-      onDismiss={() => setSearch("")}
+      onDismiss={() => {
+        setSearch("");
+        setPanel("models");
+      }}
       backgroundStyle={{
         backgroundColor: colors.popover,
         borderTopLeftRadius: radii.xl,
@@ -85,16 +144,111 @@ export const ModelPickerSheet = forwardRef<
           { paddingBottom: 20 + insets.bottom },
         ]}
         keyboardShouldPersistTaps="handled"
-        showsVerticalScrollIndicator={models.length > SEARCH_THRESHOLD}
+        showsVerticalScrollIndicator={
+          panel === "models" && models.length > SEARCH_THRESHOLD
+        }
       >
-        <Text
-          style={[
-            styles.title,
-            { color: colors.popoverForeground, fontFamily: fonts.serifSemiBold },
-          ]}
-        >
-          Models
-        </Text>
+        <View style={styles.titleRow}>
+          {panel === "thinking" ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Back to models"
+              onPress={() => setPanel("models")}
+              style={({ pressed }) => [
+                styles.backButton,
+                { opacity: pressed ? 0.7 : 1 },
+              ]}
+            >
+              <Ionicons
+                name="chevron-back"
+                size={21}
+                color={colors.popoverForeground}
+              />
+            </Pressable>
+          ) : null}
+          <View style={styles.titleCopy}>
+            <Text
+              style={[
+                styles.title,
+                {
+                  color: colors.popoverForeground,
+                  fontFamily: fonts.serifSemiBold,
+                },
+              ]}
+            >
+              {panel === "thinking" ? "Thinking" : "Models"}
+            </Text>
+            {panel === "thinking" && selectedModel ? (
+              <Text
+                numberOfLines={1}
+                style={[
+                  styles.titleSubtitle,
+                  {
+                    color: colors.mutedForeground,
+                    fontFamily: fonts.sansRegular,
+                  },
+                ]}
+              >
+                {selectedModel.label}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+
+        {panel === "models" && showThinking && effectiveReasoningLevel ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Thinking level: ${reasoningLabel(effectiveReasoningLevel)}`}
+            onPress={() => {
+              setSearch("");
+              setPanel("thinking");
+            }}
+            style={({ pressed }) => [
+              styles.thinkingControl,
+              {
+                backgroundColor: pressed ? colors.accent : colors.muted,
+                borderRadius: radii.md,
+              },
+            ]}
+          >
+            <Ionicons
+              name="bulb-outline"
+              size={18}
+              color={colors.popoverForeground}
+            />
+            <Text
+              style={[
+                styles.thinkingControlLabel,
+                {
+                  color: colors.popoverForeground,
+                  fontFamily: fonts.sansMedium,
+                },
+              ]}
+            >
+              Thinking
+            </Text>
+            <Text
+              numberOfLines={1}
+              style={[
+                styles.thinkingControlValue,
+                {
+                  color: colors.mutedForeground,
+                  fontFamily: fonts.sansRegular,
+                },
+              ]}
+            >
+              {reasoningLabel(effectiveReasoningLevel)}
+              {effectiveReasoningLevel === reasoningControls?.defaultLevel
+                ? " (default)"
+                : ""}
+            </Text>
+            <Ionicons
+              name="chevron-forward"
+              size={17}
+              color={colors.mutedForeground}
+            />
+          </Pressable>
+        ) : null}
 
         {showSearch ? (
           <View
@@ -125,8 +279,11 @@ export const ModelPickerSheet = forwardRef<
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Clear model search"
-                hitSlop={8}
                 onPress={() => setSearch("")}
+                style={({ pressed }) => [
+                  styles.searchClearButton,
+                  { opacity: pressed ? 0.7 : 1 },
+                ]}
               >
                 <Ionicons
                   name="close-circle"
@@ -138,7 +295,22 @@ export const ModelPickerSheet = forwardRef<
           </View>
         ) : null}
 
-        {loading ? (
+        {panel === "thinking" ? (
+          <View accessibilityRole="radiogroup" style={styles.list}>
+            {reasoningOptions.map((option) => (
+              <ReasoningRow
+                key={option}
+                option={option}
+                selected={option === effectiveReasoningLevel}
+                isDefault={option === reasoningControls?.defaultLevel}
+                onPress={() => {
+                  onSelectReasoningLevel(option);
+                  modalRef.current?.dismiss();
+                }}
+              />
+            ))}
+          </View>
+        ) : loading ? (
           <StatusState
             title="Loading models…"
             icon={<ActivityIndicator color={colors.mutedForeground} />}
@@ -169,7 +341,7 @@ export const ModelPickerSheet = forwardRef<
                 onPress={() => {
                   onSelect(model.id);
                   setSearch("");
-                  (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
+                  modalRef.current?.dismiss();
                 }}
               />
             ))}
@@ -179,6 +351,80 @@ export const ModelPickerSheet = forwardRef<
     </BottomSheetModal>
   );
 });
+
+function ReasoningRow({
+  option,
+  selected,
+  isDefault,
+  onPress,
+}: {
+  option: ModelReasoningLevel;
+  selected: boolean;
+  isDefault: boolean;
+  onPress: () => void;
+}) {
+  const { colors, radii, fonts } = useTheme();
+
+  return (
+    <Pressable
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected }}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.row,
+        {
+          backgroundColor: selected || pressed ? colors.accent : "transparent",
+          borderRadius: radii.md,
+          opacity: pressed ? 0.85 : 1,
+        },
+      ]}
+    >
+      <Ionicons name="bulb-outline" size={17} color={colors.mutedForeground} />
+      <View style={styles.rowText}>
+        <Text
+          style={[
+            styles.label,
+            {
+              color: colors.popoverForeground,
+              fontFamily: fonts.sansSemiBold,
+            },
+          ]}
+        >
+          {reasoningLabel(option)}
+          {isDefault ? " (default)" : ""}
+        </Text>
+      </View>
+      {selected ? (
+        <Ionicons
+          name="checkmark"
+          size={18}
+          color={colors.primary}
+          style={styles.rowCheck}
+        />
+      ) : null}
+    </Pressable>
+  );
+}
+
+export function reasoningOptionsForControls(
+  controls: ModelReasoningControls | undefined,
+): ModelReasoningLevel[] {
+  if (!controls) return [];
+  const options: ModelReasoningLevel[] = [];
+  if (controls.efforts?.length) {
+    if (controls.toggle) options.push("off");
+    if (controls.defaultLevel === "on") options.push("on");
+    options.push(...controls.efforts);
+  } else if (controls.toggle) {
+    options.push("on", "off");
+  }
+  return [...new Set(options)];
+}
+
+export function reasoningLabel(level: ChatReasoningLevel): string {
+  if (level === "xhigh") return "Extra high";
+  return level.charAt(0).toUpperCase() + level.slice(1);
+}
 
 function ModelRow({
   model,
@@ -278,9 +524,40 @@ function StatusState({
 
 const styles = StyleSheet.create({
   body: { paddingHorizontal: 12, paddingTop: 4, gap: 8 },
-  title: { fontSize: 18, paddingHorizontal: 8, paddingBottom: 8 },
+  titleRow: {
+    minHeight: 48,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 4,
+    paddingBottom: 8,
+  },
+  backButton: {
+    width: 48,
+    height: 48,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  titleCopy: { flex: 1, minWidth: 0, paddingHorizontal: 4 },
+  title: { fontSize: 18 },
+  titleSubtitle: { fontSize: 12, marginTop: 1 },
+  thinkingControl: {
+    minHeight: 48,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 12,
+    marginHorizontal: 4,
+    marginBottom: 4,
+  },
+  thinkingControlLabel: { fontSize: 14 },
+  thinkingControlValue: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 13,
+    textAlign: "right",
+  },
   searchBox: {
-    minHeight: 42,
+    minHeight: 48,
     borderWidth: StyleSheet.hairlineWidth,
     flexDirection: "row",
     alignItems: "center",
@@ -290,6 +567,13 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   searchInput: { flex: 1, fontSize: 15, paddingVertical: 8 },
+  searchClearButton: {
+    width: 48,
+    height: 48,
+    marginRight: -12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   list: { gap: 2 },
   row: {
     flexDirection: "row",

--- a/apps/mobile/src/lib/reasoningPreferences.ts
+++ b/apps/mobile/src/lib/reasoningPreferences.ts
@@ -1,0 +1,64 @@
+import {
+  type ChatReasoningLevel,
+  REASONING_EFFORTS,
+} from "@overtchat/shared";
+import * as SecureStore from "expo-secure-store";
+import { useSyncExternalStore } from "react";
+
+const KEY = "overtchat.reasoningLevels";
+
+type ReasoningLevels = Record<string, ChatReasoningLevel>;
+
+function isReasoningLevel(value: unknown): value is ChatReasoningLevel {
+  return (
+    value === "default" ||
+    value === "off" ||
+    value === "on" ||
+    REASONING_EFFORTS.includes(value as (typeof REASONING_EFFORTS)[number])
+  );
+}
+
+function read(): ReasoningLevels {
+  const raw = SecureStore.getItem(KEY);
+  if (!raw) return {};
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        ([modelId, level]) => modelId.length > 0 && isReasoningLevel(level),
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+const listeners = new Set<() => void>();
+let cached = read();
+
+function subscribe(callback: () => void) {
+  listeners.add(callback);
+  return () => listeners.delete(callback);
+}
+
+function getSnapshot() {
+  return cached;
+}
+
+export function useReasoningLevels(): ReasoningLevels {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function setReasoningLevel(
+  modelId: string,
+  level: ChatReasoningLevel,
+) {
+  if (cached[modelId] === level) return;
+  cached = { ...cached, [modelId]: level };
+  SecureStore.setItem(KEY, JSON.stringify(cached));
+  listeners.forEach((callback) => callback());
+}


### PR DESCRIPTION
## Summary

- add per-model reasoning-level selection and persist the preference on device
- send the selected reasoning level for submit, edit, and regenerate requests
- move the model and thinking indicator into the composer and add thinking controls to the model sheet
- keep Search in the stable composer toolbar and normalize compact visual controls with appropriate touch targets

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx expo export --platform android`
- `npx expo export --platform ios`
- `git diff --check`

## Manual testing

- Physical-device/simulator smoke testing remains to be completed for Android and iOS.