### PR TITLE
release: app 0.21.2 and mobile 1.5.0

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "overtchat",
     "slug": "overtchat",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "orientation": "portrait",
     "scheme": "overtchat",
     "userInterfaceStyle": "automatic",
@@ -10,11 +10,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.overtchat.mobile",
-      "buildNumber": "13"
+      "buildNumber": "14"
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 13,
+      "versionCode": 14,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@overtchat/mobile",
   "main": "expo-router/entry",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "dev": "expo start --host=lan",

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.13",
-  "appVersion": "0.21.1",
+  "appVersion": "0.21.2",
   "voiceVersion": "0.1.1",
   "connectorVersion": "0.11.1",
   "sttVersion": "0.1.1",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.21.1}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.21.2}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -1081,7 +1081,7 @@
     },
     "apps/mobile": {
       "name": "@overtchat/mobile",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "@ai-sdk/react": "^4.0.87",
         "@better-auth/expo": "1.6.23",


### PR DESCRIPTION
## Summary

- bump the stable app release from 0.21.1 to 0.21.2
- bump mobile from 1.4.1 to 1.5.0 with Android/iOS build number 14
- keep CLI, connector, voice, STT, and bundled image selections unchanged

## Release scope

- native reasoning-level discovery and controls for supported local and cloud models
- unified web model/reasoning controls and current chat title
- matching per-model reasoning controls on mobile
- full-width mobile drawer swipe

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build -w apps/site --`
- `npx expo export --platform android`
- `npx expo export --platform ios`
- production app Docker image build and runtime-content inspection from `docs/release.md`
- `git diff --check`

## Release gates

- [x] Complete focused Android/iOS interaction smoke testing for the new mobile composer, reasoning preference, submit/edit/regenerate paths, and drawer gesture
- [x] Run the non-publishing `Mobile release` workflow and verify signed AAB/APK builds plus the clean Android emulator smoke gate ([run](https://github.com/yoloyash/overtchat/actions/runs/34102167503))
- [x] Publish [`v0.21.2`](https://github.com/yoloyash/overtchat/releases/tag/v0.21.2), promote it, and verify the public stable manifest
- [x] Publish [`mobile-v1.5.0`](https://github.com/yoloyash/overtchat/releases/tag/mobile-v1.5.0), submit the AAB to Play production, and attach the verified APK ([run](https://github.com/yoloyash/overtchat/actions/runs/34107507553))
