### PR TITLE
Polish settings layout and theme controls

### DIFF
--- a/apps/web/app/(app)/settings/SettingsNav.tsx
+++ b/apps/web/app/(app)/settings/SettingsNav.tsx
@@ -170,10 +170,11 @@ function NavLink({ item, pathname }: { item: Item; pathname: string }) {
   return (
     <Link
       href={item.href}
+      aria-current={active ? "page" : undefined}
       className={cn(
-        "flex shrink-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm motion-colors",
+        "flex min-h-9 shrink-0 items-center gap-2 rounded-lg px-2.5 py-2 text-sm motion-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
         active
-          ? "bg-accent text-accent-foreground"
+          ? "bg-accent font-medium text-accent-foreground"
           : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
       )}
     >

--- a/apps/web/app/(app)/settings/_components/SettingsChoiceGroup.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsChoiceGroup.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Radio } from "@base-ui/react/radio";
+import { RadioGroup } from "@/components/ui/radio-group";
+
+export function SettingsChoiceGroup({
+  label,
+  value,
+  onValueChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: ReadonlyArray<{ value: string; label: React.ReactNode }>;
+}) {
+  return (
+    <RadioGroup
+      aria-label={label}
+      value={value}
+      onValueChange={onValueChange}
+      className="grid min-h-10 w-full auto-cols-fr grid-flow-col gap-1 rounded-lg border bg-muted/30 p-1"
+    >
+      {options.map((option) => (
+        <Radio.Root
+          key={option.value}
+          value={option.value}
+          className="flex min-h-7 min-w-0 cursor-pointer items-center justify-center gap-2 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground motion-colors outline-none select-none hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 data-checked:bg-background data-checked:text-foreground data-checked:shadow-xs [&_svg]:size-3.5 [&_svg]:shrink-0"
+        >
+          {option.label}
+        </Radio.Root>
+      ))}
+    </RadioGroup>
+  );
+}

--- a/apps/web/app/(app)/settings/_components/SettingsRows.tsx
+++ b/apps/web/app/(app)/settings/_components/SettingsRows.tsx
@@ -1,6 +1,47 @@
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
+export function SettingsPage({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "@container/settings w-full max-w-4xl space-y-8 [&_[data-slot=input]]:h-10 [&_[data-slot=select-trigger]]:h-10",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function SettingsEmptyState({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="px-4 py-10 text-center">
+      <p className="text-sm font-medium">{title}</p>
+      {description && (
+        <p className="mx-auto mt-1 max-w-md text-xs leading-5 text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {children && <div className="mt-4 flex justify-center">{children}</div>}
+    </div>
+  );
+}
+
 interface SettingsSectionProps {
   title: string;
   description?: string;
@@ -20,9 +61,11 @@ export function SettingsSection({
 }: SettingsSectionProps) {
   return (
     <section className={cn("@container space-y-3", className)}>
-      <div className="flex flex-col gap-3 @xl:flex-row @xl:items-start @xl:justify-between">
+      <div className="flex flex-col gap-3 @2xl:flex-row @2xl:items-start @2xl:justify-between">
         <div className="min-w-0">
-          <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
+          <h2 className="text-sm font-semibold leading-6 tracking-tight">
+            {title}
+          </h2>
           {description && (
             <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
               {description}
@@ -32,7 +75,9 @@ export function SettingsSection({
         {action && <div className="shrink-0">{action}</div>}
       </div>
       {children ? (
-        <div className={cn("divide-y divide-border/70 border-y", contentClassName)}>
+        <div
+          className={cn("divide-y divide-border/70 border-y", contentClassName)}
+        >
           {children}
         </div>
       ) : null}
@@ -57,13 +102,13 @@ export function SettingsPageHeader({
 }: SettingsPageHeaderProps) {
   return (
     <header className={cn("@container", className)}>
-      <div className="flex flex-col gap-3 @xl:flex-row @xl:items-start @xl:justify-between">
+      <div className="flex flex-col gap-3 @2xl:flex-row @2xl:items-start @2xl:justify-between">
         <div className="flex min-w-0 items-start gap-2">
           {leading && <div className="shrink-0">{leading}</div>}
           <div className="min-w-0">
             <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
             {description && (
-              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              <p className="mt-1 break-words text-sm leading-6 text-muted-foreground">
                 {description}
               </p>
             )}
@@ -83,6 +128,7 @@ interface SettingsRowProps {
   align?: "start" | "center";
   controlAlign?: "start" | "end" | "stretch";
   controlClassName?: string;
+  layout?: "field" | "toggle";
   className?: string;
 }
 
@@ -91,9 +137,10 @@ export function SettingsRow({
   description,
   htmlFor,
   children,
-  align = "start",
+  align = "center",
   controlAlign = "stretch",
   controlClassName,
+  layout = "field",
   className,
 }: SettingsRowProps) {
   const titleClass = "text-sm font-medium leading-5 text-foreground";
@@ -108,12 +155,15 @@ export function SettingsRow({
   return (
     <div
       className={cn(
-        "grid gap-3 py-4 @2xl:grid-cols-[minmax(0,18rem)_minmax(0,1fr)] @2xl:gap-6",
-        align === "center" && "@2xl:items-center",
+        "grid gap-3 py-4 @2xl:gap-8",
+        layout === "toggle"
+          ? "grid-cols-[minmax(0,1fr)_auto] items-center"
+          : "@2xl:grid-cols-2",
+        align === "center" && "items-center",
         className,
       )}
     >
-      <div className="min-w-0">
+      <div className="min-w-0 break-words">
         {titleNode}
         {description && (
           <p className="mt-1 text-xs leading-5 text-muted-foreground">
@@ -124,8 +174,8 @@ export function SettingsRow({
       <div
         className={cn(
           "min-w-0",
-          controlAlign === "start" && "@2xl:flex @2xl:justify-start",
-          controlAlign === "end" && "@2xl:flex @2xl:justify-end",
+          controlAlign === "start" && "flex justify-start",
+          controlAlign === "end" && "flex justify-end",
           controlClassName,
         )}
       >
@@ -172,6 +222,9 @@ export function SettingsNotice({
 }: SettingsNoticeProps) {
   return (
     <p
+      role={
+        tone === "error" ? "alert" : tone === "success" ? "status" : undefined
+      }
       className={cn(
         "text-sm leading-5",
         tone === "muted" && "text-muted-foreground",

--- a/apps/web/app/(app)/settings/account/AccountForm.tsx
+++ b/apps/web/app/(app)/settings/account/AccountForm.tsx
@@ -7,6 +7,7 @@ import { authClient } from "@/lib/auth/client";
 import {
   SettingsActions,
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -40,7 +41,7 @@ export function AccountForm({ email }: { email: string }) {
   }
 
   return (
-    <div className="max-w-3xl space-y-8">
+    <SettingsPage>
       <SettingsPageHeader
         title="Security"
         description={
@@ -71,7 +72,7 @@ export function AccountForm({ email }: { email: string }) {
             align="center"
             controlAlign="end"
           >
-            <div className="w-full @2xl:max-w-sm">
+            <div className="w-full">
               <PasswordInput
                 id="current"
                 autoComplete="current-password"
@@ -93,7 +94,7 @@ export function AccountForm({ email }: { email: string }) {
             align="center"
             controlAlign="end"
           >
-            <div className="w-full @2xl:max-w-sm">
+            <div className="w-full">
               <PasswordInput
                 id="new"
                 autoComplete="new-password"
@@ -123,6 +124,6 @@ export function AccountForm({ email }: { email: string }) {
           </Button>
         </SettingsActions>
       </form>
-    </div>
+    </SettingsPage>
   );
 }

--- a/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
+++ b/apps/web/app/(app)/settings/connections/ConnectionsPanel.tsx
@@ -53,6 +53,7 @@ import { motionClasses } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 import {
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsSection,
 } from "../_components/SettingsRows";
@@ -179,7 +180,7 @@ export function ConnectionsPanel({
   }
 
   return (
-    <div className="max-w-4xl space-y-6">
+    <SettingsPage>
       <SettingsPageHeader
         title={
           <span className="inline-flex items-center gap-2">
@@ -502,7 +503,7 @@ export function ConnectionsPanel({
           </AlertDialog.Popup>
         </AlertDialog.Portal>
       </AlertDialog.Root>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/apps/web/app/(app)/settings/data/DataForm.tsx
+++ b/apps/web/app/(app)/settings/data/DataForm.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/queries/keys";
 import {
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -80,7 +81,7 @@ export function DataForm() {
   }
 
   return (
-    <div className="max-w-3xl space-y-8">
+    <SettingsPage>
       <SettingsPageHeader
         title="Data"
         description="Import chats from other platforms, or export your own."
@@ -141,6 +142,6 @@ export function DataForm() {
           </Button>
         </SettingsRow>
       </SettingsSection>
-    </div>
+    </SettingsPage>
   );
 }

--- a/apps/web/app/(app)/settings/general/GeneralForm.tsx
+++ b/apps/web/app/(app)/settings/general/GeneralForm.tsx
@@ -11,10 +11,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { SettingsChoiceGroup } from "../_components/SettingsChoiceGroup";
 import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
 import {
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -50,23 +50,28 @@ const getServerSnapshot = () => false;
 
 export function GeneralForm() {
   const { theme, setTheme } = useTheme();
-  const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-  const current = (mounted ? theme : undefined) as ThemeValue | undefined;
-  const [messageStatsEnabled, setMessageStatsEnabled] = useLocalStorage<boolean>(
-    MESSAGE_STATS_STORAGE_KEY,
-    false,
+  const mounted = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
   );
+  // Keep the radio group controlled during hydration so it follows the saved theme.
+  const current = (mounted ? (theme ?? "system") : "system") as ThemeValue;
+  const [messageStatsEnabled, setMessageStatsEnabled] =
+    useLocalStorage<boolean>(MESSAGE_STATS_STORAGE_KEY, false);
   const [contextMeterEnabled, setContextMeterEnabled] =
     useLocalStorage<boolean>(
       CONTEXT_METER_STORAGE_KEY,
       DEFAULT_CONTEXT_METER_ENABLED,
     );
-  const [sessionCostEnabled, setSessionCostEnabled] =
-    useLocalStorage<boolean>(
-      SESSION_COST_STORAGE_KEY,
-      DEFAULT_SESSION_COST_ENABLED,
-    );
-  const [fontId, setFontId] = useLocalStorage<FontId>(FONT_STORAGE_KEY, DEFAULT_FONT_ID);
+  const [sessionCostEnabled, setSessionCostEnabled] = useLocalStorage<boolean>(
+    SESSION_COST_STORAGE_KEY,
+    DEFAULT_SESSION_COST_ENABLED,
+  );
+  const [fontId, setFontId] = useLocalStorage<FontId>(
+    FONT_STORAGE_KEY,
+    DEFAULT_FONT_ID,
+  );
   const currentFont = mounted ? fontId : DEFAULT_FONT_ID;
 
   function selectFont(next: FontId) {
@@ -74,12 +79,13 @@ export function GeneralForm() {
     // The blocking script only runs on page load; apply the change live too.
     const opt = FONT_OPTIONS.find((f) => f.id === next);
     const root = document.documentElement;
-    if (!opt || opt.cssValue === null) root.style.removeProperty("--app-font-sans");
+    if (!opt || opt.cssValue === null)
+      root.style.removeProperty("--app-font-sans");
     else root.style.setProperty("--app-font-sans", opt.cssValue);
   }
 
   return (
-    <div className="max-w-3xl space-y-8">
+    <SettingsPage>
       <SettingsPageHeader
         title="General"
         description="Preferences saved for this browser."
@@ -87,7 +93,7 @@ export function GeneralForm() {
 
       <SettingsSection
         title="Appearance"
-        description="Choose how overtchat looks and reads."
+        description="Choose how OvertChat looks and reads."
       >
         <SettingsRow
           title="Theme"
@@ -95,41 +101,46 @@ export function GeneralForm() {
           align="center"
           controlAlign="end"
         >
-          <RadioGroup
-            aria-label="Theme"
+          <SettingsChoiceGroup
+            label="Theme"
             value={current}
-            onValueChange={(next) => setTheme(next as ThemeValue)}
-            className="grid w-full grid-cols-3 gap-1 rounded-lg border bg-muted/30 p-1 @2xl:max-w-xs"
-          >
-            {OPTIONS.map(({ value, label, icon: Icon }) => (
-              <Label
-                key={value}
-                className="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-md px-2 text-sm font-medium text-muted-foreground motion-colors outline-none has-data-[checked]:bg-background has-data-[checked]:text-foreground has-data-[checked]:shadow-xs has-focus-visible:ring-3 has-focus-visible:ring-ring/50 not-has-data-[checked]:hover:text-foreground"
-              >
-                <RadioGroupItem value={value} className="sr-only" />
-                <Icon className="size-3.5" />
-                <span>{label}</span>
-              </Label>
-            ))}
-          </RadioGroup>
+            onValueChange={setTheme}
+            options={OPTIONS.map(({ value, label, icon: Icon }) => ({
+              value,
+              label: (
+                <>
+                  <Icon aria-hidden="true" />
+                  <span>{label}</span>
+                </>
+              ),
+            }))}
+          />
         </SettingsRow>
 
         <SettingsRow
-          title="Chat font"
+          title="Interface font"
           description="Choose the font used throughout the app."
+          htmlFor="interface-font"
           align="center"
           controlAlign="end"
         >
-          <Select value={currentFont} onValueChange={(next) => selectFont(next as FontId)}>
-            <SelectTrigger aria-label="Chat font" className="w-full @2xl:w-64">
-              <SelectValue />
+          <Select
+            value={currentFont}
+            onValueChange={(next) => selectFont(next as FontId)}
+          >
+            <SelectTrigger id="interface-font" className="w-full">
+              <SelectValue>
+                {FONT_OPTIONS.find((font) => font.id === currentFont)?.label}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               {FONT_OPTIONS.map(({ id, label, cssValue }) => (
                 <SelectItem
                   key={id}
                   value={id}
-                  style={{ fontFamily: cssValue ?? "var(--font-plus-jakarta-sans)" }}
+                  style={{
+                    fontFamily: cssValue ?? "var(--font-plus-jakarta-sans)",
+                  }}
                 >
                   {label}
                 </SelectItem>
@@ -141,7 +152,7 @@ export function GeneralForm() {
 
       <SettingsSection
         title="Messages"
-        description="Message display preferences saved for this browser."
+        description="Choose which details appear in your conversations."
       >
         <SettingsRow
           title="Message stats"
@@ -149,6 +160,7 @@ export function GeneralForm() {
           htmlFor="message-stats"
           align="center"
           controlAlign="end"
+          layout="toggle"
         >
           <Switch
             id="message-stats"
@@ -164,6 +176,7 @@ export function GeneralForm() {
           htmlFor="context-meter"
           align="center"
           controlAlign="end"
+          layout="toggle"
         >
           <Switch
             id="context-meter"
@@ -179,6 +192,7 @@ export function GeneralForm() {
           htmlFor="session-cost"
           align="center"
           controlAlign="end"
+          layout="toggle"
         >
           <Switch
             id="session-cost"
@@ -188,6 +202,6 @@ export function GeneralForm() {
           />
         </SettingsRow>
       </SettingsSection>
-    </div>
+    </SettingsPage>
   );
 }

--- a/apps/web/app/(app)/settings/layout.tsx
+++ b/apps/web/app/(app)/settings/layout.tsx
@@ -25,10 +25,10 @@ export default function SettingsLayout({
         </Button>
       </header>
       <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
-        <aside className="shrink-0 overflow-y-auto border-b p-3 md:w-52 md:border-r md:border-b-0 md:p-4">
+        <aside className="shrink-0 overflow-y-auto border-b bg-muted/15 p-3 md:w-52 md:border-r md:border-b-0 md:p-4">
           <SettingsNav />
         </aside>
-        <div className="min-w-0 flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">
+        <div className="min-w-0 flex-1 overflow-y-auto overscroll-contain p-4 pb-8 md:p-6 md:pb-12 lg:p-8 lg:pb-12">
           {children}
         </div>
       </div>

--- a/apps/web/app/(app)/settings/loading.tsx
+++ b/apps/web/app/(app)/settings/loading.tsx
@@ -1,16 +1,31 @@
+import { SettingsPage } from "./_components/SettingsRows";
+
 export default function SettingsLoading() {
   return (
-    <div className="max-w-4xl space-y-6">
-      <div className="space-y-2">
-        <div className="h-6 w-40 rounded motion-skeleton" />
-        <div className="h-4 w-72 max-w-full rounded motion-skeleton" />
+    <SettingsPage>
+      <span className="sr-only" role="status">
+        Loading settings…
+      </span>
+      <div aria-hidden="true" className="space-y-8">
+        <div className="space-y-2">
+          <div className="h-6 w-40 rounded motion-skeleton" />
+          <div className="h-4 w-72 max-w-full rounded motion-skeleton" />
+        </div>
+        <div className="space-y-4">
+          <div className="h-5 w-32 rounded motion-skeleton" />
+          <div className="divide-y border-y">
+            {[0, 1, 2].map((row) => (
+              <div
+                key={row}
+                className="grid gap-3 py-4 @2xl/settings:grid-cols-2 @2xl/settings:gap-8"
+              >
+                <div className="h-5 w-32 rounded motion-skeleton" />
+                <div className="h-10 rounded-lg motion-skeleton" />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
-      <div className="space-y-4 rounded-lg border p-4">
-        <div className="h-5 w-32 rounded motion-skeleton" />
-        <div className="h-10 rounded-lg motion-skeleton" />
-        <div className="h-10 rounded-lg motion-skeleton" />
-        <div className="h-10 rounded-lg motion-skeleton" />
-      </div>
-    </div>
+    </SettingsPage>
   );
 }

--- a/apps/web/app/(app)/settings/models/AdvancedFields.tsx
+++ b/apps/web/app/(app)/settings/models/AdvancedFields.tsx
@@ -116,7 +116,7 @@ export function AdvancedFields({
               min={1}
               step={1}
               inputMode="numeric"
-              className="w-full font-mono @2xl:max-w-xl"
+              className="w-full font-mono"
               placeholder={
                 contextWindowPlaceholder === undefined &&
                 resolvedContextWindow === undefined
@@ -135,6 +135,7 @@ export function AdvancedFields({
 
           <SettingsRow
             title="System prompt"
+            align="start"
             description="Optional instructions sent before each chat."
             htmlFor="p-system-prompt"
           >
@@ -154,7 +155,7 @@ export function AdvancedFields({
             align={pricing || catalogPricing ? "start" : "center"}
             controlAlign="end"
           >
-            <div className="w-full @2xl:max-w-xl">
+            <div className="w-full">
               <div className="flex min-h-8 items-center justify-between gap-3">
                 <span className="text-xs text-muted-foreground">
                   {pricing
@@ -187,7 +188,7 @@ export function AdvancedFields({
                 </div>
               </div>
               {pricing || catalogPricing ? (
-                <div className="mt-3 grid grid-cols-2 gap-3 @xl:grid-cols-4">
+                <div className="mt-3 grid grid-cols-2 gap-3">
                   <PricingInput
                     id="p-price-input"
                     label="Input"
@@ -268,6 +269,7 @@ export function AdvancedFields({
 
           <SettingsRow
             title="Provider options"
+            align="start"
             description="Optional AI SDK options for the selected provider."
             htmlFor="p-provider-options"
           >

--- a/apps/web/app/(app)/settings/models/ConnectionFields.tsx
+++ b/apps/web/app/(app)/settings/models/ConnectionFields.tsx
@@ -237,9 +237,9 @@ export function ConnectionFields({
             clearProbeState();
           }}
         >
-          <SelectTrigger id="p-provider" className="w-full @2xl:max-w-xl">
+          <SelectTrigger id="p-provider" className="w-full">
             <ModelBrandIcon iconId={provider.iconId} />
-            <SelectValue />
+            <SelectValue>{provider.label}</SelectValue>
           </SelectTrigger>
           <SelectContent>
             {PROVIDER_IDS.map((id) => (
@@ -272,8 +272,12 @@ export function ConnectionFields({
               clearProbeState();
             }}
           >
-            <SelectTrigger id="p-api-format" className="w-full @2xl:max-w-xl">
-              <SelectValue />
+            <SelectTrigger id="p-api-format" className="w-full">
+              <SelectValue>
+                {draft.apiFormat === "auto"
+                  ? "Automatic"
+                  : API_FORMATS[draft.apiFormat].label}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               {EXPLICIT_API_FORMAT_IDS.map((id) => (
@@ -299,7 +303,7 @@ export function ConnectionFields({
       >
         <Input
           id="p-base-url"
-          className="w-full @2xl:max-w-xl"
+          className="w-full"
           placeholder={provider.defaultBaseUrl || "https://api.example.com/v1"}
           required
           autoFocus={draft.providerId === "custom"}
@@ -322,7 +326,7 @@ export function ConnectionFields({
         align="center"
         controlAlign="end"
       >
-        <div className="w-full @2xl:max-w-xl">
+        <div className="w-full">
           <PasswordInput
             id="p-api-key"
             autoComplete="new-password"
@@ -343,7 +347,7 @@ export function ConnectionFields({
         htmlFor="p-model"
         controlAlign="end"
       >
-        <div className="w-full space-y-2 @2xl:max-w-xl">
+        <div className="w-full space-y-2">
           <div className="flex flex-col gap-2 @lg:flex-row">
             {showList ? (
               <Select
@@ -356,7 +360,7 @@ export function ConnectionFields({
               >
                 <SelectTrigger id="p-model" className="min-w-0 flex-1">
                   <ModelBrandIcon iconId={modelIconForModel(draft.model)} />
-                  <SelectValue />
+                  <SelectValue>{draft.model}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {models.map((model) => (

--- a/apps/web/app/(app)/settings/models/ModelEditor.tsx
+++ b/apps/web/app/(app)/settings/models/ModelEditor.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import type { ModelCapabilities } from "@overtchat/shared";
-import { ArrowLeft, XCircle } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -32,6 +32,8 @@ import { ConnectionFields } from "./ConnectionFields";
 import { ConnectionTester } from "./ConnectionTester";
 import {
   SettingsActions,
+  SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -275,9 +277,8 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
   }
 
   return (
-    <div className="max-w-4xl">
+    <SettingsPage>
       <SettingsPageHeader
-        className="mb-6"
         title={isEditing ? "Edit model" : "Add model"}
         description="Configure a model that everyone on this server can use."
         leading={
@@ -359,6 +360,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
             description={toolCallingDescription(capabilitiesHint)}
             align="center"
             controlAlign="end"
+            layout="toggle"
           >
             <Switch
               checked={draft.toolCallingEnabled}
@@ -403,7 +405,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
           >
             <Input
               id="p-label"
-              className="w-full @2xl:max-w-xl"
+              className="w-full"
               placeholder={
                 draft.model
                   ? defaultLabelFor(draft.model)
@@ -421,6 +423,7 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
             description="Turn off to keep this model saved without showing it in chat."
             align="center"
             controlAlign="end"
+            layout="toggle"
           >
             <Switch
               checked={draft.enabled}
@@ -461,28 +464,22 @@ export function ModelEditor({ modelId }: ModelEditorProps) {
           defaultOpen={advancedDefaultOpen}
         />
 
-        {saveError && (
-          <div className="flex items-start gap-1.5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            <XCircle className="size-3.5 shrink-0 mt-0.5" />
-            <span className="break-words">{saveError}</span>
-          </div>
-        )}
+        {saveError && <SettingsNotice tone="error">{saveError}</SettingsNotice>}
 
         <SettingsActions>
           <Button
             type="button"
-            variant="ghost"
-            size="sm"
+            variant="outline"
             render={<Link href="/settings/models" />}
           >
             Cancel
           </Button>
-          <Button type="submit" size="sm" disabled={!canSave}>
-            {saving ? "Saving…" : isEditing ? "Save" : "Create"}
+          <Button type="submit" disabled={!canSave}>
+            {saving ? "Saving…" : isEditing ? "Save changes" : "Add model"}
           </Button>
         </SettingsActions>
       </form>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/apps/web/app/(app)/settings/models/ModelsPanel.tsx
+++ b/apps/web/app/(app)/settings/models/ModelsPanel.tsx
@@ -29,6 +29,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -138,7 +139,7 @@ export function ModelsPanel() {
   }
 
   return (
-    <div className="@container max-w-4xl space-y-6">
+    <SettingsPage>
       <SettingsPageHeader
         title="Models"
         description="Manage models used in chat and background tasks."
@@ -169,7 +170,7 @@ export function ModelsPanel() {
             >
               <SelectTrigger
                 aria-label="Task model"
-                className="w-full @2xl:w-72"
+                className="w-full"
               >
                 <SelectValue>
                   {taskModel ? taskModel.label : "Same as chat model"}
@@ -393,7 +394,7 @@ export function ModelsPanel() {
           </AlertDialog.Popup>
         </AlertDialog.Portal>
       </AlertDialog.Root>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/apps/web/app/(app)/settings/personalization/PersonalizationForm.tsx
+++ b/apps/web/app/(app)/settings/personalization/PersonalizationForm.tsx
@@ -4,6 +4,7 @@ import { getErrorMessage } from "@/lib/errors";
 import { usePersonalization } from "@/lib/queries/personalization";
 import {
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
 } from "../_components/SettingsRows";
 import { MemoryManager } from "./MemoryManager";
@@ -12,34 +13,28 @@ import { ProfileEditor } from "./ProfileEditor";
 export function PersonalizationForm() {
   const { data, isPending, error: loadError } = usePersonalization();
 
-  if (isPending) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        Loading personalization…
-      </p>
-    );
-  }
-  if (loadError || !data) {
-    return (
-      <SettingsNotice tone="error">
-        {getErrorMessage(loadError, "Unable to load personalization.")}
-      </SettingsNotice>
-    );
-  }
-
   return (
-    <div className="max-w-3xl space-y-8">
+    <SettingsPage>
       <SettingsPageHeader
         title="Personalization"
         description="Tell OvertChat about you and manage what it remembers between chats."
       />
 
-      <ProfileEditor
-        key={JSON.stringify(data.personalization)}
-        personalization={data.personalization}
-      />
-
-      <MemoryManager memories={data.memories} usage={data.contextUsage} />
-    </div>
+      {isPending ? (
+        <SettingsNotice>Loading personalization…</SettingsNotice>
+      ) : loadError || !data ? (
+        <SettingsNotice tone="error">
+          {getErrorMessage(loadError, "Unable to load personalization.")}
+        </SettingsNotice>
+      ) : (
+        <>
+          <ProfileEditor
+            key={JSON.stringify(data.personalization)}
+            personalization={data.personalization}
+          />
+          <MemoryManager memories={data.memories} usage={data.contextUsage} />
+        </>
+      )}
+    </SettingsPage>
   );
 }

--- a/apps/web/app/(app)/settings/personalization/ProfileEditor.tsx
+++ b/apps/web/app/(app)/settings/personalization/ProfileEditor.tsx
@@ -68,6 +68,7 @@ export function ProfileEditor({
           htmlFor="personalization-enabled"
           align="center"
           controlAlign="end"
+          layout="toggle"
         >
           <Switch
             id="personalization-enabled"
@@ -99,6 +100,7 @@ export function ProfileEditor({
         </SettingsRow>
         <SettingsRow
           title="More about you"
+          align="start"
           description="Interests, values, or preferences to keep in mind."
           htmlFor="about-user"
         >

--- a/apps/web/app/(app)/settings/profile/ProfileForm.tsx
+++ b/apps/web/app/(app)/settings/profile/ProfileForm.tsx
@@ -13,6 +13,7 @@ import { activityKeys } from "@/lib/queries/keys";
 import {
   SettingsActions,
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -84,7 +85,7 @@ export function ProfileForm({
   }
 
   return (
-    <div className="max-w-3xl space-y-8">
+    <SettingsPage>
       <SettingsPageHeader
         title="Profile"
         description="Choose how you appear to other people on this server."
@@ -110,7 +111,7 @@ export function ProfileForm({
             align="center"
             controlAlign="end"
           >
-            <div className="flex w-full items-center gap-4 @2xl:max-w-sm">
+            <div className="flex w-full items-center gap-4">
               <ProfileAvatar
                 id={userId}
                 name={previewName}
@@ -137,7 +138,7 @@ export function ProfileForm({
               id="display-name"
               type="text"
               autoComplete="name"
-              className="w-full @2xl:max-w-sm"
+              className="w-full"
               maxLength={80}
               required
               value={name}
@@ -155,7 +156,7 @@ export function ProfileForm({
             align="center"
             controlAlign="end"
           >
-            <div className="relative w-full @2xl:max-w-sm">
+            <div className="relative w-full">
               <ImageIcon className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 id="avatar-url"
@@ -190,7 +191,7 @@ export function ProfileForm({
           </Button>
         </SettingsActions>
       </form>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/apps/web/app/(app)/settings/services/ServicesPanel.tsx
+++ b/apps/web/app/(app)/settings/services/ServicesPanel.tsx
@@ -25,6 +25,7 @@ import {
 import {
   SettingsActions,
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -93,7 +94,8 @@ export function voiceServicePresentation(
     case "not-installed":
       return {
         label: "Not installed",
-        description: "Run overtchat setup and enable realtime voice conversations.",
+        description:
+          "Run overtchat setup and enable realtime voice conversations.",
         configured: false,
       };
     case "stt-unavailable":
@@ -112,7 +114,8 @@ export function voiceServicePresentation(
     default:
       return {
         label: "Incomplete setup",
-        description: "Run overtchat setup to repair the realtime voice configuration.",
+        description:
+          "Run overtchat setup to repair the realtime voice configuration.",
         configured: false,
       };
   }
@@ -194,11 +197,11 @@ function CapabilitySection({
                   model:
                     current.provider !== "openai-compatible"
                       ? "tts-1"
-                      : current.model ?? "tts-1",
+                      : (current.model ?? "tts-1"),
                   voice:
                     current.provider !== "openai-compatible"
                       ? "alloy"
-                      : current.voice ?? "alloy",
+                      : (current.voice ?? "alloy"),
                 };
               }
               if (current.id === "stt" && provider === "bundled") {
@@ -215,15 +218,24 @@ function CapabilitySection({
                   model:
                     current.provider !== "openai-compatible"
                       ? "whisper-1"
-                      : current.model ?? "whisper-1",
+                      : (current.model ?? "whisper-1"),
                 };
               }
               return { ...current, provider };
             });
           }}
         >
-          <SelectTrigger className="w-full" aria-label={`${TITLES[draft.id]} provider`}>
-            <SelectValue />
+          <SelectTrigger
+            className="w-full"
+            aria-label={`${TITLES[draft.id]} provider`}
+          >
+            <SelectValue>
+              {
+                PROVIDERS[draft.id].find(
+                  (provider) => provider.value === draft.provider,
+                )?.label
+              }
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {PROVIDERS[draft.id].map((provider) => (
@@ -350,12 +362,10 @@ function CapabilitySection({
 export function ServicesPanel() {
   const { data, isPending, error } = useServerCapabilities();
   const capabilities = data?.capabilities ?? [];
-  const voiceStatus = data?.voice
-    ? voiceServicePresentation(data.voice)
-    : null;
+  const voiceStatus = data?.voice ? voiceServicePresentation(data.voice) : null;
 
   return (
-    <div className="max-w-3xl space-y-8">
+    <SettingsPage>
       <SettingsPageHeader
         title="Services"
         description="Manage search and speech providers for this server. Local services are installed with overtchat setup."
@@ -394,6 +404,6 @@ export function ServicesPanel() {
           </SettingsRow>
         </SettingsSection>
       )}
-    </div>
+    </SettingsPage>
   );
 }

--- a/apps/web/app/(app)/settings/tools/AvailableMcpServersPanel.tsx
+++ b/apps/web/app/(app)/settings/tools/AvailableMcpServersPanel.tsx
@@ -10,10 +10,14 @@ import {
   useAvailableMcpServers,
   useSetMcpServerPreference,
 } from "@/lib/queries/mcpServers";
-import { SettingsSection } from "../_components/SettingsRows";
+import {
+  SettingsEmptyState,
+  SettingsNotice,
+  SettingsSection,
+} from "../_components/SettingsRows";
 
 export function AvailableMcpServersPanel() {
-  const { data: servers = [] } = useAvailableMcpServers();
+  const { data: servers = [], isPending, error } = useAvailableMcpServers();
   const setPreference = useSetMcpServerPreference();
   const [togglingId, setTogglingId] = useState<string | null>(null);
 
@@ -36,17 +40,22 @@ export function AvailableMcpServersPanel() {
       title="MCP servers"
       description="Choose which available MCP servers can provide tools in your chats."
     >
-      {servers.length === 0 ? (
-        <div className="py-8 text-center">
-          <p className="text-sm text-muted-foreground">
-            No MCP servers are available to you.
-          </p>
-        </div>
+      {isPending ? (
+        <SettingsNotice className="py-6">Loading MCP servers…</SettingsNotice>
+      ) : error ? (
+        <SettingsNotice tone="error" className="py-6">
+          {getErrorMessage(error, "Unable to load MCP servers.")}
+        </SettingsNotice>
+      ) : servers.length === 0 ? (
+        <SettingsEmptyState
+          title="No MCP servers available"
+          description="Ask an administrator to connect a tool server."
+        />
       ) : (
         servers.map((server) => (
           <div
             key={server.id}
-            className="flex items-center justify-between gap-4 py-3"
+            className="flex items-center justify-between gap-4 py-4"
           >
             <div className="flex min-w-0 items-center gap-3">
               <div className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/30">

--- a/apps/web/app/(app)/settings/tools/McpServersPanel.tsx
+++ b/apps/web/app/(app)/settings/tools/McpServersPanel.tsx
@@ -14,10 +14,7 @@ import {
 } from "@/components/ui/select";
 import { toast } from "@/components/ui/toast";
 import { getErrorMessage } from "@/lib/errors";
-import type {
-  McpServer,
-  McpServerAvailability,
-} from "@/lib/mcp/schema";
+import type { McpServer, McpServerAvailability } from "@/lib/mcp/schema";
 import { motionClasses } from "@/lib/motion";
 import {
   useDeleteMcpServer,
@@ -26,13 +23,14 @@ import {
 } from "@/lib/queries/mcpServers";
 import { cn } from "@/lib/utils";
 import {
+  SettingsEmptyState,
   SettingsNotice,
   SettingsSection,
 } from "../_components/SettingsRows";
 import { McpHealthBadge } from "./McpHealthBadge";
 
 export function McpServersPanel() {
-  const { data: servers = [] } = useMcpServers();
+  const { data: servers = [], isPending, error } = useMcpServers();
   const updateServer = useUpdateMcpServer();
   const deleteServer = useDeleteMcpServer();
   const [togglingId, setTogglingId] = useState<string | null>(null);
@@ -80,26 +78,28 @@ export function McpServersPanel() {
         title="Manage MCP servers"
         description="Connect external tool servers and choose who can use them. Commands run inside the OvertChat server environment."
         action={
-          <Button
-            render={<Link href="/settings/tools/mcp/new" />}
-            size="sm"
-          >
+          <Button render={<Link href="/settings/tools/mcp/new" />} size="sm">
             <Plus /> Add server
           </Button>
         }
       >
-        {servers.length === 0 ? (
-          <div className="py-8 text-center">
-            <p className="text-sm text-muted-foreground">
-              No MCP servers configured.
-            </p>
-          </div>
+        {isPending ? (
+          <SettingsNotice className="py-6">Loading MCP servers…</SettingsNotice>
+        ) : error ? (
+          <SettingsNotice tone="error" className="py-6">
+            {getErrorMessage(error, "Unable to load MCP servers.")}
+          </SettingsNotice>
+        ) : servers.length === 0 ? (
+          <SettingsEmptyState
+            title="No MCP servers available"
+            description="Connect a server to make its tools available in chats."
+          />
         ) : (
           servers.map((server) => (
             <div
               key={server.id}
               className={cn(
-                "grid gap-3 py-3 @xl:grid-cols-[minmax(0,1fr)_auto] @xl:items-center",
+                "grid gap-3 py-4 @xl:grid-cols-[minmax(0,1fr)_auto] @xl:items-center",
                 server.availability === "disabled" && "opacity-65",
               )}
             >
@@ -109,7 +109,9 @@ export function McpServersPanel() {
                 </div>
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center gap-2">
-                    <p className="truncate text-sm font-medium">{server.name}</p>
+                    <p className="truncate text-sm font-medium">
+                      {server.name}
+                    </p>
                     <McpHealthBadge id={server.id} />
                   </div>
                   <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
@@ -125,7 +127,7 @@ export function McpServersPanel() {
                 </div>
               </div>
 
-              <div className="flex items-center justify-end gap-2">
+              <div className="flex flex-wrap items-center justify-end gap-2">
                 <span className="hidden text-xs text-muted-foreground @2xl:inline">
                   Available to
                 </span>

--- a/apps/web/app/(app)/settings/tools/ToolsForm.tsx
+++ b/apps/web/app/(app)/settings/tools/ToolsForm.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/tool-preferences";
 import { useLocalStorage } from "@/lib/useLocalStorage";
 import {
+  SettingsPage,
   SettingsPageHeader,
   SettingsRow,
   SettingsSection,
@@ -21,7 +22,7 @@ export function ToolsForm({ isAdmin }: { isAdmin: boolean }) {
   );
 
   return (
-    <div className="max-w-3xl space-y-8">
+    <SettingsPage>
       <SettingsPageHeader
         title="Tools"
         description="Control model capabilities and connect external tool servers."
@@ -37,6 +38,7 @@ export function ToolsForm({ isAdmin }: { isAdmin: boolean }) {
           htmlFor="web-search-enabled"
           align="center"
           controlAlign="end"
+          layout="toggle"
         >
           <Switch
             id="web-search-enabled"
@@ -50,6 +52,6 @@ export function ToolsForm({ isAdmin }: { isAdmin: boolean }) {
       <AvailableMcpServersPanel />
 
       {isAdmin && <McpServersPanel />}
-    </div>
+    </SettingsPage>
   );
 }

--- a/apps/web/app/(app)/settings/tools/mcp/McpServerEditor.tsx
+++ b/apps/web/app/(app)/settings/tools/mcp/McpServerEditor.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/toast";
 import { getErrorMessage } from "@/lib/errors";
 import {
@@ -19,12 +18,16 @@ import {
   useCreateMcpServer,
   useUpdateMcpServer,
 } from "@/lib/queries/mcpServers";
-import { cn } from "@/lib/utils";
 import {
   SettingsActions,
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
+  SettingsRow,
+  SettingsSection,
 } from "../../_components/SettingsRows";
+
+import { SettingsChoiceGroup } from "../../_components/SettingsChoiceGroup";
 
 type Pair = { id: string; key: string; value: string };
 type ValueRow = { id: string; value: string };
@@ -140,7 +143,9 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
       config: configFromForm(),
     });
     if (parsed.success) return parsed.data;
-    setError(parsed.error.issues[0]?.message ?? "Check the server configuration.");
+    setError(
+      parsed.error.issues[0]?.message ?? "Check the server configuration.",
+    );
     return null;
   }
 
@@ -166,63 +171,66 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
   }
 
   return (
-    <form onSubmit={save} className="max-w-4xl space-y-5">
-      <SettingsPageHeader
-        leading={
-          <Button
-            render={<Link href="/settings/tools" />}
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Back to tools"
-          >
-            <ArrowLeft />
-          </Button>
-        }
-        title={server ? "Edit custom MCP" : "Connect to a custom MCP"}
-        description={
-          <a
-            href="https://modelcontextprotocol.io/docs"
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 hover:text-foreground"
-          >
-            Docs <Globe2 className="size-3.5" />
-          </a>
-        }
-      />
-
-      <FieldCard>
-        <Field label="Name" htmlFor="mcp-name">
-          <Input
-            id="mcp-name"
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            placeholder="MCP server name"
-            autoComplete="off"
-          />
-        </Field>
-        <div className="flex items-center justify-between gap-4 border-t pt-4">
-          <Label>Type</Label>
-          <div className="flex rounded-lg bg-muted p-0.5">
-            <TransportButton
-              active={transport === "stdio"}
-              onClick={() => setTransport("stdio")}
+    <SettingsPage>
+      <form onSubmit={save} className="space-y-8">
+        <SettingsPageHeader
+          leading={
+            <Button
+              render={<Link href="/settings/tools" />}
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Back to tools"
             >
-              STDIO
-            </TransportButton>
-            <TransportButton
-              active={transport === "http"}
-              onClick={() => setTransport("http")}
+              <ArrowLeft />
+            </Button>
+          }
+          title={server ? "Edit MCP server" : "Add MCP server"}
+          description={
+            <a
+              href="https://modelcontextprotocol.io/docs"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 hover:text-foreground"
             >
-              Streamable HTTP
-            </TransportButton>
-          </div>
-        </div>
-      </FieldCard>
+              MCP documentation <Globe2 className="size-3.5" />
+            </a>
+          }
+        />
 
-      {transport === "stdio" ? (
-        <>
-          <FieldCard>
+        <SettingsSection
+          title="Connection"
+          description="Name this server and choose how OvertChat connects to it."
+        >
+          <Field label="Name" htmlFor="mcp-name">
+            <Input
+              id="mcp-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="MCP server name"
+              autoComplete="off"
+            />
+          </Field>
+          <SettingsRow
+            title="Transport"
+            description="Run a local process or connect to an HTTP server."
+          >
+            <SettingsChoiceGroup
+              label="Transport"
+              value={transport}
+              onValueChange={(next) => setTransport(next as "stdio" | "http")}
+              options={[
+                { value: "stdio", label: "STDIO" },
+                { value: "http", label: "Streamable HTTP" },
+              ]}
+            />
+          </SettingsRow>
+        </SettingsSection>
+
+        {transport === "stdio" ? (
+          <SettingsSection
+            title="Local process"
+            description="Configure the command and environment used to start this server."
+          >
             <Field label="Command to launch" htmlFor="mcp-command">
               <Input
                 id="mcp-command"
@@ -233,9 +241,7 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
                 className="font-mono"
               />
             </Field>
-          </FieldCard>
 
-          <FieldCard>
             <RepeatableValues
               label="Arguments"
               rows={args}
@@ -243,9 +249,7 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
               addLabel="Add argument"
               onChange={setArgs}
             />
-          </FieldCard>
 
-          <FieldCard>
             <RepeatablePairs
               label="Environment variables"
               rows={environment}
@@ -254,9 +258,7 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
               addLabel="Add environment variable"
               onChange={setEnvironment}
             />
-          </FieldCard>
 
-          <FieldCard>
             <RepeatableValues
               label="Environment variable passthrough"
               rows={passthrough}
@@ -264,9 +266,7 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
               addLabel="Add variable"
               onChange={setPassthrough}
             />
-          </FieldCard>
 
-          <FieldCard>
             <Field label="Working directory" htmlFor="mcp-cwd">
               <Input
                 id="mcp-cwd"
@@ -277,11 +277,12 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
                 className="font-mono"
               />
             </Field>
-          </FieldCard>
-        </>
-      ) : (
-        <>
-          <FieldCard>
+          </SettingsSection>
+        ) : (
+          <SettingsSection
+            title="HTTP connection"
+            description="Configure the server address and optional authentication."
+          >
             <Field label="Server URL" htmlFor="mcp-url">
               <Input
                 id="mcp-url"
@@ -292,9 +293,7 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
                 className="font-mono"
               />
             </Field>
-          </FieldCard>
 
-          <FieldCard>
             <RepeatablePairs
               label="HTTP headers"
               rows={headers}
@@ -303,9 +302,7 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
               addLabel="Add header"
               onChange={setHeaders}
             />
-          </FieldCard>
 
-          <FieldCard>
             <RepeatablePairs
               label="Environment variable HTTP headers"
               rows={envHeaders}
@@ -314,9 +311,7 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
               addLabel="Add environment header"
               onChange={setEnvHeaders}
             />
-          </FieldCard>
 
-          <FieldCard>
             <Field
               label="Bearer token environment variable"
               htmlFor="mcp-bearer-env"
@@ -330,26 +325,21 @@ export function McpServerEditor({ server }: { server?: McpServer }) {
                 className="font-mono"
               />
             </Field>
-          </FieldCard>
-        </>
-      )}
+          </SettingsSection>
+        )}
 
-      {error && <SettingsNotice tone="error">{error}</SettingsNotice>}
+        {error && <SettingsNotice tone="error">{error}</SettingsNotice>}
 
-      <SettingsActions>
-        <Button type="submit" disabled={saving}>
-          {saving ? "Saving…" : "Save"}
-        </Button>
-      </SettingsActions>
-    </form>
-  );
-}
-
-function FieldCard({ children }: { children: React.ReactNode }) {
-  return (
-    <section className="space-y-4 rounded-2xl border bg-card/40 p-4">
-      {children}
-    </section>
+        <SettingsActions>
+          <Button variant="outline" render={<Link href="/settings/tools" />}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={saving}>
+            {saving ? "Saving…" : server ? "Save changes" : "Add server"}
+          </Button>
+        </SettingsActions>
+      </form>
+    </SettingsPage>
   );
 }
 
@@ -363,35 +353,9 @@ function Field({
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-2">
-      <Label htmlFor={htmlFor}>{label}</Label>
+    <SettingsRow title={label} htmlFor={htmlFor}>
       {children}
-    </div>
-  );
-}
-
-function TransportButton({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick(): void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "rounded-md px-3 py-1.5 text-sm motion-colors",
-        active
-          ? "bg-background text-foreground shadow-sm"
-          : "text-muted-foreground hover:text-foreground",
-      )}
-    >
-      {children}
-    </button>
+    </SettingsRow>
   );
 }
 
@@ -409,41 +373,45 @@ function RepeatableValues({
   onChange(rows: ValueRow[]): void;
 }) {
   return (
-    <div className="space-y-3">
-      <Label>{label}</Label>
-      {rows.map((row) => (
-        <div key={row.id} className="flex items-center gap-2">
-          <Input
-            value={row.value}
-            onChange={(event) =>
-              onChange(
-                rows.map((item) =>
-                  item.id === row.id
-                    ? { ...item, value: event.target.value }
-                    : item,
-                ),
-              )
-            }
-            placeholder={placeholder}
-            autoComplete="off"
-            className="font-mono"
-          />
-          <RemoveButton
-            label={`Remove ${label.toLowerCase()} row`}
-            disabled={rows.length === 1 && row.value === ""}
-            onClick={() => onChange(rows.filter((item) => item.id !== row.id))}
-          />
-        </div>
-      ))}
-      <Button
-        type="button"
-        variant="secondary"
-        className="w-full"
-        onClick={() => onChange([...rows, { id: rowId(), value: "" }])}
-      >
-        <Plus /> {addLabel}
-      </Button>
-    </div>
+    <SettingsRow title={label} align="start">
+      <div className="space-y-3">
+        {rows.map((row, index) => (
+          <div key={row.id} className="flex items-center gap-2">
+            <Input
+              value={row.value}
+              aria-label={`${label} value ${index + 1}`}
+              onChange={(event) =>
+                onChange(
+                  rows.map((item) =>
+                    item.id === row.id
+                      ? { ...item, value: event.target.value }
+                      : item,
+                  ),
+                )
+              }
+              placeholder={placeholder}
+              autoComplete="off"
+              className="font-mono"
+            />
+            <RemoveButton
+              label={`Remove ${label.toLowerCase()} row`}
+              disabled={rows.length === 1 && row.value === ""}
+              onClick={() =>
+                onChange(rows.filter((item) => item.id !== row.id))
+              }
+            />
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full"
+          onClick={() => onChange([...rows, { id: rowId(), value: "" }])}
+        >
+          <Plus /> {addLabel}
+        </Button>
+      </div>
+    </SettingsRow>
   );
 }
 
@@ -463,58 +431,66 @@ function RepeatablePairs({
   onChange(rows: Pair[]): void;
 }) {
   return (
-    <div className="space-y-3">
-      <Label>{label}</Label>
-      {rows.map((row) => (
-        <div key={row.id} className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2">
-          <Input
-            value={row.key}
-            onChange={(event) =>
-              onChange(
-                rows.map((item) =>
-                  item.id === row.id
-                    ? { ...item, key: event.target.value }
-                    : item,
-                ),
-              )
-            }
-            placeholder={keyPlaceholder}
-            autoComplete="off"
-            className="font-mono"
-          />
-          <Input
-            value={row.value}
-            onChange={(event) =>
-              onChange(
-                rows.map((item) =>
-                  item.id === row.id
-                    ? { ...item, value: event.target.value }
-                    : item,
-                ),
-              )
-            }
-            placeholder={valuePlaceholder}
-            autoComplete="off"
-            className="font-mono"
-          />
-          <RemoveButton
-            label={`Remove ${label.toLowerCase()} row`}
-            disabled={rows.length === 1 && row.key === "" && row.value === ""}
-            onClick={() => onChange(rows.filter((item) => item.id !== row.id))}
-          />
-        </div>
-      ))}
-      <Button
-        type="button"
-        variant="secondary"
-        className="w-full"
-        onClick={() =>
-          onChange([...rows, { id: rowId(), key: "", value: "" }])
-        }
-      >
-        <Plus /> {addLabel}
-      </Button>
-    </div>
+    <SettingsRow title={label} align="start">
+      <div className="space-y-3">
+        {rows.map((row, index) => (
+          <div
+            key={row.id}
+            className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2"
+          >
+            <Input
+              value={row.key}
+              aria-label={`${label} key ${index + 1}`}
+              onChange={(event) =>
+                onChange(
+                  rows.map((item) =>
+                    item.id === row.id
+                      ? { ...item, key: event.target.value }
+                      : item,
+                  ),
+                )
+              }
+              placeholder={keyPlaceholder}
+              autoComplete="off"
+              className="font-mono"
+            />
+            <Input
+              value={row.value}
+              aria-label={`${label} value ${index + 1}`}
+              onChange={(event) =>
+                onChange(
+                  rows.map((item) =>
+                    item.id === row.id
+                      ? { ...item, value: event.target.value }
+                      : item,
+                  ),
+                )
+              }
+              placeholder={valuePlaceholder}
+              autoComplete="off"
+              className="font-mono"
+            />
+            <RemoveButton
+              label={`Remove ${label.toLowerCase()} row`}
+              disabled={rows.length === 1 && row.key === "" && row.value === ""}
+              onClick={() =>
+                onChange(rows.filter((item) => item.id !== row.id))
+              }
+            />
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full"
+          onClick={() =>
+            onChange([...rows, { id: rowId(), key: "", value: "" }])
+          }
+        >
+          <Plus /> {addLabel}
+        </Button>
+      </div>
+    </SettingsRow>
   );
 }
 

--- a/apps/web/app/(app)/settings/users/UsersPanel.tsx
+++ b/apps/web/app/(app)/settings/users/UsersPanel.tsx
@@ -23,6 +23,7 @@ import { motionClasses } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 import {
   SettingsNotice,
+  SettingsPage,
   SettingsPageHeader,
   SettingsSection,
 } from "../_components/SettingsRows";
@@ -91,7 +92,7 @@ export function UsersPanel({ currentUserId }: { currentUserId: string }) {
   }
 
   return (
-    <div className="max-w-4xl space-y-6">
+    <SettingsPage>
       <SettingsPageHeader
         title="Users"
         description="Manage who can sign in to this server."
@@ -321,7 +322,7 @@ export function UsersPanel({ currentUserId }: { currentUserId: string }) {
           </AlertDialog.Popup>
         </AlertDialog.Portal>
       </AlertDialog.Root>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "@playwright/test";
+import { resetE2eDatabase } from "./helpers/database";
+
+test.beforeEach(async ({ page }) => {
+  resetE2eDatabase();
+  await page.goto("/signup");
+  await page.getByLabel("Name", { exact: true }).fill("Settings Tester");
+  await page.getByLabel("Email").fill("settings@overtchat-test.local");
+  await page.locator("#password").fill("test-password-123");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL("**/");
+});
+
+test("appearance controls align, support the keyboard, and persist", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto("/settings/general");
+  const theme = page.getByRole("radiogroup", { name: "Theme" });
+  const font = page.getByRole("combobox", { name: "Interface font" });
+  await expect(font.locator('[data-slot="select-value"]')).toHaveText(
+    "Plus Jakarta Sans",
+  );
+  await expect(
+    page.getByRole("link", { name: "General", exact: true }),
+  ).toHaveAttribute("aria-current", "page");
+
+  const themeBox = (await theme.boundingBox())!;
+  const fontBox = (await font.boundingBox())!;
+  expect(Math.abs(themeBox.x - fontBox.x)).toBeLessThan(1);
+  expect(Math.abs(themeBox.width - fontBox.width)).toBeLessThan(1);
+  expect(Math.abs(themeBox.height - fontBox.height)).toBeLessThan(1);
+  for (const icon of await theme.locator("svg").all()) {
+    const box = (await icon.boundingBox())!;
+    expect(box.width).toBe(14);
+    expect(box.height).toBe(14);
+  }
+
+  await page.getByRole("radio", { name: "Light", exact: true }).click();
+  await page.keyboard.press("ArrowRight");
+  await expect(
+    page.getByRole("radio", { name: "Dark", exact: true }),
+  ).toBeChecked();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await font.click();
+  await page.getByRole("option", { name: "System", exact: true }).click();
+  await page.getByRole("switch", { name: "Message stats", exact: true }).click();
+  await page.reload();
+  await expect(font.locator('[data-slot="select-value"]')).toHaveText("System");
+  await expect(
+    page.getByRole("radio", { name: "Dark", exact: true }),
+  ).toBeChecked();
+  await expect(
+    page.getByRole("switch", { name: "Message stats", exact: true }),
+  ).toBeChecked();
+  await page.screenshot({ path: testInfo.outputPath("general-desktop.png") });
+
+  await page.setViewportSize({ width: 375, height: 812 });
+  const labelBox = (await page
+    .locator('label[for="message-stats"]')
+    .boundingBox())!;
+  const switchBox = (await page
+    .getByRole("switch", { name: "Message stats", exact: true })
+    .boundingBox())!;
+  expect(switchBox.x).toBeGreaterThan(labelBox.x + labelBox.width);
+  expect(switchBox.y).toBeLessThan(labelBox.y + 55);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(
+    375,
+  );
+  await page.screenshot({ path: testInfo.outputPath("general-mobile.png") });
+  await page.getByRole("combobox", { name: "Settings page" }).click();
+  await page.getByRole("option", { name: "Profile", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Profile", exact: true }),
+  ).toBeVisible();
+});
+
+test("all settings pages fit narrow screens and MCP transport preserves draft fields", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  for (const [route, title] of [
+    ["general", "General"],
+    ["personalization", "Personalization"],
+    ["tools", "Tools"],
+    ["profile", "Profile"],
+    ["account", "Security"],
+    ["data", "Data"],
+    ["models", "Models"],
+    ["services", "Services"],
+    ["connections", "Agents"],
+    ["users", "Users"],
+    ["models/new", "Add model"],
+    ["tools/mcp/new", "Add MCP server"],
+  ]) {
+    await page.goto(`/settings/${route}`);
+    await expect(
+      page
+        .getByRole("heading", { name: title, exact: title !== "Agents" })
+        .first(),
+    ).toBeVisible();
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth),
+      route,
+    ).toBe(375);
+    const overflow = await page
+      .locator('div[class*="overflow-y-auto"]')
+      .evaluateAll((elements) =>
+        elements
+          .filter(
+            (element) =>
+              element.clientWidth > 0 &&
+              element.scrollWidth > element.clientWidth + 1,
+          )
+          .map((element) => element.className),
+      );
+    expect(overflow, route).toEqual([]);
+  }
+
+  await page.getByLabel("Name", { exact: true }).fill("My tools");
+  await page.getByLabel("Command to launch").fill("npx");
+  await page.getByLabel("Arguments value 1", { exact: true }).fill("-y");
+  await page.getByRole("button", { name: "Add argument", exact: true }).click();
+  await expect(
+    page.getByLabel("Arguments value 2", { exact: true }),
+  ).toBeVisible();
+  await page
+    .getByRole("radio", { name: "Streamable HTTP", exact: true })
+    .click();
+  await expect(page.getByLabel("Server URL", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Command to launch")).toHaveCount(0);
+  await page.getByRole("radio", { name: "STDIO", exact: true }).click();
+  await expect(page.getByLabel("Command to launch")).toHaveValue("npx");
+  await expect(
+    page.getByLabel("Arguments value 1", { exact: true }),
+  ).toHaveValue("-y");
+  await expect(page.getByLabel("Name", { exact: true })).toHaveValue(
+    "My tools",
+  );
+  await page.screenshot({ path: testInfo.outputPath("mcp-mobile.png") });
+  await page.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(page).toHaveURL(/\/settings\/tools$/);
+});

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -39,7 +39,7 @@ test("signup, configure Gemini, stream a response", async ({ page }) => {
     }
 
     await page.locator("#p-label").fill("Gemini Lite Smoke Test");
-    await page.getByRole("button", { name: "Create", exact: true }).click();
+    await page.getByRole("button", { name: "Add model", exact: true }).click();
     await page.waitForURL("**/settings/models");
   });
 


### PR DESCRIPTION
Settings used inconsistent page widths, control sizes, and alignment. This pass gives preferences, administration pages, and model/MCP editors a shared layout with aligned fields, consistent spacing, and switches that stay beside their labels on phones.

The theme selector now keeps equal-sized options and icons, aligns with the font picker, and correctly restores its selected state after reload. Dropdowns show readable labels; navigation, loading/error states, and the MCP editor follow the same settings patterns.

Validation:
- Web typecheck, lint, and production build passed.
- Five focused service tests passed.
- Settings, personalization, and user-management browser tests passed, including all 12 settings/editor routes at phone width, desktop control geometry, keyboard theme selection, saved preferences, and MCP transport draft preservation.
- Reviewed desktop and phone screenshots.

The changes are confined to the web settings UI and browser tests; no database migrations, API contracts, authentication logic, or connector runtime changes.
