### PR TITLE
Fix mobile agent reconnects and banner flicker

### DIFF
--- a/apps/mobile/src/app/(authed)/agents/[id].tsx
+++ b/apps/mobile/src/app/(authed)/agents/[id].tsx
@@ -24,6 +24,7 @@ import {
   AgentContextSheet,
 } from "@/components/agents/AgentContextUsage";
 import { AgentComposer } from "@/components/agents/AgentComposer";
+import { AgentConnectionFeedback } from "@/components/agents/AgentConnectionFeedback";
 import { AgentControls } from "@/components/agents/AgentControls";
 import { AgentInteraction } from "@/components/agents/AgentInteraction";
 import { AgentTranscript } from "@/components/agents/AgentTranscript";
@@ -254,14 +255,13 @@ function AgentSession({
           retry={session.reconnect}
         />
       )}
-      {snapshot &&
-        session.status !== "connected" &&
-        session.status !== "paused" && (
-          <AgentFeedback
-            error={session.error || "Reconnecting to your agent…"}
-            retry={session.reconnect}
-          />
-        )}
+      {snapshot && (
+        <AgentConnectionFeedback
+          status={session.status}
+          error={session.error}
+          retry={session.reconnect}
+        />
+      )}
       {snapshot?.readOnly && (
         <View style={{ padding: 12 }}>
           <AgentText muted>{snapshot.readOnly.reason}</AgentText>

--- a/apps/mobile/src/components/agents/AgentConnectionFeedback.tsx
+++ b/apps/mobile/src/components/agents/AgentConnectionFeedback.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { View } from "react-native";
+import type { StreamStatus } from "@/lib/agents/stream";
+import { AgentButton, AgentFeedback, AgentText } from "./AgentPrimitives";
+
+/** Keep transport readiness immediate; only delay the visible recovery notice. */
+export function AgentConnectionFeedback({
+  status,
+  error,
+  retry,
+}: {
+  status: StreamStatus;
+  error?: string;
+  retry: () => void;
+}) {
+  if (status === "error") return <AgentFeedback error={error} retry={retry} />;
+  if (status === "connected" || status === "paused") return null;
+  return <ReconnectingFeedback retry={retry} />;
+}
+
+function ReconnectingFeedback({ retry }: { retry: () => void }) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+  return (
+    <View style={{ padding: 16, gap: 8 }}>
+      <AgentText muted>Reconnecting to your agent…</AgentText>
+      <AgentButton label="Retry" onPress={retry} />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/agents/AgentWorkflow.test.tsx
+++ b/apps/mobile/src/components/agents/AgentWorkflow.test.tsx
@@ -9,6 +9,7 @@ import { snapshot } from "@/lib/agents/test-fixtures";
 const mocks = vi.hoisted(() => ({
   snapshot: undefined as ReturnType<typeof snapshot> | undefined,
   status: "connected",
+  sessionError: undefined as string | undefined,
   send: vi.fn(),
   reconnect: vi.fn(),
   replace: vi.fn(),
@@ -317,6 +318,7 @@ vi.mock("@/lib/queries/agents", () => ({
   useAgentSession: () => ({
     snapshot: mocks.snapshot,
     status: mocks.status,
+    error: mocks.sessionError,
     reconnect: mocks.reconnect,
   }),
   useAgentCommand: () => ({ mutateAsync: mocks.send, isPending: false }),
@@ -418,6 +420,7 @@ beforeEach(() => {
   };
   mocks.draft = { message: "", images: [] };
   mocks.status = "connected";
+  mocks.sessionError = undefined;
   mocks.send.mockResolvedValue({});
   mocks.catalog = {
     provider: "codex",
@@ -429,6 +432,7 @@ beforeEach(() => {
 });
 afterEach(async () => {
   await act(async () => root.unmount());
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 async function render(element: ReactNode = <AgentSessionScreen />) {
@@ -505,6 +509,70 @@ describe("agent context usage", () => {
 });
 
 describe("native agent screen workflows", () => {
+  it("suppresses brief reconnect notices while disabling sends immediately", async () => {
+    vi.useFakeTimers();
+    mocks.draft.message = "Continue";
+    await render();
+    mocks.status = "reconnecting";
+    await render();
+    const sendButton = () => container.querySelector(
+      'button[aria-label="Send message"]',
+    ) as HTMLButtonElement;
+    expect(sendButton().disabled).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(container.textContent).not.toContain("Reconnecting to your agent");
+    mocks.status = "connected";
+    await render();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(container.textContent).not.toContain("Reconnecting to your agent");
+    expect(sendButton().disabled).toBe(false);
+  });
+
+  it("shows sustained recovery, keeps its deadline across retries, and clears it on pause", async () => {
+    vi.useFakeTimers();
+    mocks.status = "reconnecting";
+    await render();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    mocks.sessionError = "Network lost";
+    await render();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(container.textContent).not.toContain("Reconnecting to your agent");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(container.textContent).toContain("Reconnecting to your agent");
+    await click("Retry");
+    expect(mocks.reconnect).toHaveBeenCalledTimes(1);
+    mocks.status = "paused";
+    await render();
+    expect(container.textContent).not.toContain("Reconnecting to your agent");
+    mocks.status = "reconnecting";
+    await render();
+    expect(container.textContent).not.toContain("Reconnecting to your agent");
+  });
+
+  it("shows terminal connection errors immediately and cancels a pending recovery notice", async () => {
+    vi.useFakeTimers();
+    mocks.status = "reconnecting";
+    await render();
+    mocks.status = "error";
+    mocks.sessionError = "Your session expired. Sign in again.";
+    await render();
+    expect(container.textContent).toContain(mocks.sessionError);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(container.textContent).not.toContain("Reconnecting to your agent");
+  });
+
   it("renders a resumed transcript, sends a prompt, and clears only acknowledged drafts", async () => {
     mocks.snapshot!.messages = [
       { role: "user", content: "Earlier request" },

--- a/apps/mobile/src/lib/queries/agents.test.tsx
+++ b/apps/mobile/src/lib/queries/agents.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { parseHTML } from "linkedom";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { AgentSessionStream } from "@/lib/agents/stream";
+import type { NetworkState } from "expo-network";
 import { snapshot } from "@/lib/agents/test-fixtures";
 import { queryKeys } from "./keys";
 import { useAgentSession, useAgentConnections } from "./agents";
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   stop: vi.fn(),
   reconnect: vi.fn(),
   fetch: vi.fn(),
+  networkListener: undefined as ((state: NetworkState) => void) | undefined,
 }));
 vi.mock("react-native", () => ({
   AppState: {
@@ -27,7 +29,14 @@ vi.mock("react-native", () => ({
 }));
 vi.mock("expo-router/react-navigation", () => ({ useIsFocused: () => true }));
 vi.mock("expo-network", () => ({
-  addNetworkStateListener: () => ({ remove: vi.fn() }),
+  addNetworkStateListener: (listener: (state: NetworkState) => void) => {
+    mocks.networkListener = listener;
+    return {
+      remove: () => {
+        mocks.networkListener = undefined;
+      },
+    };
+  },
 }));
 vi.mock("@/lib/api", () => ({ getApiBase: () => "https://chat.example" }));
 vi.mock("@/lib/agents/api", () => ({
@@ -129,6 +138,50 @@ it("renders an existing replica while backgrounded without fetching or opening a
   expect(mocks.start).not.toHaveBeenCalled();
   expect(mocks.fetch).not.toHaveBeenCalled();
   expect(consoleError).not.toHaveBeenCalled();
+});
+
+it("keeps the subscription through initial and repeated online network notifications", async () => {
+  await mount();
+  const online = {
+    type: "WIFI",
+    isConnected: true,
+    isInternetReachable: true,
+  } as NetworkState;
+  await act(async () => {
+    for (let i = 0; i < 5; i++) mocks.networkListener!(online);
+    mocks.networkListener!({ ...online, isInternetReachable: undefined });
+    mocks.networkListener!({});
+    mocks.networkListener!(online);
+  });
+  expect(mocks.start).toHaveBeenCalledTimes(1);
+  expect(mocks.reconnect).not.toHaveBeenCalled();
+});
+
+it("reconnects once when the network returns or switches transport", async () => {
+  await mount();
+  const online = {
+    type: "WIFI",
+    isConnected: true,
+    isInternetReachable: true,
+  } as NetworkState;
+  await act(async () => {
+    mocks.networkListener!({ isConnected: false, isInternetReachable: false });
+    mocks.networkListener!({});
+    mocks.networkListener!(online);
+    mocks.networkListener!(online);
+  });
+  expect(mocks.reconnect).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    mocks.networkListener!({ ...online, type: "CELLULAR" } as NetworkState);
+    mocks.networkListener!({ ...online, type: "CELLULAR" } as NetworkState);
+  });
+  expect(mocks.reconnect).toHaveBeenCalledTimes(2);
+  await act(async () => {
+    mocks.networkListener!({ ...online, isInternetReachable: false });
+    mocks.networkListener!(online);
+    mocks.networkListener!(online);
+  });
+  expect(mocks.reconnect).toHaveBeenCalledTimes(3);
 });
 
 it("shows pull-to-refresh progress only for an explicit refresh", async () => {

--- a/apps/mobile/src/lib/queries/agents.ts
+++ b/apps/mobile/src/lib/queries/agents.ts
@@ -106,9 +106,25 @@ export function useAgentSession(id: string) {
     });
     stream.current = client;
     client.start();
+    let previousNetwork:
+      | { available: boolean; type?: Network.NetworkStateType }
+      | undefined;
     const listener = Network.addNetworkStateListener((state) => {
-      if (state.isConnected && state.isInternetReachable !== false)
-        client.reconnect();
+      // Native capability/path updates can repeatedly report the same online
+      // network. They are not evidence that our live SSE connection was lost.
+      if (state.isConnected === undefined) return;
+      const available = state.isConnected && state.isInternetReachable !== false;
+      const type =
+        state.type && state.type !== "UNKNOWN" && state.type !== "NONE"
+          ? state.type
+          : previousNetwork?.type;
+      const changed =
+        previousNetwork &&
+        available &&
+        (!previousNetwork.available ||
+          (type && previousNetwork.type && type !== previousNetwork.type));
+      previousNetwork = { available, type };
+      if (changed) client.reconnect();
     });
     return () => {
       listener.remove();


### PR DESCRIPTION
Repeated online network notifications caused the mobile app to abort a healthy agent event stream and reconnect, briefly flashing a red error banner. Track network availability and transport changes so initial and duplicate online notifications leave the stream running, while restored connectivity and transport switches still trigger reconciliation.

Show a neutral reconnect notice only after recovery lasts one second. Terminal errors remain immediate, and commands remain disabled during recovery. Add regression coverage for duplicate notifications, network restoration and switches, brief and sustained reconnects, and terminal errors.

Validation:
- Mobile TypeScript check passed.
- All 104 mobile tests passed.
- Android and iOS Expo bundle exports passed.
- Real-device streaming and network-transition verification remains pending.
