### PR TITLE
feat(cli): simplify access setup and update preferences

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
+# Optional reference for manual source Compose and development setups.
+# Installed with the guided installer? Run overtchat setup instead; it manages
+# addresses, listening interfaces, update notifications, and generated secrets.
+# You do not need to copy or edit this file for a managed installation.
+# See docs/deploy.md for manual Compose and docs/development.md for development.
+
+# Source Compose: set this to the address you open in your browser.
 BETTER_AUTH_URL=http://localhost:4718
 APP_PORT=4718
+# 0.0.0.0 accepts network connections; 127.0.0.1 restricts access to this host.
+APP_BIND_ADDRESS=0.0.0.0
+# Other browser addresses, comma-separated (include scheme and port).
 EXTRA_TRUSTED_ORIGINS=
 
 # Prevent the admin account menu from checking overtchat.com for new releases.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ On an **x86-64 or arm64 Linux** server:
 curl -fsSL https://overtchat.com/install | sh
 ```
 
-The guided installer handles Docker, configuration, and secrets. Choose the
-local search and speech services you want, open the printed URL, and create
+The guided installer handles Docker, configuration, and secrets; no `.env`
+editing is needed. Choose where to access OvertChat and the local search and
+speech services you want, open the printed URL, and create
 your account. The first signup becomes the administrator. Add your model
 endpoint in the app; OvertChat connects to inference servers you already run.
 With a local model and the bundled speech and search services, **no provider

--- a/apps/cli/src/access-prompts.test.ts
+++ b/apps/cli/src/access-prompts.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { promptAccess } from "./access-prompts.js";
+import { checkServeRoute, detectTailscale } from "./tailscale.js";
+import { note, select, text } from "@clack/prompts";
+import type { InstallationConfig } from "./types.js";
+
+const answers = vi.hoisted(() => new Map<string, unknown[]>());
+vi.mock("@clack/prompts", () => {
+  const answer = vi.fn(
+    async (prompt: { message: string; initialValue?: unknown }) =>
+      answers.get(prompt.message)?.shift() ?? prompt.initialValue,
+  );
+  return {
+    cancel: vi.fn(),
+    isCancel: () => false,
+    note: vi.fn(),
+    select: answer,
+    text: answer,
+    confirm: answer,
+  };
+});
+vi.mock("./network.js", () => ({ primaryLanAddress: () => "192.168.1.20" }));
+vi.mock("./tailscale.js", () => ({
+  checkServeRoute: vi.fn(),
+  detectTailscale: vi.fn(),
+}));
+const config = {
+  appPort: 4718,
+  publicUrl: "http://192.168.1.20:4718",
+  bindAddress: "0.0.0.0",
+  connectorServerUrl: "http://127.0.0.1:4718",
+  extraTrustedOrigins: [],
+  composeProject: "overtchat",
+} as unknown as InstallationConfig;
+function answer(message: string, ...values: unknown[]) {
+  answers.set(message, values);
+}
+beforeEach(() => {
+  answers.clear();
+  vi.clearAllMocks();
+  vi.mocked(checkServeRoute).mockResolvedValue();
+});
+
+describe("access wizard", () => {
+  it("restricts local access and removes addresses from the previous mode", async () => {
+    answer("Where do you want to access OvertChat?", "local");
+    const selected = await promptAccess({
+      ...config,
+      extraTrustedOrigins: ["https://old.example.com"],
+    });
+    expect(selected).toMatchObject({
+      bindAddress: "127.0.0.1",
+      publicUrl: "http://localhost:4718",
+      extraTrustedOrigins: [],
+      access: { mode: "local" },
+    });
+  });
+  it("detects a LAN address for a new installation and updates the port consistently", async () => {
+    answer("Where do you want to access OvertChat?", "lan");
+    answer("Customize the port or additional addresses?", true);
+    answer("OvertChat port", "4999");
+    answer(
+      "Additional addresses (comma-separated, optional)",
+      "http://my-server:4999",
+    );
+    const selected = await promptAccess({
+      ...config,
+      publicUrl: "http://localhost:4718",
+    });
+    expect(selected).toMatchObject({
+      bindAddress: "0.0.0.0",
+      appPort: 4999,
+      publicUrl: "http://192.168.1.20:4999",
+      connectorServerUrl: "http://127.0.0.1:4999",
+      extraTrustedOrigins: ["http://my-server:4999"],
+    });
+  });
+  it("preselects saved access choices and preserves additional addresses", async () => {
+    const selected = await promptAccess({
+      ...config,
+      extraTrustedOrigins: ["http://my-server:4718"],
+      access: { mode: "lan" },
+    });
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Where do you want to access OvertChat?",
+        initialValue: "lan",
+      }),
+    );
+    expect(selected.extraTrustedOrigins).toEqual(["http://my-server:4718"]);
+  });
+  it("lets users return to other options when Tailscale is missing", async () => {
+    answer("Where do you want to access OvertChat?", "tailscale", "local");
+    answer("Continue Tailscale setup?", false);
+    vi.mocked(detectTailscale).mockResolvedValue({
+      problem: "Tailscale not found.",
+    });
+    expect((await promptAccess(config)).access?.mode).toBe("local");
+    expect(note).toHaveBeenCalledWith(
+      "Tailscale not found.",
+      "Tailscale setup",
+    );
+    expect(checkServeRoute).not.toHaveBeenCalled();
+  });
+  it("retries sign-in and chooses another port when another app uses Serve", async () => {
+    answer("Where do you want to access OvertChat?", "tailscale");
+    answer("Continue Tailscale setup?", true);
+    answer("Continue with Tailscale Serve?", "port");
+    vi.mocked(detectTailscale)
+      .mockResolvedValueOnce({ problem: "Sign in first." })
+      .mockResolvedValueOnce({ hostname: "server.example.ts.net" });
+    vi.mocked(checkServeRoute)
+      .mockRejectedValueOnce(new Error("Port in use."))
+      .mockResolvedValueOnce();
+    const selected = await promptAccess(config);
+    expect(selected).toMatchObject({
+      bindAddress: "127.0.0.1",
+      publicUrl: "https://server.example.ts.net:8443",
+      access: {
+        mode: "tailscale",
+        connectionStatus: "pending",
+        tailscaleRoute: {
+          hostname: "server.example.ts.net",
+          port: 8443,
+          target: "http://127.0.0.1:4718",
+        },
+      },
+    });
+    expect(detectTailscale).toHaveBeenCalledTimes(2);
+  });
+  it.each([
+    ["host", "127.0.0.1", "http://127.0.0.1:4718"],
+    ["docker", "127.0.0.1", "http://app:4717"],
+    ["remote", "0.0.0.0", "LAN IP"],
+  ])(
+    "configures Cloudflare running in %s",
+    async (location, binding, target) => {
+      answer("Where do you want to access OvertChat?", "advanced");
+      answer("What address will you use?", "https://chat.example.com/");
+      answer("Where does your tunnel or proxy run?", location);
+      const selected = await promptAccess(config);
+      expect(selected).toMatchObject({
+        bindAddress: binding,
+        publicUrl: "https://chat.example.com",
+        access: {
+          mode: "advanced",
+          proxy: "cloudflare",
+          proxyLocation: location,
+          connectionStatus: "pending",
+        },
+      });
+      expect(note).toHaveBeenCalledWith(
+        expect.stringContaining(target),
+        "Connect your address",
+      );
+      expect(text).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "What address will you use?",
+          validate: expect.any(Function),
+        }),
+      );
+    },
+  );
+});

--- a/apps/cli/src/access-prompts.ts
+++ b/apps/cli/src/access-prompts.ts
@@ -1,0 +1,281 @@
+import { cancel, confirm, isCancel, note, select, text } from "@clack/prompts";
+import {
+  accessMode,
+  additionalAddressValidation,
+  addressValidation,
+  connectionInstructions,
+  lanHostValidation,
+  portValidation,
+} from "./access.js";
+import { primaryLanAddress } from "./network.js";
+import { checkServeRoute, detectTailscale } from "./tailscale.js";
+import type { AccessConfig, AccessMode, InstallationConfig } from "./types.js";
+
+function chosen<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel("Setup cancelled.");
+    process.exit(130);
+  }
+  return value;
+}
+
+async function retry(message: string): Promise<boolean> {
+  note(message, "Tailscale setup");
+  return chosen(
+    await select({
+      message: "Continue Tailscale setup?",
+      options: [
+        { value: true, label: "Retry" },
+        { value: false, label: "Choose another access option" },
+      ],
+    }),
+  );
+}
+
+export async function promptAccess(
+  initial: InstallationConfig,
+): Promise<InstallationConfig> {
+  const currentMode = accessMode(initial);
+  for (;;) {
+    const mode = chosen(
+      await select<AccessMode>({
+        message: "Where do you want to access OvertChat?",
+        initialValue: currentMode,
+        options: [
+          {
+            value: "local",
+            label: "Only on this computer",
+            hint: "keep access local",
+          },
+          {
+            value: "lan",
+            label: "On my home network",
+            hint: "phones and computers on the same network",
+          },
+          {
+            value: "tailscale",
+            label: "From anywhere with Tailscale",
+            hint: "private access from devices on your Tailscale network",
+          },
+          {
+            value: "advanced",
+            label: "Advanced setup",
+            hint: "use your own domain or reverse proxy",
+          },
+        ],
+      }),
+    );
+    let hostname: string | undefined;
+    if (mode === "tailscale") {
+      for (;;) {
+        const detected = await detectTailscale().catch(() => ({
+          problem:
+            "Could not contact Tailscale. Check that its service is running, then retry.",
+        }));
+        if ("hostname" in detected && detected.hostname) {
+          hostname = detected.hostname;
+          break;
+        }
+        if (!(await retry(detected.problem ?? "Tailscale is not ready.")))
+          break;
+      }
+      if (!hostname) continue;
+    }
+    const access: AccessConfig = { mode };
+    let appPort = initial.appPort;
+    let publicUrl = `http://localhost:${appPort}`;
+    let bindAddress = mode === "lan" ? "0.0.0.0" : "127.0.0.1";
+    // Previously generated aliases are recreated for the selected address/port.
+    let extraTrustedOrigins =
+      mode === currentMode
+        ? initial.extraTrustedOrigins.filter(
+            (url) =>
+              ![
+                initial.publicUrl,
+                `http://localhost:${initial.appPort}`,
+                `http://127.0.0.1:${initial.appPort}`,
+              ].includes(url),
+          )
+        : [];
+    if (mode === "advanced") {
+      publicUrl = new URL(
+        chosen(
+          await text({
+            message: "What address will you use?",
+            placeholder: "https://chat.example.com",
+            initialValue:
+              currentMode === "advanced" ? initial.publicUrl : undefined,
+            validate: (value) => addressValidation(value, true),
+          }),
+        ).trim(),
+      ).origin;
+      access.proxy = chosen(
+        await select({
+          message: "How will you connect it?",
+          initialValue: initial.access?.proxy ?? "cloudflare",
+          options: [
+            { value: "cloudflare", label: "Cloudflare Tunnel" },
+            { value: "other", label: "Another reverse proxy" },
+          ],
+        }),
+      );
+      access.proxyLocation = chosen(
+        await select({
+          message: "Where does your tunnel or proxy run?",
+          initialValue:
+            initial.access?.proxyLocation ??
+            (initial.bindAddress === "0.0.0.0" && currentMode === "advanced"
+              ? "remote"
+              : "host"),
+          options: [
+            { value: "host", label: "Directly on this computer" },
+            {
+              value: "docker",
+              label: "In Docker on this computer",
+              hint: "connect it to OvertChat's Docker network",
+            },
+            {
+              value: "remote",
+              label: "On another computer",
+              hint: "allow connections to OvertChat over the network",
+            },
+          ],
+        }),
+      );
+      if (access.proxyLocation === "remote") bindAddress = "0.0.0.0";
+      access.connectionStatus = "pending";
+    }
+    const customize = chosen(
+      await confirm({
+        message: "Customize the port or additional addresses?",
+        initialValue: false,
+      }),
+    );
+    if (customize) {
+      appPort = Number(
+        chosen(
+          await text({
+            message: "OvertChat port",
+            initialValue: String(appPort),
+            validate: portValidation,
+          }),
+        ),
+      );
+    }
+    if (mode === "local") {
+      publicUrl = `http://localhost:${appPort}`;
+      extraTrustedOrigins = [];
+    }
+    if (mode === "lan") {
+      const currentHost = new URL(initial.publicUrl).hostname;
+      const detected =
+        initial.access?.lanAddress ??
+        primaryLanAddress() ??
+        (currentMode === "lan" && !lanHostValidation(currentHost)
+          ? currentHost
+          : null);
+      const host =
+        detected && !customize
+          ? detected
+          : chosen(
+              await text({
+                message: "This server's LAN address",
+                initialValue: detected ?? undefined,
+                placeholder: "192.168.1.20",
+                validate: lanHostValidation,
+              }),
+            ).trim();
+      if (customize || initial.access?.lanAddress || !detected)
+        access.lanAddress = host;
+      publicUrl = `http://${host}:${appPort}`;
+      note(
+        `Other devices on your network can use ${publicUrl}.\nThe app accepts network connections, subject to your firewall. Browser microphone access on other devices requires HTTPS; Tailscale provides an HTTPS option.`,
+        "Home network access",
+      );
+    }
+    if (mode === "tailscale") {
+      let httpsPort = initial.access?.tailscaleRoute?.port ?? 443;
+      let back = false;
+      for (;;) {
+        const route = {
+          hostname: hostname!,
+          port: httpsPort,
+          target: `http://127.0.0.1:${appPort}`,
+        };
+        try {
+          await checkServeRoute(route, initial.managedTailscaleRoute);
+          access.tailscaleRoute = route;
+          break;
+        } catch (error) {
+          note(
+            error instanceof Error ? error.message : String(error),
+            "Tailscale Serve",
+          );
+          const action = chosen(
+            await select({
+              message: "Continue with Tailscale Serve?",
+              options: [
+                { value: "port", label: "Use another HTTPS port" },
+                { value: "retry", label: "Retry" },
+                { value: "back", label: "Choose another access option" },
+              ],
+            }),
+          );
+          if (action === "back") {
+            back = true;
+            break;
+          }
+          if (action === "port")
+            httpsPort = Number(
+              chosen(
+                await text({
+                  message: "Tailscale HTTPS port",
+                  initialValue: "8443",
+                  validate: portValidation,
+                }),
+              ),
+            );
+        }
+      }
+      if (back) continue;
+      publicUrl = `https://${hostname}${httpsPort === 443 ? "" : `:${httpsPort}`}`;
+      access.connectionStatus = "pending";
+      note(
+        `OvertChat will configure private HTTPS access at ${publicUrl}.\nTailscale must allow this user to manage Serve. If needed, run sudo tailscale set --operator=<your-linux-username>.`,
+        "Tailscale access",
+      );
+    }
+    if (
+      mode !== "local" &&
+      (customize ||
+        additionalAddressValidation(extraTrustedOrigins.join(","), publicUrl))
+    ) {
+      extraTrustedOrigins = chosen(
+        await text({
+          message: "Additional addresses (comma-separated, optional)",
+          initialValue: extraTrustedOrigins.join(", "),
+          validate: (value) => additionalAddressValidation(value, publicUrl),
+        }),
+      )
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map((value) => new URL(value).origin);
+    }
+    const config: InstallationConfig = {
+      ...initial,
+      access,
+      appPort,
+      bindAddress,
+      publicUrl,
+      extraTrustedOrigins,
+      connectorServerUrl:
+        initial.appPort === appPort
+          ? initial.connectorServerUrl
+          : `http://127.0.0.1:${appPort}`,
+    };
+    if (mode === "advanced")
+      note(connectionInstructions(config), "Connect your address");
+    return config;
+  }
+}

--- a/apps/cli/src/access.test.ts
+++ b/apps/cli/src/access.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import {
+  accessMode,
+  accessSummary,
+  additionalAddressValidation,
+  addressValidation,
+  connectionInstructions,
+  portValidation,
+} from "./access.js";
+import type { InstallationConfig } from "./types.js";
+
+const config = {
+  appPort: 4718,
+  publicUrl: "http://192.168.1.20:4718",
+  bindAddress: "0.0.0.0",
+  composeProject: "overtchat",
+} as InstallationConfig;
+
+describe("access configuration", () => {
+  it("infers existing installations without requiring a state migration", () => {
+    expect(accessMode(config)).toBe("lan");
+    expect(
+      accessMode({
+        ...config,
+        bindAddress: "127.0.0.1",
+        publicUrl: "http://localhost:4718",
+      }),
+    ).toBe("local");
+    expect(
+      accessMode({ ...config, publicUrl: "https://chat.example.com" }),
+    ).toBe("advanced");
+    expect(accessMode({ ...config, access: { mode: "tailscale" } })).toBe(
+      "tailscale",
+    );
+  });
+  it.each([
+    "https://user:pass@example.com",
+    "https://example.com/chat",
+    "https://example.com?q=1",
+    "https://example.com#chat",
+    "ftp://example.com",
+    "http://0.0.0.0:4718",
+  ])("rejects an unusable browser address %s", (value) => {
+    expect(addressValidation(value)).toBeTruthy();
+  });
+  it("validates HTTPS and additional addresses without opening arbitrary origins", () => {
+    expect(addressValidation("https://chat.example.com/")).toBeUndefined();
+    expect(addressValidation("http://chat.example.com", true)).toBeTruthy();
+    expect(
+      additionalAddressValidation(
+        "http://192.168.1.20:4718",
+        "https://chat.example.com",
+      ),
+    ).toBeTruthy();
+    expect(
+      additionalAddressValidation(
+        "https://other.example.com",
+        "https://chat.example.com",
+      ),
+    ).toBeUndefined();
+  });
+  it.each(["0", "65536", "1.5", "-1", "4718x", ""])(
+    "rejects invalid port %s",
+    (value) => expect(portValidation(value)).toBeTruthy(),
+  );
+  it("describes the correct proxy destination for each placement", () => {
+    const advanced = {
+      ...config,
+      publicUrl: "https://chat.example.com",
+      access: { mode: "advanced", proxy: "cloudflare" },
+    } as InstallationConfig;
+    expect(
+      connectionInstructions({
+        ...advanced,
+        access: { ...advanced.access!, proxyLocation: "host" },
+      }),
+    ).toContain("Service: http://127.0.0.1:4718");
+    const docker = connectionInstructions({
+      ...advanced,
+      access: { ...advanced.access!, proxyLocation: "docker" },
+    });
+    expect(docker).toContain("Service: http://app:4717");
+    expect(docker).toContain("overtchat_default");
+    expect(
+      connectionInstructions({
+        ...advanced,
+        access: { ...advanced.access!, proxyLocation: "remote" },
+      }),
+    ).toContain("http://<this server's LAN IP>:4718");
+    expect(
+      connectionInstructions({
+        ...advanced,
+        access: { ...advanced.access!, proxy: "other" },
+      }),
+    ).toContain("WebSocket upgrades");
+  });
+  it("does not advertise a pending public address as ready", () => {
+    expect(
+      accessSummary({
+        ...config,
+        access: { mode: "advanced", connectionStatus: "pending" },
+      }),
+    ).toContain("Connection pending:");
+    expect(accessSummary(config)).toContain(
+      "This computer: http://localhost:4718",
+    );
+  });
+  it("passes source Compose address settings into the published port and auth environment", async () => {
+    const compose = await readFile(
+      new URL("../../../compose.yml", import.meta.url),
+      "utf8",
+    );
+    expect(compose).toContain(
+      "${APP_BIND_ADDRESS:-0.0.0.0}:${APP_PORT:-4718}:4717",
+    );
+    expect(compose).toContain(
+      "EXTRA_TRUSTED_ORIGINS: ${EXTRA_TRUSTED_ORIGINS:-}",
+    );
+  });
+});

--- a/apps/cli/src/access.ts
+++ b/apps/cli/src/access.ts
@@ -1,0 +1,128 @@
+import { isIP } from "node:net";
+import type { AccessMode, InstallationConfig } from "./types.js";
+
+export function accessMode(config: InstallationConfig): AccessMode {
+  if (config.access) return config.access.mode;
+  const url = new URL(config.publicUrl);
+  if (url.protocol === "https:") return "advanced";
+  if (["127.0.0.1", "::1"].includes(config.bindAddress)) return "local";
+  return "lan";
+}
+
+export function addressValidation(
+  value: string | undefined,
+  httpsOnly = false,
+): string | undefined {
+  try {
+    const url = new URL(value?.trim() ?? "");
+    if (
+      httpsOnly
+        ? url.protocol !== "https:"
+        : !["http:", "https:"].includes(url.protocol)
+    ) {
+      return httpsOnly
+        ? "Use an https:// address."
+        : "Use an http:// or https:// address.";
+    }
+    if (
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      url.pathname !== "/"
+    ) {
+      return "Enter only the address, without a path, credentials, query, or fragment.";
+    }
+    if (["0.0.0.0", "[::]"].includes(url.hostname))
+      return "Enter a reachable hostname or IP address.";
+    if (url.hostname.includes("*"))
+      return "Enter a specific hostname, without wildcards.";
+  } catch {
+    return "Enter a valid address, such as https://chat.example.com.";
+  }
+}
+
+export function portValidation(value: string | undefined): string | undefined {
+  if (
+    !/^\d+$/u.test(value ?? "") ||
+    Number(value) < 1 ||
+    Number(value) > 65535
+  ) {
+    return "Enter a port between 1 and 65535.";
+  }
+}
+
+export function lanHostValidation(
+  value: string | undefined,
+): string | undefined {
+  if (
+    !value ||
+    isIP(value) !== 4 ||
+    value.startsWith("127.") ||
+    value === "0.0.0.0"
+  ) {
+    return "Enter this server's LAN IPv4 address.";
+  }
+}
+
+export function additionalAddressValidation(
+  value: string | undefined,
+  publicUrl: string,
+): string | undefined {
+  for (const address of (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)) {
+    const error = addressValidation(address, publicUrl.startsWith("https:"));
+    if (error) return error;
+  }
+}
+
+export function connectionInstructions(config: InstallationConfig): string {
+  const access = config.access;
+  if (access?.mode === "tailscale") {
+    return "Connect your phone or computer to Tailscale, then open the address below and sign in to OvertChat.";
+  }
+  if (access?.mode !== "advanced") return "";
+  const location = access.proxyLocation ?? "host";
+  const target =
+    location === "host"
+      ? `http://127.0.0.1:${config.appPort}`
+      : location === "docker"
+        ? "http://app:4717"
+        : `http://<this server's LAN IP>:${config.appPort}`;
+  const lines =
+    access.proxy === "cloudflare"
+      ? [
+          "In your Cloudflare Tunnel, add a published application:",
+          `Hostname: ${new URL(config.publicUrl).hostname}`,
+          `Service: ${target}`,
+          "Cloudflare setup: https://developers.cloudflare.com/tunnel/setup/",
+        ]
+      : [
+          `Forward ${config.publicUrl} to ${target}.`,
+          "Configure HTTPS and support WebSocket upgrades in your reverse proxy.",
+        ];
+  if (location === "docker") {
+    lines.push(
+      `Connect your proxy container to the OvertChat Docker network (${config.composeProject}_default).`,
+      "For an existing container: docker network connect " +
+        `${config.composeProject}_default <proxy-container>`,
+      "Also declare that external network in your proxy's Compose configuration so it survives recreation.",
+      "Inside the proxy container, localhost refers to the proxy itself.",
+    );
+  }
+  if (location === "remote")
+    lines.push(
+      "Use the OvertChat server's LAN IP in place of the placeholder. Its published port accepts network connections; allow the proxy through your firewall.",
+    );
+  return lines.join("\n");
+}
+
+export function accessSummary(config: InstallationConfig): string {
+  const mode = accessMode(config);
+  if (mode === "local") return `This computer: ${config.publicUrl}`;
+  if (mode === "lan")
+    return `This computer: http://localhost:${config.appPort}\nOther devices on your network: ${config.publicUrl}`;
+  return `${config.access?.connectionStatus === "verified" ? "Open" : "Connection pending"}: ${config.publicUrl}`;
+}

--- a/apps/cli/src/compose.test.ts
+++ b/apps/cli/src/compose.test.ts
@@ -58,6 +58,24 @@ function config(): InstallationConfig {
 }
 
 describe("managed Compose configuration", () => {
+  it.each([
+    ["local", "127.0.0.1", "http://localhost:4718"],
+    ["lan", "0.0.0.0", "http://192.168.1.20:4718"],
+    ["tailscale", "127.0.0.1", "https://server.example.ts.net"],
+    ["advanced", "127.0.0.1", "https://chat.example.com"],
+  ] as const)("coordinates binding and accepted login addresses for %s", (mode, bindAddress, publicUrl) => {
+    const selected = { ...config(), access: { mode }, bindAddress, publicUrl };
+    const environment = renderStackEnvironment(selected, {
+      betterAuthSecret: "auth", managementSecret: "management", searxngSecret: "search", voiceSharedSecret: "voice",
+    }, paths);
+    expect(environment).toContain(`APP_BIND_ADDRESS="${bindAddress}"`);
+    expect(environment).toContain(`BETTER_AUTH_URL="${publicUrl}"`);
+    expect(environment).toContain(`EXTRA_TRUSTED_ORIGINS="${publicUrl},`);
+    const compose = renderComposeFile(selected);
+    expect(compose).toContain('"${APP_BIND_ADDRESS}:${APP_PORT}:4717"');
+    expect(compose).toContain('EXTRA_TRUSTED_ORIGINS: ${EXTRA_TRUSTED_ORIGINS:-}');
+  });
+
   it("starts installed local services independently from the active provider", () => {
     const environment = renderStackEnvironment(
       config(),

--- a/apps/cli/src/compose.ts
+++ b/apps/cli/src/compose.ts
@@ -70,6 +70,7 @@ export function renderStackEnvironment(
         : config.kokoroGpuImage,
     ],
     ["APP_PORT", config.appPort],
+    ["OVERTCHAT_INSTANCE_ID", config.instanceId ?? ""],
     ["APP_BIND_ADDRESS", composeBindAddress(config.bindAddress)],
     ["BETTER_AUTH_URL", config.publicUrl],
     ["EXTRA_TRUSTED_ORIGINS", trustedOrigins.join(",")],
@@ -159,6 +160,7 @@ services:
     environment:
       BETTER_AUTH_SECRET: \${BETTER_AUTH_SECRET}
       BETTER_AUTH_URL: \${BETTER_AUTH_URL}
+      OVERTCHAT_INSTANCE_ID: \${OVERTCHAT_INSTANCE_ID:-}
       EXTRA_TRUSTED_ORIGINS: \${EXTRA_TRUSTED_ORIGINS:-}
       HOST_CONNECTOR_URL: \${HOST_CONNECTOR_URL}
       DISABLE_UPDATE_CHECK: \${DISABLE_UPDATE_CHECK:-false}

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -281,4 +281,35 @@ describe("managed installation state", () => {
       await rm(directory, { recursive: true, force: true });
     }
   });
+
+  it("round-trips access choices, aliases, and ownership of a pending Serve route", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "overtchat-access-state-"));
+    try {
+      const paths = pathsFor(directory);
+      const config = defaultInstallationConfig(null, manifest);
+      config.bindAddress = "127.0.0.1";
+      config.publicUrl = "https://server.example.ts.net:8443";
+      config.extraTrustedOrigins = ["https://chat.example.com"];
+      config.access = {
+        mode: "tailscale",
+        connectionStatus: "pending",
+        tailscaleRoute: {
+          hostname: "server.example.ts.net",
+          port: 8443,
+          target: "http://127.0.0.1:4718",
+        },
+      };
+      config.managedTailscaleRoute = config.access.tailscaleRoute;
+      await writeInstallationConfig(paths, config);
+      expect(await readInstallationConfig(paths)).toMatchObject({
+        access: config.access,
+        bindAddress: config.bindAddress,
+        publicUrl: config.publicUrl,
+        extraTrustedOrigins: config.extraTrustedOrigins,
+        managedTailscaleRoute: config.managedTailscaleRoute,
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type {
@@ -53,6 +53,7 @@ export function defaultInstallationConfig(
     : `${APP_IMAGE}:${manifest.appVersion}`;
   return {
     format: 1,
+    instanceId: randomUUID(),
     appVersion,
     appImage,
     voiceVersion: manifest.voiceVersion,
@@ -140,6 +141,7 @@ export async function readInstallationConfig(
     const config = parsed as InstallationConfig;
     const migrated = {
       ...config,
+      instanceId: config.instanceId ?? randomUUID(),
       // State written by the first installer draft only supported volumes.
       dataMountType: config.dataMountType ?? "volume",
       bindAddress: config.bindAddress ?? "0.0.0.0",

--- a/apps/cli/src/connection-check.test.ts
+++ b/apps/cli/src/connection-check.test.ts
@@ -1,0 +1,116 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { finishAccess, verifyConnection } from "./connection-check.js";
+import { startServe } from "./tailscale.js";
+import { select } from "@clack/prompts";
+import type { InstallationConfig } from "./types.js";
+vi.mock("./tailscale.js", () => ({ startServe: vi.fn() }));
+vi.mock("@clack/prompts", () => ({
+  note: vi.fn(),
+  isCancel: () => false,
+  select: vi.fn(),
+}));
+const instanceId = "a2ad863a-c435-48a3-bd73-4f0f16b30c76";
+let server: Server | undefined;
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  if (server) {
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = undefined;
+  }
+});
+beforeEach(() => vi.resetAllMocks());
+async function serve(): Promise<string> {
+  server = createServer((_req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({
+        ok: true,
+        name: "overtchat",
+        instanceId: process.env.OVERTCHAT_INSTANCE_ID,
+      }),
+    );
+  });
+  await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing server address");
+  return `http://127.0.0.1:${address.port}`;
+}
+describe("connection verification", () => {
+  it("verifies a real HTTP ping response and rejects a different instance", async () => {
+    vi.stubEnv("OVERTCHAT_INSTANCE_ID", instanceId);
+    const url = await serve();
+    expect(await verifyConnection(url, instanceId)).toBeNull();
+    expect(await verifyConnection(url, "b".repeat(64))).toContain(
+      "did not identify this",
+    );
+  });
+  it("does not follow gateway redirects or send credentials to the configured address", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: "https://elsewhere.example" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    expect(
+      await verifyConnection("https://chat.example.com", instanceId),
+    ).toContain("HTTP 302");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "manual" });
+    expect(JSON.stringify(fetchMock.mock.calls)).not.toContain(instanceId);
+    expect(fetchMock.mock.calls[0][1]).not.toHaveProperty("headers");
+  });
+  it("rejects older servers and non-OvertChat responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({ ok: true, name: "overtchat" })),
+    );
+    expect(
+      await verifyConnection("https://chat.example.com", instanceId),
+    ).toContain("did not identify");
+  });
+  it("reports network errors as pending", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("DNS failed")));
+    expect(
+      await verifyConnection("https://chat.example.com", instanceId),
+    ).toContain("DNS");
+  });
+});
+describe("finishing setup", () => {
+  it("allows deferring an external tunnel and leaves the installation pending", async () => {
+    vi.mocked(select).mockResolvedValue("later");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const config = {
+      publicUrl: "https://chat.example.com",
+      access: { mode: "advanced" },
+    } as InstallationConfig;
+    await finishAccess(config, true);
+    expect(config.access?.connectionStatus).toBe("pending");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it("retries Serve failures then verifies the actual app", async () => {
+    vi.stubEnv("OVERTCHAT_INSTANCE_ID", instanceId);
+    const url = await serve();
+    const route = {
+      hostname: "server.example.ts.net",
+      port: 443,
+      target: "http://127.0.0.1:4718",
+    };
+    const config = {
+      publicUrl: url,
+      instanceId,
+      access: { mode: "tailscale", tailscaleRoute: route },
+    } as InstallationConfig;
+    vi.mocked(startServe)
+      .mockRejectedValueOnce(new Error("Enable HTTPS"))
+      .mockResolvedValueOnce();
+    vi.mocked(select).mockResolvedValue("retry");
+    await finishAccess(config, true);
+    expect(startServe).toHaveBeenCalledTimes(2);
+    expect(config.access?.connectionStatus).toBe("verified");
+  });
+});

--- a/apps/cli/src/connection-check.ts
+++ b/apps/cli/src/connection-check.ts
@@ -1,0 +1,92 @@
+import { isCancel, note, select } from "@clack/prompts";
+import { startServe } from "./tailscale.js";
+import type { InstallationConfig } from "./types.js";
+
+export async function verifyConnection(
+  publicUrl: string,
+  instanceId: string | undefined,
+): Promise<string | null> {
+  if (!instanceId)
+    return "The installation has no identifier. Run overtchat setup again.";
+  const url = new URL("/api/ping", publicUrl);
+  url.searchParams.set("check", String(Date.now()));
+  try {
+    const response = await fetch(url, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
+      cache: "no-store",
+    });
+    if (!response.ok)
+      return `The address returned HTTP ${response.status}. Check the tunnel/proxy route and any access gateway in front of it.`;
+    const data = (await response.json()) as {
+      name?: string;
+      ok?: boolean;
+      instanceId?: string;
+    };
+    if (
+      data.name !== "overtchat" ||
+      data.ok !== true ||
+      data.instanceId !== instanceId
+    )
+      return "The address did not identify this OvertChat installation. Check that the tunnel/proxy points to this server. Older app versions need an update to support this check.";
+    return null;
+  } catch {
+    return "Could not verify the address. Check DNS, HTTPS, network connectivity, and the tunnel/proxy service address.";
+  }
+}
+
+export async function finishAccess(
+  config: InstallationConfig,
+  interactive: boolean,
+): Promise<void> {
+  if (!config.access || !["advanced", "tailscale"].includes(config.access.mode))
+    return;
+  config.access.connectionStatus = "pending";
+  if (config.access.mode === "advanced" && interactive) {
+    const choice = await select({
+      message: "Check your public address?",
+      options: [
+        { value: "check", label: "Check connection" },
+        { value: "later", label: "Finish with connection pending" },
+      ],
+    });
+    if (isCancel(choice) || choice === "later") return;
+  }
+  for (;;) {
+    let problem: string | null = null;
+    if (config.access.mode === "tailscale" && config.access.tailscaleRoute) {
+      try {
+        await startServe(
+          config.access.tailscaleRoute,
+          config.managedTailscaleRoute,
+        );
+      } catch (error) {
+        problem = error instanceof Error ? error.message : String(error);
+      }
+    }
+    problem ??= await verifyConnection(config.publicUrl, config.instanceId);
+    if (!problem) {
+      config.access.connectionStatus = "verified";
+      note(
+        `Verified ${config.publicUrl} reaches this OvertChat installation.`,
+        "Connection ready",
+      );
+      return;
+    }
+    note(
+      config.access.mode === "tailscale"
+        ? `${problem}\nTailscale may need a minute to issue the first HTTPS certificate. Wait briefly, then retry.`
+        : problem,
+      "Connection pending",
+    );
+    if (!interactive) return;
+    const choice = await select({
+      message: "Check the connection again?",
+      options: [
+        { value: "retry", label: "Retry" },
+        { value: "later", label: "Finish with connection pending" },
+      ],
+    });
+    if (isCancel(choice) || choice === "later") return;
+  }
+}

--- a/apps/cli/src/network.test.ts
+++ b/apps/cli/src/network.test.ts
@@ -1,0 +1,27 @@
+import os from "node:os";
+import { afterEach, expect, it, vi } from "vitest";
+import { primaryLanAddress } from "./network.js";
+const address = (value: string): os.NetworkInterfaceInfo => ({
+  address: value,
+  family: "IPv4",
+  internal: false,
+  netmask: "255.255.255.0",
+  mac: "00:00:00:00:00:00",
+  cidr: `${value}/24`,
+});
+afterEach(() => vi.restoreAllMocks());
+it("ignores Docker and Tailscale interfaces when selecting a home network address", () => {
+  vi.spyOn(os, "networkInterfaces").mockReturnValue({
+    docker0: [address("172.17.0.1")],
+    tailscale0: [address("100.100.1.1")],
+    eth0: [address("192.168.1.20")],
+  });
+  expect(primaryLanAddress()).toBe("192.168.1.20");
+});
+it("does not mislabel a public or Tailscale address as a LAN address", () => {
+  vi.spyOn(os, "networkInterfaces").mockReturnValue({
+    eth0: [address("203.0.113.1")],
+    tailscale0: [address("100.100.1.1")],
+  });
+  expect(primaryLanAddress()).toBeNull();
+});

--- a/apps/cli/src/network.ts
+++ b/apps/cli/src/network.ts
@@ -1,8 +1,9 @@
 import os from "node:os";
 
 export function primaryLanAddress(): string | null {
-  const candidates = Object.values(os.networkInterfaces())
-    .flatMap((addresses) => addresses ?? [])
+  const candidates = Object.entries(os.networkInterfaces())
+    .filter(([name]) => !/^(?:lo$|docker|br-|veth|tailscale|tun\d|tap\d|virbr)/u.test(name))
+    .flatMap(([, addresses]) => addresses ?? [])
     .filter(
       (address) =>
         address.family === "IPv4" &&
@@ -17,5 +18,5 @@ export function primaryLanAddress(): string | null {
       /^172\.(?:1[6-9]|2\d|3[01])\./u.test(value)
     );
   });
-  return privateAddress?.address ?? candidates[0]?.address ?? null;
+  return privateAddress?.address ?? null;
 }

--- a/apps/cli/src/process.ts
+++ b/apps/cli/src/process.ts
@@ -11,6 +11,7 @@ export type RunOptions = {
   environment?: NodeJS.ProcessEnv;
   input?: string;
   inherit?: boolean;
+  timeoutMs?: number;
 };
 
 export async function runCommand(
@@ -23,6 +24,7 @@ export async function runCommand(
       cwd: options.cwd,
       env: options.environment ?? process.env,
       stdio: options.inherit ? ["pipe", "inherit", "inherit"] : "pipe",
+      timeout: options.timeoutMs,
     });
     let stdout = "";
     let stderr = "";

--- a/apps/cli/src/prompts.test.ts
+++ b/apps/cli/src/prompts.test.ts
@@ -20,15 +20,18 @@ const confirmPrompts = vi.hoisted(
       message: string;
       active: string;
       inactive: string;
+      initialValue: boolean;
     }>,
 );
 
 vi.mock("@clack/prompts", () => ({
   cancel: vi.fn(),
   confirm: vi.fn(
-    async (prompt: { message: string; active: string; inactive: string }) => {
+    async (prompt: { message: string; active: string; inactive: string; initialValue: boolean }) => {
       confirmPrompts.push(prompt);
-      return promptAnswers.get(prompt.message);
+      return promptAnswers.has(prompt.message)
+        ? promptAnswers.get(prompt.message)
+        : prompt.initialValue;
     },
   ),
   intro: vi.fn(),
@@ -57,6 +60,8 @@ vi.mock("./process.js", () => ({
 
 beforeEach(() => {
   promptAnswers.clear();
+  promptAnswers.set("Where do you want to access OvertChat?", "local");
+  promptAnswers.set("Customize the port or additional addresses?", false);
   selectPrompts.length = 0;
   confirmPrompts.length = 0;
 });
@@ -173,6 +178,31 @@ describe("existing installation summary", () => {
 });
 
 describe("setup provider selection", () => {
+  it.each([
+    { saved: undefined, answer: true, expectedDefault: true },
+    { saved: false, answer: false, expectedDefault: true },
+    { saved: true, answer: false, expectedDefault: false },
+    { saved: true, answer: true, expectedDefault: false },
+  ])("configures update notifications with saved preference $saved and answer $answer", async ({ saved, answer, expectedDefault }) => {
+    promptAnswers.set("Web search", "disabled");
+    promptAnswers.set("Text-to-speech", "disabled");
+    promptAnswers.set("Speech-to-text", "disabled");
+    promptAnswers.set("Install Agent Connections?", false);
+    promptAnswers.set("Automatically check for updates?", answer);
+
+    const selected = await promptInstallationConfig({
+      ...setupConfig(),
+      disableUpdateCheck: saved,
+    }, []);
+
+    expect(selected.disableUpdateCheck).toBe(!answer);
+    expect(confirmPrompts.find((prompt) => prompt.message === "Automatically check for updates?")).toMatchObject({
+      initialValue: expectedDefault,
+      active: "Yes (recommended)",
+      inactive: "No",
+    });
+  });
+
   it("removes hidden bundled speech services after external providers are selected", async () => {
     const config = setupConfig();
     promptAnswers.set("Web search", "brave");

--- a/apps/cli/src/prompts.ts
+++ b/apps/cli/src/prompts.ts
@@ -9,6 +9,7 @@ import {
   text,
 } from "@clack/prompts";
 import { commandExists } from "./process.js";
+import { promptAccess } from "./access-prompts.js";
 import type {
   ExistingInstallation,
   Gpu,
@@ -420,6 +421,7 @@ export async function promptInstallationConfig(
       process.exit(0);
     }
   }
+  const configured = await promptAccess(initial);
   const search = await promptSearch(initial.search);
   const tts = await promptTts(initial.tts, gpus);
   const stt = await promptStt(initial.stt, gpus);
@@ -458,12 +460,25 @@ export async function promptInstallationConfig(
       inactive: "Set up later",
     }),
   );
+  note(
+    "The app checks overtchat.com for new releases when an administrator opens the account menu. Install updates with overtchat update.",
+    "Update notifications",
+  );
+  const checkForUpdates = chosen(
+    await confirm({
+      message: "Automatically check for updates?",
+      initialValue: !initial.disableUpdateCheck,
+      active: "Yes (recommended)",
+      inactive: "No",
+    }),
+  );
   return {
-    ...initial,
+    ...configured,
     search,
     tts,
     stt,
     voice: { installed: installVoice },
     agents: { installed: installAgents },
+    disableUpdateCheck: !checkForUpdates,
   };
 }

--- a/apps/cli/src/setup-access.test.ts
+++ b/apps/cli/src/setup-access.test.ts
@@ -1,0 +1,258 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setup } from "./setup.js";
+import {
+  defaultInstallationConfig,
+  readInstallationConfig,
+  writeInstallationConfig,
+} from "./config.js";
+import { runtimePaths } from "./paths.js";
+import { parseReleaseManifest } from "./release.js";
+import { promptInstallationConfig } from "./prompts.js";
+import { checkServeRoute, removeServe } from "./tailscale.js";
+import { finishAccess } from "./connection-check.js";
+import { requireDocker } from "./docker.js";
+import type { InstallationConfig } from "./types.js";
+
+vi.mock("@clack/prompts", () => ({
+  confirm: vi.fn(),
+  isCancel: () => false,
+  note: vi.fn(),
+  outro: vi.fn(),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+}));
+vi.mock("./prompts.js", () => ({
+  promptInstallationConfig: vi.fn(),
+  kokoroGpuVariant: () => "standard",
+}));
+vi.mock("./network.js", () => ({ primaryLanAddress: () => "192.168.1.20" }));
+vi.mock("./tailscale.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./tailscale.js")>()),
+  checkServeRoute: vi.fn(),
+  removeServe: vi.fn(),
+}));
+vi.mock("./connection-check.js", () => ({ finishAccess: vi.fn() }));
+vi.mock("./docker.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./docker.js")>()),
+  detectDockerCommand: async () => "docker",
+  detectExistingInstallation: async () => null,
+  detectNvidiaGpus: async () => [],
+  dockerComposeAvailable: async () => true,
+  reconcileManagedSidecars: async () => ({ removed: [], warnings: [] }),
+  requireDocker: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+  runDocker: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+}));
+let directory: string;
+const ttyDescriptors = [process.stdin, process.stdout].map((stream) =>
+  Object.getOwnPropertyDescriptor(stream, "isTTY"),
+);
+const manifest = parseReleaseManifest(
+  JSON.parse(
+    await readFile(
+      new URL("../../site/public/install-manifest.json", import.meta.url),
+      "utf8",
+    ),
+  ),
+);
+const route = {
+  hostname: "server.example.ts.net",
+  port: 443,
+  target: "http://127.0.0.1:4718",
+};
+const options = { dryRun: false, defaults: false, development: false };
+function local(initial: InstallationConfig): InstallationConfig {
+  return {
+    ...initial,
+    bindAddress: "127.0.0.1",
+    publicUrl: "http://localhost:4718",
+    access: { mode: "local" },
+    search: { provider: "disabled", bundledInstalled: false },
+    tts: { provider: "disabled", bundledInstalled: false },
+    stt: { provider: "disabled", bundledInstalled: false },
+    agents: { installed: false },
+    voice: { installed: false },
+  };
+}
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.mocked(removeServe).mockResolvedValue();
+  vi.mocked(checkServeRoute).mockResolvedValue();
+  vi.mocked(requireDocker)
+    .mockReset()
+    .mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+  directory = await mkdtemp(path.join(os.tmpdir(), "overtchat-access-flow-"));
+  vi.stubEnv("OVERTCHAT_HOME", directory);
+  vi.stubEnv("OVERTCHAT_CONFIG_DIR", path.join(directory, "config"));
+  vi.stubEnv("OVERTCHAT_STACK_DIR", path.join(directory, "stack"));
+  for (const stream of [process.stdin, process.stdout])
+    Object.defineProperty(stream, "isTTY", { configurable: true, value: true });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      Response.json({ capabilities: [], ok: true, name: "overtchat" }),
+    ),
+  );
+  vi.mocked(promptInstallationConfig).mockImplementation(async (initial) =>
+    local(initial),
+  );
+});
+afterEach(async () => {
+  [process.stdin, process.stdout].forEach((stream, index) => {
+    const descriptor = ttyDescriptors[index];
+    if (descriptor) Object.defineProperty(stream, "isTTY", descriptor);
+    else Reflect.deleteProperty(stream, "isTTY");
+  });
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  await rm(directory, { recursive: true, force: true });
+});
+async function savedTailscale() {
+  const config = {
+    ...local(defaultInstallationConfig(null, manifest)),
+    publicUrl: "https://server.example.ts.net",
+    access: {
+      mode: "tailscale",
+      tailscaleRoute: route,
+      connectionStatus: "verified",
+    },
+    managedTailscaleRoute: route,
+  } as InstallationConfig;
+  await writeInstallationConfig(runtimePaths(), config);
+  return config;
+}
+describe("access provisioning lifecycle", () => {
+  it("restores the previous port and retains the old route when Docker cannot start the new binding", async () => {
+    const previous = await savedTailscale();
+    vi.mocked(promptInstallationConfig).mockResolvedValue({
+      ...previous,
+      appPort: 4999,
+      access: {
+        ...previous.access!,
+        tailscaleRoute: { ...route, target: "http://127.0.0.1:4999" },
+      },
+    });
+    let starts = 0;
+    vi.mocked(requireDocker).mockImplementation(async (_docker, args) => {
+      if (args.includes("up") && ++starts === 1)
+        throw new Error("Port 4999 is already allocated");
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    await expect(setup(options, manifest)).rejects.toThrow(
+      "Previous access settings restored",
+    );
+    expect(starts).toBe(2);
+    expect(removeServe).not.toHaveBeenCalled();
+    expect(finishAccess).not.toHaveBeenCalled();
+    expect(await readInstallationConfig(runtimePaths())).toMatchObject({
+      appPort: 4718,
+      publicUrl: previous.publicUrl,
+      managedTailscaleRoute: route,
+    });
+    expect(await readFile(runtimePaths().secretsFile, "utf8")).toContain(
+      'APP_PORT="4718"',
+    );
+  });
+
+  it("reports recovery failure without claiming the old access works", async () => {
+    await savedTailscale();
+    vi.mocked(requireDocker).mockImplementation(async (_docker, args) => {
+      if (args.includes("up")) throw new Error("Docker unavailable");
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    await expect(setup(options, manifest)).rejects.toThrow(
+      "Could not restore the previous access settings",
+    );
+    expect(removeServe).not.toHaveBeenCalled();
+  });
+
+  it("uses the shared wizard for both first installation and reconfiguration", async () => {
+    await setup(options, manifest);
+    expect(promptInstallationConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access: { mode: "lan" },
+        publicUrl: "http://192.168.1.20:4718",
+      }),
+      [],
+      undefined,
+    );
+    expect(await readInstallationConfig(runtimePaths())).toMatchObject({
+      access: { mode: "local" },
+      bindAddress: "127.0.0.1",
+    });
+    await setup(options, manifest);
+    expect(promptInstallationConfig).toHaveBeenLastCalledWith(
+      expect.objectContaining({ access: { mode: "local" } }),
+      [],
+      undefined,
+    );
+    const environment = await readFile(runtimePaths().secretsFile, "utf8");
+    expect(environment).toContain('APP_BIND_ADDRESS="127.0.0.1"');
+    expect(environment).toContain('BETTER_AUTH_URL="http://localhost:4718"');
+  });
+  it("removes the old Serve route only after the replacement stack starts", async () => {
+    await savedTailscale();
+    await setup(options, manifest);
+    expect(removeServe).toHaveBeenCalledWith(route);
+    const upIndex = vi
+      .mocked(requireDocker)
+      .mock.calls.findIndex(([, args]) => args.includes("up"));
+    expect(vi.mocked(removeServe).mock.invocationCallOrder[0]).toBeGreaterThan(
+      vi.mocked(requireDocker).mock.invocationCallOrder[upIndex]!,
+    );
+    const saved = await readInstallationConfig(runtimePaths());
+    expect(saved?.access?.mode).toBe("local");
+    expect(saved?.managedTailscaleRoute).toBeUndefined();
+  });
+  it("retains old ownership during a dry run and cleans it up on the actual run", async () => {
+    await savedTailscale();
+    await setup({ ...options, dryRun: true }, manifest);
+    expect(removeServe).not.toHaveBeenCalled();
+    expect(finishAccess).not.toHaveBeenCalled();
+    expect(await readInstallationConfig(runtimePaths())).toMatchObject({
+      access: { mode: "tailscale" },
+      managedTailscaleRoute: route,
+    });
+    await setup(options, manifest);
+    expect(removeServe).toHaveBeenCalledWith(route);
+    expect(
+      (await readInstallationConfig(runtimePaths()))?.managedTailscaleRoute,
+    ).toBeUndefined();
+  });
+  it("records ownership before starting Serve so an interrupted setup is recoverable", async () => {
+    vi.mocked(promptInstallationConfig).mockImplementation(async (initial) => ({
+      ...local(initial),
+      publicUrl: "https://server.example.ts.net",
+      access: {
+        mode: "tailscale",
+        tailscaleRoute: route,
+        connectionStatus: "pending",
+      },
+    }));
+    vi.mocked(finishAccess).mockImplementationOnce(async () => {
+      expect(
+        (await readInstallationConfig(runtimePaths()))?.managedTailscaleRoute,
+      ).toEqual(route);
+    });
+    await setup(options, manifest);
+    expect(checkServeRoute).toHaveBeenCalledWith(route, undefined);
+  });
+  it("retains route ownership when cleanup fails after starting the stack", async () => {
+    await savedTailscale();
+    vi.mocked(removeServe).mockRejectedValueOnce(
+      new Error("Route changed outside setup"),
+    );
+    await expect(setup(options, manifest)).rejects.toThrow(
+      "Route changed outside setup",
+    );
+    expect(
+      vi
+        .mocked(requireDocker)
+        .mock.calls.some(([, args]) => args.includes("up")),
+    ).toBe(true);
+    expect(
+      (await readInstallationConfig(runtimePaths()))?.managedTailscaleRoute,
+    ).toEqual(route);
+  });
+});

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -43,6 +43,10 @@ import {
 } from "./release.js";
 import { createPreMigrationSnapshot } from "./snapshot.js";
 import type { ExistingInstallation, InstallationConfig } from "./types.js";
+import { accessSummary, connectionInstructions } from "./access.js";
+import { finishAccess } from "./connection-check.js";
+import { checkServeRoute, removeServe, sameServeRoute } from "./tailscale.js";
+import { startStack } from "./stack.js";
 
 export type SetupOptions = {
   dryRun: boolean;
@@ -137,8 +141,8 @@ async function exists(file: string): Promise<boolean> {
 export async function prepareFiles(
   config: InstallationConfig,
   existingSearxngConfigPath: string | undefined,
+  paths = runtimePaths(),
 ): Promise<void> {
-  const paths = runtimePaths();
   await mkdir(paths.stackDirectory, { recursive: true, mode: 0o700 });
   await mkdir(paths.searxngDirectory, { recursive: true, mode: 0o700 });
   if (
@@ -167,11 +171,12 @@ export async function prepareFiles(
 export async function waitForApp(url: string): Promise<void> {
   const deadline = Date.now() + 180_000;
   while (Date.now() < deadline) {
-    const response = await fetch(url, {
+    const response = await fetch(new URL("/api/ping", url), {
       redirect: "manual",
       signal: AbortSignal.timeout(5_000),
     }).catch(() => null);
-    if (response && response.status >= 200 && response.status < 500) return;
+    const body = response?.ok ? await response.json().catch(() => null) : null;
+    if (body?.ok === true && body?.name === "overtchat") return;
     await new Promise((resolve) => setTimeout(resolve, 2_000));
   }
   throw new Error("OvertChat did not become ready within three minutes.");
@@ -358,7 +363,9 @@ export async function setup(
   }
   if (!saved && !existing) {
     const lanAddress = primaryLanAddress();
-    if (lanAddress) config.publicUrl = `http://${lanAddress}:${config.appPort}`;
+    config.access = { mode: lanAddress ? "lan" : "local" };
+    config.bindAddress = lanAddress ? "0.0.0.0" : "127.0.0.1";
+    config.publicUrl = `http://${lanAddress ?? "localhost"}:${config.appPort}`;
   }
   const gpus = await detectNvidiaGpus();
   if (
@@ -454,10 +461,25 @@ export async function setup(
     }
   }
 
+  const oldRoute = saved?.managedTailscaleRoute;
+  const nextRoute = config.access?.tailscaleRoute;
+  if (!options.dryRun && nextRoute) await checkServeRoute(nextRoute, oldRoute);
   const secrets = initialSecrets(
     existing,
     previousSecrets,
   );
+  if (options.dryRun) {
+    const preview = runtimePaths({
+      ...process.env,
+      OVERTCHAT_CONFIG_DIR: path.join(paths.configDirectory, "preview"),
+      OVERTCHAT_STACK_DIR: path.join(paths.stackDirectory, "preview"),
+    });
+    await prepareFiles(config, existing?.searxngConfigPath, preview);
+    await writeSecretsFile(preview, renderStackEnvironment(config, secrets, preview));
+    await requireDocker(docker, ["compose", "--env-file", preview.secretsFile, "-f", preview.composeFile, "config", "--quiet"]);
+    outro(`Configuration preview written to ${preview.stackDirectory}. Installed settings were not changed.`);
+    return;
+  }
   await prepareFiles(config, existing?.searxngConfigPath);
   await writeSecretsFile(
     paths,
@@ -472,11 +494,6 @@ export async function setup(
     paths.composeFile,
   ];
   await requireDocker(docker, [...composeArgs, "config"]);
-  if (options.dryRun) {
-    await writeInstallationConfig(paths, config);
-    outro(`Configuration written to ${paths.stackDirectory}`);
-    return;
-  }
 
   const preparation = spinner();
   preparation.start(
@@ -533,7 +550,10 @@ export async function setup(
     );
   } else {
     preparation.message("Downloading the selected OvertChat components");
-    await requireDocker(docker, [...composeArgs, "pull"], { inherit: true });
+    await requireDocker(docker, [
+      ...composeArgs, "pull",
+      ...(config.appImage === "overtchat-app:setup-dev" ? ["--ignore-pull-failures"] : []),
+    ], { inherit: true });
   }
   const snapshot = adopting && existing
     ? await (async () => {
@@ -550,21 +570,27 @@ export async function setup(
 
   const progress = spinner();
   progress.start("Starting OvertChat");
-  await requireDocker(docker, [...composeArgs, "up", "-d"], { inherit: true });
-  progress.message("Waiting for OvertChat to become ready");
-  await waitForApp(`http://127.0.0.1:${config.appPort}`);
+  await startStack(config, saved, secrets, paths, docker, waitForApp);
+  if (oldRoute && !sameServeRoute(oldRoute, nextRoute)) {
+    await removeServe(oldRoute);
+  }
   progress.message("Applying provider configuration");
   await syncCapabilities(config, secrets.managementSecret);
   if (config.agents.installed) {
     progress.message("Installing Agent Connections");
     await installManagedConnector(config, secrets.managementSecret);
   }
+  // Record the route before starting Serve so interruption can be recovered.
+  config.managedTailscaleRoute = nextRoute;
   await writeInstallationConfig(paths, config);
   progress.message("Reconciling bundled services");
   const reconciliation = await reconcileManagedSidecars(docker, config);
   progress.stop("OvertChat is ready");
 
   showSidecarReconciliation(reconciliation);
-
-  outro(`Open: ${config.publicUrl}`);
+  const instructions = connectionInstructions(config);
+  if (instructions) note(instructions, "Access OvertChat");
+  await finishAccess(config, !options.defaults);
+  await writeInstallationConfig(paths, config);
+  outro(accessSummary(config));
 }

--- a/apps/cli/src/stack.ts
+++ b/apps/cli/src/stack.ts
@@ -1,0 +1,102 @@
+import { writeFile } from "node:fs/promises";
+import { renderComposeFile, renderStackEnvironment } from "./compose.js";
+import {
+  writeInstallationConfig,
+  writeSecretsFile,
+  type InstallationSecrets,
+} from "./config.js";
+import { requireDocker, type DockerCommand } from "./docker.js";
+import type { InstallationConfig, RuntimePaths } from "./types.js";
+
+function accessSettings(config: InstallationConfig) {
+  return {
+    appPort: config.appPort,
+    bindAddress: config.bindAddress,
+    publicUrl: config.publicUrl,
+    extraTrustedOrigins: config.extraTrustedOrigins,
+    connectorServerUrl: config.connectorServerUrl,
+    access: config.access,
+    managedTailscaleRoute: config.managedTailscaleRoute,
+  };
+}
+
+// Restore network configuration after a failed reconfiguration. Keep the current
+// app image and data: rolling back software after a migration is a separate task.
+export async function restoreAccess(
+  config: InstallationConfig,
+  previous: InstallationConfig,
+  secrets: InstallationSecrets,
+  paths: RuntimePaths,
+  docker: DockerCommand,
+  waitForApp: (url: string) => Promise<void>,
+): Promise<void> {
+  const restored = { ...config, ...accessSettings(previous) };
+  await writeFile(paths.composeFile, renderComposeFile(restored), {
+    mode: 0o600,
+  });
+  await writeSecretsFile(
+    paths,
+    renderStackEnvironment(restored, secrets, paths),
+  );
+  await requireDocker(
+    docker,
+    [
+      "compose",
+      "--env-file",
+      paths.secretsFile,
+      "-f",
+      paths.composeFile,
+      "up",
+      "-d",
+    ],
+    { inherit: true },
+  );
+  await waitForApp(`http://127.0.0.1:${restored.appPort}`);
+  await writeInstallationConfig(paths, restored);
+}
+
+export async function startStack(
+  config: InstallationConfig,
+  previous: InstallationConfig | null,
+  secrets: InstallationSecrets,
+  paths: RuntimePaths,
+  docker: DockerCommand,
+  waitForApp: (url: string) => Promise<void>,
+): Promise<void> {
+  try {
+    await requireDocker(
+      docker,
+      [
+        "compose",
+        "--env-file",
+        paths.secretsFile,
+        "-f",
+        paths.composeFile,
+        "up",
+        "-d",
+      ],
+      { inherit: true },
+    );
+    await waitForApp(`http://127.0.0.1:${config.appPort}`);
+  } catch (error) {
+    if (
+      !previous ||
+      JSON.stringify(accessSettings(config)) ===
+        JSON.stringify(accessSettings(previous))
+    )
+      throw error;
+    const failure = error instanceof Error ? error.message : String(error);
+    try {
+      await restoreAccess(config, previous, secrets, paths, docker, waitForApp);
+    } catch (recoveryError) {
+      throw new Error(
+        `${failure}\nCould not restore the previous access settings: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}\nRun overtchat setup to repair the installation.`,
+        { cause: error },
+      );
+    }
+    throw new Error(
+      `${failure}\nPrevious access settings restored. Open ${previous.publicUrl} and rerun overtchat setup to try again.`,
+      { cause: error },
+    );
+  }
+}

--- a/apps/cli/src/status.ts
+++ b/apps/cli/src/status.ts
@@ -1,6 +1,7 @@
 import { readInstallationConfig } from "./config.js";
 import { detectDockerCommand, runDocker } from "./docker.js";
 import { runtimePaths } from "./paths.js";
+import { accessMode } from "./access.js";
 
 export function providerStatus(provider: string): string {
   return provider === "disabled" ? "not configured" : provider;
@@ -25,6 +26,8 @@ export async function status(): Promise<void> {
   console.log(`OvertChat ${config.appVersion}`);
   console.log(`Status: ${app?.exitCode === 0 ? app.stdout.trim() : "unavailable"}`);
   console.log(`URL: ${config.publicUrl}`);
+  console.log(`Access: ${accessMode(config)}`);
+  if (config.access?.connectionStatus) console.log(`Last connection check: ${config.access.connectionStatus}`);
   console.log(`Web search: ${providerStatus(config.search.provider)}`);
   console.log(
     `Text-to-speech: ${providerStatus(config.tts.provider)}${

--- a/apps/cli/src/tailscale.test.ts
+++ b/apps/cli/src/tailscale.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  checkServeRoute,
+  detectTailscale,
+  removeServe,
+  serveConflict,
+  startServe,
+} from "./tailscale.js";
+import { commandExists, runCommand } from "./process.js";
+vi.mock("./process.js", () => ({
+  commandExists: vi.fn(),
+  runCommand: vi.fn(),
+}));
+const route = {
+  hostname: "server.example.ts.net",
+  port: 443,
+  target: "http://127.0.0.1:4718",
+};
+const configured = {
+  TCP: { "443": { HTTPS: true } },
+  Web: {
+    "server.example.ts.net:443": { Handlers: { "/": { Proxy: route.target } } },
+  },
+};
+function result(body: unknown, exitCode = 0) {
+  return { stdout: JSON.stringify(body), stderr: "", exitCode };
+}
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(commandExists).mockResolvedValue(true);
+});
+
+describe("Tailscale readiness", () => {
+  it("reports missing Tailscale without running or installing it", async () => {
+    vi.mocked(commandExists).mockResolvedValue(false);
+    expect((await detectTailscale()).problem).toContain("Tailscale not found");
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+  it.each([
+    ["NeedsLogin", "sign-in"],
+    ["NeedsMachineAuth", "approval"],
+    ["Stopped", "disconnected"],
+    ["NoState", "not ready"],
+  ])("explains %s", async (BackendState, message) => {
+    vi.mocked(runCommand).mockResolvedValue(result({ BackendState }));
+    expect((await detectTailscale()).problem).toContain(message);
+  });
+  it("reports an unavailable daemon and offline devices", async () => {
+    vi.mocked(runCommand).mockResolvedValue({
+      stdout: "",
+      stderr: "daemon unavailable",
+      exitCode: 1,
+    });
+    expect((await detectTailscale()).problem).toContain("service is running");
+    vi.mocked(runCommand).mockResolvedValue(
+      result({ BackendState: "Running", Self: { Online: false } }),
+    );
+    expect((await detectTailscale()).problem).toContain("offline");
+  });
+  it("returns a normalized device hostname only when connected", async () => {
+    vi.mocked(runCommand).mockResolvedValue(
+      result({
+        BackendState: "Running",
+        Self: { DNSName: "server.example.ts.net.", Online: true },
+      }),
+    );
+    expect(await detectTailscale()).toEqual({ hostname: route.hostname });
+  });
+});
+describe("Tailscale Serve ownership", () => {
+  it("accepts an unused port or its own exact existing route", () => {
+    expect(serveConflict({}, route)).toBeUndefined();
+    expect(serveConflict(configured, route, route)).toBeUndefined();
+    expect(
+      serveConflict(
+        configured,
+        { ...route, target: "http://127.0.0.1:4999" },
+        route,
+      ),
+    ).toBeUndefined();
+  });
+  it("rejects other apps, foreground listeners, TCP listeners, and public Funnel", () => {
+    expect(serveConflict(configured, route)).toContain("another application");
+    expect(serveConflict({ TCP: { "443": {} } }, route)).toContain(
+      "already in use",
+    );
+    expect(
+      serveConflict({ Foreground: { session: configured } }, route),
+    ).toContain("foreground");
+    expect(
+      serveConflict(
+        { ...configured, AllowFunnel: { "server.example.ts.net:443": true } },
+        route,
+        route,
+      ),
+    ).toContain("Funnel");
+  });
+  it("checks again immediately before starting and never resets Serve", async () => {
+    vi.mocked(runCommand)
+      .mockResolvedValueOnce(result({}))
+      .mockResolvedValueOnce(result({}))
+      .mockResolvedValueOnce(result(configured));
+    await startServe(route);
+    expect(runCommand).toHaveBeenNthCalledWith(
+      2,
+      "tailscale",
+      ["serve", "--bg", "--yes", "--https=443", "--set-path=/", route.target],
+      expect.any(Object),
+    );
+    expect(
+      vi
+        .mocked(runCommand)
+        .mock.calls.some(([, args]) => args.includes("reset")),
+    ).toBe(false);
+  });
+  it("does not mutate conflicting or unreadable state", async () => {
+    vi.mocked(runCommand).mockResolvedValue(result(configured));
+    await expect(startServe(route)).rejects.toThrow("another application");
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    vi.mocked(runCommand).mockResolvedValue({
+      stdout: "garbage",
+      stderr: "",
+      exitCode: 0,
+    });
+    await expect(checkServeRoute(route)).rejects.toThrow();
+  });
+  it("reports HTTPS enablement instructions on failure", async () => {
+    vi.mocked(runCommand)
+      .mockResolvedValueOnce(result({}))
+      .mockResolvedValueOnce({
+        stdout: "Enable HTTPS: https://login.tailscale.com/example",
+        stderr: "",
+        exitCode: 1,
+      });
+    await expect(startServe(route)).rejects.toThrow(
+      "https://login.tailscale.com/example",
+    );
+  });
+  it("removes only the recorded route and verifies removal", async () => {
+    vi.mocked(runCommand)
+      .mockResolvedValueOnce(result(configured))
+      .mockResolvedValueOnce(result({}))
+      .mockResolvedValueOnce(result({}));
+    await removeServe(route);
+    expect(runCommand).toHaveBeenNthCalledWith(
+      2,
+      "tailscale",
+      ["serve", "--bg", "--https=443", "--set-path=/", "off"],
+      expect.any(Object),
+    );
+  });
+  it("refuses to remove a route changed by someone else", async () => {
+    vi.mocked(runCommand).mockResolvedValue(result(configured));
+    await expect(
+      removeServe({ ...route, target: "http://127.0.0.1:9999" }),
+    ).rejects.toThrow("changed outside setup");
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cli/src/tailscale.ts
+++ b/apps/cli/src/tailscale.ts
@@ -1,0 +1,187 @@
+import { commandExists, runCommand } from "./process.js";
+import type { AccessConfig } from "./types.js";
+
+type Route = NonNullable<AccessConfig["tailscaleRoute"]>;
+type ServeConfig = {
+  TCP?: Record<string, { HTTPS?: boolean }>;
+  Web?: Record<string, { Handlers?: Record<string, { Proxy?: string }> }>;
+  AllowFunnel?: Record<string, boolean>;
+  Foreground?: Record<string, ServeConfig>;
+};
+
+export function sameServeRoute(left?: Route, right?: Route): boolean {
+  return (
+    left?.hostname === right?.hostname &&
+    left?.port === right?.port &&
+    left?.target === right?.target
+  );
+}
+
+export async function detectTailscale(): Promise<{
+  hostname?: string;
+  problem?: string;
+}> {
+  if (!(await commandExists("tailscale")))
+    return {
+      problem:
+        "Tailscale not found. Install Tailscale, then run overtchat setup again.",
+    };
+  const result = await runCommand("tailscale", ["status", "--json"], {
+    timeoutMs: 10_000,
+  });
+  let status: {
+    BackendState?: string;
+    Self?: { DNSName?: string; Online?: boolean };
+  };
+  try {
+    status = JSON.parse(result.stdout);
+  } catch {
+    return {
+      problem:
+        "Could not read Tailscale status. Check that its service is running and your user can access it.",
+    };
+  }
+  const problems: Record<string, string> = {
+    NeedsLogin:
+      "Tailscale needs sign-in. Run sudo tailscale up, complete sign-in, then retry.",
+    NeedsMachineAuth:
+      "This device is waiting for approval in the Tailscale admin console. Approve it, then retry.",
+    Stopped: "Tailscale is disconnected. Run sudo tailscale up, then retry.",
+  };
+  if (status.BackendState !== "Running")
+    return {
+      problem:
+        problems[status.BackendState ?? ""] ??
+        "Tailscale is not ready. Check tailscale status, then retry.",
+    };
+  if (result.exitCode !== 0 || status.Self?.Online === false)
+    return {
+      problem: "Tailscale is offline. Restore its connection, then retry.",
+    };
+  const hostname = status.Self?.DNSName?.replace(/\.$/u, "");
+  if (
+    !hostname ||
+    !/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.ts\.net$/iu.test(hostname)
+  ) {
+    return {
+      problem:
+        "Tailscale has no usable device DNS name. Enable MagicDNS in the Tailscale admin console, then retry.",
+    };
+  }
+  return { hostname };
+}
+
+async function serveConfig(): Promise<ServeConfig> {
+  const result = await runCommand("tailscale", ["serve", "status", "--json"], {
+    timeoutMs: 10_000,
+  });
+  if (result.exitCode !== 0)
+    throw new Error(
+      "Could not inspect Tailscale Serve. Check Tailscale permissions and use a version supporting tailscale serve status --json.",
+    );
+  const parsed: unknown = JSON.parse(result.stdout);
+  if (parsed === null) return {};
+  if (typeof parsed !== "object" || Array.isArray(parsed))
+    throw new Error("Unrecognized Tailscale Serve configuration.");
+  return parsed as ServeConfig;
+}
+
+export function serveConflict(
+  config: ServeConfig,
+  route: Route,
+  previous?: Route,
+): string | undefined {
+  const key = `${route.hostname}:${route.port}`;
+  if (config.AllowFunnel?.[key])
+    return "This Tailscale address has public Funnel access enabled. Disable Funnel for this address before using private OvertChat access.";
+  for (const foreground of Object.values(config.Foreground ?? {})) {
+    if (foreground.TCP?.[route.port] || foreground.Web?.[key])
+      return "This Tailscale port is used by a foreground Serve session. Stop that session or choose another HTTPS port.";
+  }
+  const handlers = config.Web?.[key]?.Handlers ?? {};
+  const root = handlers["/"];
+  const owned =
+    previous?.hostname === route.hostname &&
+    previous.port === route.port &&
+    root?.Proxy === previous.target;
+  if (root && !owned)
+    return "This Tailscale address already serves another application. Choose another HTTPS port.";
+  // Even an empty HTTP/TCP listener may belong to another application.
+  if (config.TCP?.[route.port] && (!config.TCP[route.port].HTTPS || !owned))
+    return "This Tailscale port is already in use. Choose another HTTPS port.";
+  if (Object.keys(handlers).some((path) => path !== "/"))
+    return "This Tailscale address has other application routes. Choose another HTTPS port.";
+}
+
+export async function checkServeRoute(
+  route: Route,
+  previous?: Route,
+): Promise<void> {
+  const problem = serveConflict(await serveConfig(), route, previous);
+  if (problem) throw new Error(problem);
+}
+
+export async function startServe(
+  route: Route,
+  previous?: Route,
+): Promise<void> {
+  await checkServeRoute(route, previous);
+  const result = await runCommand(
+    "tailscale",
+    [
+      "serve",
+      "--bg",
+      "--yes",
+      `--https=${route.port}`,
+      "--set-path=/",
+      route.target,
+    ],
+    { timeoutMs: 20_000 },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      [
+        "Tailscale Serve could not start. Complete any HTTPS enablement below, or grant your user Tailscale operator permission, then retry.",
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  const state = await serveConfig();
+  const key = `${route.hostname}:${route.port}`;
+  if (
+    state.Web?.[key]?.Handlers?.["/"]?.Proxy !== route.target ||
+    !state.TCP?.[route.port]?.HTTPS ||
+    state.AllowFunnel?.[key]
+  ) {
+    throw new Error(
+      "Tailscale did not confirm the private HTTPS route. Check tailscale serve status, then retry.",
+    );
+  }
+}
+
+export async function removeServe(route: Route): Promise<void> {
+  const config = await serveConfig();
+  const key = `${route.hostname}:${route.port}`;
+  const root = config.Web?.[key]?.Handlers?.["/"];
+  if (!root) return;
+  if (root.Proxy !== route.target)
+    throw new Error(
+      "The previous OvertChat Tailscale route was changed outside setup. Remove or move that route with tailscale serve before changing access mode.",
+    );
+  const result = await runCommand(
+    "tailscale",
+    ["serve", "--bg", `--https=${route.port}`, "--set-path=/", "off"],
+    { timeoutMs: 10_000 },
+  );
+  if (result.exitCode !== 0)
+    throw new Error(
+      "Could not remove the previous OvertChat Tailscale route. Check your Tailscale permissions, then retry setup.",
+    );
+  if ((await serveConfig()).Web?.[key]?.Handlers?.["/"])
+    throw new Error(
+      "The previous Tailscale route is still active. Remove it before changing access mode.",
+    );
+}

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -49,8 +49,20 @@ export type VoiceConfig = {
   installed: boolean;
 };
 
+export type AccessMode = "local" | "lan" | "tailscale" | "advanced";
+export type TailscaleRoute = { hostname: string; port: number; target: string };
+export type AccessConfig = {
+  mode: AccessMode;
+  proxy?: "cloudflare" | "other";
+  proxyLocation?: "host" | "docker" | "remote";
+  lanAddress?: string;
+  connectionStatus?: "pending" | "verified";
+  tailscaleRoute?: TailscaleRoute;
+};
+
 export type InstallationConfig = {
   format: 1;
+  instanceId?: string;
   appVersion: string;
   appImage: string;
   voiceVersion: string;
@@ -67,6 +79,10 @@ export type InstallationConfig = {
   publicUrl: string;
   extraTrustedOrigins: string[];
   connectorServerUrl: string;
+  access?: AccessConfig;
+  // Records the route managed by setup separately from the access choice.
+  // Only this exact Serve route may be changed or removed by the manager.
+  managedTailscaleRoute?: TailscaleRoute;
   disableUpdateCheck?: boolean;
   composeProject: string;
   dataMountType: "volume" | "bind";

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -184,6 +184,29 @@ beforeEach(() => {
 });
 
 describe("managed updates", () => {
+  it("preserves access settings and disabled update notifications across manual updates", async () => {
+    const current = config({
+      disableUpdateCheck: true,
+      publicUrl: "https://server.example.ts.net:8443",
+      access: {
+        mode: "tailscale",
+        connectionStatus: "pending",
+        tailscaleRoute: { hostname: "server.example.ts.net", port: 8443, target: "http://127.0.0.1:4718" },
+      },
+    });
+    mocks.readInstallationConfig.mockResolvedValue(current);
+    current.managedTailscaleRoute = current.access?.tailscaleRoute;
+    await update();
+    expect(mocks.writeInstallationConfig).toHaveBeenCalledWith(paths, expect.objectContaining({
+      access: current.access,
+      publicUrl: current.publicUrl,
+      bindAddress: current.bindAddress,
+      managedTailscaleRoute: current.managedTailscaleRoute,
+      disableUpdateCheck: true,
+    }));
+    expect(mocks.outro).toHaveBeenCalledWith(`Connection pending: ${current.publicUrl}`);
+  });
+
   it("rejects installations that have not been managed by setup", async () => {
     mocks.readInstallationConfig.mockResolvedValue(null);
 

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -1,4 +1,5 @@
 import { outro, spinner } from "@clack/prompts";
+import { accessSummary } from "./access.js";
 import {
   initialSecrets,
   normalizeInstallationConfig,
@@ -105,7 +106,7 @@ export async function update(): Promise<void> {
     progress.stop("OvertChat is up to date");
     progressActive = false;
     showSidecarReconciliation(reconciliation);
-    outro(`Open: ${nextConfig.publicUrl}`);
+    outro(nextConfig.access ? accessSummary(nextConfig) : `Open: ${nextConfig.publicUrl}`);
   } catch (error) {
     if (progressActive) progress.stop("OvertChat update failed", 1);
     throw error;

--- a/apps/site/app/privacy/page.tsx
+++ b/apps/site/app/privacy/page.tsx
@@ -177,9 +177,10 @@ export default function PrivacyPage() {
             <p>
               Cloudflare processes ordinary request data such as the server IP
               address and request time when delivering the manifest. Server
-              operators can disable version checks by setting the documented
-              {" "}
-              <code>DISABLE_UPDATE_CHECK</code> environment variable.
+              operators can disable version checks by running{" "}
+              <code>overtchat setup</code> and choosing No for “Automatically
+              check for updates?”. Manually managed deployments can set{" "}
+              <code>DISABLE_UPDATE_CHECK=true</code>.
             </p>
           </section>
 

--- a/apps/web/app/api/ping/route.test.ts
+++ b/apps/web/app/api/ping/route.test.ts
@@ -1,15 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { APP_VERSION } from "@/lib/version";
 import { GET } from "./route";
 
+afterEach(() => vi.unstubAllEnvs());
+
 describe("GET /api/ping", () => {
   it("reports the same release version shown in the app", async () => {
+    vi.stubEnv("OVERTCHAT_INSTANCE_ID", "");
     const response = GET(new Request("http://localhost/api/ping"));
 
     expect(await response.json()).toEqual({
       ok: true,
       name: "overtchat",
       version: APP_VERSION,
+    });
+  });
+  it("includes only the public instance identifier for a managed installation", async () => {
+    vi.stubEnv("OVERTCHAT_INSTANCE_ID", "test-installation");
+    vi.stubEnv("OVERTCHAT_MANAGEMENT_SECRET", "must-not-be-returned");
+    const response = GET(new Request("http://localhost/api/ping"));
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      ok: true,
+      name: "overtchat",
+      version: APP_VERSION,
+      instanceId: "test-installation",
     });
   });
 });

--- a/apps/web/app/api/ping/route.ts
+++ b/apps/web/app/api/ping/route.ts
@@ -3,12 +3,16 @@ import { withCors, preflight } from "@/lib/cors";
 import { APP_VERSION } from "@/lib/version";
 
 export function GET(req: Request) {
-  const body: PingResponse = {
+  const body: PingResponse & { instanceId?: string } = {
     ok: true,
     name: "overtchat",
     version: APP_VERSION,
+    instanceId: process.env.OVERTCHAT_INSTANCE_ID || undefined,
   };
-  return withCors(req, Response.json(body));
+  return withCors(
+    req,
+    Response.json(body, { headers: { "Cache-Control": "no-store" } }),
+  );
 }
 
 export function OPTIONS(req: Request) {

--- a/compose.yml
+++ b/compose.yml
@@ -5,10 +5,11 @@ services:
     container_name: overtchat-app
     restart: unless-stopped
     ports:
-      - "${APP_PORT:-4718}:4717"
+      - "${APP_BIND_ADDRESS:-0.0.0.0}:${APP_PORT:-4718}:4717"
     environment:
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:4718}
+      EXTRA_TRUSTED_ORIGINS: ${EXTRA_TRUSTED_ORIGINS:-}
       DISABLE_UPDATE_CHECK: ${DISABLE_UPDATE_CHECK:-false}
       HOST_CONNECTOR_URL: ${HOST_CONNECTOR_URL:-http://127.0.0.1:${APP_PORT:-4718}}
       OVERTCHAT_INSTALLED_CAPABILITIES: ${OVERTCHAT_INSTALLED_CAPABILITIES:-search,tts,stt}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -9,12 +9,14 @@ OvertChat with Docker Compose.
 curl -fsSL https://overtchat.com/install | sh
 ```
 
-Choose local search, speech, and voice services in the wizard. It installs
-Docker if needed. Open the printed URL, create the administrator account,
+Choose where to access OvertChat, local search, speech, and voice services,
+and whether to check for updates. The wizard installs Docker if needed and
+generates the configuration and secrets; no `.env` file editing is needed.
+Open the printed URL, create the administrator account,
 and add your model endpoint in the web app.
 
 ```sh
-overtchat setup     # change services, URL, port, or Agent Connections
+overtchat setup     # change access, services, or update notifications
 overtchat status    # check versions and service status
 overtchat update    # update the managed stack
 ```
@@ -22,6 +24,100 @@ overtchat update    # update the managed stack
 Voice requires both STT and TTS. Bundled Parakeet and Kokoro can each use CPU or
 NVIDIA GPU; setup can install NVIDIA Container Toolkit on supported systems.
 Kokoro needs roughly 3–4 GB VRAM, so choose CPU if GPU memory is limited.
+
+## Choose how to access OvertChat
+
+First-time installation and `overtchat setup` use the same access question.
+Rerunning setup preselects the saved choice and lets you change it without
+reinstalling or losing data. Updates preserve the choice. A dry run renders a
+preview without saving new installation settings or changing Tailscale routes.
+If an access reconfiguration fails to start, setup attempts to restore the
+previous network settings. It does not downgrade the app or roll back database
+migrations. The previous Tailscale route is retained until startup succeeds.
+
+| Choice | Behavior |
+| --- | --- |
+| Only on this computer | Opens at `http://localhost:4718`; the published port listens only on loopback. |
+| On my home network | Detects a LAN address and configures login for that address and localhost. The published port listens on all interfaces, subject to the host firewall. |
+| From anywhere with Tailscale | Uses Tailscale Serve to provide private HTTPS access to an app listening on loopback. |
+| Advanced setup | Uses your HTTPS address through an existing Cloudflare Tunnel or another reverse proxy. |
+
+Fresh installations suggest the home network option when a LAN address is
+detected, otherwise local access. The final output labels the address to use
+on this computer or other devices. `localhost` always means the device opening
+the address; it does not refer to your server from your phone.
+
+Use **Customize the port or additional addresses?** to change the app port or
+add browser addresses. When the main address uses HTTPS, additional addresses
+must also use HTTPS because authentication uses secure cookies. These are
+accepted login addresses; DNS, proxies, and network reachability must also be
+configured. Setup handles the authentication environment automatically.
+
+### Tailscale
+
+Install and connect Tailscale on the OvertChat host first. Setup checks that
+Tailscale is available, signed in, connected, and has a device DNS name. If it
+is missing, it shows **Tailscale not found** and lets you retry or select another
+access option. For sign-in, a stopped connection, or pending device approval,
+setup explains the next step. It does not install Tailscale or sign in for you.
+
+Setup configures a persistent background Serve route to the app's loopback
+port. It uses HTTPS port 443 when available; if another app uses that port, you
+can choose another HTTPS port. Existing Serve routes and public Funnel
+configuration are inspected before any changes. Setup only manages its own
+recorded route and never resets the device's Serve configuration.
+
+The current Linux user needs permission to manage Tailscale Serve. If needed,
+run `sudo tailscale set --operator=<your-linux-username>`. If HTTPS needs enabling,
+complete the link printed by Tailscale and retry. See
+[Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve).
+The first HTTPS request may wait while Tailscale issues a certificate. If the
+initial check times out, wait briefly and retry.
+
+Open the printed `https://<device>.<tailnet>.ts.net` address on a device connected
+to Tailscale and sign in to OvertChat normally. Access follows your Tailscale
+network permissions. Serve resumes after a host restart. Changing access mode
+or ports removes the previous OvertChat Serve route; externally changed routes
+must be resolved before setup can remove them.
+
+### Cloudflare Tunnel or another reverse proxy
+
+Select **Advanced setup**, enter the HTTPS address you will open (for example,
+`https://chat.example.com`), choose Cloudflare Tunnel or another reverse proxy,
+then select where it runs:
+
+| Tunnel/proxy placement | Service destination |
+| --- | --- |
+| Directly on the OvertChat host | `http://127.0.0.1:4718` (or the selected app port) |
+| Docker on the same host | `http://app:4717`, with the proxy connected to OvertChat's Docker network |
+| Another computer | `http://<OvertChat host LAN IP>:4718` (or the selected app port); allow the proxy through the host firewall |
+
+For Docker, setup prints the external network name, normally
+`overtchat_default`. Attach the proxy container to that network and declare it
+as an external network in the proxy's Compose configuration so the connection
+survives recreation. `localhost` inside a proxy container refers to that
+container. Same-host proxy modes keep the app's published port on loopback;
+the remote proxy option publishes it on all interfaces.
+
+For Cloudflare, create a published application route with your hostname and
+the service destination above. Manage your tunnel, domain, and credentials in
+Cloudflare; OvertChat does not install `cloudflared` or collect tunnel tokens.
+See [Cloudflare Tunnel setup](https://developers.cloudflare.com/tunnel/setup/).
+Other reverse proxies must terminate HTTPS and support WebSocket upgrades.
+
+Choose **Check connection** after configuring the route. Setup verifies that
+the address reaches this particular installation without sending management
+credentials to the public address. It checks HTTPS using normal certificate
+validation and does not follow redirects to an access gateway. This confirms
+the app route, not every client device's permissions or WebSocket support.
+The check compares a public installation ID from `/api/ping`; this is a routing
+check, not authentication. An older app without that ID needs updating before
+the check can succeed.
+
+You can retry or finish with **Connection pending**, then rerun `overtchat setup`
+after configuring the tunnel. `overtchat status` reports the last check result.
+When switching away from an externally managed tunnel or proxy, remove its
+route in that service as well; setup only removes routes it manages in Tailscale.
 
 ## Connect models and services
 
@@ -64,8 +160,14 @@ Repeat for updates; sideloaded builds do not auto-update.
 ## Update or adopt an existing installation
 
 `overtchat update` updates the CLI, app, selected services, and managed
-connector while preserving data. Rerun it if interrupted. To disable update
-notifications, run `DISABLE_UPDATE_CHECK=true overtchat setup` once.
+connector while preserving data. Rerun it if interrupted.
+
+Setup asks **Automatically check for updates?**, with **Yes (recommended)**
+selected for new installations. This enables release notifications in the
+administrator account menu. The app contacts overtchat.com to check for new
+releases; install updates by running `overtchat update`.
+To change notifications, rerun `overtchat setup` and choose Yes or No. Setup
+preselects your saved preference, and updates preserve it.
 
 To adopt a standard existing `overtchat-app` container, run `overtchat setup`.
 It preserves the data mount, port, auth secret, and standard SearXNG settings,
@@ -91,5 +193,26 @@ setup and updates may replace manual edits to generated files.
 
 A `307` redirect to login is normal. For login loops or port conflicts, run
 `overtchat setup` and correct the public URL or port.
+
+## Manual source Compose configuration
+
+Use this section when you manage Compose directly from a source checkout.
+The repository `.env.example` documents optional settings for that workflow.
+For guided installations, change these settings with `overtchat setup`; the
+manager generates its own environment files.
+
+For a manually managed checkout, set `BETTER_AUTH_URL` to the browser address,
+`APP_PORT` to the published port, and `APP_BIND_ADDRESS` to `127.0.0.1` for local
+access or `0.0.0.0` for network access. `EXTRA_TRUSTED_ORIGINS` accepts additional
+browser addresses separated by commas. Include the scheme and port.
+
+The source Compose defaults publish port 4718 on all interfaces but configure
+authentication for `http://localhost:4718`. To use a LAN IP or domain, set the
+browser address accordingly and recreate the app container. Changing the auth
+address does not change which network interfaces listen. Use the guided manager
+for automatic coordination of these settings.
+
+For manual Compose, `DISABLE_UPDATE_CHECK=true` disables release notifications.
+Guided installations expose this preference in `overtchat setup`.
 
 [Development setup](development.md) · [Release process](release.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,10 @@ connector state lives in `.overtchat-dev/`, separate from production.
 
 ## Environment and commands
 
+Development runs with checked-in defaults; copying `.env.example` is optional.
+That file is a reference for manual source configuration. Managed installations
+use `overtchat setup`, which generates their environment separately.
+
 Defaults are in `apps/web/.env.development`; machine-specific values belong in
 `apps/web/.env.local`. The root `.env` configures source development;
 `apps/web/.env` must remain a symlink to `../../.env`. For another development


### PR DESCRIPTION
Simplify first-time installation and `overtchat setup` with guided access options for localhost, LAN, Tailscale, and an existing domain or reverse proxy. Setup configures listening and authentication settings automatically, manages Tailscale Serve, and provides connection checks and recovery when access reconfiguration fails.

Add an update-notification preference and clarify that managed installations use `overtchat setup`; `.env.example` remains a reference for manual Compose and development.

Validation:
- CLI, web, and site checks passed: relevant tests, typechecks, lint, and builds.
- Verified Tailscale HTTPS authentication across devices, LAN/local access switching, and recovery from a port conflict.
- Live Cloudflare Tunnel validation remains outstanding.
