### PR TITLE
fix(chat): support submission on HTTP LAN origins

### DIFF
--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useChat } from "@ai-sdk/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { DefaultChatTransport, type FileUIPart, type UIMessage } from "ai";
+import { DefaultChatTransport, generateId, type FileUIPart, type UIMessage } from "ai";
 import {
   hasSuccessfulMemoryMutation,
   modelSupportsChatReasoningLevel,
@@ -374,7 +374,7 @@ export function ChatArea({
     forceSearch: searchAvailable && forceSearch,
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     chatId,
-    clientRequestId: crypto.randomUUID(),
+    clientRequestId: generateId(),
     projectId: projectId ?? null,
     temporary,
     action,

--- a/apps/web/e2e/stream-resumption.spec.ts
+++ b/apps/web/e2e/stream-resumption.spec.ts
@@ -140,6 +140,45 @@ function seedModel() {
   }
 }
 
+test("new chats submit without crypto.randomUUID on HTTP origins", async ({ page }) => {
+  await page.goto("/signup");
+  await page.locator("#name").fill("HTTP Chat Tester");
+  await page.locator("#email").fill("http-chat@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+  seedModel();
+  await page.reload();
+
+  // Localhost is a secure context even over HTTP. Remove the API to reproduce
+  // the browser capabilities of a plain HTTP LAN origin.
+  await page.evaluate(() => {
+    Object.defineProperty(crypto, "randomUUID", { configurable: true, value: undefined });
+  });
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  continueStream.resolve();
+
+  const requestIds: string[] = [];
+  for (const text of ["First message over HTTP", "Second message over HTTP"]) {
+    const requestPromise = page.waitForRequest((request) =>
+      new URL(request.url()).pathname === "/api/chat" && request.method() === "POST",
+    );
+    await page.getByPlaceholder("Message…").fill(text);
+    await page.getByLabel("Send message").click();
+    const body = (await requestPromise).postDataJSON();
+    expect(body.clientRequestId).toEqual(expect.any(String));
+    expect(body.clientRequestId.length).toBeGreaterThan(0);
+    requestIds.push(body.clientRequestId);
+    await expect(page.getByLabel("Send message")).toBeVisible();
+    await expect(page.getByText("Before reload. After reload.", { exact: true }))
+      .toHaveCount(requestIds.length);
+  }
+  expect(new Set(requestIds).size).toBe(2);
+  expect(streamingRequests).toBe(2);
+  expect(errors).toEqual([]);
+});
+
 test("sidebar tracks generation after leaving the active chat", async ({
   page,
 }) => {


### PR DESCRIPTION
Chat submission on an HTTP LAN origin throws `crypto.randomUUID is not a function` before sending a request. Generate client request IDs with the existing AI SDK helper so both new chats and subsequent turns work without secure-context-only browser APIs.

Adds a Chromium regression that removes `crypto.randomUUID`, submits two messages, and verifies distinct request IDs and two completed model responses.

Validation: production build, web typecheck and lint passed; the new browser regression passed against the standalone build. The fix has no dependency or schema changes.
