### PR TITLE
chore(release): web 0.21.3, connector 0.11.2, mobile 1.6.0

### DIFF
--- a/apps/connector/package.json
+++ b/apps/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overtchat/connector",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/connector/src/client.test.ts
+++ b/apps/connector/src/client.test.ts
@@ -133,7 +133,7 @@ describe.sequential("connector client compatibility", () => {
 
     const headers = new Headers(requests[0]!.init?.headers);
     expect(headers.get("x-overtchat-connector-version")).toBeNull();
-    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.11.1");
+    expect(headers.get("x-overtchat-connector-build-version")).toBe("0.11.2");
     expect(headers.get("x-overtchat-connector-protocol")).toBe(
       String(HOST_CONNECTOR_PROTOCOL_VERSION),
     );

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "overtchat",
     "slug": "overtchat",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "orientation": "portrait",
     "scheme": "overtchat",
     "userInterfaceStyle": "automatic",
@@ -10,11 +10,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.overtchat.mobile",
-      "buildNumber": "14"
+      "buildNumber": "15"
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 14,
+      "versionCode": 15,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@overtchat/mobile",
   "main": "expo-router/entry",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "expo start --host=lan",

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -18,6 +18,7 @@
 /install/connector/0.10.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.10.0/install-connector.sh 302
 /install/connector/0.11.0 https://github.com/yoloyash/overtchat/releases/download/connector-v0.11.0/install-connector.sh 302
 /install/connector/0.11.1 https://github.com/yoloyash/overtchat/releases/download/connector-v0.11.1/install-connector.sh 302
+/install/connector/0.11.2 https://github.com/yoloyash/overtchat/releases/download/connector-v0.11.2/install-connector.sh 302
 
 # Friendly alias for the current connector release.
-/install-connector.sh /install/connector/0.11.1 302
+/install-connector.sh /install/connector/0.11.2 302

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,9 +1,9 @@
 {
   "format": 1,
   "cliVersion": "0.1.13",
-  "appVersion": "0.21.2",
+  "appVersion": "0.21.3",
   "voiceVersion": "0.1.1",
-  "connectorVersion": "0.11.1",
+  "connectorVersion": "0.11.2",
   "sttVersion": "0.1.1",
   "redisImage": "docker.io/library/redis@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2",
   "searxngImage": "docker.io/searxng/searxng@sha256:11a9b34cdc0b1ec2b991470a2762ecb5a1a531898289fb51dcd015260450729e",

--- a/apps/web/app/api/host-connectors/route.test.ts
+++ b/apps/web/app/api/host-connectors/route.test.ts
@@ -83,7 +83,7 @@ describe("Host Connectors route", () => {
       pairCode: "ocp_pair.secret",
       expiresAt: 10_000,
       command:
-        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.11.1 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
+        "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.11.2 | sh -s -- --server 'http://127.0.0.1:9000' --pair-code 'ocp_pair.secret'",
     });
     expect(mocks.createPairing).toHaveBeenCalledWith("admin");
   });
@@ -157,9 +157,9 @@ describe("Host Connectors route", () => {
           lastSeenAt: 12_000,
           online: true,
           upgrade: {
-            version: "0.11.1",
+            version: "0.11.2",
             command:
-              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.11.1 | sh -s -- --upgrade",
+              "curl --proto '=https' --tlsv1.2 -fsSL https://overtchat.com/install/connector/0.11.2 | sh -s -- --upgrade",
           },
         },
       ],
@@ -172,7 +172,7 @@ describe("Host Connectors route", () => {
         id: "current",
         name: "Current",
         managed: false,
-        version: "0.11.1",
+        version: "0.11.2",
         lastSeenAt: null,
       },
       {

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.21.2}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.21.3}
     build: .
     container_name: overtchat-app
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,7 +552,7 @@
     },
     "apps/connector": {
       "name": "@overtchat/connector",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "dependencies": {
         "@overtchat/agent-bridge": "*",
         "@overtchat/agent-runtime": "*"
@@ -1081,7 +1081,7 @@
     },
     "apps/mobile": {
       "name": "@overtchat/mobile",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@ai-sdk/react": "^4.0.87",
         "@better-auth/expo": "1.6.23",

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -22,7 +22,7 @@ import {
 /** Increment only for a breaking web-to-connector wire contract change. */
 export const HOST_CONNECTOR_PROTOCOL_VERSION = 3;
 /** Published connector artifact version; independent of wire compatibility. */
-export const HOST_CONNECTOR_RELEASE_VERSION = "0.11.1";
+export const HOST_CONNECTOR_RELEASE_VERSION = "0.11.2";
 export const HOST_CONNECTOR_EVENT_BATCH_LIMIT = 256;
 
 export const HOST_CONNECTOR_CAPABILITIES = [

--- a/scripts/install-connector.sh
+++ b/scripts/install-connector.sh
@@ -2,7 +2,7 @@
 set -eu
 
 repository="yoloyash/overtchat"
-connector_version="0.11.1"
+connector_version="0.11.2"
 server=""
 pair_code=""
 connector_name=""


### PR DESCRIPTION
Prepare web 0.21.3, Host Connector 0.11.2, and mobile 1.6.0 (Android/iOS build 15) for a combined release.

Web includes safer upload serving, restricted attachment sources, and the HTTP chat submission fix. Mobile adds Agent Connections workflows; the connector fixes Codex file-change approval details. Align the manifest, Compose default, package versions, connector installer and redirects, and mobile build metadata. Preserve existing immutable installer URLs.

Validation: connector bundle built locally. All PR checks passed: repository lint, typechecks and tests, Chromium E2E, the production app image and runtime contents, site export, and both connector binaries. The eight connector-route tests also passed locally. Tagged mobile builds run crash-reporting preflight and emulator smoke tests before submitting the AAB to Google Play production.
