### PR TITLE
chore(release): web 0.21.4, mobile 1.7.0

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "overtchat",
     "slug": "overtchat",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "orientation": "portrait",
     "scheme": "overtchat",
     "userInterfaceStyle": "automatic",
@@ -10,11 +10,11 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.overtchat.mobile",
-      "buildNumber": "15"
+      "buildNumber": "16"
     },
     "android": {
       "package": "com.overtchat.mobile",
-      "versionCode": 15,
+      "versionCode": 16,
       "predictiveBackGestureEnabled": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@overtchat/mobile",
   "main": "expo-router/entry",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "expo start --host=lan",

--- a/apps/site/public/install-manifest.json
+++ b/apps/site/public/install-manifest.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "cliVersion": "0.1.13",
-  "appVersion": "0.21.3",
+  "appVersion": "0.21.4",
   "voiceVersion": "0.1.1",
   "connectorVersion": "0.11.2",
   "sttVersion": "0.1.1",

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.21.3}
+    image: ghcr.io/yoloyash/overtchat-app:${APP_VERSION:-0.21.4}
     build: .
     container_name: overtchat-app
     restart: unless-stopped


### PR DESCRIPTION
Combined release for the stack accumulated since 0.21.3/1.6.0.

- App 0.21.3 -> 0.21.4: chat file library (#275), push notification backend + `push_devices` migration 0016 (#282), settings/theme and activity polish (#280, #273), model catalog refreshes, security patches (Next 16.3.4, hono, babel, sharp, js-yaml).
- Mobile 1.6.0 -> 1.7.0 (versionCode/buildNumber 15 -> 16): response notifications + first-login opt-in (#282), agent reconnect/banner-flicker fix (#283).
- No connector/CLI/voice/STT/image-digest changes: only devDependency bumps landed in those paths since their last tags.

Tags to cut after merge: `v0.21.4` and `mobile-v1.7.0`.