### PR TITLE
fix(web): secure upload serving and chat attachment sources

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -370,6 +370,30 @@ describe("chat route setup boundary", () => {
     consoleSpy.mockRestore();
   });
 
+  it("rejects remote attachments before saving or starting a generation", async () => {
+    mocks.parseChatRequest.mockResolvedValue({
+      ...parsedRequest,
+      messages: [{
+        ...messages[0],
+        parts: [{ type: "file", mediaType: "image/png", url: "http://internal/image.png" }],
+      }],
+    });
+    const response = await POST(request());
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("Upload the file again");
+    expect(mocks.inlineUploads).not.toHaveBeenCalled();
+    expect(mocks.commitChatTurn).not.toHaveBeenCalled();
+    expect(mocks.agentStream).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("disables automatic attachment downloads with tools enabled=%s", async (toolCallingEnabled) => {
+    mocks.getModelConfig.mockResolvedValue({ ...modelConfig, toolCallingEnabled });
+    await POST(request());
+    const download = mocks.agentSettings[0]?.experimental_download as (urls: unknown[]) => Promise<unknown>;
+    await expect(download([{ url: new URL("http://internal/image.png"), isUrlSupportedByModel: true }]))
+      .rejects.toThrow("Upload the file again");
+  });
+
   it.each([
     [
       "upload",

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -380,7 +380,7 @@ describe("chat route setup boundary", () => {
     });
     const response = await POST(request());
     expect(response.status).toBe(400);
-    expect(await response.text()).toContain("Upload the file again");
+    expect(await response.text()).toContain("Edit the original message");
     expect(mocks.inlineUploads).not.toHaveBeenCalled();
     expect(mocks.commitChatTurn).not.toHaveBeenCalled();
     expect(mocks.agentStream).not.toHaveBeenCalled();
@@ -391,7 +391,7 @@ describe("chat route setup boundary", () => {
     await POST(request());
     const download = mocks.agentSettings[0]?.experimental_download as (urls: unknown[]) => Promise<unknown>;
     await expect(download([{ url: new URL("http://internal/image.png"), isUrlSupportedByModel: true }]))
-      .rejects.toThrow("Upload the file again");
+      .rejects.toThrow("must provide file data instead");
   });
 
   it.each([

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -17,6 +17,10 @@ import {
   type InferenceActivity,
 } from "@/lib/chat/inference-activity";
 import { currentDateSystemPrompt } from "@/lib/chat/current-date";
+import {
+  assertUploadedAttachments,
+  rejectAttachmentDownloads,
+} from "@/lib/chat/attachment-security";
 import { projectSystemPrompt } from "@/lib/chat/project-prompt";
 import {
   markAnthropicConversationCacheBoundary,
@@ -247,6 +251,7 @@ async function handlePost(req: Request): Promise<Response> {
       reasoningLevel,
     });
   const chatTools = createWebTools({ userId, supportsImageInput });
+  assertUploadedAttachments(messages);
   const inlined = await inlineUploads(messages, userId);
   const convertedMessages = await convertToModelMessages(inlined, {
     tools: chatTools,
@@ -428,6 +433,7 @@ async function handlePost(req: Request): Promise<Response> {
     const result = toolsEnabled
       ? await new ToolLoopAgent<never, ToolSet>({
           model,
+          experimental_download: rejectAttachmentDownloads,
           instructions,
           tools: agentTools,
           toolOrder,
@@ -447,6 +453,7 @@ async function handlePost(req: Request): Promise<Response> {
         }).stream({ messages: modelMessages, abortSignal })
       : await new ToolLoopAgent<never, Record<string, never>>({
           model,
+          experimental_download: rejectAttachmentDownloads,
           instructions,
           providerOptions: requestProviderOptions,
           ...(streamInclude ? { include: streamInclude } : {}),

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/chat/inference-activity";
 import { currentDateSystemPrompt } from "@/lib/chat/current-date";
 import {
-  assertUploadedAttachments,
+  assertChatAttachments,
   rejectAttachmentDownloads,
 } from "@/lib/chat/attachment-security";
 import { projectSystemPrompt } from "@/lib/chat/project-prompt";
@@ -251,7 +251,7 @@ async function handlePost(req: Request): Promise<Response> {
       reasoningLevel,
     });
   const chatTools = createWebTools({ userId, supportsImageInput });
-  assertUploadedAttachments(messages);
+  assertChatAttachments(messages);
   const inlined = await inlineUploads(messages, userId);
   const convertedMessages = await convertToModelMessages(inlined, {
     tools: chatTools,

--- a/apps/web/app/api/uploads/[id]/route.test.ts
+++ b/apps/web/app/api/uploads/[id]/route.test.ts
@@ -23,6 +23,7 @@ describe("authenticated upload response", () => {
     mocks.getSession.mockResolvedValue({ user: { id: "user-id" } });
     mocks.getUpload.mockResolvedValue({
       mediaType: "image/png",
+      filename: "image.png",
     });
     mocks.readFile.mockResolvedValue(Uint8Array.from([1, 2, 3]));
   });
@@ -35,5 +36,29 @@ describe("authenticated upload response", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("image/png");
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Content-Disposition")).toContain("inline;");
+  });
+
+  it.each(["text/html", "image/svg+xml", "application/xhtml+xml"])(
+    "forces existing %s uploads to download with a safely encoded filename",
+    async (mediaType) => {
+      mocks.getUpload.mockResolvedValue({ mediaType, filename: "résumé's\r\n.html" });
+      const response = await GET(new Request("http://localhost/api/uploads/id"), {
+        params: Promise.resolve({ id: "upload-id" }),
+      });
+      expect(response.headers.get("Content-Disposition")).toBe(
+        "attachment; filename*=UTF-8''r%C3%A9sum%C3%A9%27s%0D%0A.html",
+      );
+    },
+  );
+
+  it("does not read a file when it belongs to another user", async () => {
+    mocks.getUpload.mockResolvedValue(null);
+    const response = await GET(new Request("http://localhost/api/uploads/id"), {
+      params: Promise.resolve({ id: "upload-id" }),
+    });
+    expect(response.status).toBe(404);
+    expect(mocks.getUpload).toHaveBeenCalledWith("upload-id", "user-id");
+    expect(mocks.readFile).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/uploads/[id]/route.ts
+++ b/apps/web/app/api/uploads/[id]/route.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import { auth } from "@/lib/auth/server";
 import { getUpload, uploadPath } from "@/lib/db/uploads";
 
+const INLINE_MEDIA_TYPES = new Set([
+  "image/png", "image/jpeg", "image/gif", "image/webp",
+  "application/pdf", "text/plain",
+]);
+
 export async function GET(
   req: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -15,9 +20,17 @@ export async function GET(
 
   try {
     const bytes = await fs.readFile(uploadPath(id));
+    // Active documents such as HTML must download instead of executing on the
+    // authenticated app origin. Apply this on read to cover existing uploads.
+    const disposition = INLINE_MEDIA_TYPES.has(row.mediaType) ? "inline" : "attachment";
+    const filename = encodeURIComponent(row.filename).replace(
+      /['()*]/gu,
+      (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+    );
     return new Response(new Uint8Array(bytes), {
       headers: {
         "Content-Type": row.mediaType,
+        "Content-Disposition": `${disposition}; filename*=UTF-8''${filename}`,
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "private, max-age=31536000, immutable",
       },

--- a/apps/web/e2e/attachment-security.spec.ts
+++ b/apps/web/e2e/attachment-security.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+import { openE2eDatabase, resetE2eDatabase } from "./helpers/database";
+
+test.beforeEach(resetE2eDatabase);
+
+test("HTML uploads download safely, images display, and remote chat attachments are rejected", async ({ page, playwright }) => {
+  await page.goto("/signup");
+  await page.locator("#name").fill("Attachment Test Admin");
+  await page.locator("#email").fill("attachments@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+
+  const html = Buffer.from('<!doctype html><script>localStorage.setItem("upload-script-ran", "yes")</script>');
+  const uploaded = await page.request.post("/api/uploads", {
+    multipart: { file: { name: "résumé.html", mimeType: "text/html", buffer: html } },
+  });
+  expect(uploaded.ok()).toBeTruthy();
+  const { url } = await uploaded.json();
+  const response = await page.request.get(url);
+  expect(response.headers()["content-disposition"]).toMatch(/^attachment;/);
+  expect(await response.body()).toEqual(html);
+
+  // Navigate via a link just as someone opening a stored attachment URL would.
+  await page.evaluate((href) => {
+    const link = document.createElement("a");
+    link.href = href;
+    link.textContent = "Open HTML attachment";
+    document.body.append(link);
+  }, url);
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("link", { name: "Open HTML attachment" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("résumé.html");
+  expect(await download.failure()).toBeNull();
+  expect(await page.evaluate(() => localStorage.getItem("upload-script-ran"))).toBeNull();
+
+  const imageUpload = await page.request.post("/api/uploads", {
+    multipart: { file: {
+      name: "pixel.png", mimeType: "image/png",
+      buffer: Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aZ1sAAAAASUVORK5CYII=", "base64"),
+    } },
+  });
+  expect(imageUpload.ok()).toBeTruthy();
+  const image = await imageUpload.json();
+  await page.goto(image.url);
+  await expect(page.locator("img")).toBeVisible();
+  expect(await page.locator("img").evaluate((element) => (element as HTMLImageElement).naturalWidth)).toBe(1);
+
+  const anonymous = await playwright.request.newContext();
+  try {
+    expect((await anonymous.get(new URL(url, page.url()).href)).status()).toBe(401);
+  } finally {
+    await anonymous.dispose();
+  }
+
+  const model = await page.request.post("/api/model-configs", { data: {
+    label: "Attachment test", providerId: "custom", apiFormat: "openai-chat",
+    baseUrl: "http://127.0.0.1:9999/v1", model: "attachment-test", toolCallingEnabled: false,
+  } });
+  expect(model.ok()).toBeTruthy();
+  const { modelConfig } = await model.json();
+  const remoteFile = { type: "file", mediaType: "image/png", url: "http://internal/image.png" };
+  const rejected = await page.request.post("/api/chat", { data: {
+    chatId: "rejected-attachment", modelConfigId: modelConfig.id,
+    messages: [{ id: "turn", role: "user", parts: [remoteFile, { type: "text", text: "Inspect this" }] }],
+  } });
+  expect(rejected.status()).toBe(400);
+  expect(await rejected.text()).toContain("Upload the file again");
+
+  // Imported history must pass the same boundary as a new attachment.
+  const imported = await page.request.post("/api/import", { multipart: { file: {
+    name: "chats.json", mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify({ format: "overtchat", chats: [{
+      title: "Imported remote attachment",
+      messages: [{ role: "user", parts: [remoteFile] }],
+    }] })),
+  } } });
+  expect(imported.ok()).toBeTruthy();
+  const database = openE2eDatabase();
+  try {
+    expect(database.prepare("SELECT id FROM chats WHERE id = ?").get("rejected-attachment")).toBeUndefined();
+    const chat = database.prepare("SELECT id FROM chats LIMIT 1").get() as { id: string };
+    const continued = await page.request.post("/api/chat", { data: {
+      chatId: chat.id, modelConfigId: modelConfig.id,
+      messages: [{ id: "continuation", role: "user", parts: [{ type: "text", text: "Continue" }] }],
+    } });
+    expect(continued.status()).toBe(400);
+    expect(await continued.text()).toContain("Upload the file again");
+    expect(database.prepare("SELECT COUNT(*) AS count FROM messages").get()).toEqual({ count: 1 });
+  } finally {
+    database.close();
+  }
+});

--- a/apps/web/e2e/attachment-security.spec.ts
+++ b/apps/web/e2e/attachment-security.spec.ts
@@ -1,7 +1,36 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { expect, test } from "@playwright/test";
 import { openE2eDatabase, resetE2eDatabase } from "./helpers/database";
 
 test.beforeEach(resetE2eDatabase);
+
+let modelServer: Server;
+let modelBaseUrl: string;
+const modelRequests: unknown[] = [];
+
+test.beforeAll(async () => {
+  modelServer = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    modelRequests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    const event = {
+      id: "attachment-response", object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000), model: "attachment-test",
+      choices: [{ index: 0, delta: { role: "assistant", content: "Inline attachment accepted" }, finish_reason: null }],
+    };
+    response.write(`data: ${JSON.stringify(event)}\n\n`);
+    response.write(`data: ${JSON.stringify({ ...event, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`);
+    response.end("data: [DONE]\n\n");
+  });
+  await new Promise<void>((resolve) => modelServer.listen(0, "127.0.0.1", resolve));
+  modelBaseUrl = `http://127.0.0.1:${(modelServer.address() as AddressInfo).port}/v1`;
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => modelServer.close((error) => error ? reject(error) : resolve()));
+});
 
 test("HTML uploads download safely, images display, and remote chat attachments are rejected", async ({ page, playwright }) => {
   await page.goto("/signup");
@@ -56,7 +85,7 @@ test("HTML uploads download safely, images display, and remote chat attachments 
 
   const model = await page.request.post("/api/model-configs", { data: {
     label: "Attachment test", providerId: "custom", apiFormat: "openai-chat",
-    baseUrl: "http://127.0.0.1:9999/v1", model: "attachment-test", toolCallingEnabled: false,
+    baseUrl: modelBaseUrl, model: "attachment-test", toolCallingEnabled: false,
   } });
   expect(model.ok()).toBeTruthy();
   const { modelConfig } = await model.json();
@@ -66,7 +95,7 @@ test("HTML uploads download safely, images display, and remote chat attachments 
     messages: [{ id: "turn", role: "user", parts: [remoteFile, { type: "text", text: "Inspect this" }] }],
   } });
   expect(rejected.status()).toBe(400);
-  expect(await rejected.text()).toContain("Upload the file again");
+  expect(await rejected.text()).toContain("Edit the original message");
 
   // Imported history must pass the same boundary as a new attachment.
   const imported = await page.request.post("/api/import", { multipart: { file: {
@@ -86,8 +115,30 @@ test("HTML uploads download safely, images display, and remote chat attachments 
       messages: [{ id: "continuation", role: "user", parts: [{ type: "text", text: "Continue" }] }],
     } });
     expect(continued.status()).toBe(400);
-    expect(await continued.text()).toContain("Upload the file again");
+    expect(await continued.text()).toContain("Edit the original message");
     expect(database.prepare("SELECT COUNT(*) AS count FROM messages").get()).toEqual({ count: 1 });
+    expect(modelRequests).toHaveLength(0);
+
+    // Inline data in imported history is already local and needs no URL fetch.
+    const inlineUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aZ1sAAAAASUVORK5CYII=";
+    const inlineImport = await page.request.post("/api/import", { multipart: { file: {
+      name: "inline.json", mimeType: "application/json",
+      buffer: Buffer.from(JSON.stringify({ format: "overtchat", chats: [{
+        title: "Imported inline attachment",
+        messages: [{ role: "user", parts: [{ type: "file", mediaType: "image/png", url: inlineUrl }] }],
+      }] })),
+    } } });
+    expect(inlineImport.ok()).toBeTruthy();
+    const inlineChat = database.prepare("SELECT id FROM chats WHERE title = ?")
+      .get("Imported inline attachment") as { id: string };
+    const accepted = await page.request.post("/api/chat", { data: {
+      chatId: inlineChat.id, modelConfigId: modelConfig.id,
+      messages: [{ id: "inline-continuation", role: "user", parts: [{ type: "text", text: "Describe the image" }] }],
+    } });
+    expect(accepted.status()).toBe(200);
+    expect(await accepted.text()).toContain("Inline attachment accepted");
+    expect(modelRequests).toHaveLength(1);
+    expect(JSON.stringify(modelRequests[0])).toContain(inlineUrl);
   } finally {
     database.close();
   }

--- a/apps/web/lib/chat/attachment-security.test.ts
+++ b/apps/web/lib/chat/attachment-security.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { convertToModelMessages, ToolLoopAgent, type UIMessage } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { assertUploadedAttachments, rejectAttachmentDownloads } from "./attachment-security";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function message(url: string): UIMessage {
+  return {
+    id: "message", role: "user",
+    parts: [{ type: "file", mediaType: "image/png", url }],
+  };
+}
+
+describe("chat attachment boundary", () => {
+  it("accepts upload references for resolution under the authenticated user", () => {
+    expect(() => assertUploadedAttachments([message("/api/uploads/owned-id")])).not.toThrow();
+  });
+
+  it.each([
+    "https://example.com/image.png", "http://searxng:8080/",
+    "http://127.0.0.1/image.png", "//example.com/image.png",
+    "data:image/png;base64,aGVsbG8=", "file:///etc/passwd",
+    "/api/uploads/", "/api/uploads/id/other", "/api/uploads/id?download=1",
+  ])("rejects unsupported attachment %s", (url) => {
+    expect(() => assertUploadedAttachments([message(url)])).toThrow("Upload the file again");
+  });
+
+  it("checks persisted assistant attachments and reasoning files too", () => {
+    expect(() => assertUploadedAttachments([
+      { ...message("https://example.com/image.png"), role: "assistant" },
+    ])).toThrow("Upload the file again");
+    expect(() => assertUploadedAttachments([{
+      id: "reasoning", role: "assistant",
+      parts: [{ type: "reasoning-file", mediaType: "image/png", url: "/api/uploads/id" }],
+    }])).toThrow("Upload the file again");
+  });
+
+  it.each([false, true])("blocks SDK URL downloads even when provider URL support is %s", async (supported) => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const model = new MockLanguageModelV4({
+      supportedUrls: supported ? { "image/*": [/.*/] } : {},
+    });
+    const agent = new ToolLoopAgent({ model, experimental_download: rejectAttachmentDownloads, maxRetries: 0 });
+
+    await expect(agent.generate({
+      messages: await convertToModelMessages([message("https://example.com/image.png")]),
+    })).rejects.toThrow("Upload the file again");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(model.doGenerateCalls).toHaveLength(0);
+  });
+
+  it("passes inlined upload bytes to the model without fetching", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const model = new MockLanguageModelV4({
+      doGenerate: {
+        content: [{ type: "text", text: "ok" }],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+        warnings: [],
+      },
+    });
+    const agent = new ToolLoopAgent({ model, experimental_download: rejectAttachmentDownloads });
+    const result = await agent.generate({
+      messages: await convertToModelMessages([message("data:image/png;base64,aGVsbG8=")]),
+    });
+    expect(result.text).toBe("ok");
+    expect(model.doGenerateCalls).toHaveLength(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("also blocks remote files nested in tool results", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const model = new MockLanguageModelV4();
+    const agent = new ToolLoopAgent({ model, experimental_download: rejectAttachmentDownloads, maxRetries: 0 });
+    await expect(agent.generate({ messages: [{
+      role: "tool",
+      content: [{
+        type: "tool-result", toolCallId: "call", toolName: "image",
+        output: { type: "content", value: [{
+          type: "file", mediaType: "image/png",
+          data: { type: "url", url: new URL("https://example.com/image.png") },
+        }] },
+      }],
+    }] })).rejects.toThrow("Upload the file again");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(model.doGenerateCalls).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/chat/attachment-security.test.ts
+++ b/apps/web/lib/chat/attachment-security.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { convertToModelMessages, ToolLoopAgent, type UIMessage } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
-import { assertUploadedAttachments, rejectAttachmentDownloads } from "./attachment-security";
+import { assertChatAttachments, rejectAttachmentDownloads } from "./attachment-security";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -14,26 +14,26 @@ function message(url: string): UIMessage {
 
 describe("chat attachment boundary", () => {
   it("accepts upload references for resolution under the authenticated user", () => {
-    expect(() => assertUploadedAttachments([message("/api/uploads/owned-id")])).not.toThrow();
+    expect(() => assertChatAttachments([message("/api/uploads/owned-id")])).not.toThrow();
   });
 
   it.each([
     "https://example.com/image.png", "http://searxng:8080/",
     "http://127.0.0.1/image.png", "//example.com/image.png",
-    "data:image/png;base64,aGVsbG8=", "file:///etc/passwd",
+    "file:///etc/passwd",
     "/api/uploads/", "/api/uploads/id/other", "/api/uploads/id?download=1",
   ])("rejects unsupported attachment %s", (url) => {
-    expect(() => assertUploadedAttachments([message(url)])).toThrow("Upload the file again");
+    expect(() => assertChatAttachments([message(url)])).toThrow("Edit the original message");
   });
 
   it("checks persisted assistant attachments and reasoning files too", () => {
-    expect(() => assertUploadedAttachments([
+    expect(() => assertChatAttachments([
       { ...message("https://example.com/image.png"), role: "assistant" },
-    ])).toThrow("Upload the file again");
-    expect(() => assertUploadedAttachments([{
+    ])).toThrow("Edit the original message");
+    expect(() => assertChatAttachments([{
       id: "reasoning", role: "assistant",
       parts: [{ type: "reasoning-file", mediaType: "image/png", url: "/api/uploads/id" }],
-    }])).toThrow("Upload the file again");
+    }])).toThrow("Edit the original message");
   });
 
   it.each([false, true])("blocks SDK URL downloads even when provider URL support is %s", async (supported) => {
@@ -46,12 +46,12 @@ describe("chat attachment boundary", () => {
 
     await expect(agent.generate({
       messages: await convertToModelMessages([message("https://example.com/image.png")]),
-    })).rejects.toThrow("Upload the file again");
+    })).rejects.toThrow("must provide file data instead");
     expect(fetch).not.toHaveBeenCalled();
     expect(model.doGenerateCalls).toHaveLength(0);
   });
 
-  it("passes inlined upload bytes to the model without fetching", async () => {
+  it.each(["user", "assistant", "reasoning"] as const)("passes %s inline data to the model without fetching", async (kind) => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
     const model = new MockLanguageModelV4({
@@ -63,8 +63,12 @@ describe("chat attachment boundary", () => {
       },
     });
     const agent = new ToolLoopAgent({ model, experimental_download: rejectAttachmentDownloads });
+    const inlineMessage: UIMessage = kind === "reasoning"
+      ? { id: "reasoning", role: "assistant", parts: [{ type: "reasoning-file", mediaType: "image/png", url: "data:image/png;base64,aGVsbG8=" }] }
+      : { ...message("data:image/png;base64,aGVsbG8="), role: kind };
+    assertChatAttachments([inlineMessage]);
     const result = await agent.generate({
-      messages: await convertToModelMessages([message("data:image/png;base64,aGVsbG8=")]),
+      messages: await convertToModelMessages([inlineMessage]),
     });
     expect(result.text).toBe("ok");
     expect(model.doGenerateCalls).toHaveLength(1);
@@ -85,7 +89,7 @@ describe("chat attachment boundary", () => {
           data: { type: "url", url: new URL("https://example.com/image.png") },
         }] },
       }],
-    }] })).rejects.toThrow("Upload the file again");
+    }] })).rejects.toThrow("must provide file data instead");
     expect(fetch).not.toHaveBeenCalled();
     expect(model.doGenerateCalls).toHaveLength(0);
   });

--- a/apps/web/lib/chat/attachment-security.ts
+++ b/apps/web/lib/chat/attachment-security.ts
@@ -1,0 +1,27 @@
+import type { Experimental_DownloadFunction, UIMessage } from "ai";
+import { ChatRequestError } from "./request";
+
+const UPLOAD_URL = /^\/api\/uploads\/[^/\\?#]+$/u;
+const UPLOAD_REQUIRED = "This chat contains an unsupported attachment. Upload the file again to continue.";
+
+/** Validate reconstructed history too, including attachments from imported chats. */
+export function assertUploadedAttachments(messages: UIMessage[]): void {
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (
+        part.type === "reasoning-file" ||
+        (part.type === "file" && !UPLOAD_URL.test(part.url))
+      ) {
+        throw new ChatRequestError(UPLOAD_REQUIRED);
+      }
+    }
+  }
+}
+
+// Owned uploads and fetched-image tool results already provide bytes. Prevent
+// the SDK from fetching URLs in other file parts, including tool results, or
+// forwarding those URLs to providers that support remote attachments.
+export const rejectAttachmentDownloads: Experimental_DownloadFunction = async (downloads) => {
+  if (downloads.length > 0) throw new ChatRequestError(UPLOAD_REQUIRED);
+  return [];
+};

--- a/apps/web/lib/chat/attachment-security.ts
+++ b/apps/web/lib/chat/attachment-security.ts
@@ -2,26 +2,32 @@ import type { Experimental_DownloadFunction, UIMessage } from "ai";
 import { ChatRequestError } from "./request";
 
 const UPLOAD_URL = /^\/api\/uploads\/[^/\\?#]+$/u;
-const UPLOAD_REQUIRED = "This chat contains an unsupported attachment. Upload the file again to continue.";
+const UNSUPPORTED_ATTACHMENT =
+  "This chat contains an unsupported attachment URL. Edit the original message to remove it, or start a new chat and upload the file.";
 
 /** Validate reconstructed history too, including attachments from imported chats. */
-export function assertUploadedAttachments(messages: UIMessage[]): void {
+export function assertChatAttachments(messages: UIMessage[]): void {
   for (const message of messages) {
     for (const part of message.parts) {
       if (
-        part.type === "reasoning-file" ||
-        (part.type === "file" && !UPLOAD_URL.test(part.url))
+        (part.type === "file" || part.type === "reasoning-file") &&
+        !part.url.startsWith("data:") &&
+        !(part.type === "file" && UPLOAD_URL.test(part.url))
       ) {
-        throw new ChatRequestError(UPLOAD_REQUIRED);
+        throw new ChatRequestError(UNSUPPORTED_ATTACHMENT);
       }
     }
   }
 }
 
-// Owned uploads and fetched-image tool results already provide bytes. Prevent
+// Owned uploads, inline data, and fetched-image tool results provide bytes. Prevent
 // the SDK from fetching URLs in other file parts, including tool results, or
 // forwarding those URLs to providers that support remote attachments.
 export const rejectAttachmentDownloads: Experimental_DownloadFunction = async (downloads) => {
-  if (downloads.length > 0) throw new ChatRequestError(UPLOAD_REQUIRED);
+  if (downloads.length > 0) {
+    throw new ChatRequestError(
+      "A remote attachment URL cannot be sent to the model. Attachments and tool results must provide file data instead.",
+    );
+  }
   return [];
 };


### PR DESCRIPTION
HTML uploads could execute on the authenticated app origin when opened directly, and chat file URLs could trigger automatic SDK downloads. Serve active documents as attachments and restrict chat file parts to upload references resolved under the authenticated user or inline data.

The change uses standard `Content-Disposition` headers and the existing upload store. Raster images, PDFs, and plain text remain viewable inline. Validation covers reconstructed history before chat persistence, including imported attachments. The SDK's download hook rejects remaining URLs, including nested tool-result files and URLs supported directly by a provider. No dependencies, DNS filtering, schema changes, or migrations are added.

Compatibility: inline data-URL attachments remain supported, including imported history and inline reasoning files. Remote attachments remain blocked: edit the original message to remove them, or start a new chat and upload the file. The error now explains this recovery path. MCP tools must return file bytes rather than remote file URLs. Normal web/mobile uploads and the existing stored-image web tool continue to supply inline bytes.

Validation:
- Web unit/integration suite: 126 files, 813 tests passed. Includes real AI SDK coverage for blocked URL downloads, nested tool-result URLs, provider URL support, and accepted inline bytes in user, assistant, and reasoning parts.
- Web typecheck, lint, and production build passed.
- Chromium regression against the standalone production build passed: HTML triggers a download with its original Unicode filename, script does not execute, PNG still renders, anonymous reads fail, and new/imported remote attachments are rejected without persisting a turn. An imported chat with inline image data successfully continues against a local mock model.
