### PR TITLE
feat(web): add reusable chat file library

### DIFF
--- a/apps/web/app/(app)/library/page.tsx
+++ b/apps/web/app/(app)/library/page.tsx
@@ -1,0 +1,20 @@
+import { LibraryBrowser } from "@/components/library/LibraryBrowser";
+import { SidebarToggle } from "@/components/SidebarToggle";
+
+export default function LibraryPage() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="flex h-12 shrink-0 items-center gap-2 px-3">
+        <SidebarToggle />
+        <span className="text-sm font-medium">Library</span>
+      </header>
+      <div className="mx-auto flex min-h-0 w-full max-w-5xl flex-1 flex-col">
+        <div className="px-4 pb-4 pt-6 sm:px-6">
+          <h1 className="text-2xl font-semibold tracking-tight">Library</h1>
+          <p className="mt-2 text-sm text-muted-foreground">Files from your saved chats. Reuse them with “Add from library” in any chat.</p>
+        </div>
+        <LibraryBrowser />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -8,6 +8,7 @@ import { toast } from "@/components/ui/toast";
 import { getErrorMessage } from "@/lib/errors";
 import {
   chatKeys,
+  libraryKeys,
   personalizationKeys,
   projectKeys,
 } from "@/lib/queries/keys";
@@ -57,6 +58,7 @@ export function DataForm() {
       }
       const result = body as ImportResult;
       qc.invalidateQueries({ queryKey: chatKeys.list() });
+      qc.invalidateQueries({ queryKey: libraryKeys.all() });
       qc.invalidateQueries({ queryKey: projectKeys.list() });
       qc.invalidateQueries({ queryKey: personalizationKeys.all() });
       toast.success({

--- a/apps/web/app/api/library/route.test.ts
+++ b/apps/web/app/api/library/route.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ getSession: vi.fn(), listLibrary: vi.fn() }));
+vi.mock("@/lib/auth/server", () => ({ auth: { api: { getSession: mocks.getSession } } }));
+vi.mock("@/lib/db/library", () => ({ listLibrary: mocks.listLibrary }));
+import { GET } from "./route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSession.mockResolvedValue({ user: { id: "alice" } });
+  mocks.listLibrary.mockResolvedValue({ items: [], nextCursor: null });
+});
+
+describe("library API", () => {
+  it("requires authentication before querying", async () => {
+    mocks.getSession.mockResolvedValue(null);
+    expect((await GET(new Request("http://localhost/api/library"))).status).toBe(401);
+    expect(mocks.listLibrary).not.toHaveBeenCalled();
+  });
+
+  it("uses the session owner, validates pagination, and prevents shared caching", async () => {
+    const cursor = { createdAt: 1000, id: "file-05" };
+    const params = new URLSearchParams({ q: "report", cursor: JSON.stringify(cursor), userId: "bob" });
+    const response = await GET(new Request(`http://localhost/api/library?${params}`));
+    expect(response.status).toBe(200);
+    expect(mocks.listLibrary).toHaveBeenCalledWith("alice", "report", cursor);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(await response.json()).toEqual({ items: [], nextCursor: null });
+  });
+
+  it.each([
+    "cursor=abc", "cursor=null", "cursor={}",
+    ...[
+      { createdAt: -1, id: "file" }, { createdAt: 1.5, id: "file" },
+      { createdAt: "1000", id: "file" }, { createdAt: 1e20, id: "file" },
+      { createdAt: 1000, id: "" }, { createdAt: 1000, id: "a".repeat(201) },
+    ].map((cursor) => `cursor=${encodeURIComponent(JSON.stringify(cursor))}`),
+    `q=${"a".repeat(201)}`,
+  ])("rejects invalid parameters: %s", async (params) => {
+    expect((await GET(new Request(`http://localhost/api/library?${params}`))).status).toBe(400);
+    expect(mocks.listLibrary).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/library/route.ts
+++ b/apps/web/app/api/library/route.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { auth } from "@/lib/auth/server";
+import { listLibrary } from "@/lib/db/library";
+
+const cursorSchema = z.object({
+  createdAt: z.number().int().min(0).max(8_640_000_000_000_000),
+  id: z.string().min(1).max(200),
+});
+
+const paramsSchema = z.object({
+  q: z.string().trim().max(200).default(""),
+  cursor: z.string().max(1000).transform((value, ctx) => {
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      ctx.addIssue({ code: "custom", message: "Invalid library cursor." });
+      return z.NEVER;
+    }
+  }).pipe(cursorSchema).optional(),
+});
+
+export async function GET(req: Request) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+
+  const params = paramsSchema.safeParse(
+    Object.fromEntries(new URL(req.url).searchParams),
+  );
+  if (!params.success) {
+    return Response.json({ error: "Invalid library search parameters." }, { status: 400 });
+  }
+  const { q, cursor } = params.data;
+  return Response.json(await listLibrary(session.user.id, q, cursor), {
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}

--- a/apps/web/components/SidebarChatList.tsx
+++ b/apps/web/components/SidebarChatList.tsx
@@ -365,6 +365,9 @@ export function SidebarItem({
               ) : (
                 "This chat will be permanently deleted."
               )}
+              <span className="mt-2 block text-xs">
+                Files used only in this chat will also be removed from your library.
+              </span>
             </AlertDialog.Description>
             {deleteError && (
               <p className="mt-3 text-xs text-destructive">{deleteError}</p>

--- a/apps/web/components/SidebarClient.tsx
+++ b/apps/web/components/SidebarClient.tsx
@@ -8,6 +8,7 @@ import {
   Activity,
   Check,
   FolderPlus,
+  Library,
   MoreHorizontal,
   PanelLeft,
   Pencil,
@@ -125,6 +126,19 @@ export function SidebarClient({ isAdmin }: { isAdmin: boolean }) {
             <span className="flex-1 text-left">Search chats</span>
             <Shortcut keys={["Ctrl", "K"]} />
           </button>
+          <Link
+            href="/library"
+            onClick={closeMobile}
+            aria-current={pathname === "/library" ? "page" : undefined}
+            className={cn(
+              "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors hover:bg-sidebar-accent",
+              pathname === "/library" && "bg-sidebar-accent",
+            )}
+          >
+            <Library className="size-4 shrink-0 text-muted-foreground" />
+            <span className="flex-1">Library</span>
+            <LinkPendingIndicator />
+          </Link>
           <Link
             href="/activity"
             onClick={closeMobile}

--- a/apps/web/components/chat/ChatArea.tsx
+++ b/apps/web/components/chat/ChatArea.tsx
@@ -20,6 +20,7 @@ import { useModelConfigs } from "@/lib/queries/modelConfigs";
 import {
   activityKeys,
   chatKeys,
+  libraryKeys,
   personalizationKeys,
 } from "@/lib/queries/keys";
 import { usePublicCapabilities } from "@/lib/queries/capabilities";
@@ -277,6 +278,7 @@ export function ChatArea({
       setInferenceActivity(null);
       if (!temporaryRef.current) {
         void qc.invalidateQueries({ queryKey: chatKeys.active() });
+        void qc.invalidateQueries({ queryKey: libraryKeys.all() });
       }
     },
     onFinish: ({ message, isError }) => {
@@ -290,6 +292,7 @@ export function ChatArea({
         });
       }
       if (temporaryRef.current) return;
+      void qc.invalidateQueries({ queryKey: libraryKeys.all() });
       setActiveChatInCache(qc, chatId, false);
       if (hasSuccessfulMemoryMutation(message)) {
         void qc.invalidateQueries({ queryKey: personalizationKeys.all() });
@@ -309,6 +312,7 @@ export function ChatArea({
     setChatPersisted(true);
     setActiveChatInCache(qc, chatId, false);
     void Promise.all([
+      qc.invalidateQueries({ queryKey: libraryKeys.all() }),
       qc.invalidateQueries({ queryKey: chatKeys.list() }),
       qc.invalidateQueries({ queryKey: chatKeys.active() }),
       qc.invalidateQueries({ queryKey: chatKeys.usage(chatId) }),

--- a/apps/web/components/chat/Composer.tsx
+++ b/apps/web/components/chat/Composer.tsx
@@ -24,6 +24,7 @@ import {
   Ghost,
   Globe,
   Loader2,
+  Library,
   Mic,
   Paperclip,
   Pencil,
@@ -36,6 +37,7 @@ import {
 import { Menu } from "@base-ui/react/menu";
 import { Button } from "@/components/ui/button";
 import { ModelPicker } from "@/components/ModelPicker";
+import { LibraryPicker } from "@/components/library/LibraryPicker";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import {
@@ -148,6 +150,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   draftEnabled,
 }, ref) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [libraryOpen, setLibraryOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const handleDraftRestore = useCallback(() => {
     requestAnimationFrame(() => {
@@ -172,6 +175,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     addFiles,
     removeAttachment,
     clearAttachments,
+    addReadyParts,
   } = useChatAttachments();
 
   useImperativeHandle(
@@ -586,6 +590,17 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
                           </span>
                         </span>
                       </Menu.Item>
+                      <Menu.Item
+                        onClick={() => setLibraryOpen(true)}
+                        disabled={!attachmentsEnabled}
+                        className="flex min-h-12 cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2 outline-none motion-colors data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                      >
+                        <Library className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-medium">Add from library</span>
+                          <span className="block text-xs text-muted-foreground">Reuse files from your chats</span>
+                        </span>
+                      </Menu.Item>
                       <Menu.CheckboxItem
                         checked={searchRequested}
                         onCheckedChange={onToggleSearch}
@@ -724,6 +739,24 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           </div>
         </div>
       </div>
+      {libraryOpen && attachmentsEnabled && (
+        <LibraryPicker
+          attachedUrls={new Set(readyParts.map((part) => part.url))}
+          onClose={() => {
+            setLibraryOpen(false);
+            textareaRef.current?.focus({ preventScroll: true });
+          }}
+          onAdd={(items) => addReadyParts(
+            items.map((item) => ({
+              type: "file" as const,
+              url: item.url,
+              filename: item.filename,
+              mediaType: item.mediaType,
+            })),
+            new Map(items.map((item) => [item.url, item])),
+          )}
+        />
+      )}
     </>
   );
 });

--- a/apps/web/components/chat/useChatAttachments.ts
+++ b/apps/web/components/chat/useChatAttachments.ts
@@ -72,7 +72,10 @@ export function useChatAttachments() {
     });
   }
 
-  function addReadyParts(parts: readonly FileUIPart[]): void {
+  function addReadyParts(
+    parts: readonly FileUIPart[],
+    metadata?: ReadonlyMap<string, AttachmentMeta>,
+  ): void {
     const next = parts.map((part) => ({
       id: nextIdRef.current++,
       status: "ready" as const,
@@ -83,6 +86,7 @@ export function useChatAttachments() {
         category: part.mediaType.startsWith("image/")
           ? ("image" as const)
           : undefined,
+        ...metadata?.get(part.url),
       },
     }));
     setAttachments((prev) => [...prev, ...next]);

--- a/apps/web/components/library/LibraryBrowser.tsx
+++ b/apps/web/components/library/LibraryBrowser.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, LayoutGrid, Library, List, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { CategoryIcon } from "@/components/chat/attachment-icons";
+import { formatSize, humanMediaLabel } from "@/lib/chat/attachments";
+import { useLibrary } from "@/lib/queries/library";
+import type { LibraryItem } from "@/lib/library";
+import { cn } from "@/lib/utils";
+
+interface LibraryBrowserProps {
+  selected?: ReadonlyMap<string, LibraryItem>;
+  attachedUrls?: ReadonlySet<string>;
+  onToggle?: (item: LibraryItem) => void;
+}
+
+export function LibraryBrowser({ selected, attachedUrls, onToggle }: LibraryBrowserProps) {
+  const [search, setSearch] = useState("");
+  const [query, setQuery] = useState("");
+  const [view, setView] = useState<"list" | "grid">("list");
+  useEffect(() => {
+    const timer = setTimeout(() => setQuery(search.trim()), 200);
+    return () => clearTimeout(timer);
+  }, [search]);
+  const library = useLibrary(query);
+  const items = library.data?.pages.flatMap((page) => page.items) ?? [];
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-3 border-b px-4 py-4 sm:px-6">
+        <div className="relative min-w-0 flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            aria-label="Search library"
+            placeholder="Search library"
+            maxLength={200}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="h-10 pl-9"
+          />
+        </div>
+        <div role="group" aria-label="Library view" className="flex gap-1">
+          <Button variant="ghost" size="icon" aria-label="List view" aria-pressed={view === "list"} onClick={() => setView("list")} className={cn(view === "list" && "bg-accent")}>
+            <List />
+          </Button>
+          <Button variant="ghost" size="icon" aria-label="Grid view" aria-pressed={view === "grid"} onClick={() => setView("grid")} className={cn(view === "grid" && "bg-accent")}>
+            <LayoutGrid />
+          </Button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6" aria-busy={library.isFetching}>
+        {library.isPending ? (
+          <p role="status" className="py-12 text-center text-sm text-muted-foreground">Loading library…</p>
+        ) : library.isError && !items.length ? (
+          <div role="alert" className="space-y-3 py-12 text-center">
+            <p className="text-sm text-muted-foreground">Could not load your library.</p>
+            <Button variant="outline" onClick={() => void library.refetch()}>Try again</Button>
+          </div>
+        ) : !items.length ? (
+          <div role="status" className="flex flex-col items-center gap-3 py-12 text-center">
+            <Library className="size-8 text-muted-foreground" />
+            <p className="font-medium">{query ? "No matching files" : "Your library is empty"}</p>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              {query ? "Try another filename." : "Files you attach to saved chats appear here, ready to use again."}
+            </p>
+          </div>
+        ) : (
+          <ul aria-label="Library files" className={cn(view === "grid" ? "grid grid-cols-2 gap-3 sm:grid-cols-3" : "space-y-1")}>
+            {items.map((item) => {
+              const attached = attachedUrls?.has(item.url) ?? false;
+              const checked = attached || (selected?.has(item.id) ?? false);
+              const className = cn(
+                "relative flex w-full min-w-0 gap-3 rounded-xl p-3 text-left motion-colors hover:bg-accent/60 focus-visible:outline-2 focus-visible:outline-ring",
+                view === "grid" ? "h-full flex-col border" : "items-center",
+                onToggle && checked && "bg-accent",
+                attached && "opacity-50",
+              );
+              const content = (
+                <>
+                  <LibraryPreview item={item} grid={view === "grid"} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium" title={item.filename}>{item.filename}</span>
+                    <span className="mt-1 block truncate text-xs text-muted-foreground">
+                      {humanMediaLabel(item.mediaType)} · {formatSize(item.size)}
+                    </span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {attached ? "Already attached" : new Date(item.createdAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                    </span>
+                  </span>
+                  {onToggle && (
+                    <span aria-hidden="true" className={cn("flex size-5 shrink-0 items-center justify-center rounded border", view === "grid" && "absolute right-3 top-3", checked ? "border-primary bg-primary text-primary-foreground" : "bg-background")}>
+                      {checked && <Check className="size-3.5" />}
+                    </span>
+                  )}
+                </>
+              );
+              return (
+                <li key={item.id} className="min-w-0">
+                  {onToggle ? (
+                    <button type="button" className={className} aria-label={item.filename} aria-pressed={checked} disabled={attached} onClick={() => onToggle(item)}>{content}</button>
+                  ) : (
+                    <a className={className} href={item.url} target="_blank" rel="noopener noreferrer" aria-label={`Open ${item.filename}`}>{content}</a>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {items.length > 0 && library.isError && (
+          <div role="alert" className="mt-4 text-center text-sm">
+            Could not refresh your library. <Button variant="ghost" onClick={() => void library.refetch()}>Try again</Button>
+          </div>
+        )}
+        {library.hasNextPage && (
+          <div className="mt-5 text-center">
+            <Button variant="outline" disabled={library.isFetching} onClick={() => void library.fetchNextPage()}>
+              {library.isFetchingNextPage ? "Loading…" : "Load more"}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LibraryPreview({ item, grid }: { item: LibraryItem; grid: boolean }) {
+  const className = cn("flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted", grid ? "aspect-[4/3] w-full" : "size-12");
+  return (
+    <span className={className}>
+      {item.category === "image" ? (
+        // Authenticated upload URLs are already local and should bypass optimization.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={item.url} alt="" loading="lazy" className="size-full object-cover" />
+      ) : (
+        <CategoryIcon category={item.category} className={cn("text-muted-foreground", grid ? "size-10" : "size-6")} />
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/library/LibraryPicker.tsx
+++ b/apps/web/components/library/LibraryPicker.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { LibraryBrowser } from "@/components/library/LibraryBrowser";
+import type { LibraryItem } from "@/lib/library";
+import { motionClasses } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export function LibraryPicker({ onClose, onAdd, attachedUrls }: {
+  onClose: () => void;
+  onAdd: (items: LibraryItem[]) => void;
+  attachedUrls: ReadonlySet<string>;
+}) {
+  const [selected, setSelected] = useState(new Map<string, LibraryItem>());
+  const additions = Array.from(selected.values()).filter((item) => !attachedUrls.has(item.url));
+  return (
+    <Dialog.Root open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={cn("fixed inset-0 z-50 bg-black/40", motionClasses.overlay)} />
+        <Dialog.Popup className={cn("fixed left-1/2 top-1/2 z-50 flex h-[min(44rem,calc(100dvh-2rem))] w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border bg-background shadow-lg outline-none", motionClasses.dialog)}>
+          <div className="flex items-center justify-between gap-4 px-4 pt-5 sm:px-6">
+            <Dialog.Title className="text-xl font-semibold tracking-tight">Add from library</Dialog.Title>
+            <Dialog.Close render={<Button variant="ghost" size="icon" aria-label="Close library" />}><X /></Dialog.Close>
+          </div>
+          <Dialog.Description className="px-4 pb-2 text-sm text-muted-foreground sm:px-6">Choose files from your saved chats.</Dialog.Description>
+          <LibraryBrowser
+            attachedUrls={attachedUrls}
+            selected={selected}
+            onToggle={(item) => setSelected((current) => {
+              const next = new Map(current);
+              if (next.has(item.id)) next.delete(item.id);
+              else next.set(item.id, item);
+              return next;
+            })}
+          />
+          <div className="flex shrink-0 items-center justify-between gap-3 border-t px-4 py-4 sm:px-6">
+            <span className="text-sm text-muted-foreground" role="status">{additions.length} selected</span>
+            <Button disabled={!additions.length} onClick={() => { onAdd(additions); onClose(); }}>
+              Add {additions.length || ""} {additions.length === 1 ? "file" : "files"}
+            </Button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/e2e/library.spec.ts
+++ b/apps/web/e2e/library.spec.ts
@@ -1,0 +1,221 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { expect, test } from "@playwright/test";
+import { openE2eDatabase, resetE2eDatabase } from "./helpers/database";
+
+let modelServer: Server;
+let modelBaseUrl: string;
+const modelRequests: unknown[] = [];
+
+test.beforeEach(resetE2eDatabase);
+test.beforeAll(async () => {
+  modelServer = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    modelRequests.push(body);
+    if (!body.stream) {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({
+        id: "library-title", object: "chat.completion", created: 1, model: "library-test",
+        choices: [{ index: 0, message: { role: "assistant", content: "Reused library files" }, finish_reason: "stop" }],
+      }));
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    const event = {
+      id: "library-response", object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000), model: "library-test",
+      choices: [{ index: 0, delta: { role: "assistant", content: "Library files received" }, finish_reason: null }],
+    };
+    response.write(`data: ${JSON.stringify(event)}\n\n`);
+    response.write(`data: ${JSON.stringify({ ...event, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`);
+    response.end("data: [DONE]\n\n");
+  });
+  await new Promise<void>((resolve) => modelServer.listen(0, "127.0.0.1", resolve));
+  modelBaseUrl = `http://127.0.0.1:${(modelServer.address() as AddressInfo).port}/v1`;
+});
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => modelServer.close((error) => error ? reject(error) : resolve()));
+});
+
+test("library pagination survives chat deletion and search matches Unicode filenames", async ({ page }) => {
+  await page.goto("/signup");
+  await page.locator("#name").fill("Library Pagination Admin");
+  await page.locator("#email").fill("library-pages@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+  const database = openE2eDatabase();
+  try {
+    const user = database.prepare("SELECT id FROM user LIMIT 1").get() as { id: string };
+    for (const id of ["page-one", "page-two"]) {
+      database.prepare("INSERT INTO chats (id, user_id, title) VALUES (?, ?, ?)").run(id, user.id, id);
+    }
+    // Listing needs metadata only; this fixture does not create or download bytes.
+    for (let i = 0; i < 45; i++) {
+      const id = `page-file-${String(i).padStart(2, "0")}`;
+      const filename = i === 4 ? "RÉSUMÉ.pdf" : `${id}.txt`;
+      database.prepare(`INSERT INTO uploads (id, user_id, filename, media_type, category, size, created_at)
+        VALUES (?, ?, ?, 'text/plain', 'text', 12, 1000)`).run(id, user.id, filename);
+      database.prepare("INSERT INTO messages (id, chat_id, role, parts) VALUES (?, ?, 'user', ?)").run(
+        id, i >= 5 ? "page-one" : "page-two",
+        JSON.stringify([{ type: "file", url: `/api/uploads/${id}`, filename, mediaType: "text/plain" }]),
+      );
+    }
+  } finally {
+    database.close();
+  }
+  await page.getByRole("link", { name: "Library", exact: true }).click();
+  const files = page.getByRole("list", { name: "Library files" }).getByRole("link");
+  await expect(files).toHaveCount(40);
+  // Mimic a deletion in another client, without invalidating this tab's query.
+  expect((await page.request.delete("/api/chats/page-one")).ok()).toBeTruthy();
+  await page.getByRole("button", { name: "Load more" }).click();
+  await expect(files).toHaveCount(45);
+  await expect(page.getByRole("link", { name: "Open RÉSUMÉ.pdf", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Load more" })).toHaveCount(0);
+  await page.getByRole("searchbox", { name: "Search library" }).fill("re\u0301sume\u0301");
+  await expect(files).toHaveCount(1);
+  await expect(page.getByRole("link", { name: "Open RÉSUMÉ.pdf", exact: true })).toBeVisible();
+});
+
+test("browse, select, reuse and delete library attachments across chats", async ({ page, playwright }, testInfo) => {
+  test.setTimeout(90_000);
+  await page.goto("/signup");
+  await page.locator("#name").fill("Library Admin");
+  await page.locator("#email").fill("library@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+  await page.getByRole("link", { name: "Library", exact: true }).click();
+  await expect(page.getByText("Your library is empty")).toBeVisible();
+
+  const modelResponse = await page.request.post("/api/model-configs", { data: {
+    label: "Library test", providerId: "custom", apiFormat: "openai-chat",
+    baseUrl: modelBaseUrl, model: "library-test", toolCallingEnabled: false,
+  } });
+  expect(modelResponse.ok()).toBeTruthy();
+  const { modelConfig } = await modelResponse.json();
+  const files = [];
+  for (const [name, content] of [
+    ["Project brief.txt", "The library project codename is Pinecone."],
+    ["Meeting notes.md", "The planning meeting is on Thursday."],
+    ["Only in source.txt", "This file is not reused."],
+    ["Unsent.txt", "This file has not been sent."],
+  ]) {
+    const response = await page.request.post("/api/uploads", { multipart: { file: {
+      name, mimeType: "text/plain", buffer: Buffer.from(content),
+    } } });
+    expect(response.ok()).toBeTruthy();
+    files.push(await response.json());
+  }
+  const imageResponse = await page.request.post("/api/uploads", { multipart: { file: {
+    name: "pixel.png", mimeType: "image/png",
+    buffer: Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aZ1sAAAAASUVORK5CYII=", "base64"),
+  } } });
+  expect(imageResponse.ok()).toBeTruthy();
+  const image = await imageResponse.json();
+
+  // Seed an existing saved conversation, including an image for thumbnail coverage.
+  const database = openE2eDatabase();
+  try {
+    const user = database.prepare("SELECT id FROM user LIMIT 1").get() as { id: string };
+    database.prepare("INSERT INTO chats (id, user_id, title) VALUES (?, ?, ?)").run("source-chat", user.id, "Source chat");
+    database.prepare("INSERT INTO messages (id, chat_id, role, parts) VALUES (?, ?, 'user', ?)").run(
+      "source-message", "source-chat", JSON.stringify([...files.slice(0, 3), image].map((file) => ({
+        type: "file", url: file.url, filename: file.filename, mediaType: file.mediaType,
+      }))),
+    );
+  } finally {
+    database.close();
+  }
+  // A temporary turn can use an upload without making it a library entry.
+  const temporary = await page.request.post("/api/chat", { data: {
+    chatId: "temporary-chat", temporary: true, modelConfigId: modelConfig.id,
+    messages: [{ id: "temporary-turn", role: "user", parts: [
+      { type: "file", url: files[3].url, filename: files[3].filename, mediaType: files[3].mediaType },
+      { type: "text", text: "Read this temporarily" },
+    ] }],
+  } });
+  expect(temporary.ok()).toBeTruthy();
+  await temporary.text();
+
+  const anonymous = await playwright.request.newContext();
+  try {
+    expect((await anonymous.get(new URL("/api/library", page.url()).href)).status()).toBe(401);
+  } finally {
+    await anonymous.dispose();
+  }
+  await page.reload();
+  await expect(page.getByRole("link", { name: "Open Project brief.txt", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Open Unsent.txt", exact: true })).toHaveCount(0);
+  await page.getByRole("button", { name: "Grid view" }).click();
+  await expect(page.getByRole("button", { name: "Grid view" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator('img[src="' + image.url + '"]')).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("library-grid.png") });
+  await page.getByRole("searchbox", { name: "Search library" }).fill("missing-file");
+  await expect(page.getByText("No matching files")).toBeVisible();
+
+  await page.getByRole("link", { name: "New chat" }).click();
+  await page.getByRole("button", { name: "Add to message" }).click();
+  await page.getByRole("menuitem", { name: "Add from library" }).click();
+  const picker = page.getByRole("dialog", { name: "Add from library" });
+  await expect(picker).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("library-picker.png") });
+  await picker.getByRole("searchbox", { name: "Search library" }).fill("brief");
+  await picker.getByRole("button", { name: "Project brief.txt", exact: true }).click();
+  await picker.getByRole("searchbox", { name: "Search library" }).fill("notes");
+  await picker.getByRole("button", { name: "Meeting notes.md", exact: true }).click();
+  await picker.getByRole("button", { name: "Add 2 files", exact: true }).click();
+  await expect(picker).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Remove Project brief.txt", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Remove Meeting notes.md", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Add to message" }).click();
+  await page.getByRole("menuitem", { name: "Add from library" }).click();
+  await expect(picker.getByRole("button", { name: "Project brief.txt", exact: true })).toBeDisabled();
+  await page.keyboard.press("Escape");
+  await page.locator("textarea").fill("Use these library files");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText("Library files received", { exact: true }).first()).toBeVisible();
+  await page.waitForURL("**/chat/**");
+  const newChatId = new URL(page.url()).pathname.split("/").at(-1)!;
+  expect(newChatId).not.toBe("source-chat");
+  expect(JSON.stringify(modelRequests)).toContain("The library project codename is Pinecone.");
+  expect(JSON.stringify(modelRequests)).toContain("The planning meeting is on Thursday.");
+
+  // Stay on Library while deleting through the sidebar to exercise cache invalidation.
+  await page.getByRole("link", { name: "Library", exact: true }).click();
+  const sourceRow = page.locator("li").filter({ has: page.getByRole("link", { name: "Source chat", exact: true }) });
+  await sourceRow.hover();
+  await sourceRow.getByRole("button", { name: "Chat actions" }).click();
+  await page.getByRole("menuitem", { name: "Delete", exact: true }).click();
+  const deletion = page.getByRole("alertdialog", { name: "Delete chat?" });
+  await expect(deletion).toContainText("Files used only in this chat will also be removed from your library.");
+  await deletion.getByRole("button", { name: "Delete", exact: true }).click();
+  await expect(page.getByRole("link", { name: "Open Only in source.txt", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Open Project brief.txt", exact: true })).toBeVisible();
+  expect((await page.request.get(files[0].url)).ok()).toBeTruthy();
+  const library = await (await page.request.get("/api/library")).json();
+  expect(library.items.map((item: { url: string }) => item.url).sort()).toEqual(files.slice(0, 2).map((file) => file.url).sort());
+
+  // The same browser fits the mobile web layout and its navigation drawer.
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.getByRole("heading", { name: "Library", exact: true })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  await page.getByRole("button", { name: "Open sidebar" }).click();
+  await page.getByRole("dialog", { name: "Navigation" }).getByRole("link", { name: "Library", exact: true }).click();
+  await expect(page.getByRole("dialog", { name: "Navigation" })).toHaveCount(0);
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Add to message" }).click();
+  await page.getByRole("menuitem", { name: "Add from library" }).click();
+  await expect(picker.getByRole("button", { name: "Project brief.txt", exact: true })).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("library-picker-mobile.png") });
+  expect(await picker.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+  await picker.getByRole("button", { name: "Close library" }).click();
+
+  expect((await page.request.delete(`/api/chats/${newChatId}`)).ok()).toBeTruthy();
+  await page.goto("/library");
+  await expect(page.getByText("Your library is empty")).toBeVisible();
+});

--- a/apps/web/lib/db/client.ts
+++ b/apps/web/lib/db/client.ts
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import path from "node:path";
 import fs from "node:fs";
+import { registerSqliteFunctions } from "./sqlite-functions";
 
 const DB_PATH = process.env.DATABASE_URL ?? "./data/chat.db";
 
@@ -9,6 +10,7 @@ fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
 
 const sqlite = new Database(DB_PATH);
 sqlite.pragma("foreign_keys = ON");
+registerSqliteFunctions(sqlite);
 
 export const db = drizzle({ client: sqlite });
 

--- a/apps/web/lib/db/library.test.ts
+++ b/apps/web/lib/db/library.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/db/client", async () => {
+  const { default: Database } = await import("better-sqlite3");
+  const { drizzle } = await import("drizzle-orm/better-sqlite3");
+  const { registerSqliteFunctions } = await import("./sqlite-functions");
+  const sqlite = new Database(":memory:");
+  registerSqliteFunctions(sqlite);
+  return { db: drizzle(sqlite) };
+});
+
+import { db } from "@/lib/db/client";
+import { listLibrary } from "./library";
+
+const raw = db.$client;
+raw.exec(`
+  PRAGMA foreign_keys = ON;
+  CREATE TABLE chats (id TEXT PRIMARY KEY, user_id TEXT NOT NULL);
+  CREATE TABLE messages (
+    id TEXT PRIMARY KEY, chat_id TEXT REFERENCES chats(id) ON DELETE CASCADE,
+    role TEXT NOT NULL, parts TEXT NOT NULL
+  );
+  CREATE TABLE uploads (
+    id TEXT PRIMARY KEY, user_id TEXT NOT NULL, filename TEXT NOT NULL,
+    media_type TEXT NOT NULL, category TEXT NOT NULL, size INTEGER NOT NULL,
+    page_count INTEGER, extracted_text TEXT, truncated INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+  );
+`);
+afterAll(() => raw.close());
+beforeEach(() => {
+  raw.exec("DELETE FROM messages; DELETE FROM chats; DELETE FROM uploads;");
+  raw.prepare("INSERT INTO chats VALUES (?, ?)").run("chat-a", "alice");
+  raw.prepare("INSERT INTO chats VALUES (?, ?)").run("chat-b", "alice");
+  raw.prepare("INSERT INTO chats VALUES (?, ?)").run("bob-chat", "bob");
+});
+
+function upload(id: string, user = "alice", filename = `${id}.txt`) {
+  raw.prepare(`INSERT INTO uploads VALUES (?, ?, ?, 'text/plain', 'text', 12, NULL, 'private document contents', 0, 1000)`)
+    .run(id, user, filename);
+  return { type: "file", url: `/api/uploads/${id}`, filename, mediaType: "text/plain" };
+}
+function message(chat: string, parts: unknown[], role = "user") {
+  raw.prepare("INSERT INTO messages VALUES (?, ?, ?, ?)")
+    .run(crypto.randomUUID(), chat, role, JSON.stringify(parts));
+}
+
+describe("library membership", () => {
+  it("lists saved owned file parts once, excluding drafts, tool results and URL mentions", async () => {
+    const shared = upload("shared");
+    const fetched = upload("fetched");
+    const mentioned = upload("mentioned");
+    upload("unsent");
+    message("chat-a", [shared]);
+    message("chat-b", [shared]);
+    message("chat-a", [{ type: "text", text: mentioned.url }, { type: "tool-fetch_url", output: { uploadUrl: fetched.url } }]);
+    message("chat-a", [fetched], "assistant");
+    // Imported messages can contain unexpected JSON values, not only typed parts.
+    message("chat-a", [null, "not an object", 4]);
+    const result = await listLibrary("alice");
+    expect(result.items.map((item) => item.id)).toEqual(["shared"]);
+    expect(result.items[0]).toMatchObject({ url: shared.url, createdAt: 1000, size: 12 });
+    expect(result.items[0]).not.toHaveProperty("extractedText");
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("requires ownership of both the upload and the referencing chat", async () => {
+    const alice = upload("alice-file");
+    const bob = upload("bob-file", "bob");
+    const onlyForeignReference = upload("foreign-reference");
+    message("chat-a", [alice, bob]);
+    message("bob-chat", [bob, onlyForeignReference]);
+    expect((await listLibrary("alice")).items.map((item) => item.id)).toEqual(["alice-file"]);
+    expect((await listLibrary("bob")).items.map((item) => item.id)).toEqual(["bob-file"]);
+    expect((await listLibrary("outsider")).items).toEqual([]);
+  });
+
+  it("keeps reused files until their last referencing chat is deleted, without waiting for disk cleanup", async () => {
+    const shared = upload("shared");
+    message("chat-a", [shared, upload("exclusive")]);
+    message("chat-b", [shared]);
+    raw.prepare("DELETE FROM chats WHERE id = ?").run("chat-a");
+    expect((await listLibrary("alice")).items.map((item) => item.id)).toEqual(["shared"]);
+    raw.prepare("DELETE FROM chats WHERE id = ?").run("chat-b");
+    expect((await listLibrary("alice")).items).toEqual([]);
+    expect(raw.prepare("SELECT count(*) AS count FROM uploads").get()).toEqual({ count: 2 });
+  });
+
+  it("removes files when their attachment is edited out of saved history", async () => {
+    message("chat-a", [upload("edited")]);
+    raw.prepare("UPDATE messages SET parts = ?").run(JSON.stringify([{ type: "text", text: "replacement" }]));
+    expect((await listLibrary("alice")).items).toEqual([]);
+  });
+
+  it("searches literal filenames case-insensitively and paginates equal timestamps deterministically", async () => {
+    for (let i = 0; i < 45; i++) message("chat-a", [upload(`file-${String(i).padStart(2, "0")}`)]);
+    message("chat-a", [upload("special", "alice", "Report_100%.TXT")]);
+    expect((await listLibrary("alice", "report_100%")).items.map((item) => item.id)).toEqual(["special"]);
+    expect((await listLibrary("alice", "' OR 1=1 --")).items).toEqual([]);
+    const first = await listLibrary("alice", "file-");
+    expect(first.items).toHaveLength(40);
+    expect(JSON.parse(first.nextCursor!)).toEqual({ createdAt: 1000, id: "file-05" });
+    const second = await listLibrary("alice", "file-", JSON.parse(first.nextCursor!));
+    expect(second.items).toHaveLength(5);
+    expect(second.nextCursor).toBeNull();
+    expect(new Set([...first.items, ...second.items].map((item) => item.id)).size).toBe(45);
+  });
+
+  it("does not skip or repeat surviving files when chats disappear and uploads arrive between pages", async () => {
+    for (let i = 0; i < 45; i++) {
+      message(i >= 5 ? "chat-a" : "chat-b", [upload(`file-${String(i).padStart(2, "0")}`)]);
+    }
+    const first = await listLibrary("alice");
+    // Delete every first-page reference, including the cursor's own file.
+    raw.prepare("DELETE FROM chats WHERE id = ?").run("chat-a");
+    raw.prepare("DELETE FROM uploads WHERE id = ?").run("file-05");
+    message("chat-b", [upload("new-file")]);
+    raw.prepare("UPDATE uploads SET created_at = 2000 WHERE id = ?").run("new-file");
+    const second = await listLibrary("alice", "", JSON.parse(first.nextCursor!));
+    expect(second.items.map((item) => item.id)).toEqual(["file-04", "file-03", "file-02", "file-01", "file-00"]);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it.each([
+    ["RÉSUMÉ.pdf", "résumé"],
+    ["Re\u0301sume\u0301.pdf", "RÉSUMÉ"],
+    ["Résumé.pdf", "re\u0301sume\u0301"],
+    ["ПРОЕКТ.txt", "проект"],
+  ])("matches Unicode filename %s with %s", async (filename, query) => {
+    message("chat-a", [upload("unicode", "alice", filename)]);
+    expect((await listLibrary("alice", query)).items.map((item) => item.id)).toEqual(["unicode"]);
+  });
+});

--- a/apps/web/lib/db/library.ts
+++ b/apps/web/lib/db/library.ts
@@ -1,0 +1,60 @@
+import "server-only";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { chats, messages, uploads } from "@/lib/db/schema";
+import type { LibraryCursor, LibraryPage } from "@/lib/library";
+
+const PAGE_SIZE = 40;
+
+/** Library membership follows saved user attachments, independently of cleanup. */
+export async function listLibrary(
+  userId: string,
+  query = "",
+  cursor?: LibraryCursor,
+): Promise<LibraryPage> {
+  const rows = await db
+    .select({
+      id: uploads.id,
+      filename: uploads.filename,
+      mediaType: uploads.mediaType,
+      category: uploads.category,
+      size: uploads.size,
+      pageCount: uploads.pageCount,
+      truncated: uploads.truncated,
+      createdAt: uploads.createdAt,
+    })
+    .from(uploads)
+    .where(and(
+      eq(uploads.userId, userId),
+      cursor ? sql`(${uploads.createdAt}, ${uploads.id}) < (${cursor.createdAt}, ${cursor.id})` : undefined,
+      // Match actual file parts, not text mentioning a URL or fetched tool images.
+      // Both sides are scoped: imported references never grant ownership.
+      inArray(sql`'/api/uploads/' || ${uploads.id}`, sql`(
+        SELECT json_extract(part.value, '$.url')
+        FROM ${messages}
+        INNER JOIN ${chats} ON ${chats.id} = ${messages.chatId}
+        CROSS JOIN json_each(${messages.parts}) AS part
+        WHERE ${chats.userId} = ${userId}
+          AND ${messages.role} = 'user'
+          AND part.type = 'object'
+          AND json_extract(part.value, '$.type') = 'file'
+      )`),
+      // Treat search as a literal substring (including %, _ and quotes).
+      query ? sql`instr(unicode_lower(${uploads.filename}), unicode_lower(${query})) > 0` : undefined,
+    ))
+    .orderBy(desc(uploads.createdAt), desc(uploads.id))
+    .limit(PAGE_SIZE + 1);
+
+  const page = rows.slice(0, PAGE_SIZE);
+  const last = page.at(-1);
+  return {
+    items: page.map((row) => ({
+      ...row,
+      url: `/api/uploads/${row.id}`,
+      createdAt: row.createdAt.getTime(),
+    })),
+    nextCursor: rows.length > PAGE_SIZE && last
+      ? JSON.stringify({ createdAt: last.createdAt.getTime(), id: last.id })
+      : null,
+  };
+}

--- a/apps/web/lib/db/sqlite-functions.ts
+++ b/apps/web/lib/db/sqlite-functions.ts
@@ -1,0 +1,9 @@
+import type Database from "better-sqlite3";
+
+export function registerSqliteFunctions(sqlite: Database.Database): void {
+  // SQLite's built-in lower() only folds ASCII. Normalize equivalent Unicode
+  // spellings too, so filenames from different operating systems match.
+  sqlite.function("unicode_lower", { deterministic: true }, (value: unknown) =>
+    typeof value === "string" ? value.normalize("NFC").toLowerCase().normalize("NFC") : null,
+  );
+}

--- a/apps/web/lib/library.ts
+++ b/apps/web/lib/library.ts
@@ -1,0 +1,23 @@
+import type { AttachmentCategory } from "@/lib/chat/attachments";
+
+export interface LibraryItem {
+  id: string;
+  url: string;
+  filename: string;
+  mediaType: string;
+  category: AttachmentCategory;
+  size: number;
+  pageCount: number | null;
+  truncated: boolean;
+  createdAt: number;
+}
+
+export interface LibraryPage {
+  items: LibraryItem[];
+  nextCursor: string | null;
+}
+
+export interface LibraryCursor {
+  createdAt: number;
+  id: string;
+}

--- a/apps/web/lib/queries/chats.ts
+++ b/apps/web/lib/queries/chats.ts
@@ -9,7 +9,7 @@ import {
 import type { UIMessage } from "ai";
 import type { ChatKind } from "@overtchat/shared";
 import { CHAT_MESSAGE_PAGE_SIZE } from "@/lib/chat/history";
-import { chatKeys } from "@/lib/queries/keys";
+import { chatKeys, libraryKeys } from "@/lib/queries/keys";
 import type { ChatUsageResponse, UsageTotals } from "@/lib/usage/types";
 
 export type ChatListItem = {
@@ -137,7 +137,10 @@ export function useDeleteChat() {
       const r = await fetch(`/api/chats/${id}`, { method: "DELETE" });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
+    onSuccess: () => Promise.all([
+      qc.invalidateQueries({ queryKey: chatKeys.list() }),
+      qc.invalidateQueries({ queryKey: libraryKeys.all() }),
+    ]),
   });
 }
 

--- a/apps/web/lib/queries/keys.ts
+++ b/apps/web/lib/queries/keys.ts
@@ -1,3 +1,8 @@
+export const libraryKeys = {
+  all: () => ["library"] as const,
+  list: (query: string) => [...libraryKeys.all(), "list", query] as const,
+};
+
 export const chatKeys = {
   all: () => ["chats"] as const,
   list: () => [...chatKeys.all(), "list"] as const,

--- a/apps/web/lib/queries/library.ts
+++ b/apps/web/lib/queries/library.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { libraryKeys } from "@/lib/queries/keys";
+import type { LibraryPage } from "@/lib/library";
+
+export function useLibrary(query: string) {
+  return useInfiniteQuery({
+    queryKey: libraryKeys.list(query),
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam, signal }): Promise<LibraryPage> => {
+      const params = new URLSearchParams({ q: query });
+      if (pageParam) params.set("cursor", pageParam);
+      const response = await fetch(`/api/library?${params}`, { signal });
+      if (!response.ok) throw new Error("Could not load your library.");
+      return response.json();
+    },
+    getNextPageParam: (page) => page.nextCursor,
+    staleTime: 0,
+    refetchOnMount: "always",
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench:library": "node --conditions=react-server --import tsx scripts/benchmark-library.ts",
     "test:e2e": "rm -f data/test.db* && playwright test",
     "test:e2e:ui": "rm -f data/test.db* && playwright test --ui",
     "catalog:generate": "tsx scripts/generate-model-catalog.ts",

--- a/apps/web/scripts/benchmark-library.ts
+++ b/apps/web/scripts/benchmark-library.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir, cpus } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+// Run from apps/web via npm run bench:library. Always uses synthetic data in a
+// disposable database; DATABASE_URL from the caller is deliberately ignored.
+async function main() {
+  const directory = await mkdtemp(path.join(tmpdir(), "overtchat-library-bench-"));
+  process.env.DATABASE_URL = path.join(directory, "benchmark.db");
+  process.env.MIGRATIONS_FOLDER = path.resolve("drizzle");
+  const { db } = await import("../lib/db/client");
+  try {
+    const { runMigrations } = await import("../lib/db/migrate");
+    const { listLibrary } = await import("../lib/db/library");
+    runMigrations();
+    const sqlite = db.$client;
+    const insertChat = sqlite.prepare("INSERT INTO chats (id, user_id, title) VALUES (?, 'benchmark', 'Synthetic chat')");
+    const insertMessage = sqlite.prepare("INSERT INTO messages (id, chat_id, role, parts) VALUES (?, ?, ?, ?)");
+    const insertUpload = sqlite.prepare(`INSERT INTO uploads
+      (id, user_id, filename, media_type, category, size, created_at)
+      VALUES (?, 'benchmark', ?, 'text/plain', 'text', 1024, ?)`);
+    console.log(JSON.stringify({
+      cpu: cpus()[0]?.model, node: process.version,
+      sqlite: sqlite.prepare("SELECT sqlite_version() AS version").get(),
+      method: "Actual listLibrary query; production migrations/indexes; disk-backed WAL; 1 warm-up + 7 timed sequential calls; no HTTP or UI; 20 user/assistant pairs per chat; one upload every 20 user messages; assistant text 4 KiB; OS cache not flushed.",
+    }));
+
+    async function measure(run: () => Promise<unknown>) {
+      await run();
+      const times = [];
+      for (let i = 0; i < 7; i++) {
+        const start = performance.now();
+        await run();
+        times.push(performance.now() - start);
+      }
+      times.sort((a, b) => a - b);
+      return { medianMs: +times[3].toFixed(1), maxMs: +times[6].toFixed(1) };
+    }
+
+    for (const userTextBytes of [1024, 8192]) {
+      sqlite.prepare("DELETE FROM user WHERE id = 'benchmark'").run();
+      sqlite.prepare("INSERT INTO user (id, name, email) VALUES ('benchmark', 'Synthetic', 'synthetic@example.invalid')").run();
+      let seeded = 0;
+      let messageJsonBytes = 0;
+      const userText = "x".repeat(userTextBytes);
+      const assistantParts = JSON.stringify([{ type: "text", text: "y".repeat(4096) }]);
+      for (const userMessages of [1000, 10_000, 50_000, 100_000]) {
+        sqlite.transaction(() => {
+          for (let i = seeded; i < userMessages; i++) {
+            const chatId = `chat-${Math.floor(i / 20)}`;
+            if (i % 20 === 0) insertChat.run(chatId);
+            const parts: unknown[] = [{ type: "text", text: userText }];
+            if (i % 20 === 0) {
+              const id = `file-${String(i).padStart(8, "0")}`;
+              const filename = i % 40 === 0 ? `RÉSUMÉ-${i}.txt` : `notes-${i}.txt`;
+              insertUpload.run(id, filename, 1_700_000_000_000 + i);
+              parts.push({ type: "file", url: `/api/uploads/${id}`, filename, mediaType: "text/plain" });
+            }
+            const userParts = JSON.stringify(parts);
+            insertMessage.run(`user-${i}`, chatId, "user", userParts);
+            insertMessage.run(`assistant-${i}`, chatId, "assistant", assistantParts);
+            messageJsonBytes += Buffer.byteLength(userParts) + Buffer.byteLength(assistantParts);
+          }
+        })();
+        seeded = userMessages;
+        sqlite.pragma("wal_checkpoint(TRUNCATE)");
+        const first = await listLibrary("benchmark");
+        console.log(JSON.stringify({
+          userTextBytes, userMessages, totalMessages: userMessages * 2,
+          chats: userMessages / 20, uploads: userMessages / 20,
+          messageJsonMiB: +(messageJsonBytes / 1024 ** 2).toFixed(1),
+          browse: await measure(() => listLibrary("benchmark")),
+          unicodeSearch: await measure(() => listLibrary("benchmark", "résumé")),
+          nextPage: await measure(() => listLibrary("benchmark", "", JSON.parse(first.nextCursor!))),
+        }));
+      }
+    }
+  } finally {
+    db.$client.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -145,6 +145,14 @@ npm run dev:mobile
 npm run dev:site
 ```
 
+To measure Library query performance, run `npm run bench:library -w apps/web --`.
+It creates and removes a temporary database using the production migrations and
+synthetic chat histories; it ignores the configured `DATABASE_URL`. Results
+report median and maximum query times across seven calls after a warm-up, for
+2,000–200,000 total messages and two message sizes. Run it without competing
+builds or tests. These timings exclude HTTP, rendering, concurrent users, and
+cold operating-system caches; compare results on the intended server hardware.
+
 For mobile Agent Connections changes, run `npm run typecheck -w apps/mobile --`
 and `npm run test -w apps/mobile --`. The tests cover event stream recovery,
 message retry identities, explicit delivery recovery, draft persistence and


### PR DESCRIPTION
Files attached to saved chats can now be reused without uploading them again. Adds `/library` and a sidebar entry, plus an “Add from library” multi-select picker in the chat composer's `+` menu. The page and picker share filename search, list/grid views, and image previews.

Library membership follows saved user-message attachments. Unsent uploads, temporary-chat uploads, and tool-fetched images are excluded. Deleting a chat removes files used only there from the library; files referenced by other saved chats remain available. The delete dialog explains this behavior, and existing orphan cleanup continues to own disk deletion.

The API checks both upload and chat ownership, returns metadata only, uses cursor pagination, and supports Unicode filename casing and normalization. Existing upload records and message references are reused; no database migration is required. Includes a disposable synthetic-data benchmark and its development instructions.

Validation:

- 36 focused tests covering library queries/API, upload persistence, and chat turns.
- Both library E2E tests pass against a production build: search, pagination across deletion, cross-chat reuse, provider input, deletion behavior, and desktop/mobile web layouts.
- Existing attachment-security E2E passed during implementation.
- Web lint and typecheck pass; production build passes.
- Synthetic library benchmark completed at 2,000–200,000 total messages per user.
