### PR TITLE
ci(mobile): install push config before the release gate

### DIFF
--- a/.github/workflows/mobile-eas.yml
+++ b/.github/workflows/mobile-eas.yml
@@ -57,6 +57,19 @@ jobs:
             echo "expected_tag=$EXPECTED_TAG"
           } >> "$GITHUB_OUTPUT"
 
+      # The gate below evaluates the Expo config, so gitignored mobile secret
+      # material must be installed before any config evaluation.
+      - name: Install local Android credentials
+        run: |
+          CREDENTIALS_DIR="${OVERTCHAT_MOBILE_CREDENTIALS_DIR:-$HOME/.overtchat/mobile-credentials}"
+          if [[ ! -f apps/mobile/credentials.json ]]; then
+            cp "$CREDENTIALS_DIR/credentials.json" apps/mobile/credentials.json
+            cp -R "$CREDENTIALS_DIR/credentials" apps/mobile/credentials
+          fi
+          if [[ ! -f apps/mobile/google-services.json ]]; then
+            cp "$CREDENTIALS_DIR/google-services.json" apps/mobile/google-services.json
+          fi
+
       # A secret-visibility DSN is unreadable here and ships crash reporting
       # silently disabled, which is how 1.2.3 went out.
       - name: Check crash reporting and push configuration
@@ -78,16 +91,6 @@ jobs:
             echo "Crash reporting is configured."
             node ../../.github/scripts/check-mobile-push.mjs
           '
-
-      - name: Install local Android credentials
-        run: |
-          if [[ -f apps/mobile/credentials.json ]]; then
-            exit 0
-          fi
-
-          CREDENTIALS_DIR="${OVERTCHAT_MOBILE_CREDENTIALS_DIR:-$HOME/.overtchat/mobile-credentials}"
-          cp "$CREDENTIALS_DIR/credentials.json" apps/mobile/credentials.json
-          cp -R "$CREDENTIALS_DIR/credentials" apps/mobile/credentials
 
       - name: Build AAB locally
         working-directory: apps/mobile

--- a/docs/release.md
+++ b/docs/release.md
@@ -64,11 +64,13 @@ Do not change unrelated manifest fields.
 automatic increments disabled unless this release model is deliberately
 replaced.
 
-Android signing files are local and gitignored at
-`apps/mobile/credentials.json` and
-`apps/mobile/credentials/android/keystore.jks`. A self-hosted runner may supply
-them from `$HOME/.overtchat/mobile-credentials`. Retrieve a missing local copy
-through EAS credentials rather than committing it.
+Android signing files and the Android Firebase push configuration are local and
+gitignored at `apps/mobile/credentials.json`,
+`apps/mobile/credentials/android/keystore.jks`, and
+`apps/mobile/google-services.json`. A self-hosted runner supplies them from
+`$HOME/.overtchat/mobile-credentials`, including `google-services.json`, because
+the release workflow installs and evaluates them before the build. Retrieve a
+missing local copy through EAS credentials rather than committing it.
 
 `.github/workflows/mobile-eas.yml` owns the Android release pipeline:
 


### PR DESCRIPTION
The mobile-v1.7.0 run failed the push-config gate: the gate evaluates the Expo config before any credentials install, and `eas env:exec` does not expose EAS file env vars (platform limitation, eas-cli 20/24).

- Move the credentials install step ahead of the crash-reporting/push gate and make it per-file guarded.
- Also install the gitignored `google-services.json` from the runner credentials dir so the gate and `eas build --local` resolve it from the repo-relative path.
- Update the mobile release runbook.

Unblocks re-running the `mobile-v1.7.0` tag.