### PR TITLE
Polish activity profiles and contribution grid

### DIFF
--- a/apps/web/app/(app)/activity/_components/ActivityHeatmap.tsx
+++ b/apps/web/app/(app)/activity/_components/ActivityHeatmap.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Tooltip } from "@base-ui/react/tooltip";
+import type { ActivityTotals } from "@/lib/activity/types";
+import { cn } from "@/lib/utils";
+import { formatCompact, formatExact } from "./activity-format";
+
+const HEAT_CLASSES = [
+  "bg-muted",
+  "bg-primary/20",
+  "bg-primary/35",
+  "bg-primary/50",
+  "bg-primary/70",
+];
+
+export function ActivityHeatmap({
+  daily,
+  throughDate,
+  name,
+}: {
+  daily: Array<ActivityTotals & { date: string }>;
+  throughDate: string;
+  name: string;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [focusedDay, setFocusedDay] = useState(364);
+  const [activeDay, setActiveDay] = useState<number | null>(null);
+  const byDate = new Map(daily.map((day) => [day.date, day]));
+  const start = new Date(`${throughDate}T00:00:00.000Z`);
+  start.setUTCDate(start.getUTCDate() - 364);
+  const leading = start.getUTCDay();
+  const weeks = Math.ceil((leading + 365) / 7);
+  const columns = { gridTemplateColumns: `repeat(${weeks}, minmax(0, 1fr))` };
+  const days = Array.from({ length: 365 }, (_, index) => {
+    const day = new Date(start);
+    day.setUTCDate(start.getUTCDate() + index);
+    const date = day.toISOString().slice(0, 10);
+    return { day, date, usage: byDate.get(date) };
+  });
+  const maxTokens = Math.max(1, ...daily.map((day) => day.totalTokens));
+
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    if (scroller) scroller.scrollLeft = scroller.scrollWidth;
+  }, [throughDate]);
+
+  return (
+    <Tooltip.Provider delay={100}>
+      <div ref={scrollRef} className="mt-5 overflow-x-auto pb-2">
+        <div className="min-w-[636px]">
+          <div role="grid" aria-label={`${name} token activity over the past year`} className="grid gap-1">
+            {Array.from({ length: 7 }, (_, weekday) => (
+              <div key={weekday} role="row" className="grid gap-1" style={columns}>
+                {Array.from({ length: weeks }, (_, week) => {
+                  const index = week * 7 + weekday - leading;
+                  const entry = days[index];
+                  if (!entry) return <span key={week} role="gridcell" aria-hidden="true" />;
+                  const tokens = entry.usage?.totalTokens ?? 0;
+                  const responses = entry.usage?.generations ?? 0;
+                  const level = tokens > 0 ? Math.min(4, Math.ceil((tokens / maxTokens) * 4)) : 0;
+                  const dateLabel = new Intl.DateTimeFormat(undefined, {
+                    month: "short", day: "numeric", year: "numeric", timeZone: "UTC",
+                  }).format(entry.day);
+                  return (
+                    <Tooltip.Root
+                      key={week}
+                      open={activeDay === index}
+                      onOpenChange={(open) => setActiveDay((active) => open ? index : active === index ? null : active)}
+                    >
+                      <Tooltip.Trigger
+                        role="gridcell"
+                        data-day-index={index}
+                        aria-label={`${dateLabel}: ${formatExact(tokens)} chat tokens, ${formatExact(responses)} responses`}
+                        tabIndex={focusedDay === index ? 0 : -1}
+                        closeOnClick={false}
+                        onClick={() => setActiveDay(index)}
+                        onFocus={() => setFocusedDay(index)}
+                        onKeyDown={(event) => {
+                          const offsets: Record<string, number> = { ArrowLeft: -7, ArrowRight: 7, ArrowUp: -1, ArrowDown: 1 };
+                          const offset = offsets[event.key];
+                          if (offset === undefined) return;
+                          event.preventDefault();
+                          const next = Math.max(0, Math.min(364, index + offset));
+                          scrollRef.current?.querySelector<HTMLElement>(`[data-day-index="${next}"]`)?.focus();
+                        }}
+                        className={cn(
+                          "aspect-square w-full rounded-[3px] motion-colors hover:ring-1 hover:ring-primary/40 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                          HEAT_CLASSES[level],
+                        )}
+                      />
+                      <Tooltip.Portal>
+                        <Tooltip.Positioner side="top" sideOffset={8} className="z-50">
+                          <Tooltip.Popup role="tooltip" className="rounded-lg border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md">
+                            <p className="font-medium">{formatCompact(tokens)} tokens on {dateLabel}</p>
+                            <p className="mt-1 text-muted-foreground">{formatExact(responses)} {responses === 1 ? "response" : "responses"}</p>
+                          </Tooltip.Popup>
+                        </Tooltip.Positioner>
+                      </Tooltip.Portal>
+                    </Tooltip.Root>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+          <div aria-hidden="true" className="mt-3 grid gap-1 text-xs text-muted-foreground" style={columns}>
+            {days.map(({ day, date }, index) => {
+              const week = Math.floor((leading + index) / 7);
+              // Leave enough room for each month label at the edges.
+              if (index === 0 && day.getUTCDate() > 14) return null;
+              if (index !== 0 && day.getUTCDate() !== 1) return null;
+              if (week > weeks - 2) return null;
+              return (
+                <span key={date} className="whitespace-nowrap" style={{ gridColumn: `${week + 1} / span ${Math.min(3, weeks - week)}` }}>
+                  {new Intl.DateTimeFormat(undefined, { month: "short", timeZone: "UTC" }).format(day)}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </Tooltip.Provider>
+  );
+}

--- a/apps/web/app/(app)/activity/_components/ActivityLeaderboard.tsx
+++ b/apps/web/app/(app)/activity/_components/ActivityLeaderboard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { ChevronRight, Trophy } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import {
   ACTIVITY_PERIODS,
   type ActivityPeriod,
@@ -11,6 +11,7 @@ import {
 import { ProfileAvatar } from "@/components/ProfileAvatar";
 import { useActivityLeaderboard } from "@/lib/queries/activity";
 import { cn } from "@/lib/utils";
+import { ActivityMetric } from "./ActivityMetric";
 import { formatCompact, formatDate, formatExact } from "./activity-format";
 
 const PERIOD_LABELS: Record<ActivityPeriod, string> = {
@@ -66,8 +67,8 @@ export function ActivityLeaderboard() {
     data?.entries.filter((entry) => entry.generations > 0).length ?? 0;
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-8 md:px-8 md:py-10">
-      <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+    <div className="@container mx-auto w-full max-w-5xl px-4 py-8 md:px-8 md:py-10">
+      <div className="flex flex-col gap-5 @xl:flex-row @xl:items-end @xl:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">
             Leaderboard
@@ -81,7 +82,7 @@ export function ActivityLeaderboard() {
         <div
           role="group"
           aria-label="Leaderboard period"
-          className="grid grid-cols-3 rounded-md bg-muted p-1"
+          className="grid grid-cols-3 rounded-lg border border-border/70 bg-muted/50 p-1"
         >
           {ACTIVITY_PERIODS.map((value) => (
             <button
@@ -90,7 +91,7 @@ export function ActivityLeaderboard() {
               aria-pressed={period === value}
               onClick={() => setPeriod(value)}
               className={cn(
-                "min-w-20 rounded px-3 py-1.5 text-xs font-medium motion-colors",
+                "min-w-20 rounded-md px-3 py-2 text-xs font-medium motion-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
                 period === value
                   ? "bg-background text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground",
@@ -102,16 +103,31 @@ export function ActivityLeaderboard() {
         </div>
       </div>
 
-      <dl className="mt-8 grid grid-cols-3 divide-x border-y">
-        <Metric label="Chat tokens" value={totals.totalTokens} />
-        <Metric label="Responses" value={totals.generations} />
-        <Metric label="Active people" value={activePeople} />
+      <dl className="mt-7 grid grid-cols-3 gap-2 sm:gap-3">
+        <ActivityMetric
+          label="Chat tokens"
+          value={isError ? undefined : totals.totalTokens}
+          pending={isPending}
+        />
+        <ActivityMetric
+          label="Responses"
+          value={isError ? undefined : totals.generations}
+          pending={isPending}
+        />
+        <ActivityMetric
+          label="Active people"
+          value={isError ? undefined : activePeople}
+          pending={isPending}
+        />
       </dl>
 
       <section className="mt-9">
-        <h2 className="mb-3 text-sm font-semibold">People</h2>
-        <div className="border-y">
-          <div className="hidden grid-cols-[3rem_minmax(12rem,1fr)_8rem_7rem_8rem_8rem_1.5rem] items-center border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground md:grid">
+        <div className="mb-4 flex items-baseline justify-between gap-3">
+          <h2 className="text-sm font-semibold">People</h2>
+          <span className="text-xs text-muted-foreground">Ranked by chat tokens</span>
+        </div>
+        <div className="overflow-hidden rounded-lg border border-border/70 bg-card">
+          <div className="hidden grid-cols-[2.5rem_minmax(0,1fr)_6rem_5.5rem_5.5rem_5.5rem_1.5rem] items-center border-b bg-muted/40 px-4 py-3 text-xs font-medium text-muted-foreground @3xl:grid">
             <span>Rank</span>
             <span>Person</span>
             <span className="text-right">Chat tokens</span>
@@ -127,81 +143,56 @@ export function ActivityLeaderboard() {
             <p className="px-3 py-10 text-center text-sm text-destructive">
               Activity could not be loaded.
             </p>
+          ) : data?.entries.length === 0 ? (
+            <p className="px-4 py-12 text-center text-sm text-muted-foreground">
+              No activity to show for this period.
+            </p>
           ) : (
             data?.entries.map((entry, index) => (
               <Link
                 key={entry.userId}
                 href={`/activity/${entry.userId}`}
-                className="grid min-h-16 grid-cols-[2.25rem_minmax(0,1fr)_auto_1.25rem] items-center gap-2 border-b px-3 py-2.5 motion-colors last:border-b-0 hover:bg-muted/45 md:grid-cols-[3rem_minmax(12rem,1fr)_8rem_7rem_8rem_8rem_1.5rem] md:gap-0"
+                className="group grid min-h-20 grid-cols-[2.25rem_minmax(0,1fr)_auto_1.25rem] items-center gap-2 border-b border-border/60 px-4 py-4 motion-colors focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring last:border-b-0 hover:bg-muted/45 @3xl:grid-cols-[2.5rem_minmax(0,1fr)_6rem_5.5rem_5.5rem_5.5rem_1.5rem] @3xl:gap-0"
               >
-                <Rank
-                  value={index + 1}
-                  active={entry.generations > 0}
-                />
+                <span
+                  aria-label={`Rank ${index + 1}`}
+                  className="text-center text-xs tabular-nums text-muted-foreground"
+                >
+                  {String(index + 1).padStart(2, "0")}
+                </span>
                 <span className="flex min-w-0 items-center gap-3">
                   <ProfileAvatar
                     id={entry.userId}
                     name={entry.name}
                     image={entry.image}
+                    tone="muted"
                   />
                   <span className="min-w-0">
                     <span className="block truncate text-sm font-medium">
                       {entry.name}
                     </span>
-                    <span className="block text-xs text-muted-foreground md:hidden">
+                    <span className="block text-xs text-muted-foreground @3xl:hidden">
                       {formatCompact(entry.generations)} responses
                     </span>
                   </span>
                 </span>
                 <Value value={entry.totalTokens} />
-                <span className="hidden text-right text-sm text-muted-foreground md:block">
+                <span className="hidden text-right text-sm tabular-nums text-muted-foreground @3xl:block">
                   {formatCompact(entry.generations)}
                 </span>
-                <span className="hidden text-right text-sm text-muted-foreground md:block">
+                <span className="hidden text-right text-sm tabular-nums text-muted-foreground @3xl:block">
                   {formatCompact(entry.inputTokens)}
                 </span>
-                <span className="hidden text-right text-sm text-muted-foreground md:block">
+                <span className="hidden text-right text-sm tabular-nums text-muted-foreground @3xl:block">
                   {formatCompact(entry.outputTokens)}
                 </span>
-                <ChevronRight className="size-4 text-muted-foreground" />
+                <ChevronRight className="size-4 text-muted-foreground/50 motion-colors group-hover:text-foreground" />
               </Link>
             ))
           )}
         </div>
       </section>
     </div>
-  );
-}
-
-function Metric({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="min-w-0 px-3 py-4 sm:px-5">
-      <dt className="truncate text-xs text-muted-foreground">{label}</dt>
-      <dd
-        className="mt-1 truncate text-lg font-semibold tabular-nums sm:text-xl"
-        title={formatExact(value)}
-      >
-        {formatCompact(value)}
-      </dd>
-    </div>
-  );
-}
-
-function Rank({ value, active }: { value: number; active: boolean }) {
-  if (value === 1 && active) {
-    return (
-      <span
-        className="flex size-7 items-center justify-center text-amber-600 dark:text-amber-400"
-        aria-label="Rank 1"
-      >
-        <Trophy className="size-4" />
-      </span>
-    );
-  }
-  return (
-    <span className="pl-2 text-sm tabular-nums text-muted-foreground">
-      {value}
-    </span>
   );
 }
 
@@ -222,7 +213,7 @@ function LeaderboardSkeleton() {
       {Array.from({ length: 4 }).map((_, index) => (
         <div
           key={index}
-          className="flex h-16 items-center gap-3 border-b px-3 last:border-b-0"
+          className="flex h-20 items-center gap-3 border-b px-4 last:border-b-0"
         >
           <div className="h-4 w-5 rounded motion-skeleton" />
           <div className="size-9 rounded-full motion-skeleton" />

--- a/apps/web/app/(app)/activity/_components/ActivityMetric.tsx
+++ b/apps/web/app/(app)/activity/_components/ActivityMetric.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+import { formatCompact, formatExact } from "./activity-format";
+
+export function ActivityMetric({
+  label,
+  value,
+  pending = false,
+  inline = false,
+}: {
+  label: string;
+  value: number | undefined;
+  pending?: boolean;
+  inline?: boolean;
+}) {
+  return (
+    <div className={cn(
+      "min-w-0 px-4 py-5 sm:px-5",
+      inline
+        ? "flex flex-col-reverse items-center gap-1 border-border/60 text-center odd:border-r nth-[-n+2]:border-b @xl:border-r @xl:nth-[-n+2]:border-b-0 @xl:last:border-r-0"
+        : "rounded-lg border border-border/70 bg-card",
+    )}>
+      <dt className={cn("text-xs text-muted-foreground", !inline && "min-h-8 font-medium sm:min-h-0")}>
+        {label}
+      </dt>
+      <dd
+        className={cn("tracking-tight tabular-nums", inline ? "text-xl font-medium" : "mt-2 text-2xl font-semibold")}
+        title={value === undefined ? undefined : formatExact(value)}
+      >
+        {pending ? (
+          <span
+            aria-label="Loading"
+            className="block h-8 w-16 rounded motion-skeleton"
+          />
+        ) : value === undefined ? (
+          "—"
+        ) : (
+          formatCompact(value)
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/activity/_components/ActivityProfile.tsx
+++ b/apps/web/app/(app)/activity/_components/ActivityProfile.tsx
@@ -1,29 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
-import { ArrowLeft, Bot, CalendarDays, MessageSquareText } from "lucide-react";
+import { useState } from "react";
+import { ArrowLeft } from "lucide-react";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
-import type { ActivityTotals } from "@/lib/activity/types";
 import { useActivityProfile } from "@/lib/queries/activity";
-import { cn } from "@/lib/utils";
-import { formatCompact, formatDate, formatExact } from "./activity-format";
-
-const EMPTY_TOTALS: ActivityTotals = {
-  generations: 0,
-  pricedGenerations: 0,
-  inputTokens: 0,
-  uncachedInputTokens: 0,
-  outputTokens: 0,
-  cacheReadTokens: 0,
-  cacheWriteTokens: 0,
-  totalTokens: 0,
-  inputCostNanoUsd: 0,
-  outputCostNanoUsd: 0,
-  cacheReadCostNanoUsd: 0,
-  cacheWriteCostNanoUsd: 0,
-  totalCostNanoUsd: 0,
-};
+import { PROVIDERS } from "@/lib/providers/catalog";
+import { ActivityHeatmap } from "./ActivityHeatmap";
+import { ActivityMetric } from "./ActivityMetric";
+import { formatCompact, formatDate } from "./activity-format";
 
 export function ActivityProfile({ userId }: { userId: string }) {
   const [timeZone] = useState(
@@ -49,112 +34,123 @@ export function ActivityProfile({ userId }: { userId: string }) {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-7 md:px-8 md:py-10">
+    <div className="@container mx-auto w-full max-w-5xl px-4 py-8 md:px-8 md:py-10">
       <Link
         href="/activity"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground motion-colors hover:text-foreground"
+        className="inline-flex items-center gap-2 rounded-sm text-xs font-medium text-muted-foreground motion-colors hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
       >
         <ArrowLeft className="size-4" />
         Leaderboard
       </Link>
 
-      <section className="mt-6 flex items-center gap-4 md:gap-5">
+      <section className="mt-4 flex flex-col items-center gap-4 text-center">
         <ProfileAvatar
           id={data.member.id}
           name={data.member.name}
           image={data.member.image}
           size="lg"
+          tone="muted"
         />
-        <div className="min-w-0">
-          <h1 className="truncate text-2xl font-semibold tracking-tight md:text-3xl">
+        <div className="min-w-0 max-w-full">
+          <h1 className="truncate text-2xl font-semibold tracking-tight">
             {data.member.name}
           </h1>
-          <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-            <CalendarDays className="size-3.5" />
+          <p className="mt-1.5 text-xs text-muted-foreground">
             Member since {formatDate(data.member.createdAt)}
           </p>
         </div>
       </section>
 
-      <dl className="mt-8 grid grid-cols-2 divide-x divide-y border-y md:grid-cols-4 md:divide-y-0">
-        <ProfileMetric
+      <dl className="mt-8 grid grid-cols-2 overflow-hidden rounded-xl border border-border/60 @xl:grid-cols-4">
+        <ActivityMetric
           label="Chat tokens"
+          inline
           value={data.totals.totalTokens}
-          icon={MessageSquareText}
         />
-        <ProfileMetric
+        <ActivityMetric
           label="Responses"
+          inline
           value={data.totals.generations}
-          icon={Bot}
         />
-        <ProfileMetric label="Input" value={data.totals.inputTokens} />
-        <ProfileMetric label="Output" value={data.totals.outputTokens} />
+        <ActivityMetric inline label="Input" value={data.totals.inputTokens} />
+        <ActivityMetric inline label="Output" value={data.totals.outputTokens} />
       </dl>
 
       <section className="mt-10">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <div>
-            <h2 className="text-base font-semibold">Activity</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">
+            <h2 className="text-sm font-semibold">Token activity</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
               {data.trackingStartedAt
                 ? `Tracked since ${formatDate(data.trackingStartedAt)}`
                 : "No tracked responses yet"}
             </p>
           </div>
-          <span className="text-xs text-muted-foreground">Past year</span>
+          <span className="text-xs text-muted-foreground">Past 365 days</span>
         </div>
-        <UsageHeatmap
+        <ActivityHeatmap
+          key={`${userId}:${data.throughDate}`}
           daily={data.daily}
           throughDate={data.throughDate}
           name={data.member.name}
         />
       </section>
 
-      <section className="mt-10">
+      <section className="mt-8">
         <div className="flex items-baseline justify-between gap-3">
-          <h2 className="text-base font-semibold">Models</h2>
+          <div>
+            <h2 className="text-sm font-semibold">Models</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Share of all responses by model
+            </p>
+          </div>
           <span className="text-xs text-muted-foreground">
             {data.models.length} used
           </span>
         </div>
-        <div className="mt-3 border-y">
+        <div className="mt-4 divide-y divide-border/50">
           {data.models.length === 0 ? (
             <p className="px-3 py-10 text-center text-sm text-muted-foreground">
               No model activity yet.
             </p>
           ) : (
             data.models.map((model) => {
-              const maxGenerations = data.models[0]?.generations ?? 1;
-              const width = `${Math.max(
-                4,
-                (model.generations / maxGenerations) * 100,
-              )}%`;
+              const share =
+                data.totals.generations > 0
+                  ? (model.generations / data.totals.generations) * 100
+                  : 0;
               return (
                 <div
                   key={`${model.providerId}:${model.model}`}
-                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-b px-3 py-3 last:border-b-0"
+                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-5 py-4 sm:gap-8"
                 >
                   <div className="min-w-0">
-                    <div className="flex items-baseline gap-2">
-                      <span className="truncate text-sm font-medium">
+                    <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-2">
+                      <span
+                        className="truncate text-sm font-medium"
+                        title={model.model}
+                      >
                         {model.model}
                       </span>
-                      <span className="shrink-0 text-[11px] uppercase text-muted-foreground">
+                      <span className="shrink-0 text-xs text-muted-foreground">
                         {providerLabel(model.providerId)}
                       </span>
                     </div>
-                    <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
+                    <div
+                      aria-hidden="true"
+                      className="mt-3 h-1 overflow-hidden rounded-full bg-muted"
+                    >
                       <div
-                        className="h-full rounded-full bg-teal-500 dark:bg-teal-400"
-                        style={{ width }}
+                        className="h-full rounded-full bg-primary/55"
+                        style={{ width: `${share}%` }}
                       />
                     </div>
                   </div>
-                  <div className="text-right">
-                    <p className="text-sm font-semibold tabular-nums">
+                  <div className="shrink-0 text-right">
+                    <p className="text-sm font-medium tabular-nums">
                       {formatCompact(model.generations)}
                     </p>
-                    <p className="text-[11px] text-muted-foreground">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       responses
                     </p>
                   </div>
@@ -168,170 +164,29 @@ export function ActivityProfile({ userId }: { userId: string }) {
   );
 }
 
-function ProfileMetric({
-  label,
-  value,
-  icon: Icon,
-}: {
-  label: string;
-  value: number;
-  icon?: typeof Bot;
-}) {
-  return (
-    <div className="min-w-0 px-4 py-4">
-      <dt className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        {Icon && <Icon className="size-3.5" />}
-        {label}
-      </dt>
-      <dd
-        className="mt-1 text-xl font-semibold tabular-nums"
-        title={formatExact(value)}
-      >
-        {formatCompact(value)}
-      </dd>
-    </div>
-  );
-}
-
-function UsageHeatmap({
-  daily,
-  throughDate,
-  name,
-}: {
-  daily: Array<ActivityTotals & { date: string }>;
-  throughDate: string;
-  name: string;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const byDate = new Map(daily.map((day) => [day.date, day]));
-  const days = dateRange(throughDate, 365);
-  const leading = dayOfWeek(days[0]?.date ?? throughDate);
-  const maxTokens = Math.max(0, ...daily.map((day) => day.totalTokens));
-
-  useEffect(() => {
-    const scroller = scrollRef.current;
-    if (scroller) scroller.scrollLeft = scroller.scrollWidth;
-  }, [throughDate]);
-
-  return (
-    <div className="mt-4">
-      <div className="flex min-w-0">
-        <div
-          aria-hidden="true"
-          className="mr-2 grid shrink-0 grid-rows-7 gap-[3px] pt-px text-[9px] leading-[10px] text-muted-foreground"
-        >
-          <span />
-          <span>Mon</span>
-          <span />
-          <span>Wed</span>
-          <span />
-          <span>Fri</span>
-          <span />
-        </div>
-        <div
-          ref={scrollRef}
-          className="min-w-0 flex-1 overflow-x-auto pb-2"
-        >
-          <div
-            role="grid"
-            aria-label={`${name} activity over the past year`}
-            className="grid w-max grid-flow-col grid-rows-7 gap-[3px]"
-          >
-            {Array.from({ length: leading }).map((_, index) => (
-              <span key={`empty-${index}`} className="size-2.5" />
-            ))}
-            {days.map(({ date, label }) => {
-              const usage = byDate.get(date) ?? EMPTY_TOTALS;
-              const level = heatLevel(usage.totalTokens, maxTokens);
-              const title = `${label}: ${formatExact(
-                usage.totalTokens,
-              )} chat tokens, ${formatExact(usage.generations)} responses`;
-              return (
-                <span
-                  key={date}
-                  role="gridcell"
-                  aria-label={title}
-                  title={title}
-                  className={cn(
-                    "size-2.5 rounded-[2px] ring-1 ring-inset ring-black/5 dark:ring-white/5",
-                    HEAT_CLASSES[level],
-                  )}
-                />
-              );
-            })}
-          </div>
-        </div>
-      </div>
-      <div className="mt-2 flex items-center justify-end gap-1.5 text-[10px] text-muted-foreground">
-        <span>Less</span>
-        {HEAT_CLASSES.map((className, index) => (
-          <span
-            key={index}
-            className={cn("size-2.5 rounded-[2px]", className)}
-          />
-        ))}
-        <span>More</span>
-      </div>
-    </div>
-  );
-}
-
-const HEAT_CLASSES = [
-  "bg-muted",
-  "bg-teal-200 dark:bg-teal-950",
-  "bg-teal-400 dark:bg-teal-800",
-  "bg-teal-600 dark:bg-teal-600",
-  "bg-teal-800 dark:bg-teal-400",
-];
-
-function heatLevel(value: number, max: number): number {
-  if (value <= 0 || max <= 0) return 0;
-  return Math.min(4, Math.max(1, Math.ceil((Math.log1p(value) / Math.log1p(max)) * 4)));
-}
-
-function dateRange(
-  throughDate: string,
-  count: number,
-): Array<{ date: string; label: string }> {
-  const end = new Date(`${throughDate}T00:00:00.000Z`);
-  const start = new Date(end);
-  start.setUTCDate(start.getUTCDate() - (count - 1));
-  return Array.from({ length: count }, (_, index) => {
-    const date = new Date(start);
-    date.setUTCDate(start.getUTCDate() + index);
-    return {
-      date: date.toISOString().slice(0, 10),
-      label: new Intl.DateTimeFormat(undefined, {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-        timeZone: "UTC",
-      }).format(date),
-    };
-  });
-}
-
-function dayOfWeek(date: string): number {
-  return new Date(`${date}T00:00:00.000Z`).getUTCDay();
-}
-
 function providerLabel(providerId: string): string {
-  return providerId.replaceAll("-", " ");
+  return Object.values(PROVIDERS).find((provider) => provider.id === providerId)
+    ?.label ?? providerId.replaceAll("-", " ");
 }
 
 function ProfileSkeleton() {
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-8 px-4 py-8 md:px-8">
+    <div className="@container mx-auto w-full max-w-5xl space-y-8 px-4 py-8 md:px-8">
       <div className="h-4 w-24 rounded motion-skeleton" />
-      <div className="flex items-center gap-4">
+      <div className="flex flex-col items-center gap-4">
         <div className="size-20 rounded-full motion-skeleton" />
         <div className="space-y-2">
           <div className="h-7 w-48 rounded motion-skeleton" />
           <div className="h-3 w-32 rounded motion-skeleton" />
         </div>
       </div>
-      <div className="h-20 border-y motion-skeleton" />
-      <div className="h-32 rounded-md motion-skeleton" />
+      <dl className="grid grid-cols-2 overflow-hidden rounded-xl border border-border/60 @xl:grid-cols-4">
+        {["Chat tokens", "Responses", "Input", "Output"].map((label) => (
+          <ActivityMetric key={label} inline label={label} value={undefined} pending />
+        ))}
+      </dl>
+      <div className="h-48 rounded-lg motion-skeleton" />
+      <div className="h-48 rounded-lg motion-skeleton" />
     </div>
   );
 }

--- a/apps/web/app/(app)/activity/loading.tsx
+++ b/apps/web/app/(app)/activity/loading.tsx
@@ -1,24 +1,23 @@
+import { ActivityMetric } from "./_components/ActivityMetric";
+
 export default function ActivityLoading() {
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-8 px-4 py-8 md:px-8">
-      <div className="flex items-end justify-between">
+    <div className="mx-auto w-full max-w-5xl space-y-8 px-4 py-8 md:px-8 md:py-10">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-2">
           <div className="h-7 w-52 rounded motion-skeleton" />
           <div className="h-4 w-32 rounded motion-skeleton" />
         </div>
         <div className="h-8 w-56 rounded-md motion-skeleton" />
       </div>
-      <div className="grid grid-cols-3 border-y">
-        {Array.from({ length: 3 }).map((_, index) => (
-          <div key={index} className="space-y-2 p-4">
-            <div className="h-3 w-20 rounded motion-skeleton" />
-            <div className="h-6 w-28 rounded motion-skeleton" />
-          </div>
+      <dl className="grid grid-cols-3 gap-2 sm:gap-3">
+        {["Chat tokens", "Responses", "Active people"].map((label) => (
+          <ActivityMetric key={label} label={label} value={undefined} pending />
         ))}
-      </div>
-      <div className="space-y-px border-y">
+      </dl>
+      <div className="space-y-px overflow-hidden rounded-lg border border-border/70">
         {Array.from({ length: 4 }).map((_, index) => (
-          <div key={index} className="flex h-16 items-center gap-3 px-3">
+          <div key={index} className="flex h-20 items-center gap-3 px-4">
             <div className="size-8 rounded-full motion-skeleton" />
             <div className="h-4 w-36 rounded motion-skeleton" />
             <div className="ml-auto h-4 w-20 rounded motion-skeleton" />

--- a/apps/web/components/ProfileAvatar.tsx
+++ b/apps/web/components/ProfileAvatar.tsx
@@ -21,11 +21,13 @@ export function ProfileAvatar({
   name,
   image,
   size = "md",
+  tone = "color",
 }: {
   id: string;
   name: string;
   image: string | null;
   size?: "sm" | "md" | "lg";
+  tone?: "color" | "muted";
 }) {
   return (
     <span
@@ -33,7 +35,9 @@ export function ProfileAvatar({
       aria-label={`${name} avatar`}
       className={cn(
         "relative flex shrink-0 items-center justify-center overflow-hidden rounded-full font-semibold",
-        avatarStyle(id),
+        tone === "muted"
+          ? "bg-secondary text-secondary-foreground ring-1 ring-inset ring-border/70"
+          : avatarStyle(id),
         size === "sm" && "size-7 text-[10px]",
         size === "md" && "size-9 text-xs",
         size === "lg" && "size-16 text-lg md:size-20 md:text-xl",

--- a/apps/web/e2e/activity.spec.ts
+++ b/apps/web/e2e/activity.spec.ts
@@ -384,6 +384,15 @@ test("leaderboard, activity profiles, and personal profile are verifiable", asyn
       page.getByRole("gridcell", { name: /500 chat tokens/ }),
     ).toBeVisible();
     await expect(page.getByText("1.5K").first()).toBeVisible();
+    const grid = page.getByRole("grid");
+    await expect(grid.getByRole("row")).toHaveCount(7);
+    await expect(grid.getByRole("gridcell")).toHaveCount(365);
+    const day = grid.getByRole("gridcell", { name: /500 chat tokens/ });
+    await day.hover();
+    await expect(page.getByRole("tooltip")).toContainText("500 tokens");
+    await day.focus();
+    await page.keyboard.press("ArrowLeft");
+    await expect(day).not.toBeFocused();
   });
 
   await test.step("edit the personal profile and open its activity page", async () => {
@@ -435,13 +444,16 @@ test("leaderboard, activity profiles, and personal profile are verifiable", asyn
     await expect(
       page.getByRole("heading", { name: "Taylor" }),
     ).toBeVisible();
-    const heatmapScroller = page.getByRole("grid").locator("..");
+    const heatmapScroller = page.getByRole("grid").locator("../..");
     await expect
       .poll(() => heatmapScroller.evaluate((element) => element.scrollLeft))
       .toBeGreaterThan(0);
     await expect(
       page.getByRole("gridcell", { name: /500 chat tokens/ }),
     ).toBeVisible();
+
+    await page.getByRole("gridcell", { name: /500 chat tokens/ }).click();
+    await expect(page.getByRole("tooltip")).toContainText("500 tokens");
 
     await page.goto("/settings/profile");
     await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();


### PR DESCRIPTION
The activity page used bright teal charts and inconsistent presentation. This refresh aligns it with the app's olive theme and presents profiles with centered identity, a compact stats strip, and a GitHub-style contribution grid with month labels and hover/tap usage details.

The leaderboard, model bars, loading states, and responsive spacing use consistent typography and surfaces. The grid supports keyboard navigation and keeps recent activity visible on small screens. No API, persistence, dependency, or release changes.

Validation:
- Web typecheck, lint, and production build passed.
- Activity E2E passed, including period filters, profile navigation, 365-day grid, tooltips, and keyboard navigation.
- Inspected light/dark layouts at 320, 390, 900, and 1440px; no page overflow.
